### PR TITLE
Improve Slack callback presentation

### DIFF
--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -1,4 +1,4 @@
-import { parseSlackThreadKey } from "@opentag/slack";
+import { createSlackPostMessagePayload, createSlackUpdateMessagePayload, parseSlackThreadKey } from "@opentag/slack";
 import type { CallbackMessage, CallbackSink } from "./server.js";
 
 export type FetchLike = typeof fetch;
@@ -31,6 +31,7 @@ export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: Fe
 
 export function createSlackCallbackSink(input: { botToken?: string; fetchImpl?: FetchLike }): CallbackSink {
   const fetchImpl = input.fetchImpl ?? fetch;
+  const statusMessageTsByKey = new Map<string, string>();
 
   return {
     async deliver(message: CallbackMessage): Promise<void> {
@@ -38,25 +39,39 @@ export function createSlackCallbackSink(input: { botToken?: string; fetchImpl?: 
       if (!input.botToken) return;
 
       const thread = parseSlackThreadKey(message.threadKey ?? "");
-      const response = await fetchImpl(message.uri, {
+      const existingStatusTs = message.statusMessageKey ? statusMessageTsByKey.get(message.statusMessageKey) : undefined;
+      const response = await fetchImpl(existingStatusTs ? "https://slack.com/api/chat.update" : message.uri, {
         method: "POST",
         headers: {
           authorization: `Bearer ${input.botToken}`,
           "content-type": "application/json"
         },
-        body: JSON.stringify({
-          channel: thread.channelId,
-          text: message.body,
-          thread_ts: thread.threadTs
-        })
+        body: JSON.stringify(
+          existingStatusTs
+            ? createSlackUpdateMessagePayload({
+                channelId: thread.channelId,
+                text: message.body,
+                messageTs: existingStatusTs,
+                ...(message.blocks?.length ? { blocks: message.blocks } : {})
+              })
+            : createSlackPostMessagePayload({
+                channelId: thread.channelId,
+                text: message.body,
+                threadTs: thread.threadTs,
+                ...(message.blocks?.length ? { blocks: message.blocks } : {})
+              })
+        )
       });
 
       if (!response.ok) {
         throw new Error(`deliver Slack callback failed: ${response.status} ${await response.text()}`);
       }
-      const body = (await response.json()) as { ok?: boolean; error?: string };
+      const body = (await response.json()) as { ok?: boolean; error?: string; ts?: string };
       if (body.ok === false) {
         throw new Error(`deliver Slack callback failed: ${body.error ?? "unknown_error"}`);
+      }
+      if (message.statusMessageKey && !existingStatusTs && body.ts) {
+        statusMessageTsByKey.set(message.statusMessageKey, body.ts);
       }
     }
   };

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -3,6 +3,10 @@ import type { CallbackMessage, CallbackSink } from "./server.js";
 
 export type FetchLike = typeof fetch;
 
+function slackUpdateUriFrom(postMessageUri: string): string {
+  return postMessageUri.replace(/\/chat\.postMessage$/, "/chat.update");
+}
+
 export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: FetchLike }): CallbackSink {
   const fetchImpl = input.fetchImpl ?? fetch;
 
@@ -40,7 +44,7 @@ export function createSlackCallbackSink(input: { botToken?: string; fetchImpl?: 
 
       const thread = parseSlackThreadKey(message.threadKey ?? "");
       const existingStatusTs = message.statusMessageKey ? statusMessageTsByKey.get(message.statusMessageKey) : undefined;
-      const response = await fetchImpl(existingStatusTs ? "https://slack.com/api/chat.update" : message.uri, {
+      const response = await fetchImpl(existingStatusTs ? slackUpdateUriFrom(message.uri) : message.uri, {
         method: "POST",
         headers: {
           authorization: `Bearer ${input.botToken}`,
@@ -72,6 +76,13 @@ export function createSlackCallbackSink(input: { botToken?: string; fetchImpl?: 
       }
       if (message.statusMessageKey && !existingStatusTs && body.ts) {
         statusMessageTsByKey.set(message.statusMessageKey, body.ts);
+      }
+      if (message.kind === "final") {
+        for (const key of statusMessageTsByKey.keys()) {
+          if (key.startsWith(`${message.runId}:`)) {
+            statusMessageTsByKey.delete(key);
+          }
+        }
       }
     }
   };

--- a/packages/dispatcher/src/index.ts
+++ b/packages/dispatcher/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./callbacks.js";
+export * from "./presentation.js";
 export * from "./server.js";

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -1,0 +1,47 @@
+import type { OpenTagRunResult } from "@opentag/core";
+import { renderAcknowledgement, renderFinalResult, renderProgress } from "@opentag/github";
+import { createSlackFinalResultBlocks, renderSlackAcknowledgement, renderSlackFinalResult, type SlackBlock } from "@opentag/slack";
+import type { CallbackMessage } from "./server.js";
+
+export type CallbackProvider = CallbackMessage["provider"];
+
+export type PresentedCallbackBody = {
+  body: string;
+  blocks?: SlackBlock[];
+};
+
+export type CallbackPresentation = {
+  shouldDeliverProgress(provider: CallbackProvider): boolean;
+  acknowledgement(input: { provider: CallbackProvider; runId: string }): string;
+  progress(input: { provider: CallbackProvider; runId: string; message: string }): string;
+  final(input: { provider: CallbackProvider; result: OpenTagRunResult }): PresentedCallbackBody;
+};
+
+export function createDefaultCallbackPresentation(): CallbackPresentation {
+  return {
+    shouldDeliverProgress(provider) {
+      return provider !== "slack";
+    },
+
+    acknowledgement(input) {
+      if (input.provider === "slack") {
+        return renderSlackAcknowledgement(input.runId);
+      }
+      return renderAcknowledgement(input.runId);
+    },
+
+    progress(input) {
+      return renderProgress({ runId: input.runId, message: input.message });
+    },
+
+    final(input) {
+      if (input.provider === "slack") {
+        return {
+          body: renderSlackFinalResult(input.result),
+          blocks: createSlackFinalResultBlocks(input.result)
+        };
+      }
+      return { body: renderFinalResult(input.result) };
+    }
+  };
+}

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -235,7 +235,8 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
           provider: stored.event.callback.provider,
           uri: stored.event.callback.uri,
           body: presentation.progress({ provider: stored.event.callback.provider, runId, message: body.message }),
-          ...(stored.event.callback.threadKey ? { threadKey: stored.event.callback.threadKey } : {})
+          ...(stored.event.callback.threadKey ? { threadKey: stored.event.callback.threadKey } : {}),
+          statusMessageKey: `${runId}:status`
         }
       });
     }

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -1,10 +1,11 @@
 import { OpenTagEventSchema, OpenTagRunResultSchema } from "@opentag/core";
-import { renderAcknowledgement, renderFinalResult, renderProgress } from "@opentag/github";
+import type { SlackBlock } from "@opentag/slack";
 import { createOpenTagRepository, migrateSchema } from "@opentag/store";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { Hono } from "hono";
 import { z } from "zod";
+import { createDefaultCallbackPresentation, type CallbackPresentation } from "./presentation.js";
 
 const CreateRunnerSchema = z.object({
   runnerId: z.string().min(1),
@@ -70,6 +71,8 @@ export type CallbackMessage = {
   uri: string;
   body: string;
   threadKey?: string;
+  statusMessageKey?: string;
+  blocks?: SlackBlock[];
 };
 
 export type CallbackSink = {
@@ -100,12 +103,13 @@ function isAuthorized(request: Request, pairingToken: string | undefined): boole
   return request.headers.get("authorization") === `Bearer ${pairingToken}`;
 }
 
-export function createDispatcherApp(input: { databasePath: string; callbackSink?: CallbackSink; pairingToken?: string }) {
+export function createDispatcherApp(input: { databasePath: string; callbackSink?: CallbackSink; pairingToken?: string; presentation?: CallbackPresentation }) {
   const sqlite = new Database(input.databasePath);
   migrateSchema(sqlite);
   const repo = createOpenTagRepository(drizzle(sqlite));
   const app = new Hono();
   const callbackSink = input.callbackSink ?? noopCallbackSink;
+  const presentation = input.presentation ?? createDefaultCallbackPresentation();
 
   app.get("/healthz", (c) => c.json({ ok: true }));
 
@@ -184,7 +188,7 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
         kind: "acknowledgement",
         provider: parsed.event.callback.provider,
         uri: parsed.event.callback.uri,
-        body: renderAcknowledgement(run.id),
+        body: presentation.acknowledgement({ provider: parsed.event.callback.provider, runId: run.id }),
         ...(parsed.event.callback.threadKey ? { threadKey: parsed.event.callback.threadKey } : {})
       }
     });
@@ -221,18 +225,20 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
       ...(body.type ? { type: body.type } : {}),
       ...(body.at ? { at: body.at } : {})
     });
-    await deliverAndAudit({
-      repo,
-      sink: callbackSink,
-      message: {
-        runId,
-        kind: "progress",
-        provider: stored.event.callback.provider,
-        uri: stored.event.callback.uri,
-        body: renderProgress({ runId, message: body.message }),
-        ...(stored.event.callback.threadKey ? { threadKey: stored.event.callback.threadKey } : {})
-      }
-    });
+    if (presentation.shouldDeliverProgress(stored.event.callback.provider)) {
+      await deliverAndAudit({
+        repo,
+        sink: callbackSink,
+        message: {
+          runId,
+          kind: "progress",
+          provider: stored.event.callback.provider,
+          uri: stored.event.callback.uri,
+          body: presentation.progress({ provider: stored.event.callback.provider, runId, message: body.message }),
+          ...(stored.event.callback.threadKey ? { threadKey: stored.event.callback.threadKey } : {})
+        }
+      });
+    }
     return c.json({ ok: true });
   });
 
@@ -243,6 +249,7 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
     if (!stored) return c.json({ error: "run_not_found" }, 404);
 
     await repo.completeRun({ runId, result: parsed.result });
+    const finalPresentation = presentation.final({ provider: stored.event.callback.provider, result: parsed.result });
     await deliverAndAudit({
       repo,
       sink: callbackSink,
@@ -251,8 +258,9 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
         kind: "final",
         provider: stored.event.callback.provider,
         uri: stored.event.callback.uri,
-        body: renderFinalResult(parsed.result),
-        ...(stored.event.callback.threadKey ? { threadKey: stored.event.callback.threadKey } : {})
+        body: finalPresentation.body,
+        ...(stored.event.callback.threadKey ? { threadKey: stored.event.callback.threadKey } : {}),
+        ...(finalPresentation.blocks?.length ? { blocks: finalPresentation.blocks } : {})
       }
     });
     return c.json({ ok: true });

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -88,6 +88,119 @@ describe("createGitHubCallbackSink", () => {
     ]);
   });
 
+  it("edits an existing Slack status message when statusMessageKey repeats", async () => {
+    const requests: { url: string; body: unknown; authorization: string | null }[] = [];
+    const sink = createSlackCallbackSink({
+      botToken: "xoxb-test",
+      fetchImpl: (async (url, init) => {
+        const body = JSON.parse(String(init?.body));
+        requests.push({
+          url: String(url),
+          body,
+          authorization: new Headers(init?.headers).get("authorization")
+        });
+        if (String(url).endsWith("/chat.postMessage")) {
+          return Response.json({ ok: true, ts: "1720000000.000100" });
+        }
+        return Response.json({ ok: true, ts: body.ts });
+      }) as typeof fetch
+    });
+
+    await sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      body: "Starting",
+      statusMessageKey: "run_1:status"
+    });
+    await sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      body: "Still working",
+      statusMessageKey: "run_1:status"
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "https://slack.com/api/chat.postMessage",
+        authorization: "Bearer xoxb-test",
+        body: {
+          channel: "C123",
+          text: "Starting",
+          thread_ts: "1710000000.000100"
+        }
+      },
+      {
+        url: "https://slack.com/api/chat.update",
+        authorization: "Bearer xoxb-test",
+        body: {
+          channel: "C123",
+          text: "Still working",
+          ts: "1720000000.000100"
+        }
+      }
+    ]);
+  });
+
+  it("includes Slack blocks when present", async () => {
+    const requests: { url: string; body: unknown; authorization: string | null }[] = [];
+    const sink = createSlackCallbackSink({
+      botToken: "xoxb-test",
+      fetchImpl: (async (url, init) => {
+        requests.push({
+          url: String(url),
+          body: JSON.parse(String(init?.body)),
+          authorization: new Headers(init?.headers).get("authorization")
+        });
+        return Response.json({ ok: true, ts: "1720000000.000100" });
+      }) as typeof fetch
+    });
+
+    await sink.deliver({
+      runId: "run_1",
+      kind: "final",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      body: "**done**",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*done*"
+          }
+        }
+      ]
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "https://slack.com/api/chat.postMessage",
+        authorization: "Bearer xoxb-test",
+        body: {
+          channel: "C123",
+          text: "*done*",
+          thread_ts: "1710000000.000100",
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "*done*"
+              }
+            }
+          ]
+        }
+      }
+    ]);
+  });
+
   it("fans out across composed sinks", async () => {
     const messages: string[] = [];
     const sink = createCompositeCallbackSink([

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -110,7 +110,7 @@ describe("createGitHubCallbackSink", () => {
       runId: "run_1",
       kind: "progress",
       provider: "slack",
-      uri: "https://slack.com/api/chat.postMessage",
+      uri: "https://slack-proxy.example.com/api/chat.postMessage",
       threadKey: "T123|C123|1710000000.000100",
       body: "Starting",
       statusMessageKey: "run_1:status"
@@ -119,7 +119,7 @@ describe("createGitHubCallbackSink", () => {
       runId: "run_1",
       kind: "progress",
       provider: "slack",
-      uri: "https://slack.com/api/chat.postMessage",
+      uri: "https://slack-proxy.example.com/api/chat.postMessage",
       threadKey: "T123|C123|1710000000.000100",
       body: "Still working",
       statusMessageKey: "run_1:status"
@@ -127,7 +127,7 @@ describe("createGitHubCallbackSink", () => {
 
     expect(requests).toEqual([
       {
-        url: "https://slack.com/api/chat.postMessage",
+        url: "https://slack-proxy.example.com/api/chat.postMessage",
         authorization: "Bearer xoxb-test",
         body: {
           channel: "C123",
@@ -136,7 +136,7 @@ describe("createGitHubCallbackSink", () => {
         }
       },
       {
-        url: "https://slack.com/api/chat.update",
+        url: "https://slack-proxy.example.com/api/chat.update",
         authorization: "Bearer xoxb-test",
         body: {
           channel: "C123",
@@ -144,6 +144,54 @@ describe("createGitHubCallbackSink", () => {
           ts: "1720000000.000100"
         }
       }
+    ]);
+  });
+
+  it("cleans up Slack status message keys when a run finishes", async () => {
+    const requests: { url: string; body: unknown }[] = [];
+    const sink = createSlackCallbackSink({
+      botToken: "xoxb-test",
+      fetchImpl: (async (url, init) => {
+        const body = JSON.parse(String(init?.body));
+        requests.push({ url: String(url), body });
+        if (String(url).endsWith("/chat.postMessage")) {
+          return Response.json({ ok: true, ts: `posted-${requests.length}` });
+        }
+        return Response.json({ ok: true, ts: body.ts });
+      }) as typeof fetch
+    });
+
+    await sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      body: "Starting",
+      statusMessageKey: "run_1:status"
+    });
+    await sink.deliver({
+      runId: "run_1",
+      kind: "final",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      body: "Done"
+    });
+    await sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      body: "Starting again",
+      statusMessageKey: "run_1:status"
+    });
+
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://slack.com/api/chat.postMessage",
+      "https://slack.com/api/chat.postMessage",
+      "https://slack.com/api/chat.postMessage"
     ]);
   });
 

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultCallbackPresentation } from "../src/presentation.js";
+
+describe("default callback presentation", () => {
+  it("keeps Slack progress audit-only while allowing GitHub progress delivery", () => {
+    const presentation = createDefaultCallbackPresentation();
+
+    expect(presentation.shouldDeliverProgress("slack")).toBe(false);
+    expect(presentation.shouldDeliverProgress("github")).toBe(true);
+  });
+
+  it("renders GitHub and Slack with provider-specific markup", () => {
+    const presentation = createDefaultCallbackPresentation();
+    const result = {
+      conclusion: "success" as const,
+      summary: "done",
+      verification: [{ command: "echo", outcome: "passed" as const }]
+    };
+
+    expect(presentation.acknowledgement({ provider: "github", runId: "run_1" })).toBe("OpenTag picked this up. Run: `run_1`");
+    expect(presentation.acknowledgement({ provider: "slack", runId: "run_1" })).toBe("I picked this up: `run_1`");
+    expect(presentation.final({ provider: "github", result })).toEqual({
+      body: "OpenTag finished with **success**.\n\ndone\n\nVerification:\n- `echo`: passed"
+    });
+    expect(presentation.final({ provider: "slack", result })).toEqual({
+      body: "Finished with *success*.\n\ndone\n\n*Verification*\n- `echo`: passed",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*Finished with success.*\ndone"
+          }
+        },
+        { type: "divider" },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*Verification*\n- `echo`: passed"
+          }
+        }
+      ]
+    });
+  });
+});

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -78,12 +78,12 @@ describe("dispatcher API", () => {
   });
 
   it("delivers acknowledgement, progress, and final callback messages with audit events", async () => {
-    const delivered: { kind: string; body: string }[] = [];
+    const delivered: { kind: string; body: string; blocks?: unknown[] }[] = [];
     const app = createDispatcherApp({
       databasePath: ":memory:",
       callbackSink: {
         async deliver(message) {
-          delivered.push({ kind: message.kind, body: message.body });
+          delivered.push({ kind: message.kind, body: message.body, ...(message.blocks?.length ? { blocks: message.blocks } : {}) });
         }
       }
     });
@@ -136,6 +136,107 @@ describe("dispatcher API", () => {
       "callback.acknowledgement.delivered",
       "run.progress",
       "callback.progress.delivered",
+      "run.completed",
+      "callback.final.delivered"
+    ]);
+  });
+
+  it("renders Slack callbacks with Slack mrkdwn and keeps progress audit-only", async () => {
+    const delivered: { kind: string; body: string; blocks?: unknown[] }[] = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body, ...(message.blocks?.length ? { blocks: message.blocks } : {}) });
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        workspacePath: "/Users/test/demo",
+        defaultExecutor: "echo"
+      })
+    });
+
+    const slackEvent = {
+      ...validEvent,
+      id: "evt_slack_1",
+      source: "slack",
+      sourceEventId: "Ev123",
+      actor: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
+      permissions: [{ scope: "chat:postMessage", reason: "reply in thread" }],
+      callback: {
+        provider: "slack",
+        uri: "https://slack.com/api/chat.postMessage",
+        threadKey: "T123|C123|1710000000.000100"
+      }
+    };
+
+    const createResponse = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_slack_1", event: slackEvent })
+    });
+    expect(createResponse.status).toBe(201);
+
+    const progressResponse = await app.request("/v1/runs/run_slack_1/progress", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "executor.progress", message: "Echo executor started", at: "2026-06-24T00:00:01.000Z" })
+    });
+    expect(progressResponse.status).toBe(200);
+    const completeResponse = await app.request("/v1/runs/run_slack_1/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        result: {
+          conclusion: "success",
+          summary: "Echoed OpenTag command: introduce yourself",
+          verification: [{ command: "echo", outcome: "passed" }]
+        }
+      })
+    });
+    expect(completeResponse.status).toBe(200);
+
+    expect(delivered).toEqual([
+      { kind: "acknowledgement", body: "I picked this up: `run_slack_1`" },
+      {
+        kind: "final",
+        body: "Finished with *success*.\n\nEchoed OpenTag command: introduce yourself\n\n*Verification*\n- `echo`: passed",
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "*Finished with success.*\nEchoed OpenTag command: introduce yourself"
+            }
+          },
+          { type: "divider" },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "*Verification*\n- `echo`: passed"
+            }
+          }
+        ]
+      }
+    ]);
+    expect(delivered.at(-1)?.body).not.toContain("**success**");
+
+    const eventsResponse = await app.request("/v1/runs/run_slack_1/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toEqual([
+      "run.created",
+      "callback.acknowledgement.delivered",
+      "run.progress",
       "run.completed",
       "callback.final.delivered"
     ]);

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -242,6 +242,82 @@ describe("dispatcher API", () => {
     ]);
   });
 
+  it("adds a stable statusMessageKey when progress callbacks are delivered", async () => {
+    const delivered: Array<{ kind: string; statusMessageKey?: string }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      presentation: {
+        shouldDeliverProgress(provider) {
+          return provider === "slack";
+        },
+        acknowledgement({ runId }) {
+          return `ack ${runId}`;
+        },
+        progress({ message }) {
+          return `progress ${message}`;
+        },
+        final() {
+          return { body: "final" };
+        }
+      },
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({
+            kind: message.kind,
+            ...(message.statusMessageKey ? { statusMessageKey: message.statusMessageKey } : {})
+          });
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        workspacePath: "/Users/test/demo",
+        defaultExecutor: "echo"
+      })
+    });
+
+    const response = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        runId: "run_status_key",
+        event: {
+          ...validEvent,
+          id: "evt_status_key",
+          source: "slack",
+          sourceEventId: "EvStatus",
+          actor: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
+          permissions: [{ scope: "chat:postMessage", reason: "reply in thread" }],
+          callback: {
+            provider: "slack",
+            uri: "https://slack.com/api/chat.postMessage",
+            threadKey: "T123|C123|1710000000.000100"
+          }
+        }
+      })
+    });
+    expect(response.status).toBe(201);
+
+    const progressResponse = await app.request("/v1/runs/run_status_key/progress", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "executor.progress", message: "working", at: "2026-06-24T00:00:01.000Z" })
+    });
+    expect(progressResponse.status).toBe(200);
+
+    expect(delivered).toEqual([
+      { kind: "acknowledgement" },
+      { kind: "progress", statusMessageKey: "run_status_key:status" }
+    ]);
+  });
+
   it("rejects runs for repositories without an explicit binding", async () => {
     const app = createDispatcherApp({ databasePath: ":memory:" });
 

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./normalize.js";
+export * from "./render.js";

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -1,0 +1,104 @@
+import type { OpenTagRunResult } from "@opentag/core";
+
+export type SlackTextBlock = {
+  type: "section";
+  text: {
+    type: "mrkdwn";
+    text: string;
+  };
+};
+
+export type SlackDividerBlock = {
+  type: "divider";
+};
+
+export type SlackBlock = SlackTextBlock | SlackDividerBlock;
+
+export type SlackMessagePayload = {
+  channel: string;
+  text: string;
+  thread_ts?: string;
+  ts?: string;
+  blocks?: SlackBlock[];
+};
+
+export function markdownToSlackMrkdwn(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, "*$1*")
+    .replace(/__(.+?)__/g, "*$1*")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>");
+}
+
+export function renderSlackAcknowledgement(runId: string): string {
+  return `I picked this up: \`${runId}\``;
+}
+
+export function renderSlackFinalResult(result: OpenTagRunResult): string {
+  const lines = [`Finished with *${result.conclusion}*.`, "", result.summary];
+
+  if (result.verification?.length) {
+    lines.push("", "*Verification*");
+    for (const check of result.verification) {
+      lines.push(`- \`${check.command}\`: ${check.outcome}`);
+    }
+  }
+
+  if (result.nextAction) {
+    lines.push("", `*Next action*: ${result.nextAction}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlock[] {
+  const blocks: SlackBlock[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Finished with ${result.conclusion}.*\n${markdownToSlackMrkdwn(result.summary)}`
+      }
+    }
+  ];
+
+  if (result.verification?.length) {
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ["*Verification*", ...result.verification.map((check) => `- \`${check.command}\`: ${check.outcome}`)].join("\n")
+      }
+    });
+  }
+
+  if (result.nextAction) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Next action*: ${markdownToSlackMrkdwn(result.nextAction)}`
+      }
+    });
+  }
+
+  return blocks;
+}
+
+export function createSlackPostMessagePayload(input: { channelId: string; text: string; threadTs: string; blocks?: SlackBlock[] }): SlackMessagePayload {
+  return {
+    channel: input.channelId,
+    text: markdownToSlackMrkdwn(input.text),
+    thread_ts: input.threadTs,
+    ...(input.blocks?.length ? { blocks: input.blocks } : {})
+  };
+}
+
+export function createSlackUpdateMessagePayload(input: { channelId: string; text: string; messageTs: string; blocks?: SlackBlock[] }): SlackMessagePayload {
+  return {
+    channel: input.channelId,
+    text: markdownToSlackMrkdwn(input.text),
+    ts: input.messageTs,
+    ...(input.blocks?.length ? { blocks: input.blocks } : {})
+  };
+}

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -22,11 +22,21 @@ export type SlackMessagePayload = {
   blocks?: SlackBlock[];
 };
 
+function escapeSlackText(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 export function markdownToSlackMrkdwn(text: string): string {
-  return text
+  const links: string[] = [];
+  const withoutLinks = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label: string, url: string) => {
+    const token = `\u0000SLACK_LINK_${links.length}\u0000`;
+    links.push(`<${url}|${escapeSlackText(label)}>`);
+    return token;
+  });
+  const converted = escapeSlackText(withoutLinks)
     .replace(/\*\*(.+?)\*\*/g, "*$1*")
-    .replace(/__(.+?)__/g, "*$1*")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>");
+    .replace(/__(.+?)__/g, "*$1*");
+  return links.reduce((output, link, index) => output.replace(`\u0000SLACK_LINK_${index}\u0000`, link), converted);
 }
 
 export function renderSlackAcknowledgement(runId: string): string {
@@ -67,7 +77,7 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlo
       type: "section",
       text: {
         type: "mrkdwn",
-        text: ["*Verification*", ...result.verification.map((check) => `- \`${check.command}\`: ${check.outcome}`)].join("\n")
+        text: markdownToSlackMrkdwn(["*Verification*", ...result.verification.map((check) => `- \`${check.command}\`: ${check.outcome}`)].join("\n"))
       }
     });
   }

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -44,7 +44,7 @@ export function renderSlackAcknowledgement(runId: string): string {
 }
 
 export function renderSlackFinalResult(result: OpenTagRunResult): string {
-  const lines = [`Finished with *${result.conclusion}*.`, "", result.summary];
+  const lines = [`Finished with *${result.conclusion}*.`, "", markdownToSlackMrkdwn(result.summary)];
 
   if (result.verification?.length) {
     lines.push("", "*Verification*");
@@ -54,7 +54,7 @@ export function renderSlackFinalResult(result: OpenTagRunResult): string {
   }
 
   if (result.nextAction) {
-    lines.push("", `*Next action*: ${result.nextAction}`);
+    lines.push("", `*Next action*: ${markdownToSlackMrkdwn(result.nextAction)}`);
   }
 
   return lines.join("\n");

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -26,6 +26,9 @@ describe("Slack callback rendering", () => {
 
   it("converts common Markdown to Slack mrkdwn", () => {
     expect(markdownToSlackMrkdwn("**bold** and [docs](https://example.com)")).toBe("*bold* and <https://example.com|docs>");
+    expect(markdownToSlackMrkdwn("Use <tag> & [docs & api](https://example.com?a=1&b=2)")).toBe(
+      "Use &lt;tag&gt; &amp; <https://example.com?a=1&b=2|docs &amp; api>"
+    );
   });
 
   it("builds Slack post and update payloads", () => {
@@ -45,7 +48,7 @@ describe("Slack callback rendering", () => {
     const blocks = createSlackFinalResultBlocks({
       conclusion: "success",
       summary: "See [PR](https://example.com/pr)",
-      verification: [{ command: "echo", outcome: "passed" }]
+      verification: [{ command: "echo '<tag>'", outcome: "passed" }]
     });
 
     expect(blocks).toEqual([
@@ -61,7 +64,7 @@ describe("Slack callback rendering", () => {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Verification*\n- `echo`: passed"
+          text: "*Verification*\n- `echo '&lt;tag&gt;'`: passed"
         }
       }
     ]);

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSlackFinalResultBlocks,
+  createSlackPostMessagePayload,
+  createSlackUpdateMessagePayload,
+  markdownToSlackMrkdwn,
+  renderSlackAcknowledgement,
+  renderSlackFinalResult
+} from "../src/render.js";
+
+describe("Slack callback rendering", () => {
+  it("renders Slack-friendly acknowledgement messages", () => {
+    expect(renderSlackAcknowledgement("run_1")).toBe("I picked this up: `run_1`");
+  });
+
+  it("uses Slack mrkdwn for final results", () => {
+    const text = renderSlackFinalResult({
+      conclusion: "success",
+      summary: "Echoed OpenTag command: introduce yourself",
+      verification: [{ command: "echo", outcome: "passed" }]
+    });
+
+    expect(text).toBe("Finished with *success*.\n\nEchoed OpenTag command: introduce yourself\n\n*Verification*\n- `echo`: passed");
+    expect(text).not.toContain("**success**");
+  });
+
+  it("converts common Markdown to Slack mrkdwn", () => {
+    expect(markdownToSlackMrkdwn("**bold** and [docs](https://example.com)")).toBe("*bold* and <https://example.com|docs>");
+  });
+
+  it("builds Slack post and update payloads", () => {
+    expect(createSlackPostMessagePayload({ channelId: "C123", threadTs: "171.001", text: "**hello**" })).toEqual({
+      channel: "C123",
+      text: "*hello*",
+      thread_ts: "171.001"
+    });
+    expect(createSlackUpdateMessagePayload({ channelId: "C123", messageTs: "172.001", text: "[docs](https://example.com)" })).toEqual({
+      channel: "C123",
+      text: "<https://example.com|docs>",
+      ts: "172.001"
+    });
+  });
+
+  it("builds Block Kit sections for final results", () => {
+    const blocks = createSlackFinalResultBlocks({
+      conclusion: "success",
+      summary: "See [PR](https://example.com/pr)",
+      verification: [{ command: "echo", outcome: "passed" }]
+    });
+
+    expect(blocks).toEqual([
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Finished with success.*\nSee <https://example.com/pr|PR>"
+        }
+      },
+      { type: "divider" },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Verification*\n- `echo`: passed"
+        }
+      }
+    ]);
+  });
+});

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -16,11 +16,14 @@ describe("Slack callback rendering", () => {
   it("uses Slack mrkdwn for final results", () => {
     const text = renderSlackFinalResult({
       conclusion: "success",
-      summary: "Echoed OpenTag command: introduce yourself",
-      verification: [{ command: "echo", outcome: "passed" }]
+      summary: "Echoed **OpenTag** command: [introduce yourself](https://example.com/cmd)",
+      verification: [{ command: "echo", outcome: "passed" }],
+      nextAction: "Open [thread](https://example.com/thread) & follow up"
     });
 
-    expect(text).toBe("Finished with *success*.\n\nEchoed OpenTag command: introduce yourself\n\n*Verification*\n- `echo`: passed");
+    expect(text).toBe(
+      "Finished with *success*.\n\nEchoed *OpenTag* command: <https://example.com/cmd|introduce yourself>\n\n*Verification*\n- `echo`: passed\n\n*Next action*: Open <https://example.com/thread|thread> &amp; follow up"
+    );
     expect(text).not.toContain("**success**");
   });
 


### PR DESCRIPTION
## Summary
- Add a dispatcher callback presentation seam so provider-specific message formatting stays out of route handlers.
- Keep Slack progress audit-only while preserving GitHub progress callbacks.
- Add Slack mrkdwn, Block Kit final-result payloads, and optional status-message edit support via `statusMessageKey`.

## Verification
- `pnpm --filter @opentag/slack build && pnpm --filter @opentag/slack lint && pnpm --filter @opentag/dispatcher lint`
- `pnpm typecheck`
- `pnpm test`
- Real Slack smoke: `run_1782313146114` delivered only ack/final in the thread, retained `run.progress` audit events, and included final Block Kit blocks.

## Notes
- Left unrelated untracked `docs/agent-work-protocol.md` out of this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer Slack message formatting, including threaded updates, structured blocks, and improved final result rendering.
  * Introduced a configurable callback presentation layer so different providers can render messages appropriately.

* **Bug Fixes**
  * Slack status messages now update in place when the same status key is reused, instead of posting duplicates.
  * Slack progress updates are suppressed when they shouldn’t be shown, resulting in cleaner run activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->