### PR TITLE
[codex] Add structured command parser V1

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -320,8 +320,28 @@ type OpenTagCommand = {
   rawText: string;
   intent: "fix" | "review" | "investigate" | "explain" | "run" | "unknown";
   args: Record<string, string | boolean | number>;
+  parsed?: {
+    version: "v1";
+    prompt: string;
+    flags: Record<string, string | boolean | number | Array<string | boolean | number>>;
+    references: Array<{
+      kind: "file" | "path" | "line" | "range" | "url" | "text";
+      uri: string;
+      line?: number;
+      startLine?: number;
+      endLine?: number;
+      title?: string;
+    }>;
+    requestedScopes: PermissionGrant["scope"][];
+    approval?: "auto" | "required" | "never";
+    network?: "restricted";
+    executorHint?: AgentTarget["executorHint"];
+    diagnostics: Array<{ level: "warning" | "error"; code: string; message: string; token?: string }>;
+  };
 };
 ```
+
+Command Parser V1 keeps the casual mention syntax while making protocol hints explicit. A request such as `@opentag review auth changes --file packages/auth/src/index.ts --range 12-30 --approval required --executor codex` still has a natural-language prompt, but adapters can now preserve file references, requested permission scopes, executor hints, network hints, approval intent, and diagnostics in the normalized event. V1 parsing is not itself an authorization layer; dispatcher policy, runner sandboxing, and human approval still decide whether a hinted capability can be used.
 
 ### Context Pointer
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,7 +15,7 @@ pnpm add @opentag/core
 - `OpenTagEventSchema`, `OpenTagRunSchema`, `OpenTagRunResultSchema`: Zod schemas for protocol objects.
 - `OpenTagEvent`, `OpenTagRun`, `OpenTagRunResult`: TypeScript types inferred from the schemas.
 - `parseOpenTagMention`: extracts an `@opentag` command from workspace text.
-- `commandFromRawText`: maps raw command text to a normalized intent.
+- `commandFromRawText`: maps raw command text to a normalized intent and V1 command parse.
 - `OpenTagJsonSchemas`: JSON Schema definitions for systems that do not use TypeScript or Zod.
 
 ## Example
@@ -42,6 +42,24 @@ const event = OpenTagEventSchema.parse({
   metadata: { owner: "acme", repo: "demo" }
 });
 ```
+
+## Command Parser V1
+
+`parseOpenTagMention` keeps the simple launch syntax:
+
+```text
+@opentag fix this flaky test
+```
+
+It also accepts a lightweight V1 command DSL for protocol hints:
+
+```text
+@opentag review auth changes --file packages/auth/src/index.ts --range 12-30 --approval required --executor codex
+```
+
+The first word still maps to `fix`, `review`, `investigate`, `explain`, `run`, or `unknown`. Remaining free text becomes `command.args.prompt` and `command.parsed.prompt`. Supported flags include `--file`, `--path`, `--line`, `--range`, `--scope`, `--network restricted`, `--approval required|auto|never`, `--executor`, `--runner`, `--label`, `--timeout`, and `--url`.
+
+The parser is intentionally additive. Existing consumers can keep using `command.rawText`, `command.intent`, and `command.args`; newer adapters can read `command.parsed` for references, requested scopes, approval hints, executor hints, network policy hints, and parser diagnostics.
 
 ## Stability
 

--- a/packages/core/src/mention.ts
+++ b/packages/core/src/mention.ts
@@ -1,34 +1,544 @@
-import type { OpenTagCommand } from "./schema.js";
+import type {
+  AgentTarget,
+  CommandParseDiagnostic,
+  CommandReference,
+  OpenTagCommand,
+  PermissionGrant
+} from "./schema.js";
 
 type MentionMatch = { matched: false } | ({ matched: true } & OpenTagCommand);
+type KnownIntent = Exclude<OpenTagCommand["intent"], "unknown">;
+type CommandArgValue = OpenTagCommand["args"][string];
+type CommandFlagValue = CommandArgValue | CommandArgValue[];
 
-const INTENTS: OpenTagCommand["intent"][] = ["fix", "review", "investigate", "explain", "run"];
+const INTENTS: KnownIntent[] = ["fix", "review", "investigate", "explain", "run"];
+const KNOWN_FLAGS = new Set([
+  "approval",
+  "executor",
+  "file",
+  "label",
+  "line",
+  "network",
+  "path",
+  "range",
+  "runner",
+  "scope",
+  "timeout",
+  "url"
+]);
+const SINGLE_VALUE_FLAGS = new Set(["approval", "executor", "line", "network", "range", "runner", "timeout"]);
+const APPROVAL_VALUES = new Set<NonNullable<NonNullable<OpenTagCommand["parsed"]>["approval"]>>(["auto", "required", "never"]);
+const EXECUTOR_HINTS = new Set<AgentTarget["executorHint"]>(["claude-code", "codex", "hermes", "openclaw", "custom"]);
+const PERMISSION_SCOPES = new Set<PermissionGrant["scope"]>([
+  "repo:read",
+  "repo:write",
+  "issue:comment",
+  "chat:postMessage",
+  "pr:create",
+  "pr:update",
+  "runner:local",
+  "network:restricted"
+]);
 
 export function commandFromRawText(rawText: string): OpenTagCommand {
-  const firstWord = rawText.split(/\s+/, 1)[0]?.toLowerCase();
-  const intent = INTENTS.includes(firstWord as OpenTagCommand["intent"])
-    ? (firstWord as OpenTagCommand["intent"])
-    : "unknown";
+  const normalizedRawText = rawText.trim();
+  const parsed = parseCommandText(normalizedRawText);
 
   return {
-    rawText,
-    intent,
-    args: {}
+    rawText: normalizedRawText,
+    intent: parsed.intent,
+    args: parsed.args,
+    parsed: parsed.command
   };
 }
 
 export function parseOpenTagMention(body: string, mention = "@opentag"): MentionMatch {
   const escaped = mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`${escaped}\\s+([^\\n\\r]+)`, "i");
+  const pattern = new RegExp(`${escaped}(?=[\\s:,.!?]|$)`, "i");
   const match = body.match(pattern);
 
-  if (!match?.[1]) {
+  if (typeof match?.index !== "number") {
     return { matched: false };
   }
 
-  const rawText = match[1].trim();
+  const rawText = extractCommandText(body.slice(match.index + match[0].length), mention);
+  if (!rawText) {
+    return { matched: false };
+  }
+
   return {
     matched: true,
     ...commandFromRawText(rawText)
   };
+}
+
+function parseCommandText(rawText: string): { intent: OpenTagCommand["intent"]; args: OpenTagCommand["args"]; command: NonNullable<OpenTagCommand["parsed"]> } {
+  const diagnostics: CommandParseDiagnostic[] = [];
+  const { tokens, diagnostics: tokenDiagnostics } = tokenizeCommand(rawText);
+  diagnostics.push(...tokenDiagnostics);
+
+  const firstToken = tokens[0]?.toLowerCase();
+  const intent = firstToken && isKnownIntent(firstToken) ? firstToken : "unknown";
+  const commandTokens = intent === "unknown" ? tokens : tokens.slice(1);
+  const parsed = parseCommandTokens(commandTokens, diagnostics);
+  const references = referencesFromFlags(parsed.flags, diagnostics);
+  const requestedScopes = requestedScopesFromFlags(parsed.flags, diagnostics);
+  const network = stringValuesForFlag(parsed.flags, "network")[0]?.toLowerCase();
+  if (network && network !== "restricted") {
+    diagnostics.push({
+      level: "warning",
+      code: "invalid_network_policy",
+      message: `Unsupported network policy '${network}'. V1 only supports 'restricted'.`,
+      token: network
+    });
+  }
+  const approval = enumValueForFlag(parsed.flags, "approval", APPROVAL_VALUES, diagnostics);
+  const executorHint = executorHintFromFlags(parsed.flags, diagnostics);
+  const normalizedNetwork = network === "restricted" ? "restricted" : undefined;
+
+  if (normalizedNetwork === "restricted" && !requestedScopes.includes("network:restricted")) {
+    requestedScopes.push("network:restricted");
+  }
+
+  const args = argsFromParsed(parsed.prompt, parsed.flags);
+  if (approval) {
+    args.approval = approval;
+  }
+  if (normalizedNetwork) {
+    args.network = normalizedNetwork;
+  }
+  if (executorHint) {
+    args.executor = executorHint;
+  }
+
+  if (tokens.length === 0) {
+    diagnostics.push({
+      level: "error",
+      code: "empty_command",
+      message: "The OpenTag command is empty."
+    });
+  }
+
+  const command: NonNullable<OpenTagCommand["parsed"]> = {
+    version: "v1",
+    prompt: parsed.prompt,
+    flags: parsed.flags,
+    references,
+    requestedScopes,
+    diagnostics
+  };
+  if (approval) {
+    command.approval = approval;
+  }
+  if (normalizedNetwork) {
+    command.network = normalizedNetwork;
+  }
+  if (executorHint) {
+    command.executorHint = executorHint;
+  }
+
+  return { intent, args, command };
+}
+
+function extractCommandText(afterMention: string, mention: string): string | null {
+  const normalized = afterMention.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/^[ \t]*[:,-]?[ \t]*/, "");
+  const [firstLineRaw = "", ...remainingLines] = normalized.split("\n");
+  const firstLine = firstLineRaw.trim();
+
+  if (firstLine.length > 0) {
+    const lines = [stripContinuationMarker(firstLine)];
+    if (shouldConsumeContinuation(firstLine, remainingLines)) {
+      lines.push(...collectContinuationLines(remainingLines, mention));
+    }
+    return joinCommandLines(lines);
+  }
+
+  return joinCommandLines(collectContinuationLines(remainingLines, mention, true));
+}
+
+function shouldConsumeContinuation(firstLine: string, remainingLines: string[]): boolean {
+  if (!remainingLines.some((line) => line.trim().length > 0)) {
+    return false;
+  }
+
+  const { tokens } = tokenizeCommand(firstLine);
+  const firstToken = tokens[0]?.toLowerCase();
+  const nextNonBlank = remainingLines.find((line) => line.trim().length > 0)?.trim();
+  return (
+    firstLine.trimEnd().endsWith("\\") ||
+    tokens.some((token) => token.startsWith("--")) ||
+    (tokens.length === 1 && firstToken !== undefined && isKnownIntent(firstToken)) ||
+    nextNonBlank?.startsWith("--") === true
+  );
+}
+
+function collectContinuationLines(lines: string[], mention: string, skipLeadingBlank = false): string[] {
+  const collected: string[] = [];
+  let started = !skipLeadingBlank;
+  const mentionPattern = new RegExp(`^${mention.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?=[\\s:,.!?]|$)`, "i");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!started && trimmed.length === 0) {
+      continue;
+    }
+    started = true;
+    if (trimmed.length === 0 || mentionPattern.test(trimmed)) {
+      break;
+    }
+    collected.push(stripContinuationMarker(trimmed));
+  }
+
+  return collected;
+}
+
+function stripContinuationMarker(line: string): string {
+  return line.trimEnd().replace(/\\$/, "").trim();
+}
+
+function joinCommandLines(lines: string[]): string | null {
+  const joined = lines.filter((line) => line.length > 0).join("\n").trim();
+  return joined.length > 0 ? joined : null;
+}
+
+function tokenizeCommand(rawText: string): { tokens: string[]; diagnostics: CommandParseDiagnostic[] } {
+  const tokens: string[] = [];
+  const diagnostics: CommandParseDiagnostic[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  for (const char of rawText) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaped) {
+    current += "\\";
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  if (quote) {
+    diagnostics.push({
+      level: "warning",
+      code: "unterminated_quote",
+      message: `Command contains an unterminated ${quote} quote.`
+    });
+  }
+
+  return { tokens, diagnostics };
+}
+
+function parseCommandTokens(
+  tokens: string[],
+  diagnostics: CommandParseDiagnostic[]
+): { prompt: string; flags: Record<string, CommandFlagValue> } {
+  const promptTokens: string[] = [];
+  const flags: Record<string, CommandFlagValue> = {};
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!token) continue;
+
+    if (!token.startsWith("--") || token === "--") {
+      promptTokens.push(token);
+      continue;
+    }
+
+    const withoutPrefix = token.slice(2);
+    const equalsIndex = withoutPrefix.indexOf("=");
+    const rawName = equalsIndex >= 0 ? withoutPrefix.slice(0, equalsIndex) : withoutPrefix;
+    const name = normalizeFlagName(rawName);
+    if (!name) {
+      diagnostics.push({
+        level: "warning",
+        code: "empty_flag",
+        message: "Command contains an empty flag name.",
+        token
+      });
+      continue;
+    }
+
+    if (!KNOWN_FLAGS.has(name)) {
+      diagnostics.push({
+        level: "warning",
+        code: "unknown_flag",
+        message: `Unknown OpenTag command flag '--${name}'.`,
+        token
+      });
+    }
+
+    let value: CommandArgValue = true;
+    if (equalsIndex >= 0) {
+      value = parseFlagValue(withoutPrefix.slice(equalsIndex + 1));
+    } else {
+      const nextToken = tokens[index + 1];
+      if (nextToken && !nextToken.startsWith("--")) {
+        value = parseFlagValue(nextToken);
+        index += 1;
+      }
+    }
+
+    if (flags[name] !== undefined && SINGLE_VALUE_FLAGS.has(name)) {
+      diagnostics.push({
+        level: "warning",
+        code: "duplicate_flag",
+        message: `Flag '--${name}' was provided more than once; later consumers should treat the last value as authoritative.`,
+        token
+      });
+    }
+    appendFlagValue(flags, name, value);
+  }
+
+  return { prompt: promptTokens.join(" ").trim(), flags };
+}
+
+function normalizeFlagName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function parseFlagValue(value: string): CommandArgValue {
+  const trimmed = value.trim();
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  if (trimmed.toLowerCase() === "true") return true;
+  if (trimmed.toLowerCase() === "false") return false;
+  return trimmed;
+}
+
+function appendFlagValue(flags: Record<string, CommandFlagValue>, name: string, value: CommandArgValue): void {
+  const existing = flags[name];
+  if (existing === undefined) {
+    flags[name] = value;
+  } else if (Array.isArray(existing)) {
+    existing.push(value);
+  } else {
+    flags[name] = [existing, value];
+  }
+}
+
+function argsFromParsed(prompt: string, flags: Record<string, CommandFlagValue>): OpenTagCommand["args"] {
+  const args: OpenTagCommand["args"] = {};
+  if (prompt.length > 0) {
+    args.prompt = prompt;
+  }
+
+  for (const [name, value] of Object.entries(flags)) {
+    args[name] = collapseArgValue(value);
+  }
+
+  return args;
+}
+
+function collapseArgValue(value: CommandFlagValue): CommandArgValue {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  return value.map((entry) => String(entry)).join(",");
+}
+
+function referencesFromFlags(flags: Record<string, CommandFlagValue>, diagnostics: CommandParseDiagnostic[]): CommandReference[] {
+  const references: CommandReference[] = [];
+  const line = lineFromFlag(flags, diagnostics);
+  const range = rangeFromFlag(flags, diagnostics);
+
+  for (const uri of stringValuesForFlag(flags, "file")) {
+    references.push(commandReference("file", uri, line, range));
+  }
+  for (const uri of stringValuesForFlag(flags, "path")) {
+    references.push(commandReference("path", uri, line, range));
+  }
+  for (const uri of stringValuesForFlag(flags, "url")) {
+    references.push(commandReference("url", uri, undefined, undefined));
+  }
+
+  if (references.length === 0 && line !== undefined) {
+    references.push(commandReference("line", String(line), line, undefined));
+  }
+  if (references.length === 0 && range !== undefined) {
+    references.push(commandReference("range", `${range.startLine}-${range.endLine}`, undefined, range));
+  }
+
+  return references;
+}
+
+function commandReference(
+  kind: CommandReference["kind"],
+  uri: string,
+  line: number | undefined,
+  range: { startLine: number; endLine: number } | undefined
+): CommandReference {
+  const reference: CommandReference = { kind, uri };
+  if (line !== undefined) {
+    reference.line = line;
+  }
+  if (range !== undefined) {
+    reference.startLine = range.startLine;
+    reference.endLine = range.endLine;
+  }
+  return reference;
+}
+
+function requestedScopesFromFlags(
+  flags: Record<string, CommandFlagValue>,
+  diagnostics: CommandParseDiagnostic[]
+): PermissionGrant["scope"][] {
+  const requestedScopes: PermissionGrant["scope"][] = [];
+
+  for (const scope of stringValuesForFlag(flags, "scope")) {
+    if (PERMISSION_SCOPES.has(scope as PermissionGrant["scope"])) {
+      appendUnique(requestedScopes, scope as PermissionGrant["scope"]);
+    } else {
+      diagnostics.push({
+        level: "warning",
+        code: "invalid_scope",
+        message: `Unsupported permission scope '${scope}'.`,
+        token: scope
+      });
+    }
+  }
+
+  return requestedScopes;
+}
+
+function enumValueForFlag<T extends string>(
+  flags: Record<string, CommandFlagValue>,
+  name: string,
+  allowed: Set<T>,
+  diagnostics: CommandParseDiagnostic[]
+): T | undefined {
+  const value = stringValuesForFlag(flags, name)[0]?.toLowerCase();
+  if (!value) return undefined;
+  if (allowed.has(value as T)) {
+    return value as T;
+  }
+  diagnostics.push({
+    level: "warning",
+    code: `invalid_${name}`,
+    message: `Unsupported ${name} value '${value}'.`,
+    token: value
+  });
+  return undefined;
+}
+
+function executorHintFromFlags(
+  flags: Record<string, CommandFlagValue>,
+  diagnostics: CommandParseDiagnostic[]
+): AgentTarget["executorHint"] | undefined {
+  const value = stringValuesForFlag(flags, "executor")[0]?.toLowerCase();
+  if (!value) return undefined;
+  if (EXECUTOR_HINTS.has(value as AgentTarget["executorHint"])) {
+    return value as AgentTarget["executorHint"];
+  }
+  diagnostics.push({
+    level: "warning",
+    code: "invalid_executor",
+    message: `Unsupported executor hint '${value}'.`,
+    token: value
+  });
+  return undefined;
+}
+
+function lineFromFlag(flags: Record<string, CommandFlagValue>, diagnostics: CommandParseDiagnostic[]): number | undefined {
+  const value = valuesForFlag(flags, "line")[0];
+  if (value === undefined) return undefined;
+  const line = typeof value === "number" ? value : Number(value);
+  if (Number.isInteger(line) && line > 0) {
+    return line;
+  }
+  diagnostics.push({
+    level: "warning",
+    code: "invalid_line",
+    message: `Line must be a positive integer; received '${String(value)}'.`,
+    token: String(value)
+  });
+  return undefined;
+}
+
+function rangeFromFlag(
+  flags: Record<string, CommandFlagValue>,
+  diagnostics: CommandParseDiagnostic[]
+): { startLine: number; endLine: number } | undefined {
+  const value = valuesForFlag(flags, "range")[0];
+  if (value === undefined) return undefined;
+  const match = String(value).match(/^(\d+)-(\d+)$/);
+  if (!match?.[1] || !match[2]) {
+    diagnostics.push({
+      level: "warning",
+      code: "invalid_range",
+      message: `Range must look like '10-20'; received '${String(value)}'.`,
+      token: String(value)
+    });
+    return undefined;
+  }
+
+  const startLine = Number(match[1]);
+  const endLine = Number(match[2]);
+  if (startLine > 0 && endLine >= startLine) {
+    return { startLine, endLine };
+  }
+
+  diagnostics.push({
+    level: "warning",
+    code: "invalid_range",
+    message: `Range start must be less than or equal to range end; received '${String(value)}'.`,
+    token: String(value)
+  });
+  return undefined;
+}
+
+function stringValuesForFlag(flags: Record<string, CommandFlagValue>, name: string): string[] {
+  return valuesForFlag(flags, name).map((value) => String(value)).filter((value) => value.length > 0);
+}
+
+function valuesForFlag(flags: Record<string, CommandFlagValue>, name: string): CommandArgValue[] {
+  const value = flags[name];
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function appendUnique<T>(values: T[], value: T): void {
+  if (!values.includes(value)) {
+    values.push(value);
+  }
+}
+
+function isKnownIntent(value: string): value is KnownIntent {
+  return INTENTS.includes(value as KnownIntent);
 }

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -2,6 +2,47 @@ import { z } from "zod";
 
 export const SourceSchema = z.enum(["github", "slack", "lark", "cli", "webhook"]);
 export const ProviderSchema = z.enum(["github", "slack", "lark"]);
+export const ExecutorHintSchema = z.enum(["claude-code", "codex", "hermes", "openclaw", "custom"]);
+export const PermissionScopeSchema = z.enum([
+  "repo:read",
+  "repo:write",
+  "issue:comment",
+  "chat:postMessage",
+  "pr:create",
+  "pr:update",
+  "runner:local",
+  "network:restricted"
+]);
+export const CommandArgValueSchema = z.union([z.string(), z.boolean(), z.number()]);
+export const CommandFlagValueSchema = z.union([CommandArgValueSchema, z.array(CommandArgValueSchema)]);
+
+export const CommandReferenceSchema = z.object({
+  kind: z.enum(["file", "path", "line", "range", "url", "text"]),
+  uri: z.string().min(1),
+  line: z.number().int().positive().optional(),
+  startLine: z.number().int().positive().optional(),
+  endLine: z.number().int().positive().optional(),
+  title: z.string().min(1).optional()
+});
+
+export const CommandParseDiagnosticSchema = z.object({
+  level: z.enum(["warning", "error"]),
+  code: z.string().min(1),
+  message: z.string().min(1),
+  token: z.string().min(1).optional()
+});
+
+export const ParsedOpenTagCommandSchema = z.object({
+  version: z.literal("v1"),
+  prompt: z.string(),
+  flags: z.record(CommandFlagValueSchema),
+  references: z.array(CommandReferenceSchema),
+  requestedScopes: z.array(PermissionScopeSchema),
+  approval: z.enum(["auto", "required", "never"]).optional(),
+  network: z.enum(["restricted"]).optional(),
+  executorHint: ExecutorHintSchema.optional(),
+  diagnostics: z.array(CommandParseDiagnosticSchema)
+});
 
 export const ActorIdentitySchema = z.object({
   provider: ProviderSchema,
@@ -14,14 +55,15 @@ export const ActorIdentitySchema = z.object({
 export const AgentTargetSchema = z.object({
   mention: z.string().min(1),
   agentId: z.string().min(1),
-  executorHint: z.enum(["claude-code", "codex", "hermes", "openclaw", "custom"]).optional(),
+  executorHint: ExecutorHintSchema.optional(),
   workspaceHint: z.string().min(1).optional()
 });
 
 export const OpenTagCommandSchema = z.object({
   rawText: z.string(),
   intent: z.enum(["fix", "review", "investigate", "explain", "run", "unknown"]),
-  args: z.record(z.union([z.string(), z.boolean(), z.number()]))
+  args: z.record(CommandArgValueSchema),
+  parsed: ParsedOpenTagCommandSchema.optional()
 });
 
 export const ContextPointerSchema = z.object({
@@ -41,16 +83,7 @@ export const ContextPointerSchema = z.object({
 });
 
 export const PermissionGrantSchema = z.object({
-  scope: z.enum([
-    "repo:read",
-    "repo:write",
-    "issue:comment",
-    "chat:postMessage",
-    "pr:create",
-    "pr:update",
-    "runner:local",
-    "network:restricted"
-  ]),
+  scope: PermissionScopeSchema,
   reason: z.string().min(1),
   expiresAt: z.string().datetime().optional()
 });
@@ -107,6 +140,9 @@ export const OpenTagRunSchema = z.object({
 export type ActorIdentity = z.infer<typeof ActorIdentitySchema>;
 export type AgentTarget = z.infer<typeof AgentTargetSchema>;
 export type OpenTagCommand = z.infer<typeof OpenTagCommandSchema>;
+export type ParsedOpenTagCommand = z.infer<typeof ParsedOpenTagCommandSchema>;
+export type CommandParseDiagnostic = z.infer<typeof CommandParseDiagnosticSchema>;
+export type CommandReference = z.infer<typeof CommandReferenceSchema>;
 export type ContextPointer = z.infer<typeof ContextPointerSchema>;
 export type PermissionGrant = z.infer<typeof PermissionGrantSchema>;
 export type CallbackRoute = z.infer<typeof CallbackRouteSchema>;

--- a/packages/core/test/mention.test.ts
+++ b/packages/core/test/mention.test.ts
@@ -3,11 +3,19 @@ import { parseOpenTagMention } from "../src/mention.js";
 
 describe("parseOpenTagMention", () => {
   it("parses fix intent after @opentag", () => {
-    expect(parseOpenTagMention("@opentag fix this flaky test")).toEqual({
+    expect(parseOpenTagMention("@opentag fix this flaky test")).toMatchObject({
       matched: true,
       rawText: "fix this flaky test",
       intent: "fix",
-      args: {}
+      args: { prompt: "this flaky test" },
+      parsed: {
+        version: "v1",
+        prompt: "this flaky test",
+        flags: {},
+        references: [],
+        requestedScopes: [],
+        diagnostics: []
+      }
     });
   });
 
@@ -16,11 +24,114 @@ describe("parseOpenTagMention", () => {
   });
 
   it("supports multiline comments", () => {
-    expect(parseOpenTagMention("context\n@opentag review this PR\nthanks")).toEqual({
+    expect(parseOpenTagMention("context\n@opentag review this PR\nthanks")).toMatchObject({
       matched: true,
       rawText: "review this PR",
       intent: "review",
-      args: {}
+      args: { prompt: "this PR" }
     });
+  });
+
+  it("parses quoted flag values and command references", () => {
+    expect(parseOpenTagMention('@opentag review "the auth flow" --file src/auth.ts --range 10-20 --approval required')).toMatchObject({
+      matched: true,
+      rawText: 'review "the auth flow" --file src/auth.ts --range 10-20 --approval required',
+      intent: "review",
+      args: {
+        prompt: "the auth flow",
+        file: "src/auth.ts",
+        range: "10-20",
+        approval: "required"
+      },
+      parsed: {
+        prompt: "the auth flow",
+        flags: {
+          file: "src/auth.ts",
+          range: "10-20",
+          approval: "required"
+        },
+        references: [
+          {
+            kind: "file",
+            uri: "src/auth.ts",
+            startLine: 10,
+            endLine: 20
+          }
+        ],
+        approval: "required"
+      }
+    });
+  });
+
+  it("parses equals flags, repeated scopes, network, and executor hints", () => {
+    expect(
+      parseOpenTagMention("@opentag run pnpm test --scope=repo:read --scope repo:write --network restricted --executor codex")
+    ).toMatchObject({
+      matched: true,
+      intent: "run",
+      args: {
+        prompt: "pnpm test",
+        scope: "repo:read,repo:write",
+        network: "restricted",
+        executor: "codex"
+      },
+      parsed: {
+        prompt: "pnpm test",
+        flags: {
+          scope: ["repo:read", "repo:write"],
+          network: "restricted",
+          executor: "codex"
+        },
+        requestedScopes: ["repo:read", "repo:write", "network:restricted"],
+        network: "restricted",
+        executorHint: "codex"
+      }
+    });
+  });
+
+  it("collects multiline DSL blocks after an intent-only first line", () => {
+    expect(
+      parseOpenTagMention(`please take a look
+@opentag fix
+flaky login tests
+--path packages/auth
+--approval required`)
+    ).toMatchObject({
+      matched: true,
+      rawText: "fix\nflaky login tests\n--path packages/auth\n--approval required",
+      intent: "fix",
+      args: {
+        prompt: "flaky login tests",
+        path: "packages/auth",
+        approval: "required"
+      },
+      parsed: {
+        references: [{ kind: "path", uri: "packages/auth" }],
+        approval: "required"
+      }
+    });
+  });
+
+  it("reports warnings for unknown flags and invalid policy hints without dropping the command", () => {
+    const command = parseOpenTagMention("@opentag investigate outage --scope admin:all --network open --unknown yep");
+
+    expect(command).toMatchObject({
+      matched: true,
+      intent: "investigate",
+      args: {
+        prompt: "outage",
+        scope: "admin:all",
+        network: "open",
+        unknown: "yep"
+      },
+      parsed: {
+        requestedScopes: []
+      }
+    });
+    expect(command.matched && command.parsed?.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      "unknown_flag",
+      "invalid_scope",
+      "invalid_network_policy"
+    ]);
   });
 });

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -46,6 +46,8 @@ if (event) {
 
 `fix` and `run` commands receive write-capable permissions such as `repo:write` and `pr:create`. Review, explain, and investigate-style commands stay read/comment oriented.
 
+Command Parser V1 hints are also projected into GitHub events. For example, `--file`, `--path`, and `--range` add command-scoped context pointers; `--scope repo:read` and `--network restricted` add requested permission grants; `--executor codex` sets `target.executorHint`; and `--approval required` is preserved in command metadata for dispatcher or policy layers to enforce.
+
 ## Stability
 
 Normalizer input shapes are intentionally small and provider-specific. Prefer adding optional fields over changing existing fields.

--- a/packages/github/src/normalize.ts
+++ b/packages/github/src/normalize.ts
@@ -1,5 +1,5 @@
 import { parseOpenTagMention, type OpenTagEvent } from "@opentag/core";
-import type { OpenTagCommand, PermissionGrant } from "@opentag/core";
+import type { ContextPointer, OpenTagCommand, PermissionGrant } from "@opentag/core";
 
 export type GitHubIssueCommentInput = {
   id: string;
@@ -63,9 +63,81 @@ function permissionsForIntent(intent: OpenTagCommand["intent"]): PermissionGrant
   return permissions;
 }
 
+function permissionsForCommand(command: OpenTagCommand): PermissionGrant[] {
+  const permissions = permissionsForIntent(command.intent);
+  for (const scope of command.parsed?.requestedScopes ?? []) {
+    addPermission(permissions, {
+      scope,
+      reason: `requested by OpenTag command flag --scope ${scope}`
+    });
+  }
+  return permissions;
+}
+
+function addPermission(permissions: PermissionGrant[], permission: PermissionGrant): void {
+  if (!permissions.some((candidate) => candidate.scope === permission.scope)) {
+    permissions.push(permission);
+  }
+}
+
+function contextPointersForCommand(command: OpenTagCommand, privateRepo: boolean): ContextPointer[] {
+  const visibility = privateRepo ? "private" : "public";
+  const context: ContextPointer[] = [];
+
+  for (const reference of command.parsed?.references ?? []) {
+    if (reference.kind === "url") {
+      context.push({
+        kind: "url",
+        uri: reference.uri,
+        visibility,
+        title: reference.title ?? "Command URL reference"
+      });
+      continue;
+    }
+
+    if (reference.kind === "file" || reference.kind === "path") {
+      context.push({
+        kind: "file",
+        uri: uriWithLineFragment(reference.uri, reference.startLine, reference.endLine, reference.line),
+        visibility,
+        title: reference.title ?? "Command file reference"
+      });
+    }
+  }
+
+  return context;
+}
+
+function uriWithLineFragment(uri: string, startLine?: number, endLine?: number, line?: number): string {
+  if (startLine && endLine) {
+    return `${uri}#L${startLine}-L${endLine}`;
+  }
+  if (line) {
+    return `${uri}#L${line}`;
+  }
+  return uri;
+}
+
+function commandMetadata(command: OpenTagCommand): Record<string, unknown> {
+  if (!command.parsed) return {};
+  return {
+    commandParser: command.parsed.version,
+    commandDiagnostics: command.parsed.diagnostics,
+    ...(command.parsed.approval ? { approval: command.parsed.approval } : {}),
+    ...(command.parsed.network ? { network: command.parsed.network } : {})
+  };
+}
+
 export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): OpenTagEvent | null {
   const mention = parseOpenTagMention(input.commentBody);
   if (!mention.matched) return null;
+
+  const command = {
+    rawText: mention.rawText,
+    intent: mention.intent,
+    args: mention.args,
+    ...(mention.parsed ? { parsed: mention.parsed } : {})
+  };
 
   return {
     id: `evt_github_comment_${input.id}`,
@@ -79,13 +151,10 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
     },
     target: {
       mention: "@opentag",
-      agentId: "opentag"
+      agentId: "opentag",
+      ...(mention.parsed?.executorHint ? { executorHint: mention.parsed.executorHint } : {})
     },
-    command: {
-      rawText: mention.rawText,
-      intent: mention.intent,
-      args: mention.args
-    },
+    command,
     context: [
       {
         kind: "github.issue",
@@ -96,9 +165,10 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
         kind: "github.comment",
         uri: input.commentUrl,
         visibility: input.private ? "private" : "public"
-      }
+      },
+      ...contextPointersForCommand(command, input.private)
     ],
-    permissions: permissionsForIntent(mention.intent),
+    permissions: permissionsForCommand(command),
     callback: {
       provider: "github",
       uri: input.apiCommentsUrl,
@@ -108,6 +178,7 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
       owner: input.owner,
       repo: input.repo,
       issueNumber: input.issueNumber,
+      ...commandMetadata(command),
       ...(typeof input.installationId === "number" ? { installationId: input.installationId } : {})
     }
   };
@@ -116,6 +187,13 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
 export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequestReviewCommentInput): OpenTagEvent | null {
   const mention = parseOpenTagMention(input.commentBody);
   if (!mention.matched) return null;
+
+  const command = {
+    rawText: mention.rawText,
+    intent: mention.intent,
+    args: mention.args,
+    ...(mention.parsed ? { parsed: mention.parsed } : {})
+  };
 
   return {
     id: `evt_github_pr_review_comment_${input.id}`,
@@ -129,13 +207,10 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
     },
     target: {
       mention: "@opentag",
-      agentId: "opentag"
+      agentId: "opentag",
+      ...(mention.parsed?.executorHint ? { executorHint: mention.parsed.executorHint } : {})
     },
-    command: {
-      rawText: mention.rawText,
-      intent: mention.intent,
-      args: mention.args
-    },
+    command,
     context: [
       {
         kind: "github.pull_request",
@@ -146,9 +221,10 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
         kind: "github.comment",
         uri: input.commentUrl,
         visibility: input.private ? "private" : "public"
-      }
+      },
+      ...contextPointersForCommand(command, input.private)
     ],
-    permissions: permissionsForIntent(mention.intent),
+    permissions: permissionsForCommand(command),
     callback: {
       provider: "github",
       uri: input.apiCommentsUrl,
@@ -158,6 +234,7 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
       owner: input.owner,
       repo: input.repo,
       pullRequestNumber: input.pullRequestNumber,
+      ...commandMetadata(command),
       ...(typeof input.installationId === "number" ? { installationId: input.installationId } : {})
     }
   };

--- a/packages/github/test/normalize.test.ts
+++ b/packages/github/test/normalize.test.ts
@@ -21,8 +21,46 @@ describe("normalizeGitHubIssueComment", () => {
 
     expect(event?.source).toBe("github");
     expect(event?.command.intent).toBe("fix");
+    expect(event?.command.args).toMatchObject({ prompt: "this" });
     expect(event?.permissions.map((permission) => permission.scope)).toContain("pr:create");
     expect(event?.metadata).toMatchObject({ owner: "acme", repo: "demo", issueNumber: 1, installationId: 99 });
+  });
+
+  it("maps command parser hints into GitHub event fields", () => {
+    const event = normalizeGitHubIssueComment({
+      id: "789",
+      commentBody: "@opentag review auth changes --file packages/auth/src/index.ts --range 12-30 --scope repo:read --network restricted --executor codex --approval required",
+      commentUrl: "https://github.com/acme/demo/issues/3#issuecomment-789",
+      apiCommentsUrl: "https://api.github.com/repos/acme/demo/issues/3/comments",
+      issueUrl: "https://github.com/acme/demo/issues/3",
+      issueNumber: 3,
+      owner: "acme",
+      repo: "demo",
+      actorId: 42,
+      actorLogin: "octocat",
+      private: true,
+      receivedAt: "2026-06-24T00:00:00.000Z"
+    });
+
+    expect(event?.target.executorHint).toBe("codex");
+    expect(event?.command.parsed).toMatchObject({
+      prompt: "auth changes",
+      approval: "required",
+      network: "restricted",
+      requestedScopes: ["repo:read", "network:restricted"]
+    });
+    expect(event?.context).toContainEqual({
+      kind: "file",
+      uri: "packages/auth/src/index.ts#L12-L30",
+      visibility: "private",
+      title: "Command file reference"
+    });
+    expect(event?.permissions.map((permission) => permission.scope)).toContain("network:restricted");
+    expect(event?.metadata).toMatchObject({
+      commandParser: "v1",
+      approval: "required",
+      network: "restricted"
+    });
   });
 
   it("normalizes an @opentag pull request review comment", () => {

--- a/packages/slack/src/normalize.ts
+++ b/packages/slack/src/normalize.ts
@@ -1,4 +1,4 @@
-import { commandFromRawText, type OpenTagEvent, type PermissionGrant } from "@opentag/core";
+import { commandFromRawText, type ContextPointer, type OpenTagCommand, type OpenTagEvent, type PermissionGrant } from "@opentag/core";
 
 export type SlackChannelBinding = {
   teamId: string;
@@ -48,7 +48,7 @@ export function parseSlackThreadKey(threadKey: string): { teamId: string; channe
   return { teamId, channelId, threadTs };
 }
 
-function permissionsForIntent(intent: ReturnType<typeof commandFromRawText>["intent"]): PermissionGrant[] {
+function permissionsForIntent(intent: OpenTagCommand["intent"]): PermissionGrant[] {
   const permissions: PermissionGrant[] = [
     {
       scope: "chat:postMessage",
@@ -80,6 +80,70 @@ function permissionsForIntent(intent: ReturnType<typeof commandFromRawText>["int
   return permissions;
 }
 
+function permissionsForCommand(command: OpenTagCommand): PermissionGrant[] {
+  const permissions = permissionsForIntent(command.intent);
+  for (const scope of command.parsed?.requestedScopes ?? []) {
+    addPermission(permissions, {
+      scope,
+      reason: `requested by OpenTag command flag --scope ${scope}`
+    });
+  }
+  return permissions;
+}
+
+function addPermission(permissions: PermissionGrant[], permission: PermissionGrant): void {
+  if (!permissions.some((candidate) => candidate.scope === permission.scope)) {
+    permissions.push(permission);
+  }
+}
+
+function contextPointersForCommand(command: OpenTagCommand): ContextPointer[] {
+  const context: ContextPointer[] = [];
+
+  for (const reference of command.parsed?.references ?? []) {
+    if (reference.kind === "url") {
+      context.push({
+        kind: "url",
+        uri: reference.uri,
+        visibility: "organization",
+        title: reference.title ?? "Command URL reference"
+      });
+      continue;
+    }
+
+    if (reference.kind === "file" || reference.kind === "path") {
+      context.push({
+        kind: "file",
+        uri: uriWithLineFragment(reference.uri, reference.startLine, reference.endLine, reference.line),
+        visibility: "organization",
+        title: reference.title ?? "Command file reference"
+      });
+    }
+  }
+
+  return context;
+}
+
+function uriWithLineFragment(uri: string, startLine?: number, endLine?: number, line?: number): string {
+  if (startLine && endLine) {
+    return `${uri}#L${startLine}-L${endLine}`;
+  }
+  if (line) {
+    return `${uri}#L${line}`;
+  }
+  return uri;
+}
+
+function commandMetadata(command: OpenTagCommand): Record<string, unknown> {
+  if (!command.parsed) return {};
+  return {
+    commandParser: command.parsed.version,
+    commandDiagnostics: command.parsed.diagnostics,
+    ...(command.parsed.approval ? { approval: command.parsed.approval } : {}),
+    ...(command.parsed.network ? { network: command.parsed.network } : {})
+  };
+}
+
 export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEvent | null {
   const rawText = stripSlackAppMention(input.text, input.botUserId);
   if (!rawText) return null;
@@ -100,7 +164,8 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
     },
     target: {
       mention: input.botUserId ? `<@${input.botUserId}>` : "<@app>",
-      agentId: "opentag"
+      agentId: "opentag",
+      ...(command.parsed?.executorHint ? { executorHint: command.parsed.executorHint } : {})
     },
     command,
     context: [
@@ -115,9 +180,10 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
         uri: input.text,
         visibility: "organization",
         title: "Slack message text"
-      }
+      },
+      ...contextPointersForCommand(command)
     ],
-    permissions: permissionsForIntent(command.intent),
+    permissions: permissionsForCommand(command),
     callback: {
       provider: "slack",
       uri: input.callbackUri ?? "https://slack.com/api/chat.postMessage",
@@ -133,7 +199,8 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
       messageTs: input.ts,
       repoProvider: "github",
       owner: input.binding.owner,
-      repo: input.binding.repo
+      repo: input.binding.repo,
+      ...commandMetadata(command)
     }
   };
 }

--- a/packages/slack/test/normalize.test.ts
+++ b/packages/slack/test/normalize.test.ts
@@ -27,9 +27,48 @@ describe("Slack normalization", () => {
 
     expect(event?.source).toBe("slack");
     expect(event?.command.intent).toBe("fix");
+    expect(event?.command.args).toMatchObject({ prompt: "this" });
     expect(event?.metadata).toMatchObject({ teamId: "T123", channelId: "C123", owner: "acme", repo: "demo" });
     expect(event?.permissions.map((permission) => permission.scope)).toContain("chat:postMessage");
     expect(event?.callback.uri).toBe("http://127.0.0.1:3102/github-comment");
+  });
+
+  it("maps parser hints from Slack mentions into event fields", () => {
+    const event = normalizeSlackAppMention({
+      teamId: "T123",
+      channelId: "C123",
+      userId: "U456",
+      text: "<@U_APP> run \"pnpm test\" --path packages/core --scope repo:read --network restricted --executor codex --approval required",
+      ts: "1710000000.000100",
+      eventId: "Ev456",
+      eventTime: 1710000000,
+      botUserId: "U_APP",
+      binding: {
+        teamId: "T123",
+        channelId: "C123",
+        owner: "acme",
+        repo: "demo"
+      }
+    });
+
+    expect(event?.target.executorHint).toBe("codex");
+    expect(event?.command.parsed).toMatchObject({
+      prompt: "pnpm test",
+      approval: "required",
+      requestedScopes: ["repo:read", "network:restricted"]
+    });
+    expect(event?.context).toContainEqual({
+      kind: "file",
+      uri: "packages/core",
+      visibility: "organization",
+      title: "Command file reference"
+    });
+    expect(event?.permissions.map((permission) => permission.scope)).toContain("network:restricted");
+    expect(event?.metadata).toMatchObject({
+      commandParser: "v1",
+      approval: "required",
+      network: "restricted"
+    });
   });
 
   it("encodes and decodes Slack thread keys", () => {


### PR DESCRIPTION
## Summary

Adds Command Parser V1 for OpenTag mentions while preserving the existing `rawText` / `intent` / `args` command surface.

## What changed

- Extends `OpenTagCommand` with optional `parsed` metadata for V1 command structure.
- Parses shell-like flags from mentions, including quoted values and `--key=value` syntax.
- Supports command hints for file/path/range/url references, requested scopes, `--network restricted`, `--approval required|auto|never`, and `--executor`.
- Keeps old mentions such as `@opentag fix this` working, now with a structured `args.prompt` and `command.parsed.prompt`.
- Projects parser hints into GitHub and Slack normalized events:
  - command references become context pointers
  - requested scopes become permission grants
  - executor hints populate `target.executorHint`
  - approval/network/parser diagnostics are preserved in metadata
- Documents the V1 DSL and clarifies that parsing is a protocol hint layer, not an authorization/enforcement layer.

## Why

The previous parser was enough for v0 demos, but it treated mentions as a single free-form line and inferred intent from the first word only. This gives OpenTag a lightweight protocol-layer foundation without introducing a heavy grammar, changing dispatcher lifecycle, or forcing runners to consume a new command shape immediately.

## Validation

- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc -b`
- package/app build loop with `tsup` and declaration emit
