### PR TITLE
[codex] Harden dispatcher reliability guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The goal is simple: make "tag an agent into work" a protocol, not a closed surfa
 - **GitHub mentions** - `issue_comment.created` and `pull_request_review_comment.created` become normalized OpenTag events.
 - **Slack app mentions** - bound Slack channels can route `app_mention` events to the same dispatcher and local daemon path.
 - **Auditable dispatch** - every run is stored with event metadata, status transitions, progress, result, and callback delivery events.
+- **Reliability guardrails** - dispatcher run creation is idempotent per source event, runner claims use conditional leases, and callback failures are retried then preserved as dead-letter audit events.
 - **Explicit runner binding** - a runner only claims runs for repositories it is bound to.
 - **Local-first execution** - `opentagd` resolves a configured local checkout before executing anything.
 - **Executor adapters** - `echo` is available for smoke tests, and `codex` can run a real Codex CLI task on an isolated branch.
@@ -125,10 +126,10 @@ curl http://localhost:3030/v1/runs/run_demo_1/events
 ## How It Works
 
 1. **Ingress normalizes platform events.** GitHub and Slack adapters translate comments or app mentions into one `OpenTagEvent` schema.
-2. **The dispatcher validates scope.** Runs must include repository metadata, and the repository must be explicitly bound to a runner.
+2. **The dispatcher validates scope.** Runs must include repository metadata, and the repository must be explicitly bound to a runner. Replayed source events return the existing run instead of creating duplicates.
 3. **The local daemon claims only mapped work.** `opentagd` checks its local repository config before running an executor.
 4. **The executor does the work.** The echo executor proves the loop; the Codex executor creates an isolated `opentag/<runId>` branch and runs `codex exec`.
-5. **Callbacks and audit events close the loop.** Progress and final results can be posted back to GitHub or Slack, and every step stays queryable through the dispatcher.
+5. **Callbacks and audit events close the loop.** Progress and final results can be posted back to GitHub or Slack, callback delivery is retried, and exhausted callback failures are queryable as dead-letter events.
 
 ## Packages
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -60,13 +60,18 @@ export type CreateRunInput = {
   event: OpenTagEvent;
 };
 
+export type CreateRunResult = {
+  run: OpenTagRun;
+  idempotentReplay?: boolean;
+};
+
 export type OpenTagClient = {
   registerRunner(input: { runnerId: string; name?: string }): Promise<void>;
   bindRepository(input: RepoBindingInput): Promise<void>;
   getRepositoryBinding(input: { provider: string; owner: string; repo: string }): Promise<{ binding: RepoBindingInput }>;
   bindSlackChannel(input: SlackChannelBindingInput): Promise<void>;
   getSlackChannelBinding(input: { teamId: string; channelId: string }): Promise<{ binding: SlackChannelBindingInput }>;
-  createRun(input: CreateRunInput): Promise<{ run: OpenTagRun }>;
+  createRun(input: CreateRunInput): Promise<CreateRunResult>;
   claim(input: { runnerId: string }): Promise<ClaimedOpenTagRun | null>;
   heartbeat(input: { runnerId: string; runId: string }): Promise<void>;
   markRunning(input: { runId: string; executor: string }): Promise<void>;
@@ -166,8 +171,11 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
         body: JSON.stringify({ runId: input.runId, event })
       });
       await assertOk(response, "createRun");
-      const body = (await response.json()) as { run: unknown };
-      return { run: OpenTagRunSchema.parse(body.run) };
+      const body = (await response.json()) as { run: unknown; idempotentReplay?: unknown };
+      return {
+        run: OpenTagRunSchema.parse(body.run),
+        ...(body.idempotentReplay === true ? { idempotentReplay: true } : {})
+      };
     },
 
     async claim(input) {

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -32,6 +32,7 @@ describe("@opentag/client", () => {
       fetchImpl: async (url, init) => {
         requests.push({ url: String(url), init });
         return jsonResponse({
+          idempotentReplay: true,
           run: {
             id: "run_1",
             eventId: "evt_1",
@@ -43,9 +44,10 @@ describe("@opentag/client", () => {
       }
     });
 
-    const { run } = await client.createRun({ runId: "run_1", event });
+    const { run, idempotentReplay } = await client.createRun({ runId: "run_1", event });
 
     expect(run.id).toBe("run_1");
+    expect(idempotentReplay).toBe(true);
     expect(requests).toHaveLength(1);
     expect(requests[0]?.url).toBe("http://dispatcher.test/v1/runs");
     expect(requests[0]?.init?.headers).toMatchObject({

--- a/packages/dispatcher/README.md
+++ b/packages/dispatcher/README.md
@@ -48,6 +48,17 @@ When `pairingToken` is set, every `/v1/*` endpoint requires:
 Authorization: Bearer <pairingToken>
 ```
 
+## Reliability Notes
+
+The v0 dispatcher includes lightweight reliability guardrails without adding a queue service:
+
+- `POST /v1/runs` is idempotent per normalized source event ID. Replayed GitHub or Slack events return the existing run with `idempotentReplay: true`.
+- runner claim uses a conditional SQLite update so a queued run can only move to `assigned` once.
+- callback delivery is retried before being written as `callback.<kind>.dead_lettered` in the run audit log.
+- `GET /v1/runs/:runId/callback-dead-letters` returns exhausted callback delivery failures for operator follow-up.
+
+This is intentionally still a SQLite-first v0 control plane. Multi-instance deployments should continue toward stronger database transactions, callback workers, metrics, and external dead-letter handling.
+
 ## Stability
 
 The Hono app factory and callback sink interfaces are public API. Individual HTTP endpoint semantics should remain backward compatible within a major version.

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -76,23 +76,65 @@ export type CallbackSink = {
   deliver(message: CallbackMessage): Promise<void>;
 };
 
+export type CallbackRetryPolicy = {
+  maxAttempts?: number;
+  initialDelayMs?: number;
+};
+
 const noopCallbackSink: CallbackSink = {
   async deliver() {
     return;
   }
 };
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorPayload(error: unknown): { message: string; name?: string } {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      ...(error.name ? { name: error.name } : {})
+    };
+  }
+  return { message: String(error) };
+}
+
 async function deliverAndAudit(input: {
   repo: ReturnType<typeof createOpenTagRepository>;
   sink: CallbackSink;
   message: CallbackMessage;
+  retryPolicy?: CallbackRetryPolicy;
 }): Promise<void> {
-  await input.sink.deliver(input.message);
-  await input.repo.appendRunEvent({
-    runId: input.message.runId,
-    type: `callback.${input.message.kind}.delivered`,
-    payload: input.message
-  });
+  const maxAttempts = Math.max(1, input.retryPolicy?.maxAttempts ?? 3);
+  const initialDelayMs = Math.max(0, input.retryPolicy?.initialDelayMs ?? 100);
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await input.sink.deliver(input.message);
+      await input.repo.appendRunEvent({
+        runId: input.message.runId,
+        type: `callback.${input.message.kind}.delivered`,
+        payload: { ...input.message, attempt }
+      });
+      return;
+    } catch (error) {
+      const payload = {
+        ...input.message,
+        attempt,
+        maxAttempts,
+        error: errorPayload(error)
+      };
+      await input.repo.appendRunEvent({
+        runId: input.message.runId,
+        type: attempt >= maxAttempts ? `callback.${input.message.kind}.dead_lettered` : `callback.${input.message.kind}.attempt_failed`,
+        payload
+      });
+      if (attempt < maxAttempts && initialDelayMs > 0) {
+        await sleep(initialDelayMs * 2 ** (attempt - 1));
+      }
+    }
+  }
 }
 
 function isAuthorized(request: Request, pairingToken: string | undefined): boolean {
@@ -100,7 +142,12 @@ function isAuthorized(request: Request, pairingToken: string | undefined): boole
   return request.headers.get("authorization") === `Bearer ${pairingToken}`;
 }
 
-export function createDispatcherApp(input: { databasePath: string; callbackSink?: CallbackSink; pairingToken?: string }) {
+export function createDispatcherApp(input: {
+  databasePath: string;
+  callbackSink?: CallbackSink;
+  pairingToken?: string;
+  callbackRetryPolicy?: CallbackRetryPolicy;
+}) {
   const sqlite = new Database(input.databasePath);
   migrateSchema(sqlite);
   const repo = createOpenTagRepository(drizzle(sqlite));
@@ -175,20 +222,23 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
       return c.json({ error: "actor_not_allowed_for_write" }, 403);
     }
 
-    const run = await repo.createRun({ id: parsed.runId, event: parsed.event });
-    await deliverAndAudit({
-      repo,
-      sink: callbackSink,
-      message: {
-        runId: run.id,
-        kind: "acknowledgement",
-        provider: parsed.event.callback.provider,
-        uri: parsed.event.callback.uri,
-        body: renderAcknowledgement(run.id),
-        ...(parsed.event.callback.threadKey ? { threadKey: parsed.event.callback.threadKey } : {})
-      }
-    });
-    return c.json({ run }, 201);
+    const { run, created } = await repo.createRun({ id: parsed.runId, event: parsed.event });
+    if (created) {
+      await deliverAndAudit({
+        repo,
+        sink: callbackSink,
+        ...(input.callbackRetryPolicy ? { retryPolicy: input.callbackRetryPolicy } : {}),
+        message: {
+          runId: run.id,
+          kind: "acknowledgement",
+          provider: parsed.event.callback.provider,
+          uri: parsed.event.callback.uri,
+          body: renderAcknowledgement(run.id),
+          ...(parsed.event.callback.threadKey ? { threadKey: parsed.event.callback.threadKey } : {})
+        }
+      });
+    }
+    return c.json({ run, idempotentReplay: !created }, created ? 201 : 200);
   });
 
   app.post("/v1/runners/:runnerId/claim", async (c) => {
@@ -224,6 +274,7 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
     await deliverAndAudit({
       repo,
       sink: callbackSink,
+      ...(input.callbackRetryPolicy ? { retryPolicy: input.callbackRetryPolicy } : {}),
       message: {
         runId,
         kind: "progress",
@@ -246,6 +297,7 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
     await deliverAndAudit({
       repo,
       sink: callbackSink,
+      ...(input.callbackRetryPolicy ? { retryPolicy: input.callbackRetryPolicy } : {}),
       message: {
         runId,
         kind: "final",
@@ -266,6 +318,11 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
 
   app.get("/v1/runs/:runId/events", async (c) => {
     const events = await repo.listRunEvents({ runId: c.req.param("runId") });
+    return c.json({ events });
+  });
+
+  app.get("/v1/runs/:runId/callback-dead-letters", async (c) => {
+    const events = await repo.listCallbackDeadLetters({ runId: c.req.param("runId") });
     return c.json({ events });
   });
 

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -141,6 +141,94 @@ describe("dispatcher API", () => {
     ]);
   });
 
+  it("handles replayed source events idempotently without duplicating acknowledgement callbacks", async () => {
+    const delivered: { kind: string; body: string }[] = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ provider: "github", owner: "acme", repo: "demo", runnerId: "runner_1" })
+    });
+
+    const first = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_original", event: validEvent })
+    });
+    const replay = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_replay", event: validEvent })
+    });
+
+    expect(first.status).toBe(201);
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      idempotentReplay: true,
+      run: { id: "run_original" }
+    });
+    expect(delivered).toEqual([{ kind: "acknowledgement", body: "OpenTag picked this up. Run: `run_original`" }]);
+
+    const eventsResponse = await app.request("/v1/runs/run_original/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toEqual([
+      "run.created",
+      "callback.acknowledgement.delivered",
+      "run.create_idempotent_replay"
+    ]);
+  });
+
+  it("records callback retries and dead letters without failing the run API", async () => {
+    let attempts = 0;
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackRetryPolicy: { maxAttempts: 2, initialDelayMs: 0 },
+      callbackSink: {
+        async deliver() {
+          attempts += 1;
+          throw new Error("provider unavailable");
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ provider: "github", owner: "acme", repo: "demo", runnerId: "runner_1" })
+    });
+
+    const response = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_dead_letter", event: { ...validEvent, id: "evt_dead_letter" } })
+    });
+
+    expect(response.status).toBe(201);
+    expect(attempts).toBe(2);
+
+    const eventsResponse = await app.request("/v1/runs/run_dead_letter/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toEqual([
+      "run.created",
+      "callback.acknowledgement.attempt_failed",
+      "callback.acknowledgement.dead_lettered"
+    ]);
+    expect(events.at(-1).payload.error.message).toBe("provider unavailable");
+
+    const deadLettersResponse = await app.request("/v1/runs/run_dead_letter/callback-dead-letters");
+    const deadLetters = await deadLettersResponse.json();
+    expect(deadLetters.events).toHaveLength(1);
+    expect(deadLetters.events[0].type).toBe("callback.acknowledgement.dead_lettered");
+  });
+
   it("rejects runs for repositories without an explicit binding", async () => {
     const app = createDispatcherApp({ databasePath: ":memory:" });
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -38,6 +38,10 @@ await repo.createRepoBinding({
 });
 ```
 
+## Reliability Notes
+
+`createRun` uses a unique source event index plus `ON CONFLICT DO NOTHING` so webhook replays can return the original run instead of creating duplicate work. `claimNextRun` uses a conditional status update before returning a claimed run, which keeps concurrent runners from claiming the same queued row. Callback dead letters are stored as run audit events and can be listed through `listCallbackDeadLetters`.
+
 ## Stability
 
 The repository methods are public API for embedded control planes. The raw Drizzle table definitions are lower-level and may evolve with migrations.

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -16,6 +16,11 @@ export type OpenTagAuditEvent = {
   createdAt: string;
 };
 
+export type CreateRunResult = {
+  run: OpenTagRun;
+  created: boolean;
+};
+
 export type RepoBinding = {
   provider: string;
   owner: string;
@@ -53,6 +58,13 @@ function runFromRow(row: typeof runs.$inferSelect): OpenTagRun {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     ...(result ? { result } : {})
+  };
+}
+
+function claimedRunFromRow(row: typeof runs.$inferSelect): ClaimedOpenTagRun {
+  return {
+    run: runFromRow(row),
+    event: OpenTagEventSchema.parse(JSON.parse(row.eventJson))
   };
 }
 
@@ -133,17 +145,31 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         });
     },
 
-    async createRun(input: { id: string; event: OpenTagEvent }): Promise<OpenTagRun> {
+    async createRun(input: { id: string; event: OpenTagEvent }): Promise<CreateRunResult> {
       const event = OpenTagEventSchema.parse(input.event);
       const createdAt = nowIso();
-      await db.insert(runs).values({
+      const insertResult = await db.insert(runs).values({
         id: input.id,
         eventId: event.id,
         status: "queued",
         eventJson: JSON.stringify(event),
         createdAt,
         updatedAt: createdAt
-      });
+      }).onConflictDoNothing({ target: runs.eventId });
+
+      if (insertResult.changes === 0) {
+        const existingBySourceEvent = await db.select().from(runs).where(eq(runs.eventId, event.id)).limit(1).get();
+        if (!existingBySourceEvent) {
+          throw new Error(`Run already exists for event ${event.id}, but it could not be loaded`);
+        }
+        await appendRunEvent({
+          runId: existingBySourceEvent.id,
+          type: "run.create_idempotent_replay",
+          payload: { requestedRunId: input.id, eventId: event.id }
+        });
+        return { run: runFromRow(existingBySourceEvent), created: false };
+      }
+
       await appendRunEvent({
         runId: input.id,
         type: "run.created",
@@ -151,11 +177,14 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         createdAt
       });
       return {
-        id: input.id,
-        eventId: event.id,
-        status: "queued",
-        createdAt,
-        updatedAt: createdAt
+        run: {
+          id: input.id,
+          eventId: event.id,
+          status: "queued",
+          createdAt,
+          updatedAt: createdAt
+        },
+        created: true
       };
     },
 
@@ -209,7 +238,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const updatedAt = nowIso();
       const leasedAt = updatedAt;
       const leaseExpiresAt = new Date(Date.now() + input.leaseSeconds * 1000).toISOString();
-      await db
+      const updateResult = await db
         .update(runs)
         .set({
           status: "assigned",
@@ -219,7 +248,10 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           heartbeatAt: leasedAt,
           updatedAt
         })
-        .where(eq(runs.id, row.id));
+        .where(and(eq(runs.id, row.id), eq(runs.status, "queued")));
+      if (updateResult.changes === 0) {
+        return null;
+      }
       await appendRunEvent({
         runId: row.id,
         type: "run.claimed",
@@ -227,18 +259,9 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         createdAt: updatedAt
       });
 
-      return {
-        run: {
-          id: row.id,
-          eventId: row.eventId,
-          status: "assigned",
-          assignedRunnerId: input.runnerId,
-          executor: row.executor ?? undefined,
-          createdAt: row.createdAt,
-          updatedAt
-        },
-        event: OpenTagEventSchema.parse(JSON.parse(row.eventJson))
-      };
+      const claimedRow = await db.select().from(runs).where(eq(runs.id, row.id)).limit(1).get();
+      if (!claimedRow) return null;
+      return claimedRunFromRow(claimedRow);
     },
 
     async getRepoBinding(input: { provider: string; owner: string; repo: string }): Promise<RepoBinding | null> {
@@ -341,10 +364,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
     async getRun(input: { runId: string }): Promise<ClaimedOpenTagRun | null> {
       const row = await db.select().from(runs).where(eq(runs.id, input.runId)).limit(1).get();
       if (!row) return null;
-      return {
-        run: runFromRow(row),
-        event: OpenTagEventSchema.parse(JSON.parse(row.eventJson))
-      };
+      return claimedRunFromRow(row);
     },
 
     async listRunEvents(input: { runId: string }): Promise<OpenTagAuditEvent[]> {
@@ -356,6 +376,19 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         payload: JSON.parse(row.payloadJson) as unknown,
         createdAt: row.createdAt
       }));
+    },
+
+    async listCallbackDeadLetters(input: { runId: string }): Promise<OpenTagAuditEvent[]> {
+      const rows = await db.select().from(runEvents).where(eq(runEvents.runId, input.runId)).orderBy(asc(runEvents.id));
+      return rows
+        .filter((row) => row.type.startsWith("callback.") && row.type.endsWith(".dead_lettered"))
+        .map((row) => ({
+          id: row.id,
+          runId: row.runId,
+          type: row.type,
+          payload: JSON.parse(row.payloadJson) as unknown,
+          createdAt: row.createdAt
+        }));
     }
   };
 }

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -19,7 +19,8 @@ export const runs = sqliteTable(
   },
   (table) => ({
     statusIdx: index("runs_status_idx").on(table.status),
-    runnerIdx: index("runs_runner_idx").on(table.assignedRunnerId)
+    runnerIdx: index("runs_runner_idx").on(table.assignedRunnerId),
+    sourceEventIdx: uniqueIndex("runs_source_event_id_idx").on(table.eventId)
   })
 );
 
@@ -125,6 +126,22 @@ export function migrateSchema(sqlite: Database.Database): void {
     );
     CREATE UNIQUE INDEX IF NOT EXISTS slack_channel_bindings_team_channel_idx
       ON slack_channel_bindings(team_id, channel_id);
+  `);
+  sqlite.exec(`
+    UPDATE runs
+    SET event_id = event_id || '#duplicate:' || id
+    WHERE rowid NOT IN (
+      SELECT MIN(rowid)
+      FROM runs
+      GROUP BY event_id
+    )
+    AND event_id IN (
+      SELECT event_id
+      FROM runs
+      GROUP BY event_id
+      HAVING COUNT(*) > 1
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS runs_source_event_id_idx ON runs(event_id);
   `);
   const columns = sqlite.prepare("PRAGMA table_info(repo_bindings)").all() as { name: string }[];
   const columnNames = new Set(columns.map((column) => column.name));

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -1,8 +1,9 @@
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { createOpenTagRepository } from "../src/repository.js";
-import { migrateSchema } from "../src/schema.js";
+import { migrateSchema, runs } from "../src/schema.js";
 
 describe("OpenTag repository", () => {
   it("creates and claims a run once", async () => {
@@ -215,5 +216,63 @@ describe("OpenTag repository", () => {
 
     const events = await repo.listRunEvents({ runId: "run_2" });
     expect(events.map((event) => event.type)).toEqual(["run.created", "run.completed"]);
+  });
+
+  it("returns the existing run when a source event is replayed", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+    const event = {
+      id: "evt_replay",
+      source: "github" as const,
+      sourceEventId: "comment_replay",
+      receivedAt: "2026-06-24T00:00:00.000Z",
+      actor: { provider: "github" as const, providerUserId: "42" },
+      target: { mention: "@opentag", agentId: "opentag" },
+      command: { rawText: "fix this", intent: "fix" as const, args: {} },
+      context: [],
+      permissions: [{ scope: "issue:comment" as const, reason: "reply to source thread" }],
+      callback: { provider: "github" as const, uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
+      metadata: { owner: "acme", repo: "demo" }
+    };
+
+    const first = await repo.createRun({ id: "run_original", event });
+    const replay = await repo.createRun({ id: "run_duplicate", event });
+
+    expect(first.created).toBe(true);
+    expect(replay.created).toBe(false);
+    expect(replay.run.id).toBe("run_original");
+    const events = await repo.listRunEvents({ runId: "run_original" });
+    expect(events.map((entry) => entry.type)).toEqual(["run.created", "run.create_idempotent_replay"]);
+  });
+
+  it("does not claim a run if a competing worker assigned it first", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.registerRunner({ runnerId: "runner_1", name: "Runner One" });
+    await repo.createRepoBinding({ provider: "github", owner: "acme", repo: "demo", runnerId: "runner_1" });
+    await repo.createRun({
+      id: "run_race",
+      event: {
+        id: "evt_race",
+        source: "github",
+        sourceEventId: "comment_race",
+        receivedAt: "2026-06-24T00:00:00.000Z",
+        actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+        target: { mention: "@opentag", agentId: "opentag" },
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: [],
+        permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
+        callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
+        metadata: { owner: "acme", repo: "demo" }
+      }
+    });
+    await db.update(runs).set({ status: "assigned", assignedRunnerId: "runner_other" }).where(eq(runs.id, "run_race"));
+
+    await expect(repo.claimNextRun({ runnerId: "runner_1", leaseSeconds: 60 })).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds lightweight V1 reliability guardrails for the SQLite dispatcher path.

## What changed

- Makes `POST /v1/runs` idempotent per normalized source event id, returning the existing run on webhook replay.
- Adds a unique source-event index with migration handling for older duplicate rows.
- Hardens runner claim by using a conditional queued-to-assigned update before returning work.
- Adds callback retry with audit events for failed attempts and dead-lettered callbacks.
- Adds `GET /v1/runs/:runId/callback-dead-letters` for operator follow-up.
- Extends the client create-run result with `idempotentReplay`.
- Documents the reliability behavior and its SQLite-first v0 boundaries.

## Why

The existing dispatcher is good for a demo loop, but production-ish usage needs safer webhook replay behavior, less fragile callback delivery, and stronger claim semantics without introducing a heavy queue or workflow platform before v0 is ready.

## Validation

- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc -b`
- package/app build loop with `tsup` and declaration build for packages
