### PR TITLE
Allow Slack runs to create GitHub PRs

### DIFF
--- a/apps/opentagd/src/pr.ts
+++ b/apps/opentagd/src/pr.ts
@@ -13,6 +13,11 @@ function hasPermission(event: OpenTagEvent, scope: string): boolean {
   return event.permissions.some((permission) => permission.scope === scope);
 }
 
+function isGitHubRepositoryTarget(input: { event: OpenTagEvent; binding: RepositoryBindingConfig }): boolean {
+  const repoProvider = input.event.metadata["repoProvider"];
+  return input.binding.provider === "github" && (repoProvider == null || repoProvider === "github");
+}
+
 export async function maybeCreatePullRequest(input: {
   run: OpenTagRun;
   event: OpenTagEvent;
@@ -21,7 +26,7 @@ export async function maybeCreatePullRequest(input: {
   options: PullRequestOptions;
 }): Promise<OpenTagRunResult> {
   if (!input.options.githubToken) return input.result;
-  if (input.event.source !== "github") return input.result;
+  if (!isGitHubRepositoryTarget({ event: input.event, binding: input.binding })) return input.result;
   if (!hasPermission(input.event, "pr:create")) return input.result;
   if (!input.result.changedFiles?.length) return input.result;
 

--- a/apps/opentagd/test/pr.test.ts
+++ b/apps/opentagd/test/pr.test.ts
@@ -33,6 +33,35 @@ const result: OpenTagRunResult = {
   changedFiles: ["src/demo.ts"]
 };
 
+const slackEvent: OpenTagEvent = {
+  ...event,
+  id: "evt_slack_1",
+  source: "slack",
+  sourceEventId: "Ev123",
+  actor: { provider: "slack", providerUserId: "U456", organizationId: "T123" },
+  target: { mention: "<@U_APP>", agentId: "opentag" },
+  permissions: [
+    { scope: "chat:postMessage", reason: "reply in the originating Slack thread" },
+    { scope: "runner:local", reason: "execute the run on a paired local daemon" },
+    { scope: "repo:read", reason: "inspect the repository in the paired local checkout" },
+    { scope: "repo:write", reason: "commit code changes on an isolated run branch" },
+    { scope: "pr:create", reason: "open a pull request for completed code changes" }
+  ],
+  callback: {
+    provider: "slack",
+    uri: "https://slack.com/api/chat.postMessage",
+    threadKey: "T123|C123|1710000000.000100"
+  },
+  metadata: {
+    teamId: "T123",
+    channelId: "C123",
+    messageTs: "1710000000.000100",
+    repoProvider: "github",
+    owner: "acme",
+    repo: "demo"
+  }
+};
+
 describe("maybeCreatePullRequest", () => {
   it("pushes the run branch and creates a GitHub pull request when allowed", async () => {
     const commands: string[] = [];
@@ -68,6 +97,111 @@ describe("maybeCreatePullRequest", () => {
     expect(requests).toEqual(["https://api.github.com/repos/acme/demo/pulls"]);
     expect(updated.createdPullRequestUrl).toBe("https://github.com/acme/demo/pull/1");
     expect(updated.nextAction).toContain("https://github.com/acme/demo/pull/1");
+  });
+
+  it("creates a GitHub pull request for Slack runs mapped to a GitHub repository", async () => {
+    const commands: string[] = [];
+    const requests: string[] = [];
+    const updated = await maybeCreatePullRequest({
+      run,
+      event: slackEvent,
+      binding: {
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        checkoutPath: "/tmp/demo",
+        baseBranch: "main",
+        pushRemote: "origin"
+      },
+      result,
+      options: {
+        githubToken: "ghs_test",
+        commandRunner: {
+          async run(command, args) {
+            commands.push(`${command} ${args.join(" ")}`);
+            return { exitCode: 0, stdout: "", stderr: "" };
+          }
+        },
+        fetchImpl: (async (url) => {
+          requests.push(String(url));
+          return Response.json({ html_url: "https://github.com/acme/demo/pull/2" });
+        }) as typeof fetch
+      }
+    });
+
+    expect(commands).toEqual(["git push -u origin opentag/run_1"]);
+    expect(requests).toEqual(["https://api.github.com/repos/acme/demo/pulls"]);
+    expect(updated.createdPullRequestUrl).toBe("https://github.com/acme/demo/pull/2");
+    expect(updated.artifacts).toContainEqual({ title: "Pull request", uri: "https://github.com/acme/demo/pull/2" });
+  });
+
+  it("treats a null repoProvider as the default GitHub repository target", async () => {
+    const commands: string[] = [];
+    const requests: string[] = [];
+    const updated = await maybeCreatePullRequest({
+      run,
+      event: {
+        ...slackEvent,
+        metadata: {
+          ...slackEvent.metadata,
+          repoProvider: null
+        }
+      },
+      binding: {
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        checkoutPath: "/tmp/demo",
+        baseBranch: "main",
+        pushRemote: "origin"
+      },
+      result,
+      options: {
+        githubToken: "ghs_test",
+        commandRunner: {
+          async run(command, args) {
+            commands.push(`${command} ${args.join(" ")}`);
+            return { exitCode: 0, stdout: "", stderr: "" };
+          }
+        },
+        fetchImpl: (async (url) => {
+          requests.push(String(url));
+          return Response.json({ html_url: "https://github.com/acme/demo/pull/3" });
+        }) as typeof fetch
+      }
+    });
+
+    expect(commands).toEqual(["git push -u origin opentag/run_1"]);
+    expect(requests).toEqual(["https://api.github.com/repos/acme/demo/pulls"]);
+    expect(updated.createdPullRequestUrl).toBe("https://github.com/acme/demo/pull/3");
+  });
+
+  it("does not create a GitHub pull request for non-GitHub repository targets", async () => {
+    await expect(
+      maybeCreatePullRequest({
+        run,
+        event: {
+          ...slackEvent,
+          metadata: {
+            ...slackEvent.metadata,
+            repoProvider: "gitlab"
+          }
+        },
+        binding: { provider: "github", owner: "acme", repo: "demo", checkoutPath: "/tmp/demo" },
+        result,
+        options: {
+          githubToken: "ghs_test",
+          commandRunner: {
+            async run() {
+              throw new Error("should not push a branch");
+            }
+          },
+          fetchImpl: (async () => {
+            throw new Error("should not create a pull request");
+          }) as typeof fetch
+        }
+      })
+    ).resolves.toBe(result);
   });
 
   it("leaves the result unchanged without a GitHub token", async () => {


### PR DESCRIPTION
## Summary

Allow Slack-triggered OpenTag runs that are mapped to GitHub repositories to create GitHub pull requests after a successful code-changing run.

## Why

Slack app mentions already normalize to `OpenTagEvent` objects with GitHub repo metadata and `pr:create` grants for `fix` / `run` commands. The local daemon could execute those runs, but `maybeCreatePullRequest` returned early unless `event.source === "github"`, so Slack-originated code changes could never complete the same branch-push + PR handoff as GitHub-originated runs.

## Changes

- Replace the source-only GitHub check with a repository-target check based on the local binding provider and `event.metadata.repoProvider`.
- Keep PR creation limited to GitHub repository targets with an explicit `pr:create` permission and changed files.
- Add coverage for Slack runs mapped to GitHub repositories creating PRs.
- Add a guard test for non-GitHub repository targets.

## Validation

- `npm exec --yes pnpm@9.15.0 -- test apps/opentagd/test/pr.test.ts`
- `npm exec --yes pnpm@9.15.0 -- typecheck`
- `npm exec --yes pnpm@9.15.0 -- test`
- `npm exec --yes pnpm@9.15.0 -- build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request creation now works for runs mapped to GitHub repository targets, even when the originating event comes from another source.

* **Bug Fixes**
  * Improved target detection so PR creation only runs for GitHub repositories.
  * Added coverage to ensure non-GitHub repository targets do not trigger branch pushes or PR creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->