### PR TITLE
Align v0.1.0 release signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## v0.1.0 - 2026-06-24
+
+Initial public v0 release of OpenTag.
+
+### Added
+
+- Core OpenTag event and run schemas
+- GitHub issue and pull request comment mention normalization
+- Slack app mention normalization
+- Embeddable dispatcher package
+- SQLite-backed store package
+- Local daemon for polling and running assigned work
+- Echo executor for local smoke tests
+- Codex executor adapter
+- GitHub and Slack callback helpers
+- Local GitHub-to-echo smoke-test example
+- Public `@opentag/*` npm package family
+
+### Packages
+
+- `@opentag/core`
+- `@opentag/client`
+- `@opentag/dispatcher`
+- `@opentag/github`
+- `@opentag/slack`
+- `@opentag/store`
+- `@opentag/runner`
+
+### Notes
+
+OpenTag is still a young v0 project. This release is intended for local evaluation, integration experiments, and early SDK feedback. Production multi-tenant dispatcher deployments need additional hardening.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 **Open-source agent mentions for every workspace.**
 
 [![Status](https://img.shields.io/badge/status-v0-blue)](#status)
-[![npm](https://img.shields.io/npm/v/@opentag/core?label=npm)](https://www.npmjs.com/org/opentag)
+[![Release](https://img.shields.io/github/v/release/amplifthq/opentag?include_prereleases&label=release)](https://github.com/amplifthq/opentag/releases)
+[![npm](https://img.shields.io/npm/v/@opentag/core?label=%40opentag%2Fcore)](https://www.npmjs.com/package/@opentag/core)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178c6)](https://www.typescriptlang.org/)
 [![Node](https://img.shields.io/badge/Node-22.x-339933)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](#license)
@@ -142,7 +143,9 @@ curl http://localhost:3030/v1/runs/run_demo_1/events
 
 ## Packages
 
-Current public release: `0.1.0`.
+Current public release: `v0.1.0`.
+
+The npm packages are published under the `@opentag` scope at version `0.1.0`. GitHub releases track the package family version; see [CHANGELOG.md](CHANGELOG.md) for release history.
 
 | Package | Purpose |
 | --- | --- |


### PR DESCRIPTION
## Summary

Align the public v0.1.0 release signals across README, GitHub releases, and the published npm package family.

## Changes

- Add a GitHub Release badge next to the npm badge.
- Point the npm badge at `@opentag/core` directly instead of the org page.
- Clarify that `v0.1.0` is the current public release and that GitHub releases track the `@opentag/*` package family version.
- Add `CHANGELOG.md` with initial v0.1.0 release notes and package list.

## Validation

- Documentation-only change; no runtime tests were run.

## Follow-up after merge

Create the `v0.1.0` GitHub tag/release from the commit that corresponds to the published npm `0.1.0` package family, using the changelog notes as the release body.
