### PR TITLE
Generalize Slack ingress for multi-bot routing

### DIFF
--- a/apps/dispatcher/src/index.ts
+++ b/apps/dispatcher/src/index.ts
@@ -4,6 +4,15 @@ import { createCompositeCallbackSink, createDispatcherApp, createGitHubCallbackS
 const port = Number(process.env.PORT ?? "3030");
 const databasePath = process.env.OPENTAG_DATABASE_PATH ?? "opentag.db";
 
+function slackBotTokensByAgentIdFromEnv(): Record<string, string> | undefined {
+  const raw = process.env.OPENTAG_SLACK_BOT_TOKENS_JSON;
+  if (!raw) return undefined;
+  const parsed = JSON.parse(raw) as Record<string, string>;
+  return Object.keys(parsed).length > 0 ? parsed : undefined;
+}
+
+const slackBotTokensByAgentId = slackBotTokensByAgentIdFromEnv();
+
 serve({
   fetch: createDispatcherApp({
     databasePath,
@@ -13,7 +22,8 @@ serve({
         ...(process.env.OPENTAG_GITHUB_TOKEN ? { token: process.env.OPENTAG_GITHUB_TOKEN } : {})
       }),
       createSlackCallbackSink({
-        ...(process.env.OPENTAG_SLACK_BOT_TOKEN ? { botToken: process.env.OPENTAG_SLACK_BOT_TOKEN } : {})
+        ...(process.env.OPENTAG_SLACK_BOT_TOKEN ? { botToken: process.env.OPENTAG_SLACK_BOT_TOKEN } : {}),
+        ...(slackBotTokensByAgentId ? { botTokensByAgentId: slackBotTokensByAgentId } : {})
       })
     ])
   }).fetch,

--- a/apps/dispatcher/src/index.ts
+++ b/apps/dispatcher/src/index.ts
@@ -7,8 +7,17 @@ const databasePath = process.env.OPENTAG_DATABASE_PATH ?? "opentag.db";
 function slackBotTokensByAgentIdFromEnv(): Record<string, string> | undefined {
   const raw = process.env.OPENTAG_SLACK_BOT_TOKENS_JSON;
   if (!raw) return undefined;
-  const parsed = JSON.parse(raw) as Record<string, string>;
-  return Object.keys(parsed).length > 0 ? parsed : undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Value is not a JSON object");
+    }
+    return Object.keys(parsed).length > 0 ? (parsed as Record<string, string>) : undefined;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse OPENTAG_SLACK_BOT_TOKENS_JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 }
 
 const slackBotTokensByAgentId = slackBotTokensByAgentIdFromEnv();

--- a/apps/slack-events/src/app.ts
+++ b/apps/slack-events/src/app.ts
@@ -45,13 +45,40 @@ export function verifySlackSignature(input: {
 }
 
 export function createSlackEventsApp(input: {
-  signingSecret: string;
+  slackApps: Array<{
+    signingSecret: string;
+    agentId: string;
+    appId?: string;
+    callbackUri?: string;
+  }>;
   resolveChannelBinding(input: { teamId: string; channelId: string }): Promise<SlackChannelBinding | null>;
   createRun(event: OpenTagEvent): Promise<{ runId: string }>;
   now(): string;
-  callbackUri?: string;
 }) {
   const app = new Hono();
+
+  function resolveSlackApp(inputValue: {
+    apiAppId?: string;
+    rawBody: string;
+    signature: string;
+    timestamp: string;
+  }) {
+    const candidates = inputValue.apiAppId
+      ? input.slackApps.filter((candidate) => candidate.appId === inputValue.apiAppId)
+      : input.slackApps;
+    if (candidates.length === 0) {
+      return { error: "unknown_slack_app" as const };
+    }
+    const slackApp = candidates.find((candidate) =>
+      verifySlackSignature({
+        signingSecret: candidate.signingSecret,
+        timestamp: inputValue.timestamp,
+        rawBody: inputValue.rawBody,
+        signature: inputValue.signature
+      })
+    );
+    return slackApp ? { slackApp } : { error: "invalid_signature" as const };
+  }
 
   app.post("/slack/events", async (c) => {
     const rawBody = await c.req.text();
@@ -60,18 +87,17 @@ export function createSlackEventsApp(input: {
     if (!timestamp || !signature) {
       return c.json({ error: "missing_signature_headers" }, 401);
     }
-    if (
-      !verifySlackSignature({
-        signingSecret: input.signingSecret,
-        timestamp,
-        rawBody,
-        signature
-      })
-    ) {
-      return c.json({ error: "invalid_signature" }, 401);
-    }
-
     const payload = JSON.parse(rawBody) as SlackEventEnvelope;
+    const resolvedSlackApp = resolveSlackApp({
+      ...(payload.api_app_id ? { apiAppId: payload.api_app_id } : {}),
+      rawBody,
+      signature,
+      timestamp
+    });
+    if ("error" in resolvedSlackApp) {
+      return c.json({ error: resolvedSlackApp.error }, 401);
+    }
+    const { slackApp } = resolvedSlackApp;
     if (payload.type === "url_verification") {
       return c.text(payload.challenge ?? "");
     }
@@ -98,9 +124,11 @@ export function createSlackEventsApp(input: {
       ts: payload.event.ts,
       eventId: payload.event_id,
       eventTime: payload.event_time ?? Math.floor(Date.parse(input.now()) / 1000),
+      ...(payload.api_app_id ? { appId: payload.api_app_id } : {}),
+      agentId: slackApp.agentId,
       ...(payload.event.thread_ts ? { threadTs: payload.event.thread_ts } : {}),
       ...(payload.authorizations?.[0]?.user_id ? { botUserId: payload.authorizations[0].user_id } : {}),
-      ...(input.callbackUri ? { callbackUri: input.callbackUri } : {}),
+      ...(slackApp.callbackUri ? { callbackUri: slackApp.callbackUri } : {}),
       binding
     });
     if (!event) {

--- a/apps/slack-events/src/app.ts
+++ b/apps/slack-events/src/app.ts
@@ -57,6 +57,14 @@ export function createSlackEventsApp(input: {
 }) {
   const app = new Hono();
 
+  function parseSlackPayload(rawBody: string): SlackEventEnvelope | null {
+    try {
+      return JSON.parse(rawBody) as SlackEventEnvelope;
+    } catch {
+      return null;
+    }
+  }
+
   function resolveSlackApp(inputValue: {
     apiAppId?: string;
     rawBody: string;
@@ -64,7 +72,7 @@ export function createSlackEventsApp(input: {
     timestamp: string;
   }) {
     const candidates = inputValue.apiAppId
-      ? input.slackApps.filter((candidate) => candidate.appId === inputValue.apiAppId)
+      ? input.slackApps.filter((candidate) => !candidate.appId || candidate.appId === inputValue.apiAppId)
       : input.slackApps;
     if (candidates.length === 0) {
       return { error: "unknown_slack_app" as const };
@@ -87,9 +95,12 @@ export function createSlackEventsApp(input: {
     if (!timestamp || !signature) {
       return c.json({ error: "missing_signature_headers" }, 401);
     }
-    const payload = JSON.parse(rawBody) as SlackEventEnvelope;
+    const payload = parseSlackPayload(rawBody);
+    if (!payload) {
+      return c.json({ error: "invalid_json" }, 400);
+    }
     const resolvedSlackApp = resolveSlackApp({
-      ...(payload.api_app_id ? { apiAppId: payload.api_app_id } : {}),
+      apiAppId: payload.api_app_id,
       rawBody,
       signature,
       timestamp
@@ -124,11 +135,11 @@ export function createSlackEventsApp(input: {
       ts: payload.event.ts,
       eventId: payload.event_id,
       eventTime: payload.event_time ?? Math.floor(Date.parse(input.now()) / 1000),
-      ...(payload.api_app_id ? { appId: payload.api_app_id } : {}),
+      appId: payload.api_app_id,
       agentId: slackApp.agentId,
-      ...(payload.event.thread_ts ? { threadTs: payload.event.thread_ts } : {}),
-      ...(payload.authorizations?.[0]?.user_id ? { botUserId: payload.authorizations[0].user_id } : {}),
-      ...(slackApp.callbackUri ? { callbackUri: slackApp.callbackUri } : {}),
+      threadTs: payload.event.thread_ts,
+      botUserId: payload.authorizations?.[0]?.user_id,
+      callbackUri: slackApp.callbackUri,
       binding
     });
     if (!event) {

--- a/apps/slack-events/src/index.ts
+++ b/apps/slack-events/src/index.ts
@@ -4,8 +4,8 @@ import { createSlackEventsApp } from "./app.js";
 
 const signingSecret = process.env.SLACK_SIGNING_SECRET;
 const dispatcherUrl = process.env.OPENTAG_DISPATCHER_URL;
-if (!signingSecret || !dispatcherUrl) {
-  throw new Error("SLACK_SIGNING_SECRET and OPENTAG_DISPATCHER_URL are required");
+if (!dispatcherUrl) {
+  throw new Error("OPENTAG_DISPATCHER_URL is required");
 }
 
 const dispatcherToken = process.env.OPENTAG_DISPATCHER_TOKEN;
@@ -15,9 +15,42 @@ const dispatcherClient = createOpenTagClient({
   ...(dispatcherToken ? { pairingToken: dispatcherToken } : {})
 });
 
+type SlackAppConfig = {
+  signingSecret: string;
+  agentId: string;
+  appId?: string;
+  callbackUri?: string;
+};
+
+function slackAppsFromEnv(): SlackAppConfig[] {
+  const appsJson = process.env.OPENTAG_SLACK_APPS_JSON;
+  if (appsJson) {
+    const parsed = JSON.parse(appsJson) as SlackAppConfig[];
+    return parsed.filter((candidate) => candidate.signingSecret && candidate.agentId);
+  }
+
+  if (!signingSecret) {
+    return [];
+  }
+
+  return [
+    {
+      signingSecret,
+      agentId: process.env.OPENTAG_SLACK_AGENT_ID ?? "opentag",
+      ...(process.env.OPENTAG_SLACK_APP_ID ? { appId: process.env.OPENTAG_SLACK_APP_ID } : {}),
+      ...(process.env.OPENTAG_SLACK_POST_MESSAGE_URL ? { callbackUri: process.env.OPENTAG_SLACK_POST_MESSAGE_URL } : {})
+    }
+  ];
+}
+
+const slackApps = slackAppsFromEnv();
+if (slackApps.length === 0) {
+  throw new Error("Configure SLACK_SIGNING_SECRET or OPENTAG_SLACK_APPS_JSON");
+}
+
 serve({
   fetch: createSlackEventsApp({
-    signingSecret,
+    slackApps,
     async resolveChannelBinding(input) {
       try {
         const { binding } = await dispatcherClient.getSlackChannelBinding(input);
@@ -34,8 +67,7 @@ serve({
       await dispatcherClient.createRun({ runId, event });
       return { runId };
     },
-    now: () => new Date().toISOString(),
-    ...(process.env.OPENTAG_SLACK_POST_MESSAGE_URL ? { callbackUri: process.env.OPENTAG_SLACK_POST_MESSAGE_URL } : {})
+    now: () => new Date().toISOString()
   }).fetch,
   port
 });

--- a/apps/slack-events/src/index.ts
+++ b/apps/slack-events/src/index.ts
@@ -25,8 +25,23 @@ type SlackAppConfig = {
 function slackAppsFromEnv(): SlackAppConfig[] {
   const appsJson = process.env.OPENTAG_SLACK_APPS_JSON;
   if (appsJson) {
-    const parsed = JSON.parse(appsJson) as SlackAppConfig[];
-    return parsed.filter((candidate) => candidate.signingSecret && candidate.agentId);
+    try {
+      const parsed = JSON.parse(appsJson);
+      if (!Array.isArray(parsed)) {
+        throw new Error("Value is not a JSON array");
+      }
+      return parsed.filter(
+        (candidate): candidate is SlackAppConfig =>
+          Boolean(candidate) &&
+          typeof candidate === "object" &&
+          typeof candidate.signingSecret === "string" &&
+          typeof candidate.agentId === "string"
+      );
+    } catch (error) {
+      throw new Error(
+        `Failed to parse OPENTAG_SLACK_APPS_JSON: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
   }
 
   if (!signingSecret) {

--- a/apps/slack-events/test/app.test.ts
+++ b/apps/slack-events/test/app.test.ts
@@ -6,7 +6,7 @@ describe("Slack events app", () => {
     const rawBody = JSON.stringify({ type: "url_verification", challenge: "abc123" });
     const timestamp = "1710000000";
     const app = createSlackEventsApp({
-      signingSecret: "secret",
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
       async resolveChannelBinding() {
         return null;
       },
@@ -39,6 +39,7 @@ describe("Slack events app", () => {
     const createRun = vi.fn(async () => ({ runId: "run_1" }));
     const rawBody = JSON.stringify({
       type: "event_callback",
+      api_app_id: "A_GEMINI",
       team_id: "T123",
       event_id: "Ev123",
       event_time: 1710000000,
@@ -53,7 +54,7 @@ describe("Slack events app", () => {
     });
     const timestamp = "1710000000";
     const app = createSlackEventsApp({
-      signingSecret: "secret",
+      slackApps: [{ appId: "A_GEMINI", signingSecret: "secret", agentId: "gemini" }],
       async resolveChannelBinding() {
         return { teamId: "T123", channelId: "C123", owner: "acme", repo: "demo" };
       },
@@ -78,11 +79,98 @@ describe("Slack events app", () => {
 
     expect(response.status).toBe(200);
     expect(createRun).toHaveBeenCalledOnce();
+    const [event] = createRun.mock.calls[0] ?? [];
+    expect(event.target.agentId).toBe("gemini");
+  });
+
+  it("supports multiple Slack apps with different secrets and agent ids", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_2" }));
+    const rawBody = JSON.stringify({
+      type: "event_callback",
+      api_app_id: "A_DEEPSEEK",
+      team_id: "T123",
+      event_id: "Ev456",
+      event_time: 1710000100,
+      authorizations: [{ user_id: "U_DEEP" }],
+      event: {
+        type: "app_mention",
+        user: "U456",
+        text: "<@U_DEEP> explain this",
+        ts: "1710000100.000100",
+        channel: "C123"
+      }
+    });
+    const timestamp = "1710000100";
+    const app = createSlackEventsApp({
+      slackApps: [
+        { appId: "A_GEMINI", signingSecret: "secret_1", agentId: "gemini" },
+        { appId: "A_DEEPSEEK", signingSecret: "secret_2", agentId: "deepseek" }
+      ],
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", owner: "acme", repo: "demo" };
+      },
+      createRun,
+      now: () => "2026-06-24T00:00:00.000Z"
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": computeSlackSignature({
+          signingSecret: "secret_2",
+          timestamp,
+          rawBody
+        })
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    expect(createRun).toHaveBeenCalledOnce();
+    const [event] = createRun.mock.calls[0] ?? [];
+    expect(event.target.agentId).toBe("deepseek");
+  });
+
+  it("handles url_verification for one of multiple Slack apps without api_app_id", async () => {
+    const rawBody = JSON.stringify({ type: "url_verification", challenge: "abc123" });
+    const timestamp = "1710000000";
+    const app = createSlackEventsApp({
+      slackApps: [
+        { appId: "A_GEMINI", signingSecret: "secret_1", agentId: "gemini" },
+        { appId: "A_DEEPSEEK", signingSecret: "secret_2", agentId: "deepseek" }
+      ],
+      async resolveChannelBinding() {
+        return null;
+      },
+      async createRun() {
+        return { runId: "run_1" };
+      },
+      now: () => "2026-06-24T00:00:00.000Z"
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": computeSlackSignature({
+          signingSecret: "secret_2",
+          timestamp,
+          rawBody
+        })
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("abc123");
   });
 
   it("rejects invalid Slack signatures", async () => {
     const app = createSlackEventsApp({
-      signingSecret: "secret",
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
       async resolveChannelBinding() {
         return null;
       },

--- a/apps/slack-events/test/app.test.ts
+++ b/apps/slack-events/test/app.test.ts
@@ -168,6 +168,38 @@ describe("Slack events app", () => {
     await expect(response.text()).resolves.toBe("abc123");
   });
 
+  it("returns 400 for malformed JSON payloads", async () => {
+    const rawBody = "{not-json";
+    const timestamp = "1710000000";
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return null;
+      },
+      async createRun() {
+        return { runId: "run_1" };
+      },
+      now: () => "2026-06-24T00:00:00.000Z"
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": computeSlackSignature({
+          signingSecret: "secret",
+          timestamp,
+          rawBody
+        })
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_json" });
+  });
+
   it("rejects invalid Slack signatures", async () => {
     const app = createSlackEventsApp({
       slackApps: [{ signingSecret: "secret", agentId: "opentag" }],

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -7,6 +7,17 @@ function slackUpdateUriFrom(postMessageUri: string): string {
   return postMessageUri.replace(/\/chat\.postMessage$/, "/chat.update");
 }
 
+function slackBotTokenFor(input: {
+  botToken?: string;
+  botTokensByAgentId?: Record<string, string>;
+  agentId?: string;
+}): string | undefined {
+  if (input.agentId && input.botTokensByAgentId?.[input.agentId]) {
+    return input.botTokensByAgentId[input.agentId];
+  }
+  return input.botToken;
+}
+
 export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: FetchLike }): CallbackSink {
   const fetchImpl = input.fetchImpl ?? fetch;
 
@@ -33,21 +44,30 @@ export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: Fe
   };
 }
 
-export function createSlackCallbackSink(input: { botToken?: string; fetchImpl?: FetchLike }): CallbackSink {
+export function createSlackCallbackSink(input: {
+  botToken?: string;
+  botTokensByAgentId?: Record<string, string>;
+  fetchImpl?: FetchLike;
+}): CallbackSink {
   const fetchImpl = input.fetchImpl ?? fetch;
   const statusMessageTsByKey = new Map<string, string>();
 
   return {
     async deliver(message: CallbackMessage): Promise<void> {
       if (message.provider !== "slack") return;
-      if (!input.botToken) return;
+      const botToken = slackBotTokenFor({
+        ...(input.botToken ? { botToken: input.botToken } : {}),
+        ...(input.botTokensByAgentId ? { botTokensByAgentId: input.botTokensByAgentId } : {}),
+        ...(message.agentId ? { agentId: message.agentId } : {})
+      });
+      if (!botToken) return;
 
       const thread = parseSlackThreadKey(message.threadKey ?? "");
       const existingStatusTs = message.statusMessageKey ? statusMessageTsByKey.get(message.statusMessageKey) : undefined;
       const response = await fetchImpl(existingStatusTs ? slackUpdateUriFrom(message.uri) : message.uri, {
         method: "POST",
         headers: {
-          authorization: `Bearer ${input.botToken}`,
+          authorization: `Bearer ${botToken}`,
           "content-type": "application/json"
         },
         body: JSON.stringify(

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -12,7 +12,12 @@ function slackBotTokenFor(input: {
   botTokensByAgentId?: Record<string, string>;
   agentId?: string;
 }): string | undefined {
-  if (input.agentId && input.botTokensByAgentId?.[input.agentId]) {
+  if (
+    input.agentId &&
+    input.botTokensByAgentId &&
+    Object.hasOwn(input.botTokensByAgentId, input.agentId) &&
+    typeof input.botTokensByAgentId[input.agentId] === "string"
+  ) {
     return input.botTokensByAgentId[input.agentId];
   }
   return input.botToken;

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -70,6 +70,7 @@ export type CallbackMessage = {
   provider: "github" | "slack" | "lark" | "webhook";
   uri: string;
   body: string;
+  agentId?: string;
   threadKey?: string;
   statusMessageKey?: string;
   blocks?: SlackBlock[];
@@ -189,6 +190,7 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
         provider: parsed.event.callback.provider,
         uri: parsed.event.callback.uri,
         body: presentation.acknowledgement({ provider: parsed.event.callback.provider, runId: run.id }),
+        ...(parsed.event.target.agentId ? { agentId: parsed.event.target.agentId } : {}),
         ...(parsed.event.callback.threadKey ? { threadKey: parsed.event.callback.threadKey } : {})
       }
     });
@@ -235,6 +237,7 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
           provider: stored.event.callback.provider,
           uri: stored.event.callback.uri,
           body: presentation.progress({ provider: stored.event.callback.provider, runId, message: body.message }),
+          ...(stored.event.target.agentId ? { agentId: stored.event.target.agentId } : {}),
           ...(stored.event.callback.threadKey ? { threadKey: stored.event.callback.threadKey } : {}),
           statusMessageKey: `${runId}:status`
         }
@@ -260,6 +263,7 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
         provider: stored.event.callback.provider,
         uri: stored.event.callback.uri,
         body: finalPresentation.body,
+        ...(stored.event.target.agentId ? { agentId: stored.event.target.agentId } : {}),
         ...(stored.event.callback.threadKey ? { threadKey: stored.event.callback.threadKey } : {}),
         ...(finalPresentation.blocks?.length ? { blocks: finalPresentation.blocks } : {})
       }

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -88,6 +88,40 @@ describe("createGitHubCallbackSink", () => {
     ]);
   });
 
+  it("selects Slack bot tokens by agent id when provided", async () => {
+    const requests: { url: string; authorization: string | null }[] = [];
+    const sink = createSlackCallbackSink({
+      botTokensByAgentId: {
+        gemini: "xoxb-gemini",
+        deepseek: "xoxb-deepseek"
+      },
+      fetchImpl: (async (url, init) => {
+        requests.push({
+          url: String(url),
+          authorization: new Headers(init?.headers).get("authorization")
+        });
+        return Response.json({ ok: true, ts: "1720000000.000100" });
+      }) as typeof fetch
+    });
+
+    await sink.deliver({
+      runId: "run_1",
+      kind: "final",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      agentId: "deepseek",
+      body: "done"
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "https://slack.com/api/chat.postMessage",
+        authorization: "Bearer xoxb-deepseek"
+      }
+    ]);
+  });
+
   it("edits an existing Slack status message when statusMessageKey repeats", async () => {
     const requests: { url: string; body: unknown; authorization: string | null }[] = [];
     const sink = createSlackCallbackSink({

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -229,6 +229,7 @@ describe("dispatcher API", () => {
         ]
       }
     ]);
+    expect(delivered.every((message) => (message as { agentId?: string }).agentId === undefined)).toBe(true);
     expect(delivered.at(-1)?.body).not.toContain("**success**");
 
     const eventsResponse = await app.request("/v1/runs/run_slack_1/events");
@@ -469,5 +470,64 @@ describe("dispatcher API", () => {
     });
 
     expect(response.status).toBe(201);
+  });
+
+  it("passes the target agent id through Slack callbacks", async () => {
+    const delivered: Array<{ kind: string; agentId?: string }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({
+            kind: message.kind,
+            ...(message.agentId ? { agentId: message.agentId } : {})
+          });
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1"
+      })
+    });
+
+    const slackEvent = {
+      ...validEvent,
+      id: "evt_slack_agent",
+      source: "slack",
+      sourceEventId: "EvAgent",
+      actor: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
+      target: { mention: "<@U_DEEP>", agentId: "deepseek" },
+      callback: {
+        provider: "slack",
+        uri: "https://slack.com/api/chat.postMessage",
+        threadKey: "T123|C123|1710000000.000100"
+      }
+    };
+
+    const createResponse = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_slack_agent", event: slackEvent })
+    });
+    expect(createResponse.status).toBe(201);
+
+    const completeResponse = await app.request("/v1/runs/run_slack_agent/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ result: { conclusion: "success", summary: "done" } })
+    });
+    expect(completeResponse.status).toBe(200);
+
+    expect(delivered).toEqual([
+      { kind: "acknowledgement", agentId: "deepseek" },
+      { kind: "final", agentId: "deepseek" }
+    ]);
   });
 });

--- a/packages/slack/src/normalize.ts
+++ b/packages/slack/src/normalize.ts
@@ -16,6 +16,8 @@ export type SlackAppMentionInput = {
   threadTs?: string;
   eventId: string;
   eventTime: number;
+  appId?: string;
+  agentId?: string;
   botUserId?: string;
   callbackUri?: string;
   binding: SlackChannelBinding;
@@ -86,6 +88,7 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
 
   const command = commandFromRawText(rawText);
   const replyThreadTs = input.threadTs ?? input.ts;
+  const agentId = input.agentId ?? "opentag";
 
   return {
     id: `evt_slack_app_mention_${input.eventId}`,
@@ -100,7 +103,7 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
     },
     target: {
       mention: input.botUserId ? `<@${input.botUserId}>` : "<@app>",
-      agentId: "opentag"
+      agentId
     },
     command,
     context: [
@@ -131,6 +134,8 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
       teamId: input.teamId,
       channelId: input.channelId,
       messageTs: input.ts,
+      ...(input.appId ? { slackAppId: input.appId } : {}),
+      ...(input.botUserId ? { slackBotUserId: input.botUserId } : {}),
       repoProvider: "github",
       owner: input.binding.owner,
       repo: input.binding.repo

--- a/packages/slack/test/normalize.test.ts
+++ b/packages/slack/test/normalize.test.ts
@@ -15,6 +15,8 @@ describe("Slack normalization", () => {
       ts: "1710000000.000100",
       eventId: "Ev123",
       eventTime: 1710000000,
+      appId: "A123",
+      agentId: "gemini",
       botUserId: "U_APP",
       callbackUri: "http://127.0.0.1:3102/github-comment",
       binding: {
@@ -27,7 +29,12 @@ describe("Slack normalization", () => {
 
     expect(event?.source).toBe("slack");
     expect(event?.command.intent).toBe("fix");
+    expect(event?.target).toEqual({
+      mention: "<@U_APP>",
+      agentId: "gemini"
+    });
     expect(event?.metadata).toMatchObject({ teamId: "T123", channelId: "C123", owner: "acme", repo: "demo" });
+    expect(event?.metadata).toMatchObject({ slackAppId: "A123", slackBotUserId: "U_APP" });
     expect(event?.permissions.map((permission) => permission.scope)).toContain("chat:postMessage");
     expect(event?.callback.uri).toBe("http://127.0.0.1:3102/github-comment");
   });


### PR DESCRIPTION
## Summary
Generalizes OpenTag's Slack pipeline from a single bot identity to a reusable multi-bot model.

## What changed
- teaches `apps/slack-events` to accept multiple Slack apps and resolve them by `api_app_id` or request signature
- preserves Slack target agent identity through normalization and dispatcher callback delivery
- lets the dispatcher choose Slack bot tokens per agent when posting replies
- adds regression coverage for multi-app event handling and agent-specific Slack callbacks

## Why this is worth merging
This is not demo-only wiring. It fixes a real Slack integration limitation in the current architecture:
- multi-app Slack setups could not share one ingress endpoint
- Slack `url_verification` could fail in multi-app mode when `api_app_id` was absent
- callbacks could not preserve per-agent bot identity

## Validation
- `pnpm test packages/slack/test/normalize.test.ts apps/slack-events/test/app.test.ts packages/dispatcher/test/callbacks.test.ts packages/dispatcher/test/server.test.ts`
- `pnpm build`

## Not included
- local `.env` files or private tokens
- demo-specific orchestration or agent-to-agent conversation loops


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple Slack apps and selecting the right one per incoming event.
  * Enabled per-agent Slack bot tokens so callbacks can be sent with the correct credentials.
  * Added agent-aware event and callback handling so messages can carry the originating agent context.
* **Bug Fixes**
  * Improved Slack request validation and app resolution when signatures or app IDs don’t match the configured setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->