### PR TITLE
[codex] Add repository security policy guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The goal is simple: make "tag an agent into work" a protocol, not a closed surfa
 - **Slack app mentions** - bound Slack channels can route `app_mention` events to the same dispatcher and local daemon path.
 - **Auditable dispatch** - every run is stored with event metadata, status transitions, progress, result, and callback delivery events.
 - **Explicit runner binding** - a runner only claims runs for repositories it is bound to.
+- **Repository security policies** - bindings can require read/write actor allowlists, block specific actors, constrain runner IDs, and hold sensitive scopes for approval.
 - **Local-first execution** - `opentagd` resolves a configured local checkout before executing anything.
 - **Executor adapters** - `echo` is available for smoke tests, and `codex` can run a real Codex CLI task on an isolated branch.
 - **Embeddable SDK packages** - use the protocol, client, dispatcher, GitHub, Slack, runner, and store packages independently.
@@ -135,7 +136,7 @@ curl http://localhost:3030/v1/runs/run_demo_1/events
 ## How It Works
 
 1. **Ingress normalizes platform events.** GitHub and Slack adapters translate comments or app mentions into one `OpenTagEvent` schema.
-2. **The dispatcher validates scope.** Runs must include repository metadata, and the repository must be explicitly bound to a runner.
+2. **The dispatcher validates scope.** Runs must include repository metadata, and the repository must be explicitly bound to a runner. Optional repository security policy can deny actors, constrain runners, or hold scoped work for approval.
 3. **The local daemon claims only mapped work.** `opentagd` checks its local repository config before running an executor.
 4. **The executor does the work.** The echo executor proves the loop; the Codex executor creates an isolated `opentag/<runId>` branch and runs `codex exec`.
 5. **Callbacks and audit events close the loop.** Progress and final results can be posted back to GitHub or Slack, and every step stays queryable through the dispatcher.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -20,6 +20,15 @@ export type RepoBindingInput = {
   workspacePath?: string;
   defaultExecutor?: string;
   allowedActors?: string[];
+  securityPolicy?: RepoSecurityPolicy;
+};
+
+export type RepoSecurityPolicy = {
+  readAllowedActors?: string[];
+  writeAllowedActors?: string[];
+  blockedActors?: string[];
+  allowedRunnerIds?: string[];
+  approvalRequiredScopes?: string[];
 };
 
 export type RepositoryBindingConfig = {

--- a/packages/dispatcher/README.md
+++ b/packages/dispatcher/README.md
@@ -48,6 +48,10 @@ When `pairingToken` is set, every `/v1/*` endpoint requires:
 Authorization: Bearer <pairingToken>
 ```
 
+## Security Policy V1
+
+Repository bindings can include an optional `securityPolicy` with read/write actor allowlists, blocked actors, allowed runner IDs, and permission scopes that should create a `needs_approval` run instead of immediately dispatching. This is a lightweight v0 policy layer, not a replacement for organization SSO, OIDC, tenant isolation, or a full approval workflow.
+
 ## Stability
 
 The Hono app factory and callback sink interfaces are public API. Individual HTTP endpoint semantics should remain backward compatible within a major version.

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -1,6 +1,6 @@
 import { OpenTagEventSchema, OpenTagRunResultSchema } from "@opentag/core";
 import { renderAcknowledgement, renderFinalResult, renderProgress } from "@opentag/github";
-import { createOpenTagRepository, migrateSchema } from "@opentag/store";
+import { createOpenTagRepository, migrateSchema, type RepoBinding, type RepoSecurityPolicy } from "@opentag/store";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { Hono } from "hono";
@@ -18,8 +18,38 @@ const CreateRepoBindingSchema = z.object({
   runnerId: z.string().min(1),
   workspacePath: z.string().min(1).optional(),
   defaultExecutor: z.string().min(1).optional(),
-  allowedActors: z.array(z.string().min(1)).optional()
+  allowedActors: z.array(z.string().min(1)).optional(),
+  securityPolicy: z
+    .object({
+      readAllowedActors: z.array(z.string().min(1)).optional(),
+      writeAllowedActors: z.array(z.string().min(1)).optional(),
+      blockedActors: z.array(z.string().min(1)).optional(),
+      allowedRunnerIds: z.array(z.string().min(1)).optional(),
+      approvalRequiredScopes: z.array(z.string().min(1)).optional()
+    })
+    .optional()
 });
+
+function definedStringArray(values: string[] | undefined): string[] | undefined {
+  return values?.length ? values : undefined;
+}
+
+function repoSecurityPolicyFromParsed(parsed: z.infer<typeof CreateRepoBindingSchema>): RepoBinding["securityPolicy"] | undefined {
+  const policy = parsed.securityPolicy;
+  if (!policy) return undefined;
+  const normalized: RepoSecurityPolicy = {};
+  const readAllowedActors = definedStringArray(policy.readAllowedActors);
+  const writeAllowedActors = definedStringArray(policy.writeAllowedActors);
+  const blockedActors = definedStringArray(policy.blockedActors);
+  const allowedRunnerIds = definedStringArray(policy.allowedRunnerIds);
+  const approvalRequiredScopes = definedStringArray(policy.approvalRequiredScopes);
+  if (readAllowedActors) normalized.readAllowedActors = readAllowedActors;
+  if (writeAllowedActors) normalized.writeAllowedActors = writeAllowedActors;
+  if (blockedActors) normalized.blockedActors = blockedActors;
+  if (allowedRunnerIds) normalized.allowedRunnerIds = allowedRunnerIds;
+  if (approvalRequiredScopes) normalized.approvalRequiredScopes = approvalRequiredScopes;
+  return Object.keys(normalized).length ? normalized : undefined;
+}
 
 const CreateSlackChannelBindingSchema = z.object({
   teamId: z.string().min(1),
@@ -61,6 +91,67 @@ function isWriteCapable(event: z.infer<typeof OpenTagEventSchema>): boolean {
 function actorIsAllowed(event: z.infer<typeof OpenTagEventSchema>, allowedActors: string[] | undefined): boolean {
   if (!allowedActors?.length) return true;
   return allowedActors.includes(event.actor.handle ?? "") || allowedActors.includes(event.actor.providerUserId);
+}
+
+type PolicyDecision = {
+  outcome: "allow" | "deny" | "needs_approval";
+  reason: string;
+  matched?: string[];
+};
+
+function actorKeys(event: z.infer<typeof OpenTagEventSchema>): string[] {
+  return [
+    event.actor.providerUserId,
+    ...(event.actor.handle ? [event.actor.handle] : []),
+    `${event.actor.provider}:${event.actor.providerUserId}`,
+    ...(event.actor.handle ? [`${event.actor.provider}:${event.actor.handle}`] : []),
+    ...(event.actor.organizationId ? [`org:${event.actor.organizationId}`] : [])
+  ];
+}
+
+function matchingValues(values: string[] | undefined, candidates: string[]): string[] {
+  if (!values?.length) return [];
+  return values.filter((value) => candidates.includes(value));
+}
+
+function permissionScopes(event: z.infer<typeof OpenTagEventSchema>): string[] {
+  return event.permissions.map((permission) => permission.scope);
+}
+
+function evaluatePolicy(input: {
+  event: z.infer<typeof OpenTagEventSchema>;
+  binding: RepoBinding;
+}): PolicyDecision {
+  const policy = input.binding.securityPolicy;
+  const actor = actorKeys(input.event);
+  const blockedActorMatches = matchingValues(policy?.blockedActors, actor);
+  if (blockedActorMatches.length > 0) {
+    return { outcome: "deny", reason: "actor_blocked_by_policy", matched: blockedActorMatches };
+  }
+
+  const allowedRunnerMatches = matchingValues(policy?.allowedRunnerIds, [input.binding.runnerId]);
+  if (policy?.allowedRunnerIds?.length && allowedRunnerMatches.length === 0) {
+    return { outcome: "deny", reason: "runner_not_allowed_by_policy", matched: [input.binding.runnerId] };
+  }
+
+  const requiredApprovalScopes = matchingValues(policy?.approvalRequiredScopes, permissionScopes(input.event));
+  if (requiredApprovalScopes.length > 0) {
+    return { outcome: "needs_approval", reason: "permission_scope_requires_approval", matched: requiredApprovalScopes };
+  }
+
+  if (isWriteCapable(input.event)) {
+    const writeMatches = matchingValues(policy?.writeAllowedActors ?? input.binding.allowedActors, actor);
+    if ((policy?.writeAllowedActors?.length || input.binding.allowedActors?.length) && writeMatches.length === 0) {
+      return { outcome: "deny", reason: "actor_not_allowed_for_write", matched: actor };
+    }
+    return { outcome: "allow", reason: "write_allowed_by_policy", matched: writeMatches };
+  }
+
+  const readMatches = matchingValues(policy?.readAllowedActors, actor);
+  if (policy?.readAllowedActors?.length && readMatches.length === 0) {
+    return { outcome: "deny", reason: "actor_not_allowed_for_read", matched: actor };
+  }
+  return { outcome: "allow", reason: "read_allowed_by_policy", matched: readMatches };
 }
 
 export type CallbackMessage = {
@@ -124,6 +215,7 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
 
   app.post("/v1/repo-bindings", async (c) => {
     const parsed = CreateRepoBindingSchema.parse(await c.req.json());
+    const securityPolicy = repoSecurityPolicyFromParsed(parsed);
     await repo.createRepoBinding({
       provider: parsed.provider,
       owner: parsed.owner,
@@ -131,7 +223,8 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
       runnerId: parsed.runnerId,
       ...(parsed.workspacePath ? { workspacePath: parsed.workspacePath } : {}),
       ...(parsed.defaultExecutor ? { defaultExecutor: parsed.defaultExecutor } : {}),
-      ...(parsed.allowedActors?.length ? { allowedActors: parsed.allowedActors } : {})
+      ...(parsed.allowedActors?.length ? { allowedActors: parsed.allowedActors } : {}),
+      ...(securityPolicy ? { securityPolicy } : {})
     });
     return c.json({ ok: true }, 201);
   });
@@ -171,11 +264,25 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
     if (!binding) {
       return c.json({ error: "repo_not_bound" }, 403);
     }
-    if (isWriteCapable(parsed.event) && !actorIsAllowed(parsed.event, binding.allowedActors)) {
-      return c.json({ error: "actor_not_allowed_for_write" }, 403);
+    const decision = evaluatePolicy({ event: parsed.event, binding });
+    if (decision.outcome === "deny") {
+      return c.json({ error: decision.reason, policyDecision: decision }, 403);
     }
 
     const run = await repo.createRun({ id: parsed.runId, event: parsed.event });
+    await repo.appendRunEvent({
+      runId: run.id,
+      type: "policy.evaluated",
+      payload: decision
+    });
+    if (decision.outcome === "needs_approval") {
+      await repo.markNeedsApproval({
+        runId: run.id,
+        reason: decision.reason,
+        policy: decision
+      });
+      return c.json({ run: { ...run, status: "needs_approval" }, policyDecision: decision }, 202);
+    }
     await deliverAndAudit({
       repo,
       sink: callbackSink,

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -133,6 +133,7 @@ describe("dispatcher API", () => {
     const { events } = await eventsResponse.json();
     expect(events.map((event: { type: string }) => event.type)).toEqual([
       "run.created",
+      "policy.evaluated",
       "callback.acknowledgement.delivered",
       "run.progress",
       "callback.progress.delivered",
@@ -185,7 +186,133 @@ describe("dispatcher API", () => {
     });
 
     expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toEqual({ error: "actor_not_allowed_for_write" });
+    await expect(response.json()).resolves.toMatchObject({
+      error: "actor_not_allowed_for_write",
+      policyDecision: { outcome: "deny", reason: "actor_not_allowed_for_write" }
+    });
+  });
+
+  it("rejects blocked actors through repository security policy", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        securityPolicy: { blockedActors: ["github:octocat"] }
+      })
+    });
+
+    const response = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_blocked", event: validEvent })
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "actor_blocked_by_policy",
+      policyDecision: { outcome: "deny", matched: ["github:octocat"] }
+    });
+  });
+
+  it("enforces read and runner security policy before creating runs", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        securityPolicy: {
+          readAllowedActors: ["github:someone-else"],
+          allowedRunnerIds: ["runner_1"]
+        }
+      })
+    });
+
+    const response = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        runId: "run_read_denied",
+        event: { ...validEvent, command: { rawText: "investigate this", intent: "investigate", args: {} } }
+      })
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "actor_not_allowed_for_read",
+      policyDecision: { outcome: "deny" }
+    });
+  });
+
+  it("creates needs_approval runs for approval-gated permission scopes", async () => {
+    const delivered: string[] = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push(message.kind);
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        securityPolicy: {
+          writeAllowedActors: ["github:octocat"],
+          approvalRequiredScopes: ["pr:create"]
+        }
+      })
+    });
+
+    const response = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        runId: "run_needs_approval",
+        event: {
+          ...validEvent,
+          permissions: [
+            ...validEvent.permissions,
+            { scope: "repo:write", reason: "write branch" },
+            { scope: "pr:create", reason: "open pull request" }
+          ]
+        }
+      })
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      run: { id: "run_needs_approval", status: "needs_approval" },
+      policyDecision: { outcome: "needs_approval", matched: ["pr:create"] }
+    });
+    expect(delivered).toEqual([]);
+
+    const claimResponse = await app.request("/v1/runners/runner_1/claim", { method: "POST" });
+    expect(claimResponse.status).toBe(204);
+
+    const eventsResponse = await app.request("/v1/runs/run_needs_approval/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toEqual([
+      "run.created",
+      "policy.evaluated",
+      "run.needs_approval"
+    ]);
   });
 
   it("accepts runner heartbeat for claimed runs", async () => {

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -34,9 +34,17 @@ await repo.createRepoBinding({
   provider: "github",
   owner: "acme",
   repo: "demo",
-  runnerId: "runner_local"
+  runnerId: "runner_local",
+  securityPolicy: {
+    writeAllowedActors: ["github:octocat"],
+    approvalRequiredScopes: ["pr:create"]
+  }
 });
 ```
+
+## Security Policy V1
+
+Repo bindings can store a `securityPolicy` JSON object with `readAllowedActors`, `writeAllowedActors`, `blockedActors`, `allowedRunnerIds`, and `approvalRequiredScopes`. The dispatcher evaluates this policy before creating executable work and records `policy.evaluated` audit events for accepted or approval-gated runs.
 
 ## Stability
 

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -24,6 +24,15 @@ export type RepoBinding = {
   workspacePath?: string;
   defaultExecutor?: string;
   allowedActors?: string[];
+  securityPolicy?: RepoSecurityPolicy;
+};
+
+export type RepoSecurityPolicy = {
+  readAllowedActors?: string[];
+  writeAllowedActors?: string[];
+  blockedActors?: string[];
+  allowedRunnerIds?: string[];
+  approvalRequiredScopes?: string[];
 };
 
 export type SlackChannelBinding = {
@@ -93,6 +102,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       workspacePath?: string;
       defaultExecutor?: string;
       allowedActors?: string[];
+      securityPolicy?: RepoSecurityPolicy;
     }): Promise<void> {
       await db
         .insert(repoBindings)
@@ -101,6 +111,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           workspacePath: input.workspacePath ?? null,
           defaultExecutor: input.defaultExecutor ?? null,
           allowedActorsJson: input.allowedActors ? JSON.stringify(input.allowedActors) : null,
+          securityPolicyJson: input.securityPolicy ? JSON.stringify(input.securityPolicy) : null,
           createdAt: nowIso()
         })
         .onConflictDoUpdate({
@@ -109,7 +120,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
             runnerId: input.runnerId,
             workspacePath: input.workspacePath ?? null,
             defaultExecutor: input.defaultExecutor ?? null,
-            allowedActorsJson: input.allowedActors ? JSON.stringify(input.allowedActors) : null
+            allowedActorsJson: input.allowedActors ? JSON.stringify(input.allowedActors) : null,
+            securityPolicyJson: input.securityPolicy ? JSON.stringify(input.securityPolicy) : null
           }
         });
     },
@@ -258,7 +270,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         runnerId: row.runnerId,
         ...(row.workspacePath ? { workspacePath: row.workspacePath } : {}),
         ...(row.defaultExecutor ? { defaultExecutor: row.defaultExecutor } : {}),
-        ...(row.allowedActorsJson ? { allowedActors: JSON.parse(row.allowedActorsJson) as string[] } : {})
+        ...(row.allowedActorsJson ? { allowedActors: JSON.parse(row.allowedActorsJson) as string[] } : {}),
+        ...(row.securityPolicyJson ? { securityPolicy: JSON.parse(row.securityPolicyJson) as RepoSecurityPolicy } : {})
       };
     },
 
@@ -322,6 +335,20 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         runId: input.runId,
         type: "run.completed",
         payload: result,
+        createdAt: updatedAt
+      });
+    },
+
+    async markNeedsApproval(input: { runId: string; reason: string; policy?: unknown }): Promise<void> {
+      const updatedAt = nowIso();
+      await db.update(runs).set({ status: "needs_approval", updatedAt }).where(eq(runs.id, input.runId));
+      await appendRunEvent({
+        runId: input.runId,
+        type: "run.needs_approval",
+        payload: {
+          reason: input.reason,
+          ...(input.policy ? { policy: input.policy } : {})
+        },
         createdAt: updatedAt
       });
     },

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -49,6 +49,7 @@ export const repoBindings = sqliteTable(
     workspacePath: text("workspace_path"),
     defaultExecutor: text("default_executor"),
     allowedActorsJson: text("allowed_actors_json"),
+    securityPolicyJson: text("security_policy_json"),
     createdAt: text("created_at").notNull()
   },
   (table) => ({
@@ -111,6 +112,7 @@ export function migrateSchema(sqlite: Database.Database): void {
       workspace_path TEXT,
       default_executor TEXT,
       allowed_actors_json TEXT,
+      security_policy_json TEXT,
       created_at TEXT NOT NULL
     );
     CREATE UNIQUE INDEX IF NOT EXISTS repo_bindings_provider_owner_repo_idx
@@ -136,6 +138,9 @@ export function migrateSchema(sqlite: Database.Database): void {
   }
   if (!columnNames.has("allowed_actors_json")) {
     sqlite.exec("ALTER TABLE repo_bindings ADD COLUMN allowed_actors_json TEXT");
+  }
+  if (!columnNames.has("security_policy_json")) {
+    sqlite.exec("ALTER TABLE repo_bindings ADD COLUMN security_policy_json TEXT");
   }
   const runColumns = sqlite.prepare("PRAGMA table_info(runs)").all() as { name: string }[];
   const runColumnNames = new Set(runColumns.map((column) => column.name));

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -92,6 +92,38 @@ describe("OpenTag repository", () => {
     });
   });
 
+  it("stores repository security policy with repo bindings", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.createRepoBinding({
+      provider: "github",
+      owner: "acme",
+      repo: "demo",
+      runnerId: "runner_1",
+      securityPolicy: {
+        readAllowedActors: ["github:octocat"],
+        writeAllowedActors: ["github:maintainer"],
+        blockedActors: ["github:blocked"],
+        allowedRunnerIds: ["runner_1"],
+        approvalRequiredScopes: ["pr:create"]
+      }
+    });
+
+    await expect(repo.getRepoBinding({ provider: "github", owner: "acme", repo: "demo" })).resolves.toMatchObject({
+      runnerId: "runner_1",
+      securityPolicy: {
+        readAllowedActors: ["github:octocat"],
+        writeAllowedActors: ["github:maintainer"],
+        blockedActors: ["github:blocked"],
+        allowedRunnerIds: ["runner_1"],
+        approvalRequiredScopes: ["pr:create"]
+      }
+    });
+  });
+
   it("records runner heartbeats for claimed runs", async () => {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);


### PR DESCRIPTION
## Summary

Adds a lightweight repository security policy layer for OpenTag's dispatcher bindings.

## What changed

- Adds an optional `securityPolicy` object to repository bindings and the client/store types.
- Supports read/write actor allowlists, blocked actors, allowed runner IDs, and approval-gated permission scopes.
- Evaluates repository policy before creating executable work.
- Returns structured `policyDecision` data for denied or approval-gated runs.
- Creates `needs_approval` runs for configured sensitive scopes and keeps them out of runner claim flow.
- Records `policy.evaluated` and `run.needs_approval` audit events for accepted approval-gated runs.
- Documents this as a V1 policy guardrail, not a replacement for full org IAM, OIDC, SSO, or tenant isolation.

## Why

The existing `allowedActors` check is enough for a demo but too narrow as the project moves toward real teams. This adds a more explicit policy shape without introducing a heavy identity provider or approval product before v0 needs it.

## Validation

- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc -b`
- package/app build loop with `tsup` and declaration build for packages
