### PR TITLE
Implement agent work protocol runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenTag
 
-**Open-source agent mentions for every workspace.**
+**Open agent mentions for every workspace.**
 
 [![Status](https://img.shields.io/badge/status-v0-blue)](#status)
 [![npm](https://img.shields.io/npm/v/@opentag/core?label=npm)](https://www.npmjs.com/org/opentag)
@@ -10,7 +10,9 @@
 
 Claude Tag showed the new interface for team AI: tag an agent where work is already happening, let it use the right tools, and get the result back in the thread.
 
-OpenTag makes that pattern open. Bring `@opentag` to GitHub, Slack, or your own workspace surface; route the request through an auditable dispatcher; and run Claude Code, Codex, Hermes, OpenClaw, or a custom local runner without locking the whole workflow to one vendor.
+Tag agents from GitHub, Slack, or your own workspace surface. OpenTag adds bounded context, explicit permissions, auditable execution, and local-first runners when you need them.
+
+OpenTag is not another AI workspace. It is the protocol layer that brings agents to the work item thread you already use.
 
 > OpenTag is not affiliated with Anthropic. It is an open implementation of the agent-mention workflow that Claude Tag made obvious.
 
@@ -20,8 +22,13 @@ flowchart LR
   B --> C["Hosted or embedded dispatcher"]
   C --> D["Bound local daemon"]
   D --> E["Claude Code, Codex, or custom runner"]
-  E --> F["Reply, audit log, or pull request"]
+  E --> F["Proposal, PR, callback, metrics"]
 ```
+
+Real smoke tests have validated:
+
+- GitHub issue -> OpenTag -> local Claude Code -> commit branch -> pull request -> GitHub callback
+- Slack thread -> OpenTag -> local Claude Code -> Slack final callback with audit-only progress
 
 ## Why OpenTag
 
@@ -41,14 +48,21 @@ The goal is simple: make "tag an agent into work" a protocol, not a closed surfa
 
 ## What Works Today
 
-- **GitHub mentions** - `issue_comment.created` and `pull_request_review_comment.created` become normalized OpenTag events.
-- **Slack app mentions** - bound Slack channels can route `app_mention` events to the same dispatcher and local daemon path.
-- **Auditable dispatch** - every run is stored with event metadata, status transitions, progress, result, and callback delivery events.
-- **Explicit runner binding** - a runner only claims runs for repositories it is bound to.
-- **Local-first execution** - `opentagd` resolves a configured local checkout before executing anything.
-- **Executor adapters** - `echo` is available for smoke tests, and `codex` can run a real Codex CLI task on an isolated branch.
-- **Embeddable SDK packages** - use the protocol, client, dispatcher, GitHub, Slack, runner, and store packages independently.
-- **Published npm packages** - the public `@opentag/*` package family is available on npm at version `0.1.0`.
+### Core Loop
+
+- **GitHub and Slack ingress** - issue comments, PR review comments, and Slack app mentions normalize into one `OpenTagEvent`.
+- **Local-first execution** - `opentagd` claims only explicitly bound repositories and runs in your local checkout.
+- **Built-in local executors** - `echo` for smoke tests, `claude-code` for `claude --print`, and `codex` for `codex exec`.
+- **Quiet callbacks** - Slack progress stays audit-only by default; GitHub updates one run comment in place.
+
+### Protocol Runtime
+
+- **Work-thread model** - runs attach to `WorkItemReference + ConversationAnchor`, not an internal shadow task.
+- **Context packets** - execution input is assembled through collect, classify, filter, preserve, summarize, budget, and emit stages.
+- **Suggested changes** - agents can return immutable `SuggestedChangesSnapshot` objects with semantic mutation intents.
+- **Approval and apply** - approvals create separate decision objects; apply plans produce per-intent outcomes.
+- **Policy and mappings** - repo-scoped policy rules and mutation mappings compile semantic intents into adapter operations.
+- **Metrics** - run, repo, and work-thread metrics expose thread noise, proposal counts, approvals, child runs, and apply outcomes.
 
 ## Quick Start
 
@@ -65,10 +79,54 @@ Or work from this repository:
 ```bash
 pnpm install
 pnpm test
+pnpm smoke:protocol
+pnpm smoke:slack-protocol
 pnpm build
 ```
 
-For the full local GitHub-to-runner smoke test, follow [examples/github-to-echo](examples/github-to-echo/README.md). It starts the dispatcher, binds a local runner, creates a sample GitHub-shaped run, executes it with the echo executor, and lets you inspect the audit log.
+For no-secret protocol smoke tests, run `pnpm smoke:protocol` and `pnpm smoke:slack-protocol`. They start an in-process dispatcher with a temporary SQLite database and exercise the protocol chain through the client SDK.
+
+For a full local GitHub-to-runner smoke test, follow [examples/github-to-echo](examples/github-to-echo/README.md). It starts the dispatcher, binds a local runner, creates a sample GitHub-shaped run, executes it with the echo executor, and lets you inspect the audit log.
+
+## Run Claude Code Locally
+
+Set a repository binding to use the built-in Claude Code executor:
+
+```json
+{
+  "runnerId": "runner_local",
+  "dispatcherUrl": "http://localhost:3031",
+  "pairingToken": "dev_pairing_token",
+  "repositories": [
+    {
+      "provider": "github",
+      "owner": "acme",
+      "repo": "demo",
+      "checkoutPath": "/Users/example/repos/demo",
+      "defaultExecutor": "claude-code",
+      "baseBranch": "main",
+      "pushRemote": "origin"
+    }
+  ]
+}
+```
+
+Then register, bind, and run the daemon:
+
+```bash
+OPENTAG_CONFIG_PATH=opentag.local.json pnpm --filter @opentag/opentagd dev -- register-runner
+OPENTAG_CONFIG_PATH=opentag.local.json pnpm --filter @opentag/opentagd dev -- bind-repos
+OPENTAG_CONFIG_PATH=opentag.local.json pnpm --filter @opentag/opentagd dev -- serve
+```
+
+For real local smoke tests:
+
+```bash
+scripts/dev/run-gh-claude-local-test.sh
+scripts/dev/run-slack-claude-local-test.sh
+```
+
+Both scripts use real platform callbacks while keeping execution local.
 
 ## Agent Skill
 
@@ -137,8 +195,9 @@ curl http://localhost:3030/v1/runs/run_demo_1/events
 1. **Ingress normalizes platform events.** GitHub and Slack adapters translate comments or app mentions into one `OpenTagEvent` schema.
 2. **The dispatcher validates scope.** Runs must include repository metadata, and the repository must be explicitly bound to a runner.
 3. **The local daemon claims only mapped work.** `opentagd` checks its local repository config before running an executor.
-4. **The executor does the work.** The echo executor proves the loop; the Codex executor creates an isolated `opentag/<runId>` branch and runs `codex exec`.
-5. **Callbacks and audit events close the loop.** Progress and final results can be posted back to GitHub or Slack, and every step stays queryable through the dispatcher.
+4. **The executor does the work.** The echo executor proves the loop; Claude Code and Codex create isolated `opentag/<runId>` branches and run the local CLI.
+5. **Protocol artifacts capture the outcome.** Results can include suggested changes, next-action hints, proposal lineage, approval decisions, apply plans, and per-intent apply outcomes.
+6. **Callbacks and audit events close the loop.** Human threads get quiet ack/final callbacks, while detailed progress and metrics stay queryable through the dispatcher.
 
 ## Packages
 
@@ -146,13 +205,13 @@ Current public release: `0.1.0`.
 
 | Package | Purpose |
 | --- | --- |
-| [`@opentag/core`](https://www.npmjs.com/package/@opentag/core) | Zod schemas, TypeScript types, mention parsing, and JSON Schema exports |
-| [`@opentag/client`](https://www.npmjs.com/package/@opentag/client) | HTTP client for ingress apps, local runners, and admin setup |
+| [`@opentag/core`](https://www.npmjs.com/package/@opentag/core) | Zod schemas, TypeScript types, protocol helpers, mention parsing, and JSON Schema exports |
+| [`@opentag/client`](https://www.npmjs.com/package/@opentag/client) | HTTP client for ingress apps, local runners, admin setup, proposals, approvals, apply plans, policy, mappings, and metrics |
 | [`@opentag/dispatcher`](https://www.npmjs.com/package/@opentag/dispatcher) | Embeddable Hono dispatcher and callback sinks |
-| [`@opentag/github`](https://www.npmjs.com/package/@opentag/github) | GitHub event normalization, comment rendering, and PR helpers |
+| [`@opentag/github`](https://www.npmjs.com/package/@opentag/github) | GitHub event normalization, comment rendering, PR helpers, and issue mutation compilation/apply helpers |
 | [`@opentag/slack`](https://www.npmjs.com/package/@opentag/slack) | Slack event normalization, thread keys, and callback helpers |
-| [`@opentag/store`](https://www.npmjs.com/package/@opentag/store) | SQLite/Drizzle persistence and lease primitives |
-| [`@opentag/runner`](https://www.npmjs.com/package/@opentag/runner) | Executor contracts plus echo and Codex executor adapters |
+| [`@opentag/store`](https://www.npmjs.com/package/@opentag/store) | SQLite/Drizzle persistence for runs, audit events, proposals, approvals, apply plans, policy, mappings, leases, and metrics |
+| [`@opentag/runner`](https://www.npmjs.com/package/@opentag/runner) | Executor contracts plus echo, Claude Code, and Codex executor adapters |
 
 Runnable apps:
 
@@ -232,15 +291,32 @@ It returns:
 - verification results
 - optional artifacts such as a branch or pull request
 
-The built-in Codex and Claude Code executors refuse dirty workspaces, create an isolated branch, run the local CLI (`codex exec` or `claude --print`), filter internal artifacts, and report changed files. Third-party runners can implement the same `ExecutorAdapter` contract from `@opentag/runner`.
+The built-in Codex and Claude Code executors refuse dirty workspaces, create an isolated branch, run the local CLI (`codex exec` or `claude --print`), filter internal artifacts, report changed files, and return structured `OpenTagRunResult` objects. When PR creation is allowed, `opentagd` commits executor-produced file changes before pushing the run branch and opening a pull request. Third-party runners can implement the same `ExecutorAdapter` contract from `@opentag/runner`.
+
+## Protocol Runtime
+
+OpenTag's runtime is centered on engineering work item threads, not chat transcripts. The core protocol surface includes:
+
+- `WorkItemReference`, `ConversationAnchor`, and `WorkThread` for durable work context.
+- `ContextPacket` assembly with collect, classify, filter, preserve, summarize, budget, and emit stages.
+- `RunEvent` visibility and importance for quiet callbacks and audit/debug timelines.
+- `SuggestedChangesSnapshot` and semantic `MutationIntent` objects.
+- `ApprovalDecision` and `ApplyPlan` objects with per-intent outcomes.
+- `ActionHint` values that can create child runs with lineage back to parent runs, proposals, and apply plans.
+- Repo-scoped policy rules and mutation mappings for adapter compilation.
+- Run, repo, and work-thread metrics including thread noise ratio, proposal counts, approval counts, child runs, and apply outcome counts.
+
+GitHub issue mutations currently support labels and assignees directly. Status and priority are available through explicit repo mutation mappings, for example `priority: P1 -> label: priority/P1`.
 
 ## Dispatcher Callback Delivery
 
 Set `OPENTAG_GITHUB_TOKEN` on the dispatcher to post acknowledgement, progress, and final callback messages to GitHub comments.
 
+GitHub callbacks update one comment per run in place. The first callback creates the run comment, and later progress/final callbacks patch that same comment instead of flooding the issue thread.
+
 When dispatcher callbacks are enabled, set `OPENTAG_DISPATCHER_OWNS_CALLBACKS=true` on the Probot app to avoid duplicate acknowledgement comments.
 
-Set `OPENTAG_SLACK_BOT_TOKEN` on the dispatcher to post acknowledgement, progress, and final callback messages to Slack threads through `chat.postMessage`.
+Set `OPENTAG_SLACK_BOT_TOKEN` on the dispatcher to post acknowledgement and final callback messages to Slack threads through `chat.postMessage`. Routine Slack progress remains audit-only by default.
 
 Set `OPENTAG_PAIRING_TOKEN` on the dispatcher to require a shared Bearer token for `/v1/*` endpoints. Use the same value as `pairingToken` in `opentagd` config, and set `OPENTAG_DISPATCHER_TOKEN` on ingress apps that create runs through the dispatcher.
 
@@ -249,12 +325,17 @@ Set `OPENTAG_PAIRING_TOKEN` on the dispatcher to require a shared Bearer token f
 - [GitHub to echo](examples/github-to-echo/README.md) - manual end-to-end GitHub-shaped smoke test.
 - [Embedded dispatcher](examples/embedded-dispatcher/README.md) - host the dispatcher inside another Node service.
 - [Custom runner](examples/custom-runner/README.md) - build a third-party runner with `@opentag/client` and `@opentag/runner`.
+- `scripts/test/protocol-runtime-smoke.ts` - in-process GitHub-shaped protocol runtime smoke test.
+- `scripts/test/slack-protocol-runtime-smoke.ts` - in-process Slack-shaped protocol runtime smoke test.
+- `scripts/dev/run-gh-claude-local-test.sh` - GitHub CLI-assisted real local Claude Code smoke test.
+- `scripts/dev/run-slack-claude-local-test.sh` - Slack API-assisted real local Claude Code smoke test.
 
 ## Real Integration Guides
 
 - [Real integration smoke test](docs/real-integration-smoke-test.md) - real GitHub and Slack setup, trigger, and debugging order based on an actual end-to-end validation pass.
 - `scripts/dev/start-github-test.sh` - starts the dispatcher, local daemon, and GitHub Probot ingress for a real GitHub smoke test.
 - `scripts/dev/start-slack-test.sh` - starts the dispatcher, local daemon, and Slack Events ingress for a real Slack smoke test.
+- `scripts/dev/start-github-slack-claude-test.sh` - starts GitHub ingress, Slack ingress, dispatcher, and a local Claude Code daemon for combined real testing.
 
 ## Status
 
@@ -262,18 +343,18 @@ OpenTag is a young v0 project. The current codebase proves the core loop:
 
 - GitHub and Slack ingress
 - normalized protocol schemas
-- dispatcher persistence and leases
+- dispatcher persistence, leases, proposals, approvals, apply plans, policy, mappings, lineage, and metrics
 - local daemon polling and heartbeats
-- echo and Codex executors
-- GitHub and Slack callbacks
+- echo, Claude Code, and Codex executors
+- GitHub and Slack callbacks with quiet defaults
 - package-level SDK usage
 
 Next areas of work:
 
 - richer hosted setup flow
-- stronger callback delivery observability
-- more executor adapters
-- more workspace adapters
+- GitHub Project field mapping for status and priority
+- more workspace adapter compilers
+- adapter-specific context packet redaction and classification hooks
 - production hardening for multi-tenant dispatcher deployments
 
 ## Design

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ It returns:
 - verification results
 - optional artifacts such as a branch or pull request
 
-The built-in Codex executor refuses dirty workspaces, creates an isolated branch, runs `codex exec`, filters internal artifacts, and reports changed files. Third-party runners can implement the same `ExecutorAdapter` contract from `@opentag/runner`.
+The built-in Codex and Claude Code executors refuse dirty workspaces, create an isolated branch, run the local CLI (`codex exec` or `claude --print`), filter internal artifacts, and report changed files. Third-party runners can implement the same `ExecutorAdapter` contract from `@opentag/runner`.
 
 ## Dispatcher Callback Delivery
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,16 @@
 
 Claude Tag showed the new interface for team AI: tag an agent where work is already happening, let it use the right tools, and get the result back in the thread.
 
-Tag agents from GitHub, Slack, or your own workspace surface. OpenTag adds bounded context, explicit permissions, auditable execution, and local-first runners when you need them.
+Mention a configured agent where work already happens. OpenTag adds bounded context, explicit permissions, auditable execution, and local-first runners when you need them.
 
 OpenTag is not another AI workspace. It is the protocol layer that brings agents to the work item thread you already use.
 
 > OpenTag is not affiliated with Anthropic. It is an open implementation of the agent-mention workflow that Claude Tag made obvious.
 
-```mermaid
-flowchart LR
-  A["GitHub or Slack mention"] --> B["OpenTag event"]
-  B --> C["Hosted or embedded dispatcher"]
-  C --> D["Bound local daemon"]
-  D --> E["Claude Code, Codex, or custom runner"]
-  E --> F["Proposal, PR, callback, metrics"]
-```
+1. Mention a configured agent where work already happens (for example, GitHub or Slack).
+2. OpenTag normalizes the event and builds bounded context.
+3. An approved runner brings in Claude Code, Codex, or your own agent.
+4. The source thread gets a quiet result: proposal, PR, or metrics.
 
 Real smoke tests have validated:
 
@@ -38,7 +34,7 @@ OpenTag is for developers and teams who want the same interaction model with ope
 
 | Claude Tag pattern | OpenTag approach |
 | --- | --- |
-| Tag `@Claude` in Slack | Tag `@opentag` from GitHub, Slack, or another adapter |
+| Tag `@Claude` in Slack | Mention any configured agent from GitHub, Slack, or another adapter |
 | Claude executes with configured tools | Any approved executor can run: Claude Code, Codex, Hermes, OpenClaw, or custom |
 | Agent identity is provisioned by admins | Repository and channel bindings are explicit, auditable records |
 | Work happens inside Anthropic's product boundary | Dispatch can be self-hosted, embedded, or pointed at local runners |
@@ -50,7 +46,7 @@ The goal is simple: make "tag an agent into work" a protocol, not a closed surfa
 
 ### Core Loop
 
-- **GitHub and Slack ingress** - issue comments, PR review comments, and Slack app mentions normalize into one `OpenTagEvent`.
+- **GitHub and Slack adapters** - issue comments, PR review comments, and Slack app mentions normalize into one `OpenTagEvent` today; other workspace surfaces can implement the same protocol.
 - **Local-first execution** - `opentagd` claims only explicitly bound repositories and runs in your local checkout.
 - **Built-in local executors** - `echo` for smoke tests, `claude-code` for `claude --print`, and `codex` for `codex exec`.
 - **Quiet callbacks** - Slack progress stays audit-only by default; GitHub updates one run comment in place.

--- a/apps/dispatcher/src/index.ts
+++ b/apps/dispatcher/src/index.ts
@@ -26,6 +26,7 @@ serve({
   fetch: createDispatcherApp({
     databasePath,
     ...(process.env.OPENTAG_PAIRING_TOKEN ? { pairingToken: process.env.OPENTAG_PAIRING_TOKEN } : {}),
+    ...(process.env.OPENTAG_GITHUB_TOKEN ? { githubApply: { token: process.env.OPENTAG_GITHUB_TOKEN } } : {}),
     callbackSink: createCompositeCallbackSink([
       createGitHubCallbackSink({
         ...(process.env.OPENTAG_GITHUB_TOKEN ? { token: process.env.OPENTAG_GITHUB_TOKEN } : {})

--- a/apps/opentagd/src/config.ts
+++ b/apps/opentagd/src/config.ts
@@ -31,6 +31,7 @@ export type OpenTagDaemonConfig = {
   slackChannels?: SlackChannelBindingConfig[];
   claudeCode?: ClaudeCodeExecutorConfig;
   githubToken?: string;
+  allowAutoCreatePullRequest?: boolean;
   pairingToken?: string;
   pollIntervalMs?: number;
   heartbeatIntervalMs?: number;
@@ -94,6 +95,7 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
         }
       : {}),
     ...(process.env.OPENTAG_GITHUB_TOKEN ? { githubToken: process.env.OPENTAG_GITHUB_TOKEN } : {}),
+    ...(process.env.OPENTAG_ALLOW_AUTO_CREATE_PR ? { allowAutoCreatePullRequest: process.env.OPENTAG_ALLOW_AUTO_CREATE_PR === "true" } : {}),
     ...(process.env.OPENTAG_PAIRING_TOKEN ? { pairingToken: process.env.OPENTAG_PAIRING_TOKEN } : {}),
     ...(process.env.OPENTAG_POLL_INTERVAL_MS ? { pollIntervalMs: Number(process.env.OPENTAG_POLL_INTERVAL_MS) } : {}),
     ...(process.env.OPENTAG_HEARTBEAT_INTERVAL_MS ? { heartbeatIntervalMs: Number(process.env.OPENTAG_HEARTBEAT_INTERVAL_MS) } : {})

--- a/apps/opentagd/src/config.ts
+++ b/apps/opentagd/src/config.ts
@@ -37,6 +37,16 @@ export type OpenTagDaemonConfig = {
   heartbeatIntervalMs?: number;
 };
 
+const CLAUDE_PERMISSION_MODES = new Set(["acceptEdits", "auto", "bypassPermissions", "default", "plan"]);
+
+function claudePermissionModeFromEnv(value: string | undefined): ClaudeCodeExecutorConfig["permissionMode"] | undefined {
+  if (!value) return undefined;
+  if (!CLAUDE_PERMISSION_MODES.has(value)) {
+    throw new Error(`Invalid OPENTAG_CLAUDE_PERMISSION_MODE: ${value}`);
+  }
+  return value as NonNullable<ClaudeCodeExecutorConfig["permissionMode"]>;
+}
+
 export function loadConfigFromEnv(): OpenTagDaemonConfig {
   const configPath = process.env.OPENTAG_CONFIG_PATH;
   if (configPath) {
@@ -46,6 +56,7 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
   const owner = process.env.OPENTAG_REPO_OWNER;
   const repo = process.env.OPENTAG_REPO_NAME;
   const checkoutPath = process.env.OPENTAG_WORKSPACE_PATH;
+  const claudePermissionMode = claudePermissionModeFromEnv(process.env.OPENTAG_CLAUDE_PERMISSION_MODE);
   const repositories =
     owner && repo && checkoutPath
       ? [
@@ -85,9 +96,7 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
           claudeCode: {
             ...(process.env.OPENTAG_CLAUDE_COMMAND ? { command: process.env.OPENTAG_CLAUDE_COMMAND } : {}),
             ...(process.env.OPENTAG_CLAUDE_MODEL ? { model: process.env.OPENTAG_CLAUDE_MODEL } : {}),
-            ...(process.env.OPENTAG_CLAUDE_PERMISSION_MODE
-              ? { permissionMode: process.env.OPENTAG_CLAUDE_PERMISSION_MODE as NonNullable<ClaudeCodeExecutorConfig["permissionMode"]> }
-              : {}),
+            ...(claudePermissionMode ? { permissionMode: claudePermissionMode } : {}),
             ...(process.env.OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS
               ? { dangerouslySkipPermissions: process.env.OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS === "true" }
               : {})

--- a/apps/opentagd/src/config.ts
+++ b/apps/opentagd/src/config.ts
@@ -10,6 +10,13 @@ export type RepositoryBindingConfig = {
   pushRemote?: string;
 };
 
+export type ClaudeCodeExecutorConfig = {
+  command?: string;
+  model?: string;
+  permissionMode?: "acceptEdits" | "auto" | "bypassPermissions" | "default" | "plan";
+  dangerouslySkipPermissions?: boolean;
+};
+
 export type SlackChannelBindingConfig = {
   teamId: string;
   channelId: string;
@@ -22,6 +29,7 @@ export type OpenTagDaemonConfig = {
   dispatcherUrl: string;
   repositories: RepositoryBindingConfig[];
   slackChannels?: SlackChannelBindingConfig[];
+  claudeCode?: ClaudeCodeExecutorConfig;
   githubToken?: string;
   pairingToken?: string;
   pollIntervalMs?: number;
@@ -66,6 +74,23 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
               repo
             }
           ]
+        }
+      : {}),
+    ...(process.env.OPENTAG_CLAUDE_COMMAND ||
+    process.env.OPENTAG_CLAUDE_MODEL ||
+    process.env.OPENTAG_CLAUDE_PERMISSION_MODE ||
+    process.env.OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS
+      ? {
+          claudeCode: {
+            ...(process.env.OPENTAG_CLAUDE_COMMAND ? { command: process.env.OPENTAG_CLAUDE_COMMAND } : {}),
+            ...(process.env.OPENTAG_CLAUDE_MODEL ? { model: process.env.OPENTAG_CLAUDE_MODEL } : {}),
+            ...(process.env.OPENTAG_CLAUDE_PERMISSION_MODE
+              ? { permissionMode: process.env.OPENTAG_CLAUDE_PERMISSION_MODE as NonNullable<ClaudeCodeExecutorConfig["permissionMode"]> }
+              : {}),
+            ...(process.env.OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS
+              ? { dangerouslySkipPermissions: process.env.OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS === "true" }
+              : {})
+          }
         }
       : {}),
     ...(process.env.OPENTAG_GITHUB_TOKEN ? { githubToken: process.env.OPENTAG_GITHUB_TOKEN } : {}),

--- a/apps/opentagd/src/daemon.ts
+++ b/apps/opentagd/src/daemon.ts
@@ -67,7 +67,8 @@ export async function runOneDaemonIteration(input: {
     runId: claimed.run.id,
     workspacePath: binding.checkoutPath,
     command: claimed.event.command,
-    context: claimed.event.context
+    context: claimed.event.context,
+    ...(binding.baseBranch ? { baseBranch: binding.baseBranch } : {})
   });
   if (!readiness.ready) {
     await input.client.complete(claimed.run.id, {
@@ -95,7 +96,8 @@ export async function runOneDaemonIteration(input: {
         runId: claimed.run.id,
         workspacePath: binding.checkoutPath,
         command: claimed.event.command,
-        context: claimed.event.context
+        context: claimed.event.context,
+        ...(binding.baseBranch ? { baseBranch: binding.baseBranch } : {})
       },
       {
         emit: async (event) => {

--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -1,11 +1,26 @@
 #!/usr/bin/env node
-import { createCodexExecutor, createEchoExecutor } from "@opentag/runner";
+import { createClaudeCodeExecutor, createCodexExecutor, createEchoExecutor } from "@opentag/runner";
 import { createDispatcherAdminClient, createDispatcherClient } from "@opentag/client";
 import { Command } from "commander";
 import { loadConfigFromEnv } from "./config.js";
 import { runOneDaemonIteration, serveDaemon } from "./daemon.js";
 
 const program = new Command();
+
+function executorsFromConfig(config: ReturnType<typeof loadConfigFromEnv>) {
+  return {
+    echo: createEchoExecutor(),
+    codex: createCodexExecutor(),
+    "claude-code": createClaudeCodeExecutor({
+      ...(config.claudeCode?.command ? { claudeCommand: config.claudeCode.command } : {}),
+      ...(config.claudeCode?.model ? { model: config.claudeCode.model } : {}),
+      ...(config.claudeCode?.permissionMode ? { permissionMode: config.claudeCode.permissionMode } : {}),
+      ...(config.claudeCode?.dangerouslySkipPermissions !== undefined
+        ? { dangerouslySkipPermissions: config.claudeCode.dangerouslySkipPermissions }
+        : {})
+    })
+  };
+}
 
 program
   .name("opentagd")
@@ -70,10 +85,7 @@ program
     const didWork = await runOneDaemonIteration({
       runnerId: config.runnerId,
       repositories: config.repositories,
-      executors: {
-        echo: createEchoExecutor(),
-        codex: createCodexExecutor()
-      },
+      executors: executorsFromConfig(config),
       pullRequestOptions: {
         ...(config.githubToken ? { githubToken: config.githubToken } : {})
       },
@@ -95,10 +107,7 @@ program
     await serveDaemon({
       runnerId: config.runnerId,
       repositories: config.repositories,
-      executors: {
-        echo: createEchoExecutor(),
-        codex: createCodexExecutor()
-      },
+      executors: executorsFromConfig(config),
       ...(config.githubToken ? { pullRequestOptions: { githubToken: config.githubToken } } : {}),
       ...(config.heartbeatIntervalMs ? { heartbeatIntervalMs: config.heartbeatIntervalMs } : {}),
       ...(config.pollIntervalMs ? { pollIntervalMs: config.pollIntervalMs } : {}),

--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -87,7 +87,8 @@ program
       repositories: config.repositories,
       executors: executorsFromConfig(config),
       pullRequestOptions: {
-        ...(config.githubToken ? { githubToken: config.githubToken } : {})
+        ...(config.githubToken ? { githubToken: config.githubToken } : {}),
+        ...(config.allowAutoCreatePullRequest !== undefined ? { allowAutoCreatePullRequest: config.allowAutoCreatePullRequest } : {})
       },
       ...(config.heartbeatIntervalMs ? { heartbeatIntervalMs: config.heartbeatIntervalMs } : {}),
       client: createDispatcherClient({
@@ -108,7 +109,16 @@ program
       runnerId: config.runnerId,
       repositories: config.repositories,
       executors: executorsFromConfig(config),
-      ...(config.githubToken ? { pullRequestOptions: { githubToken: config.githubToken } } : {}),
+      ...(config.githubToken
+        ? {
+            pullRequestOptions: {
+              githubToken: config.githubToken,
+              ...(config.allowAutoCreatePullRequest !== undefined
+                ? { allowAutoCreatePullRequest: config.allowAutoCreatePullRequest }
+                : {})
+            }
+          }
+        : {}),
       ...(config.heartbeatIntervalMs ? { heartbeatIntervalMs: config.heartbeatIntervalMs } : {}),
       ...(config.pollIntervalMs ? { pollIntervalMs: config.pollIntervalMs } : {}),
       client: createDispatcherClient({

--- a/apps/opentagd/src/pr.ts
+++ b/apps/opentagd/src/pr.ts
@@ -23,7 +23,8 @@ export async function maybeCreatePullRequest(input: {
   if (!input.options.githubToken) return input.result;
   if (input.event.source !== "github") return input.result;
   if (!hasPermission(input.event, "pr:create")) return input.result;
-  if (!input.result.changedFiles?.length) return input.result;
+  const changedFiles = input.result.changedFiles ?? [];
+  if (changedFiles.length === 0) return input.result;
 
   const owner = input.event.metadata["owner"];
   const repo = input.event.metadata["repo"];
@@ -34,7 +35,7 @@ export async function maybeCreatePullRequest(input: {
   await commitChangedFiles({
     runner,
     workspacePath: input.binding.checkoutPath,
-    files: input.result.changedFiles,
+    files: changedFiles,
     message: `OpenTag run ${input.run.id}`
   });
   await pushBranch({

--- a/apps/opentagd/src/pr.ts
+++ b/apps/opentagd/src/pr.ts
@@ -53,7 +53,13 @@ export async function maybeCreatePullRequest(input: {
   return {
     ...input.result,
     createdPullRequestUrl: pullRequestUrl,
-    artifacts: [...(input.result.artifacts ?? []), { title: "Pull request", uri: pullRequestUrl }],
-    nextAction: `Review pull request: ${pullRequestUrl}`
+    artifacts: [...(input.result.artifacts ?? []), { kind: "pull_request", title: "Pull request", uri: pullRequestUrl }],
+    nextAction: {
+      summary: `Review pull request: ${pullRequestUrl}`,
+      hint: {
+        kind: "request_review",
+        metadata: { pullRequestUrl }
+      }
+    }
   };
 }

--- a/apps/opentagd/src/pr.ts
+++ b/apps/opentagd/src/pr.ts
@@ -5,6 +5,7 @@ import type { RepositoryBindingConfig } from "./config.js";
 
 export type PullRequestOptions = {
   githubToken?: string;
+  allowAutoCreatePullRequest?: boolean;
   commandRunner?: CommandRunner;
   fetchImpl?: FetchLike;
 };
@@ -21,6 +22,7 @@ export async function maybeCreatePullRequest(input: {
   options: PullRequestOptions;
 }): Promise<OpenTagRunResult> {
   if (!input.options.githubToken) return input.result;
+  if (!input.options.allowAutoCreatePullRequest) return input.result;
   if (input.event.source !== "github") return input.result;
   if (!hasPermission(input.event, "pr:create")) return input.result;
   const changedFiles = input.result.changedFiles ?? [];

--- a/apps/opentagd/src/pr.ts
+++ b/apps/opentagd/src/pr.ts
@@ -1,6 +1,6 @@
 import type { OpenTagEvent, OpenTagRun, OpenTagRunResult } from "@opentag/core";
 import { buildPullRequestBody, createPullRequestViaFetch, type FetchLike } from "@opentag/github";
-import { branchNameForRun, nodeCommandRunner, pushBranch, type CommandRunner } from "@opentag/runner";
+import { branchNameForRun, commitChangedFiles, nodeCommandRunner, pushBranch, type CommandRunner } from "@opentag/runner";
 import type { RepositoryBindingConfig } from "./config.js";
 
 export type PullRequestOptions = {
@@ -30,8 +30,15 @@ export async function maybeCreatePullRequest(input: {
   if (typeof owner !== "string" || typeof repo !== "string") return input.result;
 
   const branchName = branchNameForRun(input.run.id);
+  const runner = input.options.commandRunner ?? nodeCommandRunner;
+  await commitChangedFiles({
+    runner,
+    workspacePath: input.binding.checkoutPath,
+    files: input.result.changedFiles,
+    message: `OpenTag run ${input.run.id}`
+  });
   await pushBranch({
-    runner: input.options.commandRunner ?? nodeCommandRunner,
+    runner,
     workspacePath: input.binding.checkoutPath,
     remote: input.binding.pushRemote ?? "origin",
     branchName

--- a/apps/opentagd/test/config.test.ts
+++ b/apps/opentagd/test/config.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { loadConfigFromEnv } from "../src/config.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("opentagd config", () => {
+  it("rejects invalid Claude Code permission modes", () => {
+    delete process.env.OPENTAG_CONFIG_PATH;
+    process.env.OPENTAG_REPO_OWNER = "acme";
+    process.env.OPENTAG_REPO_NAME = "demo";
+    process.env.OPENTAG_WORKSPACE_PATH = "/tmp/demo";
+    process.env.OPENTAG_CLAUDE_PERMISSION_MODE = "typo";
+
+    expect(() => loadConfigFromEnv()).toThrow("Invalid OPENTAG_CLAUDE_PERMISSION_MODE: typo");
+  });
+});

--- a/apps/opentagd/test/pr.test.ts
+++ b/apps/opentagd/test/pr.test.ts
@@ -67,7 +67,14 @@ describe("maybeCreatePullRequest", () => {
     expect(commands).toEqual(["git push -u origin opentag/run_1"]);
     expect(requests).toEqual(["https://api.github.com/repos/acme/demo/pulls"]);
     expect(updated.createdPullRequestUrl).toBe("https://github.com/acme/demo/pull/1");
-    expect(updated.nextAction).toContain("https://github.com/acme/demo/pull/1");
+    expect(updated.artifacts?.at(-1)).toMatchObject({ kind: "pull_request", uri: "https://github.com/acme/demo/pull/1" });
+    expect(updated.nextAction).toMatchObject({
+      summary: "Review pull request: https://github.com/acme/demo/pull/1",
+      hint: {
+        kind: "request_review",
+        metadata: { pullRequestUrl: "https://github.com/acme/demo/pull/1" }
+      }
+    });
   });
 
   it("leaves the result unchanged without a GitHub token", async () => {

--- a/apps/opentagd/test/pr.test.ts
+++ b/apps/opentagd/test/pr.test.ts
@@ -51,6 +51,7 @@ describe("maybeCreatePullRequest", () => {
       result,
       options: {
         githubToken: "ghs_test",
+        allowAutoCreatePullRequest: true,
         commandRunner: {
           async run(command, args) {
             commands.push(`${command} ${args.join(" ")}`);
@@ -87,5 +88,27 @@ describe("maybeCreatePullRequest", () => {
         options: {}
       })
     ).resolves.toBe(result);
+  });
+
+  it("leaves the result unchanged unless auto PR creation is explicitly enabled", async () => {
+    const commands: string[] = [];
+    await expect(
+      maybeCreatePullRequest({
+        run,
+        event,
+        binding: { provider: "github", owner: "acme", repo: "demo", checkoutPath: "/tmp/demo" },
+        result,
+        options: {
+          githubToken: "ghs_test",
+          commandRunner: {
+            async run(command, args) {
+              commands.push(`${command} ${args.join(" ")}`);
+              return { exitCode: 0, stdout: "", stderr: "" };
+            }
+          }
+        }
+      })
+    ).resolves.toBe(result);
+    expect(commands).toEqual([]);
   });
 });

--- a/apps/opentagd/test/pr.test.ts
+++ b/apps/opentagd/test/pr.test.ts
@@ -64,7 +64,7 @@ describe("maybeCreatePullRequest", () => {
       }
     });
 
-    expect(commands).toEqual(["git push -u origin opentag/run_1"]);
+    expect(commands).toEqual(["git add -- src/demo.ts", "git commit -m OpenTag run run_1", "git push -u origin opentag/run_1"]);
     expect(requests).toEqual(["https://api.github.com/repos/acme/demo/pulls"]);
     expect(updated.createdPullRequestUrl).toBe("https://github.com/acme/demo/pull/1");
     expect(updated.artifacts?.at(-1)).toMatchObject({ kind: "pull_request", uri: "https://github.com/acme/demo/pull/1" });

--- a/apps/slack-events/src/app.ts
+++ b/apps/slack-events/src/app.ts
@@ -100,10 +100,10 @@ export function createSlackEventsApp(input: {
       return c.json({ error: "invalid_json" }, 400);
     }
     const resolvedSlackApp = resolveSlackApp({
-      apiAppId: payload.api_app_id,
       rawBody,
       signature,
-      timestamp
+      timestamp,
+      ...(payload.api_app_id ? { apiAppId: payload.api_app_id } : {})
     });
     if ("error" in resolvedSlackApp) {
       return c.json({ error: resolvedSlackApp.error }, 401);
@@ -135,12 +135,12 @@ export function createSlackEventsApp(input: {
       ts: payload.event.ts,
       eventId: payload.event_id,
       eventTime: payload.event_time ?? Math.floor(Date.parse(input.now()) / 1000),
-      appId: payload.api_app_id,
       agentId: slackApp.agentId,
-      threadTs: payload.event.thread_ts,
-      botUserId: payload.authorizations?.[0]?.user_id,
-      callbackUri: slackApp.callbackUri,
-      binding
+      binding,
+      ...(payload.api_app_id ? { appId: payload.api_app_id } : {}),
+      ...(payload.event.thread_ts ? { threadTs: payload.event.thread_ts } : {}),
+      ...(payload.authorizations?.[0]?.user_id ? { botUserId: payload.authorizations[0].user_id } : {}),
+      ...(slackApp.callbackUri ? { callbackUri: slackApp.callbackUri } : {})
     });
     if (!event) {
       return c.json({ ok: true, ignored: "empty_command" });

--- a/docs/agent-work-protocol.md
+++ b/docs/agent-work-protocol.md
@@ -1,0 +1,1441 @@
+# OpenTag Agent Work Protocol
+
+## Status
+
+Design proposal, 2026-06-24.
+
+This document extends the original OpenTag design from "open agent mentions" to
+an auditable Agent Work Protocol. It is intentionally a design document, not an
+implementation checklist. The goal is to capture product boundaries before we
+turn internal Chat-OPS lessons into public APIs.
+
+## Summary
+
+OpenTag should not become a generic project management system, a Lark Base
+automation tool, a hosted AI workspace, or a noisy multi-agent chat surface.
+Its core should stay small: normalize a tagged work request, construct bounded
+context, dispatch to an approved runner, record an auditable timeline, and
+return the right amount of information to the source workspace.
+
+The next design step is to make three ideas first-class:
+
+- **Attention Budget**: human attention is a scarce system resource.
+- **Context Packet**: executor input should be curated, bounded, and auditable.
+- **Quiet Agent Protocol**: agents should know when not to speak.
+
+Together, these shift OpenTag from a mention router to a protocol for bringing
+agents into real team workflows without flooding people, leaking context, or
+turning every workspace thread into an AI log stream.
+
+OpenTag is not another AI workspace. It is an open way to bring agents into the
+places where work already has context.
+
+## Problem
+
+The first OpenTag loop proves that a GitHub or Slack mention can become a
+dispatcher run, be claimed by a local daemon, execute with an adapter, and report
+back. That is necessary, but not sufficient for organizational use.
+
+Real teams need answers to a broader set of questions:
+
+- Who asked the agent to act?
+- What workspace context was included, and what was intentionally excluded?
+- What permissions did the run receive?
+- Which runner or executor handled it?
+- What state is the run in now?
+- When should humans be interrupted?
+- Where did the result go?
+- What can be audited later without posting it into the human thread?
+
+Internal Invoko/Lark Chat-OPS practice exposed the same failure modes from a
+different direction. The hard problems were not only "can the model do the
+task?" They were:
+
+- feedback in chat is natural, but unstructured;
+- keyword automation can create noisy or self-triggering records;
+- thread replies often correct priority, owner, or status;
+- default tool settings can silently flatten important signals;
+- "done" from an executor is not the same as organizational closure;
+- users lose trust when work finishes but the source surface still says running;
+- context needs boundaries, not infinite copy-paste;
+- agent chatter can overwhelm the very people it is supposed to help.
+
+OpenTag should absorb the cross-cutting lessons without hard-coding Invoko's
+specific Lark Base fields, SLA thresholds, or workflow states.
+
+The deeper product risk is not only noisy automation. It is adding yet another
+AI-shaped place that teams must monitor:
+
+- another inbox;
+- another permission surface;
+- another history;
+- another context migration step;
+- another stream of machine-generated attention demand.
+
+OpenTag should move in the opposite direction. It should bring simplicity into
+existing workspaces instead of laying another AI workspace on top of them.
+
+## Product Position
+
+OpenTag is the open Agent Work Protocol for bounded context, quiet callbacks,
+and auditable execution in real team workflows.
+
+That means:
+
+- It is not just an open-source Claude Tag clone.
+- It is not a hosted IDE or a general agent framework.
+- It is not an AI project management system.
+- It is a protocol layer between workspace surfaces and approved agent runners.
+- It treats agents as pluggable capabilities, not as a new destination where
+  humans must move their work.
+
+The core promise is:
+
+```text
+Tag an agent where work already happens.
+OpenTag curates the context, scopes the permission, dispatches execution,
+records the timeline, and returns only the callbacks humans need.
+```
+
+An equally important anti-promise is:
+
+```text
+Do not ask teams to move context into yet another AI workspace.
+Bring the agent to the work, not the work to the agent.
+```
+
+## Product Direction
+
+OpenTag should be developed as a **two-layer product on top of one protocol**.
+
+### Layer 1: Thin Invocation Layer
+
+This is the default surface for broad developers and teams:
+
+- invoke an agent from an existing work surface;
+- get a quick ack;
+- receive a useful final result;
+- avoid learning or monitoring a new AI workspace;
+- keep the default experience quiet and lightweight.
+
+The promise at this layer is not governance sophistication. It is:
+
+```text
+Do not make me move context.
+Let me call an agent where the work already lives.
+```
+
+### Layer 2: Governance Layer
+
+This is the value layer for deeper, higher-frequency, or more sensitive teams:
+
+- Attention Budget
+- Context Packet
+- Quiet Agent Protocol
+- approval and apply semantics
+- audit and lineage
+- router and policy controls
+- local execution boundaries
+
+The promise at this layer is:
+
+```text
+Do not let agents pollute my organization.
+Make their actions reviewable, bounded, and quiet by default.
+```
+
+### Product Consequence
+
+OpenTag should not force a choice between "simple mention utility" and
+"governed enterprise workflow." It should expose a minimal invocation path by
+default while allowing teams to opt into deeper governance semantics as usage
+intensifies.
+
+Broad developers buy:
+
+- less context copying;
+- less surface switching;
+- faster invocation.
+
+Deeper teams buy:
+
+- clearer authority boundaries;
+- safer external writes;
+- quieter callbacks;
+- stronger audit and routing guarantees.
+
+## Core Thesis
+
+OpenTag looks like tagged invocation on the surface, but the real product shape
+is three layers:
+
+- **Invocation**: humans summon an agent from an existing work surface.
+- **Governance**: the system decides what the agent may see, do, and return.
+- **Compression**: the system turns a large internal process into a small number
+  of outcomes humans actually need to consume.
+
+Many AI workspace products mostly optimize the first layer and present the
+result as chat. OpenTag should differentiate by taking the second and third
+layers seriously.
+
+## V1 Contract
+
+OpenTag v1 should make a narrow but strong promise:
+
+```text
+Given an engineering work item thread, OpenTag can invoke an approved agent,
+produce a bounded and auditable run, and return at least one artifact that
+meaningfully moves the work item forward without requiring a new AI workspace.
+```
+
+### Canonical V1 Job
+
+The primary v1 job is not "chat with an agent" and not even "analyze for its
+own sake." It is:
+
+**make progress on an engineering work item**
+
+That progress may begin as investigation, but it must end in an artifact that
+can be consumed, reviewed, approved, or executed.
+
+### V1 Minimum Acceptable Output
+
+The minimum acceptable output is:
+
+- a `SuggestedChangesSnapshot`
+- plus a `nextAction`
+
+This is the lowest useful floor. Under stronger executor, policy, and local
+runner conditions, OpenTag may go further:
+
+- root-cause note + next action
+- suggested changes snapshot + next action
+- concrete patch
+- pull request
+
+But v1 must at least produce a machine-addressable suggestion artifact that can
+push the work item forward.
+
+### V1 External Write Contract
+
+OpenTag v1 may write back to external systems, but external state mutation is
+not a universal default side effect.
+
+Default behavior:
+
+- write thread callbacks
+- attach artifacts
+- emit audit events
+
+Explicit capability behavior:
+
+- create PR
+- change status
+- change assignee
+- change priority
+- change labels or fields
+
+These stronger actions require explicit intent or policy-based approval. This is
+what keeps OpenTag from turning into an unbounded automation layer.
+
+### Capability Contract
+
+To keep "explicit capability" from becoming hand-wavy, OpenTag should maintain a
+clear capability contract for any external write that affects a system of
+record.
+
+At a minimum, each capability should answer:
+
+- what semantic action it enables;
+- whether it is read-only, callback-only, or system-mutating;
+- whether it requires explicit user intent;
+- whether it may be auto-applied by policy;
+- which adapters can resolve it;
+- which executor or runner conditions must hold.
+
+An initial capability matrix could look like this:
+
+| Capability | Default class | Requires explicit intent | May be policy-auto-applied | Typical adapter targets |
+| --- | --- | --- | --- | --- |
+| `reply_thread` | callback | No | Yes | GitHub, Slack, Lark |
+| `attach_artifact` | callback | No | Yes | GitHub, Slack, Lark |
+| `create_pr` | external write | Usually yes | Yes, if allowed | GitHub |
+| `set_status` | external write | Usually yes | Yes, if allowed | GitHub, Linear, Jira, Lark-mapped |
+| `set_assignee` | external write | Usually yes | Yes, if allowed | GitHub, Linear, Jira, Lark-mapped |
+| `set_priority` | external write | Usually yes | Yes, if allowed | Linear, Jira, Lark-mapped |
+| `set_labels` | external write | Usually yes | Yes, if allowed | GitHub, Linear, Jira, Lark-mapped |
+
+This matters because "Slack can create a PR" and "any GitHub-targeted run can
+create a PR" are not the same product claim. The capability contract should let
+OpenTag express that distinction cleanly.
+
+### V1 Interaction Contract
+
+The default interaction model is:
+
+- invoke from a primary anchor
+- receive `ack`
+- receive `final`
+- inspect `SuggestedChangesSnapshot`
+- explicitly approve or trigger the next action when governance is needed
+
+This means OpenTag v1 is not promising autonomous end-to-end work
+orchestration by default. It is promising:
+
+- invocation that respects existing work context;
+- governance that respects authority and platform truth;
+- compression that returns usable artifacts instead of chat exhaust.
+
+### V1 System Boundary
+
+OpenTag v1 is:
+
+- an agent protocol for engineering work item threads
+- model-neutral
+- executor-neutral
+- source-of-truth preserving
+- quiet by default
+
+OpenTag v1 is not:
+
+- a replacement for GitHub, Linear, Jira, or Lark Base
+- an all-purpose enterprise work management system
+- a chat room where agents and humans cohabitate by default
+- a promise that every invocation ends in direct code mutation
+
+The v1 bet is narrower and stronger:
+
+```text
+When teams already have work items and threads, OpenTag should be the cleanest
+way to bring agents into that flow without creating another place to work.
+```
+
+## Design Principles
+
+### Mention, Not Ambient Surveillance
+
+OpenTag should prefer explicit mentions, commands, or approvals over passive
+ambient monitoring. Platform recipes may support richer listening, but core
+OpenTag should not assume every workspace message is a potential task.
+
+### Agent As Capability, Not Place
+
+The agent should behave like a pluggable capability inside Slack, GitHub, Lark,
+Linear, Notion, Jira, or local workflows. It should not require the team to
+adopt a new AI-shaped place as the center of collaboration.
+
+### Human Attention Is A Scarce Resource
+
+Human-facing callbacks must justify why they enter the source thread. Full run
+details belong in audit by default. The main thread should receive outcomes,
+blockers, approvals, and high-value progress only.
+
+### Context Should Be Curated, Not Dumped
+
+Raw workspace material should not be blindly passed to the executor. OpenTag
+should build a Context Packet that captures intent, relevant facts, source
+links, permission scope, risks, exclusions, and must-preserve original material.
+
+### Silence Is A Product Feature
+
+Agents should not compete to speak. Router-level coordination, audit-only
+intermediate events, and quiet defaults should prevent agent-to-agent chatter
+from leaking into human threads.
+
+### Model Neutrality Is A Stability Layer
+
+OpenTag should not treat Claude, Codex, Hermes, OpenClaw, or any future agent
+runtime as the center of the product. Intelligence changes too quickly for
+teams to rebuild their workflows around one vendor. The stable layer should be
+invocation, governance, callbacks, and audit, not the current best model.
+
+### Result Artifacts Over Conversation Exhaust
+
+The most valuable output is usually not a long conversational transcript. It is
+an artifact humans can consume, verify, hand off, or approve: a PR, patch,
+summary, risk note, test result, follow-up task, or decision record.
+
+### Audit Everything, Interrupt Rarely
+
+OpenTag should record enough to reconstruct what happened. That does not mean
+every event should be posted back to GitHub, Slack, Lark, or another workspace.
+
+### Core Stays Protocol-Shaped
+
+Invoko/Lark workflows are a rich source of design evidence, but OpenTag core
+should only include primitives that remain meaningful across providers,
+executors, and organizations.
+
+## Attention Budget
+
+Attention Budget treats human attention as a system resource. It turns callbacks
+from "messages the bot feels like posting" into a policy-governed stream.
+
+### Callback Layers
+
+OpenTag callbacks should be grouped into four layers:
+
+| Layer | Purpose | Human-facing default |
+| --- | --- | --- |
+| `ack` | Confirm the request was received and queued or rejected | Yes, short |
+| `progress` | Report long-running milestones, blockers, approvals, or risk changes | Conditional |
+| `final` | Summarize conclusion, changes, verification, artifacts, and next action | Yes |
+| `audit` | Record full detail for later inspection | No |
+
+The important distinction is not "short vs long." It is whether the event
+deserves human attention now.
+
+### Event Visibility
+
+Core run events should eventually distinguish visibility from event type:
+
+```ts
+type RunEventVisibility = "human" | "audit" | "debug";
+
+type RunEventImportance = "low" | "normal" | "high" | "blocking";
+```
+
+Examples:
+
+- `run.created` can be `audit`.
+- `callback.acknowledged` can be `human`.
+- `executor.log_chunk` should usually be `debug` or `audit`.
+- `run.waiting_for_permission` should be `human` and `blocking`.
+- `verification.failed` may be `human` if it changes the next action.
+
+This lets adapters decide how to render events without losing the core policy
+intent.
+
+### Callback Defaults
+
+For v0.x, the default policy should be conservative:
+
+- Always send one ack when a run is accepted.
+- Do not stream routine internal steps into the human thread.
+- Send progress only for long tasks, approval waits, blockers, or material phase
+  changes.
+- Send one final result with conclusion, verification, artifacts, and next
+  action.
+- Keep tool logs, full prompts, internal planning, and agent-to-agent chatter in
+  audit/debug channels.
+
+This is more than terseness. It is an explicit attention policy: agents should
+earn human attention instead of assuming they deserve it whenever they can speak.
+
+## Context Packet
+
+Context Packet, or Context Capsule, is the curated execution input passed from
+OpenTag to an executor. It sits between raw workspace events and executor
+prompts.
+
+### Why It Exists
+
+Without a Context Packet, systems tend to dump everything into the executor:
+
+- full Slack or Lark threads;
+- GitHub issue bodies and all comments;
+- entire PR diffs;
+- CI logs;
+- unrelated bot messages;
+- stale prior attempts;
+- sensitive information that was visible to the platform but not necessary for
+  the task.
+
+This creates context explosion, context pollution, privacy risk, and weaker
+executor behavior. A Context Packet is the boundary object that makes execution
+input reviewable.
+
+### Packet Contents
+
+A mature packet should be able to represent:
+
+| Field | Meaning |
+| --- | --- |
+| `intent` | The requested action and concise task summary |
+| `facts` | Relevant facts extracted from source materials |
+| `sourceLinks` | Pointers back to original messages, issues, diffs, logs, docs |
+| `permissionScope` | What the executor may read, write, comment, create, or access |
+| `risks` | Known product, code, privacy, security, or compatibility risks |
+| `exclusions` | Explicit non-goals and boundaries |
+| `mustPreserve` | Original user text, logs, or claims that must not be paraphrased away |
+| `redactions` | Material withheld from the executor and why |
+
+The packet should preserve traceability. A summarized fact is less useful if we
+cannot recover its source.
+
+### Minimal V0 Shape
+
+We should not overbuild this before multiple adapters need it. A practical first
+step is:
+
+```ts
+type ContextPacket = {
+  summary: string;
+  sourcePointers: ContextPointer[];
+  facts?: Array<{ text: string; sourceUri?: string }>;
+  risks?: string[];
+  exclusions?: string[];
+};
+```
+
+The runner can receive both:
+
+- raw `context` pointers from the OpenTag event;
+- the generated `contextPacket` as the curated executor input.
+
+Over time, packet generation can become adapter-specific or policy-driven, but
+core should define the concept early.
+
+The Context Packet should be understood as context hygiene, not just context
+formatting. Its job is not to squeeze more raw material into the prompt. Its
+job is to decide what deserves to enter the run at all.
+
+### Assembly Pipeline
+
+OpenTag should define a packet assembly pipeline before packet structure becomes
+part of the schema. Otherwise adapters will all construct packets differently
+and the product will lose one of its strongest protocol claims.
+
+A practical v1 assembly pipeline is:
+
+1. **Collect**
+   - gather raw context pointers from the source surface
+   - gather any linked work-item sources such as issue, PR, CI log, or file
+   - gather prior OpenTag artifacts that are still relevant
+
+2. **Classify**
+   - mark each source as primary evidence, supporting context, background noise,
+     or sensitive material
+   - distinguish human-authored source material from machine-authored source
+     material
+
+3. **Filter**
+   - exclude sources that are irrelevant to the current intent
+   - exclude sources blocked by policy or permission scope
+   - exclude stale or superseded artifacts unless explicitly requested
+
+4. **Preserve**
+   - keep exact excerpts for must-preserve source material
+   - retain source links for every summarized fact
+
+5. **Summarize**
+   - compress large logs, long threads, and diffs into task-relevant facts
+   - preserve redaction boundaries and uncertainty notes
+
+6. **Budget**
+   - enforce context size limits
+   - prefer dropping low-signal background before dropping must-preserve material
+
+7. **Emit**
+   - produce the `ContextPacket`
+   - record assembly metadata in audit for traceability
+
+This pipeline should eventually be adapter-aware, but the stage vocabulary
+should remain stable across providers.
+
+## Quiet Agent Protocol
+
+Quiet Agent Protocol defines when agents should not speak.
+
+This is deliberately different from Attention Budget:
+
+- Attention Budget decides which events deserve human attention.
+- Quiet Agent Protocol constrains agents from entering human threads by default.
+
+### Default Rules
+
+OpenTag should bias toward these rules:
+
+- If an agent was not tagged, routed, approved, or explicitly configured, it does
+  not reply in the human thread.
+- If multiple agents could respond, a router or dispatcher speaks first; agents
+  do not all post competing messages.
+- Low-confidence suggestions should not masquerade as authoritative thread
+  replies.
+- Agent-to-agent coordination goes to audit/debug channels unless humans asked
+  to observe it.
+- The human thread receives outcomes, blockers, approvals, and final summaries,
+  not every intermediate token.
+
+### Protocol Implications
+
+Quiet behavior should affect API and product design:
+
+- callback sinks need an audit-only path;
+- run events need visibility metadata;
+- executors should be instructed to separate final user-facing output from
+  internal logs;
+- multi-agent routing should produce one human-facing voice by default;
+- adapters should avoid echoing every runner status event into source threads.
+
+## Result Artifact First
+
+OpenTag should prefer structured outcome artifacts over conversational output.
+
+Examples of first-class artifacts:
+
+- pull request;
+- patch;
+- verification summary;
+- incident triage note;
+- risk memo;
+- follow-up task;
+- audit trail;
+- decision record.
+
+This principle matters because most collaborative work is handed off, reviewed,
+approved, retried, or summarized later. A stream of assistant chatter is weak
+handoff material. An artifact with provenance is stronger.
+
+At the protocol level, this suggests that `OpenTagRunResult` should stay focused
+on decision-grade outputs instead of becoming a transcript bucket.
+
+### Artifact Taxonomy
+
+To make "artifact-first" concrete, OpenTag should define a small v1 taxonomy of
+ result objects. The goal is not exhaustive ontology design; it is to ensure
+ different executors return compatible artifacts.
+
+Suggested v1 artifact classes:
+
+| Artifact | Purpose | Can trigger next action | Can be approved/applied |
+| --- | --- | --- | --- |
+| `root_cause_note` | explain what happened and why | Yes | No |
+| `suggested_changes_snapshot` | propose semantic mutations | Yes | Yes |
+| `verification_summary` | summarize tests, checks, and evidence | Yes | No |
+| `patch` | concrete code or config diff | Yes | Sometimes |
+| `pull_request` | reviewable external artifact in GitHub | Yes | No |
+| `risk_note` | surface known uncertainty or rollout risk | Yes | No |
+| `follow_up_task` | create or link next task | Yes | No |
+
+This taxonomy should anchor:
+
+- what can appear in `OpenTagRunResult`;
+- what counts as the minimum useful output;
+- which artifact types can generate `nextAction`;
+- which artifact types participate in approval and apply flows.
+
+## Agent-To-Agent Workbench Is Not Chat
+
+If OpenTag later supports multi-agent coordination, humans should not be forced
+to watch agents imitate an IM thread.
+
+Agent-to-agent coordination is better represented as:
+
+- task graph;
+- contracts and scoped sub-assignments;
+- artifact exchange;
+- state machine transitions;
+- trace timeline;
+- conflict or escalation points.
+
+The human-facing interface should optimize for oversight:
+
+- which subtasks exist;
+- which runner or agent handled each step;
+- what artifacts were produced;
+- where evidence comes from;
+- where human decisions are needed.
+
+This is compatible with audit logging, but it avoids confusing "observability"
+with "show every intermediate sentence."
+
+## Core Protocol Primitives
+
+The following primitives are core candidates because they remain meaningful
+across GitHub, Slack, Lark, CLI, webhook, and future workspace surfaces.
+
+### Canonical V1 Scope
+
+OpenTag v1 should narrow its first serious protocol object to the
+**engineering work item thread**.
+
+That means:
+
+- the canonical work item lives in an external system of record such as GitHub,
+  Linear, Jira, or a mapped Lark object;
+- the first-class conversational surface is the thread attached to that work
+  item;
+- OpenTag enhances the thread with invocation, governance, compression,
+  callbacks, and audit;
+- OpenTag does not become the source of truth for the work item itself.
+
+This is intentionally narrower than "all collaborative work." It matches the
+current executor, artifact, verification, and local-runner strengths without
+pretending that v1 is already a universal work protocol.
+
+### `OpenTagEvent`
+
+Represents the normalized source event:
+
+- source provider;
+- source event id;
+- actor;
+- target agent;
+- command;
+- raw context pointers;
+- permission grants;
+- callback route;
+- metadata.
+
+### `ContextPointer`
+
+Points to source material without implying the whole source should be copied
+into the executor.
+
+Future kinds should include platform-specific sources without making core depend
+on platform SDKs:
+
+```text
+github.repo
+github.issue
+github.pull_request
+github.comment
+github.commit
+slack.channel
+slack.thread
+slack.message
+lark.chat
+lark.thread
+lark.message
+lark.doc
+lark.base
+lark.base_record
+file
+url
+text
+```
+
+Adding the kinds does not mean every adapter must implement them immediately.
+
+### `PermissionGrant`
+
+Scopes what a run may do. Grants should stay narrow and explain their reason.
+
+The current model already supports the right direction:
+
+```text
+repo:read
+repo:write
+issue:comment
+chat:postMessage
+pr:create
+pr:update
+runner:local
+network:restricted
+```
+
+Future grants may need provider-specific extensions, but core should preserve
+the small-reversible-permissions principle.
+
+### `CallbackRoute`
+
+Defines where OpenTag may respond. The callback route is not just a transport
+detail; it is the promise that work returns to the original context.
+
+### `OpenTagRun`
+
+Tracks lifecycle state. The current states are enough for the first loop:
+
+```text
+queued
+assigned
+running
+needs_approval
+succeeded
+failed
+cancelled
+```
+
+Before adding many organization-specific states, prefer run events for detail.
+For example, `waiting_for_input`, `waiting_for_permission`, or
+`callback_failed` can start as event types before becoming top-level statuses.
+
+### `RunEvent`
+
+RunEvent is the natural home for the Agent Work Protocol expansion:
+
+- lifecycle transition;
+- progress checkpoint;
+- permission wait;
+- context packet generation;
+- callback delivery;
+- verification result;
+- executor log reference;
+- audit/debug-only detail.
+
+RunEvent should eventually support:
+
+- event type;
+- timestamp;
+- visibility;
+- importance;
+- message or structured payload;
+- source pointer, when applicable.
+
+### `OpenTagRunResult`
+
+The final result should optimize for decision-making:
+
+- conclusion;
+- summary;
+- changed files;
+- created PR or artifact URLs;
+- verification commands and outcomes;
+- next action.
+
+It should not be a raw transcript of executor output.
+
+This is where "result artifact first" becomes concrete. The result object should
+privilege what humans can review and reuse, not what the executor happened to
+say along the way.
+
+## Canonical V1 Object Model
+
+The first durable object in OpenTag should not be the run. It should be the
+combination of:
+
+- **`workItemReference`**: the canonical external work item in the system of
+  record;
+- **`conversationAnchor`**: the specific thread or comment context where this
+  invocation lives and where callbacks return by default.
+
+`run` is then an execution instance attached to that pair.
+
+### Why The Durable Object Is Not `run`
+
+Runs are transient attempts. The longer-lived object is the threaded work
+conversation around a canonical work item:
+
+- the same work item may produce many runs over time;
+- a conversation anchor may generate proposals, approvals, reruns, and apply
+  actions;
+- audit, supersession, and approvals need a stable frame that outlives any one
+  executor attempt.
+
+### V1 Shape
+
+In protocol terms, the model should feel closer to:
+
+```ts
+type WorkThread = {
+  workItemReference: WorkItemReference;
+  primaryAnchor: ConversationAnchor;
+  secondaryAnchors?: ConversationAnchor[];
+};
+
+type OpenTagRun = {
+  id: string;
+  thread: WorkThreadRef;
+  parentRunId?: string;
+  triggeredByAction?: ActionHint;
+  sourceProposalId?: string;
+  sourceApplyPlanId?: string;
+  status: RunStatus;
+  result?: OpenTagRunResult;
+};
+```
+
+The exact schema can wait, but the object boundaries should not.
+
+### `WorkItemReference`
+
+The canonical work item is external. OpenTag should not create a shadow task
+model in core.
+
+Examples:
+
+- GitHub issue
+- Linear ticket
+- Jira issue
+- mapped Lark work record
+
+The implication is strong:
+
+**OpenTag is the agent protocol attached to a work item thread, not the source
+of truth for the work item.**
+
+### `ConversationAnchor`
+
+The anchor identifies where invocation and default callbacks occur.
+
+Examples:
+
+- GitHub issue comment thread
+- PR review comment thread
+- Slack thread
+- Lark thread
+
+V1 should maintain:
+
+- one **canonical work item**;
+- one **primary anchor**;
+- zero or more **secondary anchors**.
+
+### Primary vs Secondary Anchors
+
+The primary anchor is the control plane by default:
+
+- default callbacks return here;
+- default approvals happen here;
+- default proposal lineage is presented here.
+
+Secondary anchors exist as linked context or optional callback routes. They are
+not equal peers in v1.
+
+By default:
+
+- secondary anchors do not receive callbacks unless explicitly subscribed or
+  selected by policy;
+- secondary anchors are read surfaces, not approval surfaces;
+- a secondary anchor only becomes a control plane if policy explicitly grants it
+  that role.
+
+This protects both the attention model and the single-anchor narrative.
+
+## Proposal And Mutation Model
+
+V1 should not treat a proposal as a sentence in a thread. It should be a
+durable protocol object.
+
+### `SuggestedChangesSnapshot`
+
+Suggested changes should be represented as an immutable, addressable snapshot.
+
+Key properties:
+
+- it has a stable `proposal_id`;
+- it is immutable once created;
+- it can be approved, superseded, referenced, and audited later;
+- it is not defined as "the latest suggestion in the thread."
+
+This prevents approval from becoming ambiguous when multiple runs happen under
+the same thread.
+
+### Mutation Language
+
+The core payload of a proposal should be **semantic mutation intents**, not raw
+platform patches.
+
+Examples:
+
+- `set_priority(P1)`
+- `set_assignee(Alice)`
+- `transition_status(in_progress)`
+- `add_label(bug)`
+- `remove_label(needs-triage)`
+- `request_review(team-security)`
+- `link_artifact(pr_url)`
+
+Adapter-specific patches are still important, but they are derived execution
+plans, not the protocol body.
+
+This keeps the protocol stable while allowing GitHub, Linear, Jira, and mapped
+Lark systems to resolve the same semantic suggestion differently.
+
+### Canonical Mutation Domains
+
+To reason about supersession and approvals, core should define a small canonical
+domain vocabulary. A practical v1 set is:
+
+- `status`
+- `assignee`
+- `priority`
+- `labels`
+- `schedule`
+- `review`
+- `artifact_links`
+
+Adapters may extend this when necessary, but core should not start from a
+field-by-field mirror of every platform.
+
+### Domain-Scoped Supersession
+
+Supersession should default to the **mutation domain**, not the whole proposal.
+
+If proposal A contains:
+
+- `set_priority(P1)`
+- `set_assignee(Alice)`
+
+and proposal B later contains:
+
+- `set_priority(P0)`
+
+then B should supersede A only in the `priority` domain. The old assignment
+intent should not be thrown away just because a later run refined a different
+dimension of the work item.
+
+So:
+
+- proposal snapshots remain immutable bundles;
+- current actionability is computed per domain;
+- the "current proposal lineage" is really a domain-scoped lineage.
+
+### Proposal Preconditions
+
+A proposal should never be treated as timeless. It is valid only with respect
+to the world it observed.
+
+Each snapshot should carry preconditions such as:
+
+- external work item state at proposal time;
+- revision, version, `updated_at`, or equivalent freshness markers when the
+  adapter can provide them;
+- anchor-level or thread-level observations that materially shaped the proposal;
+- supersession relationships.
+
+This is what allows the system to mark a proposal as `stale` or `conflicted`
+instead of blindly applying it later.
+
+## Approval Model
+
+Approval should be a first-class protocol concern, not an implicit effect of
+someone typing "apply" in any visible place.
+
+### Approval Authority
+
+Approval authority should be defined as:
+
+```text
+platform capability ∩ OpenTag policy
+```
+
+That means:
+
+- platform write permissions are necessary but not sufficient;
+- OpenTag policy decides who may approve which domains;
+- authority may differ for `priority`, `assignee`, `status`, `labels`, and
+  future domains.
+
+This prevents "whoever can comment can approve" from becoming the accidental
+security model.
+
+### Approval Granularity
+
+A proposal is an immutable bundle, but approvals should support sub-selection.
+
+That means:
+
+- each intent should have a stable `intent_id`;
+- a human may approve all intents;
+- a human may approve only a subset of intents;
+- a human may reject the remainder.
+
+This should not mutate the original proposal snapshot. Instead, approval should
+create a separate decision object.
+
+### `ApprovalDecision`
+
+The conceptual shape is:
+
+```ts
+type ApprovalDecision = {
+  id: string;
+  proposalId: string;
+  approvedIntentIds: string[];
+  rejectedIntentIds?: string[];
+  approvedBy: ActorIdentity;
+  approvedAt: string;
+  scope: "manual" | "policy";
+};
+```
+
+The exact names can change, but the separateness should not. Proposal and
+approval are different objects.
+
+### Default Approval Path
+
+OpenTag should support many approval surfaces eventually, but the default should
+stay simple and portable:
+
+- a proposal appears in the primary anchor;
+- it includes both human-readable explanation and machine-readable intent ids;
+- a second explicit command approves it, such as `apply suggested changes`.
+
+Richer approval UI such as buttons or auto-approval policies can be layered on
+top later.
+
+## Apply Model
+
+Applying suggested changes should also become a durable object rather than a
+thread side effect.
+
+### `ApplyPlan`
+
+An apply plan is derived from:
+
+- a proposal snapshot;
+- an approval decision;
+- selected intent ids;
+- an adapter-specific execution resolution.
+
+Conceptually:
+
+```ts
+type ApplyPlan = {
+  id: string;
+  proposalId: string;
+  approvalDecisionId: string;
+  selectedIntentIds: string[];
+  adapterPlan?: unknown;
+};
+```
+
+Again, the exact schema can wait. The object boundary matters now.
+
+### Default Apply Semantics
+
+V1 should not pretend to have global transactionality across external systems.
+
+The default behavior should be:
+
+1. **Preflight**
+   - validate authority
+   - validate current permissions
+   - validate adapter capability
+   - validate proposal preconditions against the current world
+
+2. **Execution**
+   - run the adapter-specific patch plan
+
+3. **Per-intent outcome**
+   - `applied`
+   - `skipped`
+   - `failed`
+   - `stale`
+   - `unsupported`
+
+Only adapters that can genuinely provide transactional guarantees should be
+allowed to declare atomic apply behavior.
+
+This is intentionally "preflight first, then per-intent outcome," not fake
+atomicity.
+
+## Next Action And Run Lineage
+
+OpenTag v1 should guarantee that a run ends with something that can move the
+work item forward. The minimum acceptable result is:
+
+- `SuggestedChangesSnapshot`
+- plus `nextAction`
+
+### `nextAction`
+
+`nextAction` should not be just prose. It should have two layers:
+
+- a human-readable summary;
+- a machine-readable action hint.
+
+Examples:
+
+- `apply_suggested_changes`
+- `generate_patch`
+- `request_human_decision`
+- `link_to_work_item`
+- `request_review`
+
+This allows OpenTag to stay artifact-first without turning every next step into
+manual interpretation.
+
+### Next Actions Create New Runs
+
+OpenTag should avoid hidden long transactions.
+
+So the default rule should be:
+
+- a run ends when it produces its result;
+- executing a `nextAction` creates a **new run**;
+- the new run carries lineage back to the previous run, proposal, and apply
+  plan.
+
+This keeps:
+
+- permissions explicit;
+- world-state checks fresh;
+- audit timelines understandable;
+- continuation from becoming an unbounded hidden session.
+
+### Run Lineage
+
+Useful lineage references include:
+
+- `parent_run_id`
+- `triggered_by_action`
+- `source_proposal_id`
+- `source_apply_plan_id`
+
+Lineage is what makes a chain of small runs feel like one coherent piece of
+work without collapsing them into one giant mutable transaction.
+
+## Bootstrapping Without A Canonical Work Item
+
+V1 should not treat every tagged conversation as permission to silently create a
+new task system entry.
+
+If there is no canonical work item yet, OpenTag should default to:
+
+- suggesting a link to an existing work item;
+- proposing creation of a canonical work item in an external system;
+- or following a recipe/policy that explicitly allows automatic creation.
+
+What it should not do by default:
+
+- create an internal shadow work item as source of truth;
+- silently convert every tagged thread into a new external issue or ticket.
+
+This keeps the "not another workspace" promise honest.
+
+## Layering
+
+OpenTag should use layered ownership to prevent internal practice from hardening into
+over-specific public APIs.
+
+### 1. Core
+
+Core owns stable protocol primitives:
+
+- event;
+- command;
+- context pointer;
+- context packet;
+- permission grant;
+- callback route;
+- run state;
+- run event / timeline;
+- runner binding;
+- executor result.
+
+Rule: if the concept still matters after removing Invoko, Lark, GitHub, and any
+single executor, it may belong in core.
+
+### 2. Official Adapters
+
+Adapters connect workspace surfaces:
+
+- GitHub issue, PR, comment, diff, CI, callback comments;
+- Slack app mentions, thread keys, channel bindings, thread replies;
+- Lark messages, threads, docs, Base links, callback replies;
+- webhooks and CLI events.
+
+Adapters normalize platform shapes into core protocol. They should not define a
+team's project management method.
+
+### 3. Recipes
+
+Recipes package opinionated workflows:
+
+- GitHub PR review agent;
+- Lark Chat-OPS feedback triage;
+- support ticket investigation;
+- bug reproduction handoff;
+- release readiness review.
+
+Recipes can define how to interpret platform-specific replies, fields, or
+commands, but they should be optional.
+
+### 4. Policies
+
+Policies govern organization-specific behavior:
+
+- stale run reminders;
+- needs-acceptance flow;
+- callback verbosity;
+- approval thresholds;
+- context redaction;
+- Base sync field mapping;
+- quiet-agent defaults.
+
+Policies should be configuration or plugin territory, not core assumptions.
+
+### Policy Resolution Order
+
+Policies need a deterministic resolution model or the governance layer will
+collapse into surprising behavior.
+
+The default precedence should be:
+
+1. organization default
+2. adapter / surface default
+3. work context owner container policy
+   - repo
+   - project
+   - space
+4. optional work-item override
+5. optional primary-anchor override
+
+Conflict handling should follow two principles:
+
+- more specific scope beats less specific scope;
+- explicit deny beats implicit allow.
+
+This gives OpenTag a stable answer to questions like:
+
+- can this repo auto-create PRs?
+- can this project auto-apply status transitions?
+- can this secondary anchor approve anything?
+- does this work item require manual approval regardless of higher defaults?
+
+If we do not specify this now, "policy" will devolve into implementation
+branches rather than protocol behavior.
+
+### 5. Routers
+
+Routers decide which executor, runner, or agent path should handle a run.
+
+Routing may eventually consider:
+
+- task type;
+- repo policy;
+- privacy constraints;
+- cost and latency;
+- historical executor performance;
+- whether local execution is mandatory.
+
+Router behavior should not be hard-wired into a single model preference. It is
+the system expression of model neutrality.
+
+## What Should Not Enter Core
+
+The following should stay out of OpenTag core:
+
+- Invoko-specific fields such as "具体问题", "谁接手了", "滞后时间", or "解决人备注".
+- Fixed workflow states such as "待处理", "处理中", "已解决待验收", "已处理待发版", "Archive".
+- Fixed `P0` / `P1` / `P2` meanings or SLA durations.
+- Morning report behavior.
+- Lark Base as mandatory storage.
+- Passive monitoring of every group message.
+- An agent chat room as the canonical place where work must move in order to
+  involve AI.
+- A complex management dashboard before the protocol has proven usage.
+
+OpenTag may support all of these through adapters, recipes, and policies. It
+should not be defined by them.
+
+## Proposed Roadmap
+
+## Success Metrics
+
+OpenTag's product claim is not just "agent mentions work." It is that they work
+with less context migration, less thread pollution, and more actionable output.
+
+A useful v1 metric set should include:
+
+| Metric | Why it matters |
+| --- | --- |
+| `time_to_first_useful_artifact` | Measures whether OpenTag helps users make progress quickly |
+| `thread_noise_ratio` | Human-facing callback count vs audit/debug event count; validates Attention Budget |
+| `artifact_acceptance_rate` | Measures whether `SuggestedChangesSnapshot` and related outputs are actually useful |
+| `context_reuse_rate` | Measures whether users are reducing manual copy-paste and re-explanation |
+| `external_write_approval_rate` | Measures whether explicit capability flows are understandable and trusted |
+| `stale_proposal_rate` | Measures whether proposals remain actionable long enough to be useful |
+
+These are product metrics, not just ops metrics. They tell us whether OpenTag
+is actually reducing coordination drag.
+
+### v0.2: Run Governance
+
+Goal: make a run understandable without flooding the source thread.
+
+- Add or document a first-class run event timeline.
+- Add event visibility and importance concepts.
+- Standardize ack/progress/final/audit callback layers.
+- Improve callback delivery auditability.
+- Introduce the minimal Context Packet shape.
+- Keep source threads quiet by default.
+
+### v0.3: Lark As A First-Class Adapter
+
+Goal: support China-native workspace surfaces without baking Lark workflows into
+core.
+
+- Normalize Lark message mentions into OpenTag events.
+- Support Lark thread callback routes.
+- Add Lark context pointer kinds.
+- Treat Lark docs and Base records as pointers first, not mandatory storage.
+- Keep Base sync as optional recipe/policy behavior.
+
+### v0.4: Chat-OPS Recipes
+
+Goal: show the organizational pattern without making it universal.
+
+- Add `examples/lark-chatops-feedback`.
+- Demonstrate optional Base sync.
+- Demonstrate thread correction as recipe logic.
+- Demonstrate quiet callbacks and audit-only details.
+- Demonstrate stale-run reminder as policy.
+
+### v0.5: Executor Routing And Oversight
+
+Goal: make model neutrality operational instead of rhetorical.
+
+- Add router interfaces for executor selection.
+- Support policy-driven local vs hosted execution.
+- Make audit and artifact views good enough for human oversight.
+- Keep multi-agent coordination out of the human thread by default.
+
+### v0.6: Policy And Adapter Ecosystem
+
+Goal: let teams bring their own surfaces, executors, and governance rules.
+
+- Executor adapter SDK.
+- Workspace adapter SDK.
+- Policy plugin interface.
+- Context packet builder interface.
+- Redaction hook interface.
+- Hosted and self-hosted deployment guides.
+
+## Open Questions
+
+- Should `ContextPacket` become a required field on `OpenTagRun`, or remain an
+  optional artifact generated by dispatcher/adapter policy?
+- Should event `visibility` and `importance` live in core schema immediately, or
+  first be documented as callback sink behavior?
+- Which Lark primitives should be supported first: message mention, thread
+  callback, doc context, or Base record context?
+- How should OpenTag expose audit logs: API only, CLI rendering, or a small web
+  viewer?
+- Should `waiting_for_input` and `waiting_for_permission` become statuses, or
+  remain run events until workflows stabilize?
+- How do we keep context redaction explainable without leaking the redacted
+  content into audit logs?
+- Should routing be a dispatcher concern, a runner concern, or a separate policy
+  layer with explainable output?
+- What is the smallest useful artifact vocabulary for `OpenTagRunResult` before
+  we overfit to coding workflows?
+
+## Implementation Notes
+
+The safest path is incremental:
+
+1. Document the protocol concepts before changing schemas.
+2. Add non-breaking optional fields where existing types already have extension
+   points.
+3. Prefer run events over new top-level statuses until several workflows need
+   the same state.
+4. Build the Lark path as an adapter plus recipe, not core behavior.
+5. Treat UI/dashboard ideas as downstream consumers of timeline and audit APIs.
+6. Keep the protocol optimized for invocation, governance, and compression, not
+   for simulating agent chat as a primary product surface.
+
+## Decision Frame
+
+When evaluating a feature, ask:
+
+1. Is this cross-platform and executor-neutral? If yes, consider core.
+2. Is this provider-specific? Put it in an adapter.
+3. Is this an opinionated organizational method? Put it in a recipe or policy.
+4. Is this only true for Invoko's current workflow? Keep it in an example.
+
+The guiding sentence:
+
+```text
+Turn pain into narrative, commonality into protocol, platform differences into
+adapters, organizational methods into recipes, and governance rules into policy.
+```
+
+An even shorter version:
+
+```text
+Invocation. Governance. Compression.
+```

--- a/docs/real-integration-smoke-test.md
+++ b/docs/real-integration-smoke-test.md
@@ -8,6 +8,8 @@ Use this document when you want to prove that OpenTag works beyond local unit te
 - real Slack Events API delivery
 - real dispatcher and daemon execution
 - real callback messages posted back to the source thread
+- real local Claude Code execution
+- protocol metrics that show callback noise and artifact flow
 
 ## Goal
 
@@ -17,6 +19,7 @@ A smoke test is complete when all of these are true:
 2. The dispatcher creates a run and records audit events.
 3. The local daemon claims the run and executes the configured executor.
 4. The final result is posted back to the original GitHub thread or Slack thread.
+5. Metrics show low human callback noise relative to audit events.
 
 ## Shared Local Prerequisites
 
@@ -93,6 +96,38 @@ OPENTAG_CLAUDE_PERMISSION_MODE=acceptEdits
 `OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true` is supported for explicitly sandboxed environments, but it is not enabled by default.
 
 ## GitHub Smoke Test
+
+### GitHub CLI-Assisted Smoke Test
+
+The fastest real GitHub test does not require a GitHub App webhook. It uses the active `gh` CLI login to create a GitHub-shaped run directly in the dispatcher, then lets `opentagd` execute locally and callback to a real issue.
+
+Use an existing issue:
+
+```bash
+OPENTAG_GH_REPO=amplifthq/opentag-test \
+OPENTAG_WORKSPACE_PATH=/absolute/path/to/clean/opentag-test \
+OPENTAG_GH_TEST_ISSUE=1 \
+scripts/dev/run-gh-claude-local-test.sh
+```
+
+Or create a temporary issue:
+
+```bash
+OPENTAG_GH_REPO=amplifthq/opentag-test \
+OPENTAG_WORKSPACE_PATH=/absolute/path/to/clean/opentag-test \
+OPENTAG_GH_CREATE_ISSUE=true \
+scripts/dev/run-gh-claude-local-test.sh
+```
+
+Set `OPENTAG_GH_CREATE_PR=true` when you want the daemon to commit executor-produced file changes, push the run branch, and create a pull request. Without that flag, the smoke test validates callback delivery and local execution without opening a PR.
+
+This path has been validated with:
+
+```text
+GitHub issue -> dispatcher -> opentagd -> local Claude Code -> commit branch -> push -> PR -> GitHub callback
+```
+
+GitHub callbacks update one comment per run in place. The first callback creates the run comment, and later progress/final callbacks patch that same comment instead of creating a new issue comment for every state change.
 
 ### GitHub App Setup
 
@@ -192,6 +227,8 @@ Expected result:
   - progress
   - final result
 
+For GitHub App webhook testing, keep `OPENTAG_DISPATCHER_OWNS_CALLBACKS=true` on the Probot app so the dispatcher owns the run comment lifecycle.
+
 ### GitHub Failure Modes We Hit
 
 - **Probot setup mode**
@@ -203,7 +240,35 @@ Expected result:
 - **App installed but repo missing**
   The App installation must explicitly include the repository you are testing.
 
+- **PR push failed because no commit existed**
+  Local executors leave file changes in the run branch. `opentagd` now stages and commits changed files before pushing a run branch for PR creation.
+
 ## Slack Smoke Test
+
+### Slack API-Assisted Smoke Test
+
+The fastest real Slack test does not require a public Events API tunnel. It uses the configured Slack bot token to post a seed message in the bound channel, then creates a Slack-shaped OpenTag run against that thread.
+
+```bash
+OPENTAG_ENV_FILE=/absolute/path/to/.env.slack-test \
+scripts/dev/run-slack-claude-local-test.sh
+```
+
+By default this script reads `OPENTAG_CONFIG_PATH` from the env file, creates a temporary clean checkout for the configured repo, executes local Claude Code, and prints the run metrics plus Slack thread replies.
+
+This path has been validated with:
+
+```text
+Slack thread -> dispatcher -> opentagd -> local Claude Code -> Slack final callback + metrics
+```
+
+Expected Slack thread shape:
+
+- original user/bot seed message
+- OpenTag acknowledgement
+- OpenTag final result
+
+Routine progress stays audit-only by default, so it should not produce additional Slack thread replies.
 
 ### Slack App Setup
 
@@ -292,8 +357,9 @@ Expected result:
 - daemon claims and executes the run
 - the Slack thread receives:
   - acknowledgement
-  - progress
   - final result
+
+Routine progress should be visible in dispatcher audit events, not as Slack replies.
 
 ### Slack Failure Modes We Hit
 
@@ -311,6 +377,28 @@ Expected result:
 
 - **Replies show up in the thread, not the main channel stream**
   Slack callback delivery uses `thread_ts`, so the most reliable place to check for bot replies is the message thread you mentioned the bot in.
+
+## Protocol Metrics Checks
+
+Every real smoke test should inspect run metrics:
+
+```bash
+curl -H "authorization: Bearer $OPENTAG_PAIRING_TOKEN" \
+  http://localhost:3031/v1/runs/<run-id>/metrics
+```
+
+Important fields:
+
+- `humanCallbackCount`
+- `auditEventCount`
+- `threadNoiseRatio`
+- `suggestedChangesCount`
+- `approvalDecisionCount`
+- `applyPlanCount`
+- `childRunCount`
+- `applyOutcomeCounts`
+
+For Slack, `humanCallbackCount` should normally be `2` for a completed run: acknowledgement plus final. A low `threadNoiseRatio` means OpenTag is recording detail in audit without flooding the human thread.
 
 ## Debugging Order
 
@@ -351,3 +439,5 @@ scripts/dev/start-github-slack-claude-test.sh
 ```
 
 The config file should bind the target repository and Slack channel, and the repository binding should use `"defaultExecutor": "claude-code"`.
+
+Use `scripts/dev/run-gh-claude-local-test.sh` and `scripts/dev/run-slack-claude-local-test.sh` first. They are easier to debug because they do not require public webhook tunnels. Use the combined stack once both assisted paths work.

--- a/docs/real-integration-smoke-test.md
+++ b/docs/real-integration-smoke-test.md
@@ -65,7 +65,32 @@ Create a local runner config that binds the repository you want to test:
 }
 ```
 
-Start with `"defaultExecutor": "echo"` until the end-to-end callback loop is proven. Switch to `"codex"` only after GitHub or Slack replies are working.
+Start with `"defaultExecutor": "echo"` until the end-to-end callback loop is proven. Switch to `"codex"` or `"claude-code"` only after GitHub or Slack replies are working.
+
+For Claude Code, set the repository binding to:
+
+```json
+"defaultExecutor": "claude-code"
+```
+
+Optional daemon-level Claude Code settings can be added to the same config:
+
+```json
+"claudeCode": {
+  "command": "claude",
+  "permissionMode": "acceptEdits"
+}
+```
+
+You can also configure these through environment variables:
+
+```bash
+OPENTAG_CLAUDE_COMMAND=claude
+OPENTAG_CLAUDE_MODEL=sonnet
+OPENTAG_CLAUDE_PERMISSION_MODE=acceptEdits
+```
+
+`OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true` is supported for explicitly sandboxed environments, but it is not enabled by default.
 
 ## GitHub Smoke Test
 
@@ -309,3 +334,20 @@ When something is broken, debug in this order:
 ## Recommendation
 
 For real integration work, keep two separate public tunnels or be deliberate about switching one tunnel between GitHub and Slack. Reusing the same public hostname across both ports is possible, but it is an easy way to lose half an hour to the wrong endpoint.
+
+## Combined GitHub + Slack + Claude Code Stack
+
+After the individual GitHub and Slack paths work, you can run both ingress services against one local Claude Code daemon:
+
+```bash
+OPENTAG_CONFIG_PATH=/absolute/path/to/opentag.real.json \
+OPENTAG_GITHUB_TOKEN=<github-token> \
+OPENTAG_SLACK_BOT_TOKEN=<xoxb-token> \
+SLACK_SIGNING_SECRET=<signing-secret> \
+APP_ID=<github-app-id> \
+WEBHOOK_SECRET=<github-webhook-secret> \
+PRIVATE_KEY_PATH=/absolute/path/to/github-app.private-key.pem \
+scripts/dev/start-github-slack-claude-test.sh
+```
+
+The config file should bind the target repository and Slack channel, and the repository binding should use `"defaultExecutor": "claude-code"`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "pnpm -r build",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "lint": "pnpm -r lint"
+    "lint": "pnpm -r lint",
+    "smoke:protocol": "NODE_OPTIONS='--conditions=development' pnpm --dir apps/dispatcher exec tsx ../../scripts/test/protocol-runtime-smoke.ts",
+    "smoke:slack-protocol": "NODE_OPTIONS='--conditions=development' pnpm --dir apps/dispatcher exec tsx ../../scripts/test/slack-protocol-runtime-smoke.ts"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -120,6 +120,12 @@ export type RunMetrics = {
   staleIntentCount: number;
 };
 
+export type AggregateMetrics = Omit<RunMetrics, "runId"> & {
+  scope: "repo" | "work_thread";
+  scopeId: string;
+  runCount: number;
+};
+
 export type OpenTagClient = {
   registerRunner(input: { runnerId: string; name?: string }): Promise<void>;
   bindRepository(input: RepoBindingInput): Promise<void>;
@@ -144,6 +150,8 @@ export type OpenTagClient = {
   getRun(input: { runId: string }): Promise<ClaimedOpenTagRun>;
   listRunEvents(input: { runId: string }): Promise<{ events: unknown[] }>;
   getRunMetrics(input: { runId: string }): Promise<{ metrics: RunMetrics }>;
+  getRepoMetrics(input: { provider: string; owner: string; repo: string }): Promise<{ metrics: AggregateMetrics }>;
+  getWorkThreadMetrics(input: { threadId: string }): Promise<{ metrics: AggregateMetrics }>;
   getProposal(input: { proposalId: string }): Promise<{ runId: string; snapshot: SuggestedChangesSnapshot }>;
   getProposalLineage(input: { proposalId: string }): Promise<{ lineage: ProposalLineage }>;
   listCurrentMutationIntents(input: { proposalId: string }): Promise<{ intents: MutationIntentActionability[] }>;
@@ -358,6 +366,22 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
       });
       await assertOk(response, "getRunMetrics");
       return (await response.json()) as { metrics: RunMetrics };
+    },
+
+    async getRepoMetrics(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/repo-bindings/${input.provider}/${input.owner}/${input.repo}/metrics`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getRepoMetrics");
+      return (await response.json()) as { metrics: AggregateMetrics };
+    },
+
+    async getWorkThreadMetrics(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/work-thread-metrics?threadId=${encodeURIComponent(input.threadId)}`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getWorkThreadMetrics");
+      return (await response.json()) as { metrics: AggregateMetrics };
     },
 
     async getProposal(input) {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -440,7 +440,7 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
         body: JSON.stringify({
           ...(input.id ? { id: input.id } : {}),
           approvalDecisionId: input.approvalDecisionId,
-          ...(input.selectedIntentIds?.length ? { selectedIntentIds: input.selectedIntentIds } : {}),
+          ...(input.selectedIntentIds !== undefined ? { selectedIntentIds: input.selectedIntentIds } : {}),
           ...(input.adapter ? { adapter: input.adapter } : {}),
           ...(input.execute !== undefined ? { execute: input.execute } : {})
         })

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,6 +10,7 @@ import {
   type OpenTagEvent,
   type OpenTagRun,
   type OpenTagRunResult,
+  type PolicyRule,
   type ProposalLineage,
   type RunEventImportance,
   type RunEventVisibility,
@@ -96,10 +97,34 @@ export type ChildRunInput = {
   sourceApplyPlanId?: string;
 };
 
+export type RunMetrics = {
+  runId: string;
+  totalEventCount: number;
+  humanEventCount: number;
+  auditEventCount: number;
+  debugEventCount: number;
+  humanCallbackCount: number;
+  threadNoiseRatio: number;
+  suggestedChangesCount: number;
+  approvalDecisionCount: number;
+  applyPlanCount: number;
+  childRunCount: number;
+  applyOutcomeCounts: {
+    applied: number;
+    skipped: number;
+    failed: number;
+    stale: number;
+    unsupported: number;
+  };
+  staleIntentCount: number;
+};
+
 export type OpenTagClient = {
   registerRunner(input: { runnerId: string; name?: string }): Promise<void>;
   bindRepository(input: RepoBindingInput): Promise<void>;
   getRepositoryBinding(input: { provider: string; owner: string; repo: string }): Promise<{ binding: RepoBindingInput }>;
+  upsertRepoPolicyRule(input: { provider: string; owner: string; repo: string; rule: PolicyRule }): Promise<{ rule: PolicyRule }>;
+  listRepoPolicyRules(input: { provider: string; owner: string; repo: string }): Promise<{ rules: PolicyRule[] }>;
   bindSlackChannel(input: SlackChannelBindingInput): Promise<void>;
   getSlackChannelBinding(input: { teamId: string; channelId: string }): Promise<{ binding: SlackChannelBindingInput }>;
   createRun(input: CreateRunInput): Promise<{ run: OpenTagRun }>;
@@ -110,6 +135,7 @@ export type OpenTagClient = {
   complete(input: { runId: string; result: OpenTagRunResult }): Promise<void>;
   getRun(input: { runId: string }): Promise<ClaimedOpenTagRun>;
   listRunEvents(input: { runId: string }): Promise<{ events: unknown[] }>;
+  getRunMetrics(input: { runId: string }): Promise<{ metrics: RunMetrics }>;
   getProposal(input: { proposalId: string }): Promise<{ runId: string; snapshot: SuggestedChangesSnapshot }>;
   getProposalLineage(input: { proposalId: string }): Promise<{ lineage: ProposalLineage }>;
   listCurrentMutationIntents(input: { proposalId: string }): Promise<{ intents: MutationIntentActionability[] }>;
@@ -183,6 +209,24 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
       });
       await assertOk(response, "getRepositoryBinding");
       return (await response.json()) as { binding: RepoBindingInput };
+    },
+
+    async upsertRepoPolicyRule(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/repo-bindings/${input.provider}/${input.owner}/${input.repo}/policy-rules`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify({ rule: input.rule })
+      });
+      await assertOk(response, "upsertRepoPolicyRule");
+      return (await response.json()) as { rule: PolicyRule };
+    },
+
+    async listRepoPolicyRules(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/repo-bindings/${input.provider}/${input.owner}/${input.repo}/policy-rules`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "listRepoPolicyRules");
+      return (await response.json()) as { rules: PolicyRule[] };
     },
 
     async bindSlackChannel(input) {
@@ -280,6 +324,14 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
       });
       await assertOk(response, "listRunEvents");
       return (await response.json()) as { events: unknown[] };
+    },
+
+    async getRunMetrics(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/runs/${input.runId}/metrics`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getRunMetrics");
+      return (await response.json()) as { metrics: RunMetrics };
     },
 
     async getProposal(input) {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,6 +4,7 @@ import {
   OpenTagRunSchema,
   type ActorIdentity,
   type ActionHint,
+  type AdapterMutationMapping,
   type ApprovalDecision,
   type ApplyPlan,
   type MutationIntentActionability,
@@ -125,6 +126,13 @@ export type OpenTagClient = {
   getRepositoryBinding(input: { provider: string; owner: string; repo: string }): Promise<{ binding: RepoBindingInput }>;
   upsertRepoPolicyRule(input: { provider: string; owner: string; repo: string; rule: PolicyRule }): Promise<{ rule: PolicyRule }>;
   listRepoPolicyRules(input: { provider: string; owner: string; repo: string }): Promise<{ rules: PolicyRule[] }>;
+  upsertRepoMutationMapping(input: {
+    provider: string;
+    owner: string;
+    repo: string;
+    mapping: AdapterMutationMapping;
+  }): Promise<{ mapping: AdapterMutationMapping }>;
+  listRepoMutationMappings(input: { provider: string; owner: string; repo: string }): Promise<{ mappings: AdapterMutationMapping[] }>;
   bindSlackChannel(input: SlackChannelBindingInput): Promise<void>;
   getSlackChannelBinding(input: { teamId: string; channelId: string }): Promise<{ binding: SlackChannelBindingInput }>;
   createRun(input: CreateRunInput): Promise<{ run: OpenTagRun }>;
@@ -227,6 +235,24 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
       });
       await assertOk(response, "listRepoPolicyRules");
       return (await response.json()) as { rules: PolicyRule[] };
+    },
+
+    async upsertRepoMutationMapping(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/repo-bindings/${input.provider}/${input.owner}/${input.repo}/mutation-mappings`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify({ mapping: input.mapping })
+      });
+      await assertOk(response, "upsertRepoMutationMapping");
+      return (await response.json()) as { mapping: AdapterMutationMapping };
+    },
+
+    async listRepoMutationMappings(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/repo-bindings/${input.provider}/${input.owner}/${input.repo}/mutation-mappings`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "listRepoMutationMappings");
+      return (await response.json()) as { mappings: AdapterMutationMapping[] };
     },
 
     async bindSlackChannel(input) {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,9 +2,18 @@ import {
   OpenTagEventSchema,
   OpenTagRunResultSchema,
   OpenTagRunSchema,
+  type ActorIdentity,
+  type ActionHint,
+  type ApprovalDecision,
+  type ApplyPlan,
+  type MutationIntentActionability,
   type OpenTagEvent,
   type OpenTagRun,
-  type OpenTagRunResult
+  type OpenTagRunResult,
+  type ProposalLineage,
+  type RunEventImportance,
+  type RunEventVisibility,
+  type SuggestedChangesSnapshot
 } from "@opentag/core";
 
 export type ClaimedOpenTagRun = {
@@ -53,11 +62,38 @@ export type RunProgressInput = {
   type?: string;
   message: string;
   at?: string;
+  visibility?: RunEventVisibility;
+  importance?: RunEventImportance;
 };
 
 export type CreateRunInput = {
   runId: string;
   event: OpenTagEvent;
+};
+
+export type ApprovalDecisionInput = {
+  id?: string;
+  approvedIntentIds: string[];
+  rejectedIntentIds?: string[];
+  approvedBy: ActorIdentity;
+  approvedAt?: string;
+  scope?: "manual" | "policy";
+};
+
+export type ApplyPlanInput = {
+  id?: string;
+  approvalDecisionId: string;
+  selectedIntentIds?: string[];
+  adapter?: string;
+  execute?: boolean;
+};
+
+export type ChildRunInput = {
+  runId: string;
+  action: ActionHint;
+  commandText?: string;
+  sourceProposalId?: string;
+  sourceApplyPlanId?: string;
 };
 
 export type OpenTagClient = {
@@ -74,13 +110,21 @@ export type OpenTagClient = {
   complete(input: { runId: string; result: OpenTagRunResult }): Promise<void>;
   getRun(input: { runId: string }): Promise<ClaimedOpenTagRun>;
   listRunEvents(input: { runId: string }): Promise<{ events: unknown[] }>;
+  getProposal(input: { proposalId: string }): Promise<{ runId: string; snapshot: SuggestedChangesSnapshot }>;
+  getProposalLineage(input: { proposalId: string }): Promise<{ lineage: ProposalLineage }>;
+  listCurrentMutationIntents(input: { proposalId: string }): Promise<{ intents: MutationIntentActionability[] }>;
+  approveProposal(input: { proposalId: string } & ApprovalDecisionInput): Promise<{ decision: ApprovalDecision }>;
+  getApprovalDecision(input: { approvalDecisionId: string }): Promise<{ decision: ApprovalDecision }>;
+  createApplyPlan(input: { proposalId: string } & ApplyPlanInput): Promise<{ plan: ApplyPlan }>;
+  getApplyPlan(input: { applyPlanId: string }): Promise<{ plan: ApplyPlan }>;
+  createChildRun(input: { parentRunId: string } & ChildRunInput): Promise<{ run: OpenTagRun }>;
 };
 
 export type DispatcherRunnerClient = {
   claim(): Promise<ClaimedOpenTagRun | null>;
   markRunning(runId: string, executor: string): Promise<void>;
   heartbeat(runId: string): Promise<void>;
-  progress(runId: string, input: Required<RunProgressInput>): Promise<void>;
+  progress(runId: string, input: RunProgressInput & { type: string; at: string }): Promise<void>;
   complete(runId: string, result: OpenTagRunResult): Promise<void>;
 };
 
@@ -204,7 +248,9 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
         body: JSON.stringify({
           ...(input.type ? { type: input.type } : {}),
           message: input.message,
-          ...(input.at ? { at: input.at } : {})
+          ...(input.at ? { at: input.at } : {}),
+          ...(input.visibility ? { visibility: input.visibility } : {}),
+          ...(input.importance ? { importance: input.importance } : {})
         })
       });
       await assertOk(response, "progress");
@@ -234,6 +280,96 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
       });
       await assertOk(response, "listRunEvents");
       return (await response.json()) as { events: unknown[] };
+    },
+
+    async getProposal(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/proposals/${input.proposalId}`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getProposal");
+      return (await response.json()) as { runId: string; snapshot: SuggestedChangesSnapshot };
+    },
+
+    async getProposalLineage(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/proposals/${input.proposalId}/lineage`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getProposalLineage");
+      return (await response.json()) as { lineage: ProposalLineage };
+    },
+
+    async listCurrentMutationIntents(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/proposals/${input.proposalId}/current-intents`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "listCurrentMutationIntents");
+      return (await response.json()) as { intents: MutationIntentActionability[] };
+    },
+
+    async approveProposal(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/proposals/${input.proposalId}/approvals`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify({
+          ...(input.id ? { id: input.id } : {}),
+          approvedIntentIds: input.approvedIntentIds,
+          ...(input.rejectedIntentIds?.length ? { rejectedIntentIds: input.rejectedIntentIds } : {}),
+          approvedBy: input.approvedBy,
+          ...(input.approvedAt ? { approvedAt: input.approvedAt } : {}),
+          ...(input.scope ? { scope: input.scope } : {})
+        })
+      });
+      await assertOk(response, "approveProposal");
+      return (await response.json()) as { decision: ApprovalDecision };
+    },
+
+    async getApprovalDecision(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/approvals/${input.approvalDecisionId}`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getApprovalDecision");
+      return (await response.json()) as { decision: ApprovalDecision };
+    },
+
+    async createApplyPlan(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/proposals/${input.proposalId}/apply-plans`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify({
+          ...(input.id ? { id: input.id } : {}),
+          approvalDecisionId: input.approvalDecisionId,
+          ...(input.selectedIntentIds?.length ? { selectedIntentIds: input.selectedIntentIds } : {}),
+          ...(input.adapter ? { adapter: input.adapter } : {}),
+          ...(input.execute !== undefined ? { execute: input.execute } : {})
+        })
+      });
+      await assertOk(response, "createApplyPlan");
+      return (await response.json()) as { plan: ApplyPlan };
+    },
+
+    async getApplyPlan(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/apply-plans/${input.applyPlanId}`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getApplyPlan");
+      return (await response.json()) as { plan: ApplyPlan };
+    },
+
+    async createChildRun(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/runs/${input.parentRunId}/child-runs`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify({
+          runId: input.runId,
+          action: input.action,
+          ...(input.commandText ? { commandText: input.commandText } : {}),
+          ...(input.sourceProposalId ? { sourceProposalId: input.sourceProposalId } : {}),
+          ...(input.sourceApplyPlanId ? { sourceApplyPlanId: input.sourceApplyPlanId } : {})
+        })
+      });
+      await assertOk(response, "createChildRun");
+      const body = (await response.json()) as { run: unknown };
+      return { run: OpenTagRunSchema.parse(body.run) };
     }
   };
 }

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -300,4 +300,44 @@ describe("@opentag/client", () => {
       }
     ]);
   });
+
+  it("calls aggregate metrics endpoints", async () => {
+    const requests: string[] = [];
+    const metrics = {
+      scope: "repo",
+      scopeId: "github:acme/demo",
+      runCount: 2,
+      totalEventCount: 10,
+      humanEventCount: 2,
+      auditEventCount: 8,
+      debugEventCount: 0,
+      humanCallbackCount: 2,
+      threadNoiseRatio: 0.25,
+      suggestedChangesCount: 2,
+      approvalDecisionCount: 1,
+      applyPlanCount: 1,
+      childRunCount: 1,
+      applyOutcomeCounts: { applied: 0, skipped: 1, failed: 0, stale: 0, unsupported: 0 },
+      staleIntentCount: 0
+    };
+    const client = createOpenTagClient({
+      dispatcherUrl: "http://dispatcher.test",
+      fetchImpl: async (url) => {
+        requests.push(String(url));
+        return jsonResponse({ metrics });
+      }
+    });
+
+    await expect(client.getRepoMetrics({ provider: "github", owner: "acme", repo: "demo" })).resolves.toMatchObject({
+      metrics: { scope: "repo", runCount: 2 }
+    });
+    await expect(client.getWorkThreadMetrics({ threadId: "thread/github/acme/demo#1" })).resolves.toMatchObject({
+      metrics: { runCount: 2 }
+    });
+
+    expect(requests).toEqual([
+      "http://dispatcher.test/v1/repo-bindings/github/acme/demo/metrics",
+      "http://dispatcher.test/v1/work-thread-metrics?threadId=thread%2Fgithub%2Facme%2Fdemo%231"
+    ]);
+  });
 });

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -251,4 +251,53 @@ describe("@opentag/client", () => {
       }
     ]);
   });
+
+  it("calls repo mutation mapping endpoints", async () => {
+    const requests: Array<{ url: string; method: string; body?: unknown }> = [];
+    const mapping = {
+      id: "github_status_labels",
+      adapter: "github" as const,
+      domain: "status" as const,
+      strategy: "label" as const,
+      values: { blocked: "status/blocked" }
+    };
+    const client = createOpenTagClient({
+      dispatcherUrl: "http://dispatcher.test",
+      fetchImpl: async (url, init) => {
+        requests.push({
+          url: String(url),
+          method: init?.method ?? "GET",
+          ...(init?.body ? { body: JSON.parse(String(init.body)) } : {})
+        });
+        if (init?.method === "POST") {
+          return jsonResponse({ mapping }, 201);
+        }
+        return jsonResponse({ mappings: [mapping] });
+      }
+    });
+
+    await expect(
+      client.upsertRepoMutationMapping({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        mapping
+      })
+    ).resolves.toMatchObject({ mapping: { id: "github_status_labels" } });
+    await expect(client.listRepoMutationMappings({ provider: "github", owner: "acme", repo: "demo" })).resolves.toMatchObject({
+      mappings: [{ id: "github_status_labels" }]
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "http://dispatcher.test/v1/repo-bindings/github/acme/demo/mutation-mappings",
+        method: "POST",
+        body: { mapping }
+      },
+      {
+        url: "http://dispatcher.test/v1/repo-bindings/github/acme/demo/mutation-mappings",
+        method: "GET"
+      }
+    ]);
+  });
 });

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -100,4 +100,81 @@ describe("@opentag/client", () => {
       'createRun failed: 403 {"error":"repo_not_bound"}'
     );
   });
+
+  it("calls proposal approval and apply-plan endpoints", async () => {
+    const requests: Array<{ url: string; body: unknown; authorization: string | null }> = [];
+    const client = createOpenTagClient({
+      dispatcherUrl: "http://dispatcher.test",
+      pairingToken: "pair_1",
+      fetchImpl: async (url, init) => {
+        requests.push({
+          url: String(url),
+          body: init?.body ? JSON.parse(String(init.body)) : undefined,
+          authorization: new Headers(init?.headers).get("authorization")
+        });
+        if (String(url).endsWith("/approvals")) {
+          return jsonResponse({
+            decision: {
+              id: "approval_1",
+              proposalId: "proposal_1",
+              approvedIntentIds: ["intent_1"],
+              approvedBy: { provider: "github", providerUserId: "42" },
+              approvedAt: "2026-06-24T00:00:00.000Z",
+              scope: "manual"
+            }
+          }, 201);
+        }
+        return jsonResponse({
+          plan: {
+            id: "apply_1",
+            proposalId: "proposal_1",
+            approvalDecisionId: "approval_1",
+            selectedIntentIds: ["intent_1"],
+            mode: "preflight_then_per_intent",
+            outcomes: [{ intentId: "intent_1", outcome: "skipped" }]
+          }
+        }, 201);
+      }
+    });
+
+    await expect(
+      client.approveProposal({
+        proposalId: "proposal_1",
+        id: "approval_1",
+        approvedIntentIds: ["intent_1"],
+        approvedBy: { provider: "github", providerUserId: "42" },
+        approvedAt: "2026-06-24T00:00:00.000Z"
+      })
+    ).resolves.toMatchObject({ decision: { id: "approval_1" } });
+    await expect(
+      client.createApplyPlan({
+        proposalId: "proposal_1",
+        id: "apply_1",
+        approvalDecisionId: "approval_1",
+        adapter: "github"
+      })
+    ).resolves.toMatchObject({ plan: { id: "apply_1" } });
+
+    expect(requests).toEqual([
+      {
+        url: "http://dispatcher.test/v1/proposals/proposal_1/approvals",
+        authorization: "Bearer pair_1",
+        body: {
+          id: "approval_1",
+          approvedIntentIds: ["intent_1"],
+          approvedBy: { provider: "github", providerUserId: "42" },
+          approvedAt: "2026-06-24T00:00:00.000Z"
+        }
+      },
+      {
+        url: "http://dispatcher.test/v1/proposals/proposal_1/apply-plans",
+        authorization: "Bearer pair_1",
+        body: {
+          id: "apply_1",
+          approvalDecisionId: "approval_1",
+          adapter: "github"
+        }
+      }
+    ]);
+  });
 });

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -177,4 +177,78 @@ describe("@opentag/client", () => {
       }
     ]);
   });
+
+  it("calls repo policy rule endpoints", async () => {
+    const requests: Array<{ url: string; method: string; body?: unknown }> = [];
+    const client = createOpenTagClient({
+      dispatcherUrl: "http://dispatcher.test",
+      fetchImpl: async (url, init) => {
+        requests.push({
+          url: String(url),
+          method: init?.method ?? "GET",
+          ...(init?.body ? { body: JSON.parse(String(init.body)) } : {})
+        });
+        if (init?.method === "POST") {
+          return jsonResponse({
+            rule: {
+              id: "repo_allows_labels",
+              scope: "work_context_owner_container",
+              effect: "allow",
+              capabilityId: "set_labels",
+              reason: "Repo allows labels."
+            }
+          }, 201);
+        }
+        return jsonResponse({
+          rules: [
+            {
+              id: "repo_allows_labels",
+              scope: "work_context_owner_container",
+              effect: "allow",
+              capabilityId: "set_labels",
+              reason: "Repo allows labels."
+            }
+          ]
+        });
+      }
+    });
+
+    await expect(
+      client.upsertRepoPolicyRule({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        rule: {
+          id: "repo_allows_labels",
+          scope: "work_context_owner_container",
+          effect: "allow",
+          capabilityId: "set_labels",
+          reason: "Repo allows labels."
+        }
+      })
+    ).resolves.toMatchObject({ rule: { id: "repo_allows_labels" } });
+    await expect(client.listRepoPolicyRules({ provider: "github", owner: "acme", repo: "demo" })).resolves.toMatchObject({
+      rules: [{ id: "repo_allows_labels" }]
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "http://dispatcher.test/v1/repo-bindings/github/acme/demo/policy-rules",
+        method: "POST",
+        body: {
+          rule: {
+            id: "repo_allows_labels",
+            scope: "work_context_owner_container",
+            effect: "allow",
+            capabilityId: "set_labels",
+            reason: "Repo allows labels."
+          }
+        }
+      },
+      {
+        url: "http://dispatcher.test/v1/repo-bindings/github/acme/demo/policy-rules",
+        method: "GET"
+      }
+    ]);
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./json-schema.js";
 export * from "./mention.js";
+export * from "./protocol.js";
 export * from "./schema.js";

--- a/packages/core/src/json-schema.ts
+++ b/packages/core/src/json-schema.ts
@@ -1,6 +1,7 @@
 import { zodToJsonSchema } from "zod-to-json-schema";
 import {
   ActionHintSchema,
+  AdapterMutationMappingSchema,
   ApplyIntentOutcomeSchema,
   ApplyPlanSchema,
   ApprovalDecisionSchema,
@@ -36,6 +37,7 @@ export const OpenTagJsonSchemas = {
   RunEventImportance: zodToJsonSchema(RunEventImportanceSchema, "RunEventImportance"),
   RunEvent: zodToJsonSchema(RunEventSchema, "RunEvent"),
   ArtifactKind: zodToJsonSchema(ArtifactKindSchema, "ArtifactKind"),
+  AdapterMutationMapping: zodToJsonSchema(AdapterMutationMappingSchema, "AdapterMutationMapping"),
   CapabilityContract: zodToJsonSchema(CapabilityContractSchema, "CapabilityContract"),
   PolicyResolution: zodToJsonSchema(PolicyResolutionSchema, "PolicyResolution"),
   ProposalLineage: zodToJsonSchema(ProposalLineageSchema, "ProposalLineage"),

--- a/packages/core/src/json-schema.ts
+++ b/packages/core/src/json-schema.ts
@@ -1,8 +1,50 @@
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { OpenTagEventSchema, OpenTagRunResultSchema, OpenTagRunSchema } from "./schema.js";
+import {
+  ActionHintSchema,
+  ApplyIntentOutcomeSchema,
+  ApplyPlanSchema,
+  ApprovalDecisionSchema,
+  ArtifactKindSchema,
+  CapabilityContractSchema,
+  CanonicalMutationDomainSchema,
+  ContextPacketSchema,
+  ConversationAnchorSchema,
+  MutationIntentSchema,
+  OpenTagEventSchema,
+  OpenTagRunResultSchema,
+  OpenTagRunSchema,
+  ProposalLineageSchema,
+  RunEventImportanceSchema,
+  RunEventSchema,
+  RunEventVisibilitySchema,
+  PolicyResolutionSchema,
+  SuggestedChangesSnapshotSchema,
+  SuccessMetricNameSchema,
+  WorkItemReferenceSchema,
+  WorkThreadSchema
+} from "./schema.js";
 
 export const OpenTagJsonSchemas = {
   OpenTagEvent: zodToJsonSchema(OpenTagEventSchema, "OpenTagEvent"),
   OpenTagRun: zodToJsonSchema(OpenTagRunSchema, "OpenTagRun"),
-  OpenTagRunResult: zodToJsonSchema(OpenTagRunResultSchema, "OpenTagRunResult")
+  OpenTagRunResult: zodToJsonSchema(OpenTagRunResultSchema, "OpenTagRunResult"),
+  WorkItemReference: zodToJsonSchema(WorkItemReferenceSchema, "WorkItemReference"),
+  ConversationAnchor: zodToJsonSchema(ConversationAnchorSchema, "ConversationAnchor"),
+  WorkThread: zodToJsonSchema(WorkThreadSchema, "WorkThread"),
+  ContextPacket: zodToJsonSchema(ContextPacketSchema, "ContextPacket"),
+  RunEventVisibility: zodToJsonSchema(RunEventVisibilitySchema, "RunEventVisibility"),
+  RunEventImportance: zodToJsonSchema(RunEventImportanceSchema, "RunEventImportance"),
+  RunEvent: zodToJsonSchema(RunEventSchema, "RunEvent"),
+  ArtifactKind: zodToJsonSchema(ArtifactKindSchema, "ArtifactKind"),
+  CapabilityContract: zodToJsonSchema(CapabilityContractSchema, "CapabilityContract"),
+  PolicyResolution: zodToJsonSchema(PolicyResolutionSchema, "PolicyResolution"),
+  ProposalLineage: zodToJsonSchema(ProposalLineageSchema, "ProposalLineage"),
+  SuccessMetricName: zodToJsonSchema(SuccessMetricNameSchema, "SuccessMetricName"),
+  ActionHint: zodToJsonSchema(ActionHintSchema, "ActionHint"),
+  CanonicalMutationDomain: zodToJsonSchema(CanonicalMutationDomainSchema, "CanonicalMutationDomain"),
+  MutationIntent: zodToJsonSchema(MutationIntentSchema, "MutationIntent"),
+  SuggestedChangesSnapshot: zodToJsonSchema(SuggestedChangesSnapshotSchema, "SuggestedChangesSnapshot"),
+  ApprovalDecision: zodToJsonSchema(ApprovalDecisionSchema, "ApprovalDecision"),
+  ApplyPlan: zodToJsonSchema(ApplyPlanSchema, "ApplyPlan"),
+  ApplyIntentOutcome: zodToJsonSchema(ApplyIntentOutcomeSchema, "ApplyIntentOutcome")
 } as const;

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -36,7 +36,73 @@ export type ContextPacketAssemblyOptions = {
   risks?: string[];
   exclusions?: string[];
   redactions?: Array<{ reason: string; sourceUri?: string }>;
+  hooks?: ContextPacketAssemblyHooks;
 };
+
+export type ContextPacketAssemblyHooks = {
+  collect?(input: { event: OpenTagEvent; pointers: ContextPointer[] }): ContextPointer[];
+  classify?(input: { event: OpenTagEvent; classified: ClassifiedContextPointer[] }): ClassifiedContextPointer[];
+  filter?(input: { event: OpenTagEvent; classified: ClassifiedContextPointer[] }): ClassifiedContextPointer[];
+  preserve?(input: { event: OpenTagEvent; facts: Array<{ text: string; sourceUri?: string }> }): Array<{ text: string; sourceUri?: string }>;
+  summarize?(input: { event: OpenTagEvent; summary: string }): string;
+  budget?(input: {
+    event: OpenTagEvent;
+    classified: ClassifiedContextPointer[];
+    budgetTokens?: number;
+  }): ClassifiedContextPointer[];
+  emit?(input: { event: OpenTagEvent; packet: ContextPacket }): ContextPacket;
+};
+
+export type AdapterMutationCompilation<TOperation = unknown> =
+  | {
+      ok: true;
+      adapter: string;
+      intentId: string;
+      operation: TOperation;
+    }
+  | {
+      ok: false;
+      adapter: string;
+      outcome: ApplyIntentOutcome;
+    };
+
+export type AdapterMutationCompiler<TOperation = unknown> = {
+  adapter: string;
+  compile(intent: MutationIntent): AdapterMutationCompilation<TOperation>;
+};
+
+export type AdapterMutationCompilerRegistry = {
+  register<TOperation>(compiler: AdapterMutationCompiler<TOperation>): void;
+  get(adapter: string): AdapterMutationCompiler | undefined;
+  compile(adapter: string, intents: MutationIntent[]): AdapterMutationCompilation[];
+};
+
+export function createAdapterMutationCompilerRegistry(compilers: AdapterMutationCompiler[] = []): AdapterMutationCompilerRegistry {
+  const byAdapter = new Map(compilers.map((compiler) => [compiler.adapter, compiler]));
+  return {
+    register(compiler) {
+      byAdapter.set(compiler.adapter, compiler);
+    },
+    get(adapter) {
+      return byAdapter.get(adapter);
+    },
+    compile(adapter, intents) {
+      const compiler = byAdapter.get(adapter);
+      if (!compiler) {
+        return intents.map((intent) => ({
+          ok: false,
+          adapter,
+          outcome: {
+            intentId: intent.intentId,
+            outcome: "unsupported",
+            message: `No adapter mutation compiler is registered for ${adapter}.`
+          }
+        }));
+      }
+      return intents.map((intent) => compiler.compile(intent));
+    }
+  };
+}
 
 function classifyContextPointer(pointer: ContextPointer): ClassifiedContextPointer {
   if (pointer.kind === "text") {
@@ -92,18 +158,27 @@ export function assembleContextPacketFromEvent(
   emittedAt = event.receivedAt,
   options: ContextPacketAssemblyOptions = {}
 ): ContextPacket {
-  const collected = collectContextPointers(event);
-  const classified = classifyContextPointers(collected);
-  const filtered = filterClassifiedContextPointers(classified);
-  const budgeted = budgetContextPointers(filtered, options.budgetTokens);
+  const collected = options.hooks?.collect?.({ event, pointers: collectContextPointers(event) }) ?? collectContextPointers(event);
+  const classified = options.hooks?.classify?.({ event, classified: classifyContextPointers(collected) }) ?? classifyContextPointers(collected);
+  const filtered =
+    options.hooks?.filter?.({ event, classified: filterClassifiedContextPointers(classified) }) ??
+    filterClassifiedContextPointers(classified);
+  const budgeted =
+    options.hooks?.budget?.({
+      event,
+      classified: budgetContextPointers(filtered, options.budgetTokens),
+      ...(options.budgetTokens ? { budgetTokens: options.budgetTokens } : {})
+    }) ??
+    budgetContextPointers(filtered, options.budgetTokens);
   const writeScopes = event.permissions
     .map((permission) => permission.scope)
     .filter((scope) => scope === "repo:write" || scope === "pr:create" || scope === "pr:update");
-  const summary = summarizeContextPacket(event);
-  return {
+  const summary = options.hooks?.summarize?.({ event, summary: summarizeContextPacket(event) }) ?? summarizeContextPacket(event);
+  const facts = options.hooks?.preserve?.({ event, facts: preserveContextFacts(event, budgeted) }) ?? preserveContextFacts(event, budgeted);
+  const packet = {
     summary,
     sourcePointers: budgeted.map((entry) => entry.pointer),
-    facts: preserveContextFacts(event, budgeted),
+    facts,
     risks:
       options.risks ??
       (writeScopes.length > 0
@@ -118,6 +193,7 @@ export function assembleContextPacketFromEvent(
       emittedAt
     }
   };
+  return options.hooks?.emit?.({ event, packet }) ?? packet;
 }
 
 export const DefaultCapabilityContracts = [

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -1,0 +1,338 @@
+import type {
+  ApplyIntentOutcome,
+  CapabilityContract,
+  ContextPacket,
+  ContextPointer,
+  ConversationAnchor,
+  MutationIntent,
+  OpenTagEvent,
+  PermissionGrant,
+  PolicyResolution,
+  PolicyRule,
+  PolicyScope,
+  WorkItemReference,
+  WorkThread
+} from "./schema.js";
+
+const CONTEXT_PACKET_STAGES = ["collect", "classify", "filter", "preserve", "summarize", "budget", "emit"] as const;
+const POLICY_SCOPE_ORDER: PolicyScope[] = [
+  "organization_default",
+  "adapter_surface_default",
+  "work_context_owner_container",
+  "work_item_override",
+  "primary_anchor_override"
+];
+
+export const DefaultCapabilityContracts = [
+  {
+    id: "reply_thread",
+    semanticAction: "reply_thread",
+    capabilityClass: "callback",
+    requiresExplicitIntent: false,
+    mayAutoApplyByPolicy: true,
+    adapterTargets: ["github", "slack", "lark", "webhook"],
+    requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
+  },
+  {
+    id: "attach_artifact",
+    semanticAction: "attach_artifact",
+    capabilityClass: "callback",
+    requiresExplicitIntent: false,
+    mayAutoApplyByPolicy: true,
+    adapterTargets: ["github", "slack", "lark", "webhook"],
+    requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
+  },
+  {
+    id: "create_pr",
+    semanticAction: "create_pull_request",
+    capabilityClass: "external_write",
+    requiresExplicitIntent: true,
+    mayAutoApplyByPolicy: true,
+    adapterTargets: ["github"],
+    requiredPermissionScopes: ["pr:create"],
+    requiredExecutorConditions: ["isolated branch exists"]
+  },
+  {
+    id: "set_status",
+    semanticAction: "transition_status",
+    capabilityClass: "external_write",
+    requiresExplicitIntent: true,
+    mayAutoApplyByPolicy: true,
+    adapterTargets: ["github", "linear", "jira", "lark"],
+    requiredPermissionScopes: ["repo:write"]
+  },
+  {
+    id: "set_assignee",
+    semanticAction: "set_assignee",
+    capabilityClass: "external_write",
+    requiresExplicitIntent: true,
+    mayAutoApplyByPolicy: true,
+    adapterTargets: ["github", "linear", "jira", "lark"],
+    requiredPermissionScopes: ["repo:write"]
+  },
+  {
+    id: "set_priority",
+    semanticAction: "set_priority",
+    capabilityClass: "external_write",
+    requiresExplicitIntent: true,
+    mayAutoApplyByPolicy: true,
+    adapterTargets: ["linear", "jira", "lark"],
+    requiredPermissionScopes: ["repo:write"]
+  },
+  {
+    id: "set_labels",
+    semanticAction: "set_labels",
+    capabilityClass: "external_write",
+    requiresExplicitIntent: true,
+    mayAutoApplyByPolicy: true,
+    adapterTargets: ["github", "linear", "jira", "lark"],
+    requiredPermissionScopes: ["repo:write"]
+  },
+  {
+    id: "request_review",
+    semanticAction: "request_review",
+    capabilityClass: "callback",
+    requiresExplicitIntent: false,
+    mayAutoApplyByPolicy: true,
+    adapterTargets: ["github", "slack", "lark"],
+    requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
+  }
+] satisfies CapabilityContract[];
+
+function firstContextUri(event: OpenTagEvent, kind: ContextPointer["kind"]): string | undefined {
+  return event.context.find((pointer) => pointer.kind === kind)?.uri;
+}
+
+function stringMetadata(event: OpenTagEvent, key: string): string | undefined {
+  const value = event.metadata[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberMetadata(event: OpenTagEvent, key: string): number | undefined {
+  const value = event.metadata[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+export function workItemReferenceFromEvent(event: OpenTagEvent): WorkItemReference | undefined {
+  const owner = stringMetadata(event, "owner");
+  const repo = stringMetadata(event, "repo");
+  if (!owner || !repo) return undefined;
+
+  const issueNumber = numberMetadata(event, "issueNumber");
+  if (event.source === "github" && issueNumber !== undefined) {
+    return {
+      provider: "github",
+      kind: "issue",
+      externalId: `${owner}/${repo}#${issueNumber}`,
+      uri: firstContextUri(event, "github.issue") ?? `https://github.com/${owner}/${repo}/issues/${issueNumber}`,
+      ownerContainer: {
+        provider: "github",
+        id: `${owner}/${repo}`,
+        uri: `https://github.com/${owner}/${repo}`
+      }
+    };
+  }
+
+  const pullRequestNumber = numberMetadata(event, "pullRequestNumber");
+  if (event.source === "github" && pullRequestNumber !== undefined) {
+    return {
+      provider: "github",
+      kind: "pull_request",
+      externalId: `${owner}/${repo}#${pullRequestNumber}`,
+      uri: firstContextUri(event, "github.pull_request") ?? `https://github.com/${owner}/${repo}/pull/${pullRequestNumber}`,
+      ownerContainer: {
+        provider: "github",
+        id: `${owner}/${repo}`,
+        uri: `https://github.com/${owner}/${repo}`
+      }
+    };
+  }
+
+  return undefined;
+}
+
+export function primaryConversationAnchorFromEvent(event: OpenTagEvent): ConversationAnchor {
+  const slackThreadKey = event.callback.provider === "slack" ? event.callback.threadKey : undefined;
+  return {
+    provider: event.callback.provider,
+    kind: event.callback.provider === "slack" ? "thread" : `${event.callback.provider}_thread`,
+    externalId: event.callback.threadKey ?? event.callback.uri,
+    uri:
+      firstContextUri(event, "github.comment") ??
+      firstContextUri(event, "url") ??
+      event.callback.uri,
+    controlPlane: true,
+    canApprove: true,
+    ...(slackThreadKey ? { threadKey: slackThreadKey } : {})
+  };
+}
+
+export function workThreadFromEvent(event: OpenTagEvent): WorkThread | undefined {
+  const workItemReference = workItemReferenceFromEvent(event);
+  if (!workItemReference) return undefined;
+
+  const primaryAnchor = primaryConversationAnchorFromEvent(event);
+  return {
+    id: `thread_${workItemReference.provider}_${workItemReference.externalId}_${primaryAnchor.externalId}`,
+    workItemReference,
+    primaryAnchor
+  };
+}
+
+export function contextPacketFromEvent(event: OpenTagEvent, emittedAt = event.receivedAt): ContextPacket {
+  const sourceUri = event.context[0]?.uri;
+  const writeScopes = event.permissions
+    .map((permission) => permission.scope)
+    .filter((scope) => scope === "repo:write" || scope === "pr:create" || scope === "pr:update");
+
+  const summary = event.command.rawText || `OpenTag ${event.command.intent} request`;
+  return {
+    summary,
+    sourcePointers: event.context,
+    facts: [
+      {
+        text: `Requested intent: ${event.command.intent}`,
+        ...(sourceUri ? { sourceUri } : {})
+      }
+    ],
+    risks:
+      writeScopes.length > 0
+        ? [`External write-capable scopes were requested: ${writeScopes.join(", ")}.`]
+        : ["No external write-capable scopes were requested."],
+    exclusions: ["Do not mutate external state unless an explicit capability and policy allow it."],
+    mustPreserve: [summary],
+    assembly: {
+      stages: [...CONTEXT_PACKET_STAGES],
+      emittedAt
+    }
+  };
+}
+
+export function protocolRunFieldsFromEvent(
+  event: OpenTagEvent,
+  emittedAt = event.receivedAt
+): { thread?: WorkThread; contextPacket: ContextPacket } {
+  const thread = workThreadFromEvent(event);
+  const contextPacket = contextPacketFromEvent(event, emittedAt);
+  return {
+    ...(thread ? { thread } : {}),
+    contextPacket
+  };
+}
+
+export function capabilityForMutationIntent(
+  intent: MutationIntent,
+  capabilities: readonly CapabilityContract[] = DefaultCapabilityContracts
+): CapabilityContract | undefined {
+  const capabilityId =
+    intent.action === "create_pull_request"
+      ? "create_pr"
+      : intent.action === "request_review"
+        ? "request_review"
+        : intent.action === "link_artifact"
+          ? "attach_artifact"
+          : intent.domain === "status"
+            ? "set_status"
+            : intent.domain === "assignee"
+              ? "set_assignee"
+              : intent.domain === "priority"
+                ? "set_priority"
+                : intent.domain === "labels"
+                  ? "set_labels"
+                  : undefined;
+
+  return capabilityId ? capabilities.find((capability) => capability.id === capabilityId) : undefined;
+}
+
+export function resolvePolicy(input: {
+  capabilityId: string;
+  rules: PolicyRule[];
+  defaultDecision?: "allow" | "deny";
+}): PolicyResolution {
+  const matchingRules = input.rules.filter((rule) => !rule.capabilityId || rule.capabilityId === input.capabilityId);
+  const sortedRules = [...matchingRules].sort((left, right) => {
+    const scopeDelta = POLICY_SCOPE_ORDER.indexOf(right.scope) - POLICY_SCOPE_ORDER.indexOf(left.scope);
+    if (scopeDelta !== 0) return scopeDelta;
+    if (left.effect === right.effect) return 0;
+    return left.effect === "deny" ? -1 : 1;
+  });
+  const winningRule = sortedRules[0];
+  if (winningRule) {
+    return {
+      capabilityId: input.capabilityId,
+      decision: winningRule.effect,
+      resolvedBy: winningRule.scope,
+      rules: matchingRules,
+      reason: winningRule.reason
+    };
+  }
+
+  return {
+    capabilityId: input.capabilityId,
+    decision: input.defaultDecision ?? "deny",
+    resolvedBy: "organization_default",
+    rules: [],
+    reason: input.defaultDecision === "allow" ? "Allowed by default policy." : "Denied by default policy."
+  };
+}
+
+export function permissionScopesAllowCapability(permissions: PermissionGrant[], capability: CapabilityContract): boolean {
+  const grantedScopes = new Set(permissions.map((permission) => permission.scope));
+  return capability.requiredPermissionScopes.some((scope) => grantedScopes.has(scope));
+}
+
+export function preflightMutationIntent(input: {
+  intent: MutationIntent;
+  permissions: PermissionGrant[];
+  policyRules: PolicyRule[];
+  capabilities?: readonly CapabilityContract[];
+}): { capability?: CapabilityContract; policyResolution?: PolicyResolution; outcome: ApplyIntentOutcome } {
+  const capability = capabilityForMutationIntent(input.intent, input.capabilities);
+  if (!capability) {
+    return {
+      outcome: {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: `No capability contract maps mutation action ${input.intent.action}.`
+      }
+    };
+  }
+
+  if (!permissionScopesAllowCapability(input.permissions, capability)) {
+    return {
+      capability,
+      outcome: {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: `Missing platform permission for capability ${capability.id}.`
+      }
+    };
+  }
+
+  const policyResolution = resolvePolicy({
+    capabilityId: capability.id,
+    rules: input.policyRules,
+    defaultDecision: capability.capabilityClass === "external_write" ? "deny" : "allow"
+  });
+  if (policyResolution.decision === "deny") {
+    return {
+      capability,
+      policyResolution,
+      outcome: {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: `OpenTag policy denied capability ${capability.id}: ${policyResolution.reason}`
+      }
+    };
+  }
+
+  return {
+    capability,
+    policyResolution,
+    outcome: {
+      intentId: input.intent.intentId,
+      outcome: "skipped",
+      message: `Preflight passed for ${capability.id}; adapter execution is not implemented in this protocol slice.`
+    }
+  };
+}

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -23,6 +23,103 @@ const POLICY_SCOPE_ORDER: PolicyScope[] = [
   "primary_anchor_override"
 ];
 
+export type ContextSourceClassification = "primary_evidence" | "supporting_context" | "background_noise" | "sensitive_material";
+
+export type ClassifiedContextPointer = {
+  pointer: ContextPointer;
+  classification: ContextSourceClassification;
+  reason: string;
+};
+
+export type ContextPacketAssemblyOptions = {
+  budgetTokens?: number;
+  risks?: string[];
+  exclusions?: string[];
+  redactions?: Array<{ reason: string; sourceUri?: string }>;
+};
+
+function classifyContextPointer(pointer: ContextPointer): ClassifiedContextPointer {
+  if (pointer.kind === "text") {
+    return { pointer, classification: "primary_evidence", reason: "Original user-authored text is primary evidence." };
+  }
+  if (pointer.kind === "github.issue" || pointer.kind === "github.pull_request" || pointer.kind === "github.comment" || pointer.kind === "slack.thread" || pointer.kind === "slack.message") {
+    return { pointer, classification: "primary_evidence", reason: `${pointer.kind} is directly attached to the invocation.` };
+  }
+  if (pointer.kind === "github.repo" || pointer.kind === "file" || pointer.kind === "url") {
+    return { pointer, classification: "supporting_context", reason: `${pointer.kind} supports execution but is not itself the request.` };
+  }
+  return { pointer, classification: "supporting_context", reason: "Pointer is relevant context." };
+}
+
+export function collectContextPointers(event: OpenTagEvent): ContextPointer[] {
+  return event.context;
+}
+
+export function classifyContextPointers(pointers: ContextPointer[]): ClassifiedContextPointer[] {
+  return pointers.map((pointer) => classifyContextPointer(pointer));
+}
+
+export function filterClassifiedContextPointers(classified: ClassifiedContextPointer[]): ClassifiedContextPointer[] {
+  return classified.filter((entry) => entry.classification !== "background_noise" && entry.classification !== "sensitive_material");
+}
+
+export function preserveContextFacts(event: OpenTagEvent, classified: ClassifiedContextPointer[]): Array<{ text: string; sourceUri?: string }> {
+  const sourceUri = classified[0]?.pointer.uri;
+  return [
+    {
+      text: `Requested intent: ${event.command.intent}`,
+      ...(sourceUri ? { sourceUri } : {})
+    },
+    ...classified.map((entry) => ({
+      text: `${entry.classification}: ${entry.pointer.kind}`,
+      sourceUri: entry.pointer.uri
+    }))
+  ];
+}
+
+export function summarizeContextPacket(event: OpenTagEvent): string {
+  return event.command.rawText || `OpenTag ${event.command.intent} request`;
+}
+
+export function budgetContextPointers(classified: ClassifiedContextPointer[], budgetTokens?: number): ClassifiedContextPointer[] {
+  if (!budgetTokens) return classified;
+  const maxPointers = Math.max(1, Math.floor(budgetTokens / 500));
+  return classified.slice(0, maxPointers);
+}
+
+export function assembleContextPacketFromEvent(
+  event: OpenTagEvent,
+  emittedAt = event.receivedAt,
+  options: ContextPacketAssemblyOptions = {}
+): ContextPacket {
+  const collected = collectContextPointers(event);
+  const classified = classifyContextPointers(collected);
+  const filtered = filterClassifiedContextPointers(classified);
+  const budgeted = budgetContextPointers(filtered, options.budgetTokens);
+  const writeScopes = event.permissions
+    .map((permission) => permission.scope)
+    .filter((scope) => scope === "repo:write" || scope === "pr:create" || scope === "pr:update");
+  const summary = summarizeContextPacket(event);
+  return {
+    summary,
+    sourcePointers: budgeted.map((entry) => entry.pointer),
+    facts: preserveContextFacts(event, budgeted),
+    risks:
+      options.risks ??
+      (writeScopes.length > 0
+        ? [`External write-capable scopes were requested: ${writeScopes.join(", ")}.`]
+        : ["No external write-capable scopes were requested."]),
+    exclusions: options.exclusions ?? ["Do not mutate external state unless an explicit capability and policy allow it."],
+    mustPreserve: [summary],
+    ...(options.redactions?.length ? { redactions: options.redactions } : {}),
+    assembly: {
+      stages: [...CONTEXT_PACKET_STAGES],
+      ...(options.budgetTokens ? { budgetTokens: options.budgetTokens } : {}),
+      emittedAt
+    }
+  };
+}
+
 export const DefaultCapabilityContracts = [
   {
     id: "reply_thread",
@@ -180,32 +277,7 @@ export function workThreadFromEvent(event: OpenTagEvent): WorkThread | undefined
 }
 
 export function contextPacketFromEvent(event: OpenTagEvent, emittedAt = event.receivedAt): ContextPacket {
-  const sourceUri = event.context[0]?.uri;
-  const writeScopes = event.permissions
-    .map((permission) => permission.scope)
-    .filter((scope) => scope === "repo:write" || scope === "pr:create" || scope === "pr:update");
-
-  const summary = event.command.rawText || `OpenTag ${event.command.intent} request`;
-  return {
-    summary,
-    sourcePointers: event.context,
-    facts: [
-      {
-        text: `Requested intent: ${event.command.intent}`,
-        ...(sourceUri ? { sourceUri } : {})
-      }
-    ],
-    risks:
-      writeScopes.length > 0
-        ? [`External write-capable scopes were requested: ${writeScopes.join(", ")}.`]
-        : ["No external write-capable scopes were requested."],
-    exclusions: ["Do not mutate external state unless an explicit capability and policy allow it."],
-    mustPreserve: [summary],
-    assembly: {
-      stages: [...CONTEXT_PACKET_STAGES],
-      emittedAt
-    }
-  };
+  return assembleContextPacketFromEvent(event, emittedAt);
 }
 
 export function protocolRunFieldsFromEvent(

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -394,10 +394,15 @@ export function capabilityForMutationIntent(
 
 export function resolvePolicy(input: {
   capabilityId: string;
+  mutationDomain?: string;
   rules: PolicyRule[];
   defaultDecision?: "allow" | "deny";
 }): PolicyResolution {
-  const matchingRules = input.rules.filter((rule) => !rule.capabilityId || rule.capabilityId === input.capabilityId);
+  const matchingRules = input.rules.filter(
+    (rule) =>
+      (!rule.capabilityId || rule.capabilityId === input.capabilityId) &&
+      (!rule.mutationDomain || rule.mutationDomain === input.mutationDomain)
+  );
   const sortedRules = [...matchingRules].sort((left, right) => {
     const scopeDelta = POLICY_SCOPE_ORDER.indexOf(right.scope) - POLICY_SCOPE_ORDER.indexOf(left.scope);
     if (scopeDelta !== 0) return scopeDelta;
@@ -433,6 +438,8 @@ export function preflightMutationIntent(input: {
   intent: MutationIntent;
   permissions: PermissionGrant[];
   policyRules: PolicyRule[];
+  adapter?: string;
+  executorConditions?: string[];
   capabilities?: readonly CapabilityContract[];
 }): { capability?: CapabilityContract; policyResolution?: PolicyResolution; outcome: ApplyIntentOutcome } {
   const capability = capabilityForMutationIntent(input.intent, input.capabilities);
@@ -456,9 +463,33 @@ export function preflightMutationIntent(input: {
       }
     };
   }
+  if (input.adapter && !capability.adapterTargets.includes(input.adapter)) {
+    return {
+      capability,
+      outcome: {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: `Capability ${capability.id} cannot be applied by adapter ${input.adapter}.`
+      }
+    };
+  }
+  const missingConditions = (capability.requiredExecutorConditions ?? []).filter(
+    (condition) => !(input.executorConditions ?? []).includes(condition)
+  );
+  if (missingConditions.length > 0) {
+    return {
+      capability,
+      outcome: {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: `Missing executor condition(s) for capability ${capability.id}: ${missingConditions.join(", ")}.`
+      }
+    };
+  }
 
   const policyResolution = resolvePolicy({
     capabilityId: capability.id,
+    mutationDomain: input.intent.domain,
     rules: input.policyRules,
     defaultDecision: capability.capabilityClass === "external_write" ? "deny" : "allow"
   });

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -31,6 +31,15 @@ export const ContextPointerSchema = z.object({
     "github.pull_request",
     "github.comment",
     "github.commit",
+    "slack.channel",
+    "slack.thread",
+    "slack.message",
+    "lark.chat",
+    "lark.thread",
+    "lark.message",
+    "lark.doc",
+    "lark.base",
+    "lark.base_record",
     "file",
     "url",
     "text"
@@ -126,6 +135,15 @@ export const PolicyResolutionSchema = z.object({
   resolvedBy: PolicyScopeSchema,
   rules: z.array(PolicyRuleSchema),
   reason: z.string().min(1)
+});
+
+export const AdapterMutationMappingSchema = z.object({
+  id: z.string().min(1),
+  adapter: z.string().min(1),
+  domain: z.enum(["status", "priority"]),
+  strategy: z.enum(["label"]),
+  values: z.record(z.string().min(1)),
+  description: z.string().min(1).optional()
 });
 
 export const SuccessMetricNameSchema = z.enum([
@@ -367,6 +385,7 @@ export type PolicyScope = z.infer<typeof PolicyScopeSchema>;
 export type PolicyEffect = z.infer<typeof PolicyEffectSchema>;
 export type PolicyRule = z.infer<typeof PolicyRuleSchema>;
 export type PolicyResolution = z.infer<typeof PolicyResolutionSchema>;
+export type AdapterMutationMapping = z.infer<typeof AdapterMutationMappingSchema>;
 export type SuccessMetricName = z.infer<typeof SuccessMetricNameSchema>;
 export type CallbackRoute = z.infer<typeof CallbackRouteSchema>;
 export type WorkItemReference = z.infer<typeof WorkItemReferenceSchema>;

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -40,6 +40,39 @@ export const ContextPointerSchema = z.object({
   visibility: z.enum(["public", "private", "organization"])
 });
 
+export const ContextPacketAssemblyStageSchema = z.enum(["collect", "classify", "filter", "preserve", "summarize", "budget", "emit"]);
+
+export const ContextPacketSchema = z.object({
+  summary: z.string().min(1),
+  sourcePointers: z.array(ContextPointerSchema),
+  facts: z
+    .array(
+      z.object({
+        text: z.string().min(1),
+        sourceUri: z.string().min(1).optional()
+      })
+    )
+    .optional(),
+  risks: z.array(z.string().min(1)).optional(),
+  exclusions: z.array(z.string().min(1)).optional(),
+  mustPreserve: z.array(z.string().min(1)).optional(),
+  redactions: z
+    .array(
+      z.object({
+        reason: z.string().min(1),
+        sourceUri: z.string().min(1).optional()
+      })
+    )
+    .optional(),
+  assembly: z
+    .object({
+      stages: z.array(ContextPacketAssemblyStageSchema),
+      budgetTokens: z.number().int().positive().optional(),
+      emittedAt: z.string().datetime().optional()
+    })
+    .optional()
+});
+
 export const PermissionGrantSchema = z.object({
   scope: z.enum([
     "repo:read",
@@ -55,10 +88,211 @@ export const PermissionGrantSchema = z.object({
   expiresAt: z.string().datetime().optional()
 });
 
+export const CapabilityClassSchema = z.enum(["read_only", "callback", "external_write"]);
+
+export const CapabilityContractSchema = z.object({
+  id: z.string().min(1),
+  semanticAction: z.string().min(1),
+  capabilityClass: CapabilityClassSchema,
+  requiresExplicitIntent: z.boolean(),
+  mayAutoApplyByPolicy: z.boolean(),
+  adapterTargets: z.array(z.string().min(1)),
+  requiredPermissionScopes: z.array(PermissionGrantSchema.shape.scope),
+  requiredExecutorConditions: z.array(z.string().min(1)).optional()
+});
+
+export const PolicyScopeSchema = z.enum([
+  "organization_default",
+  "adapter_surface_default",
+  "work_context_owner_container",
+  "work_item_override",
+  "primary_anchor_override"
+]);
+
+export const PolicyEffectSchema = z.enum(["allow", "deny"]);
+
+export const PolicyRuleSchema = z.object({
+  id: z.string().min(1),
+  scope: PolicyScopeSchema,
+  effect: PolicyEffectSchema,
+  capabilityId: z.string().min(1).optional(),
+  mutationDomain: z.string().min(1).optional(),
+  reason: z.string().min(1)
+});
+
+export const PolicyResolutionSchema = z.object({
+  capabilityId: z.string().min(1),
+  decision: PolicyEffectSchema,
+  resolvedBy: PolicyScopeSchema,
+  rules: z.array(PolicyRuleSchema),
+  reason: z.string().min(1)
+});
+
+export const SuccessMetricNameSchema = z.enum([
+  "time_to_first_useful_artifact",
+  "thread_noise_ratio",
+  "artifact_acceptance_rate",
+  "context_reuse_rate",
+  "external_write_approval_rate",
+  "stale_proposal_rate"
+]);
+
 export const CallbackRouteSchema = z.object({
   provider: z.enum(["github", "slack", "lark", "webhook"]),
   uri: z.string().min(1),
   threadKey: z.string().min(1).optional()
+});
+
+export const WorkItemReferenceSchema = z.object({
+  provider: z.string().min(1),
+  kind: z.string().min(1),
+  externalId: z.string().min(1),
+  uri: z.string().min(1),
+  title: z.string().min(1).optional(),
+  ownerContainer: z
+    .object({
+      provider: z.string().min(1),
+      id: z.string().min(1),
+      uri: z.string().min(1).optional()
+    })
+    .optional(),
+  metadata: z.record(z.unknown()).optional()
+});
+
+export const ConversationAnchorSchema = z.object({
+  provider: z.enum(["github", "slack", "lark", "webhook"]),
+  kind: z.string().min(1),
+  externalId: z.string().min(1),
+  uri: z.string().min(1),
+  threadKey: z.string().min(1).optional(),
+  controlPlane: z.boolean().optional(),
+  canApprove: z.boolean().optional(),
+  metadata: z.record(z.unknown()).optional()
+});
+
+export const WorkThreadSchema = z.object({
+  id: z.string().min(1).optional(),
+  workItemReference: WorkItemReferenceSchema,
+  primaryAnchor: ConversationAnchorSchema,
+  secondaryAnchors: z.array(ConversationAnchorSchema).optional()
+});
+
+export const RunEventVisibilitySchema = z.enum(["human", "audit", "debug"]);
+export const RunEventImportanceSchema = z.enum(["low", "normal", "high", "blocking"]);
+
+export const RunEventSchema = z.object({
+  id: z.union([z.string().min(1), z.number().int().nonnegative()]).optional(),
+  runId: z.string().min(1),
+  type: z.string().min(1),
+  createdAt: z.string().datetime(),
+  visibility: RunEventVisibilitySchema,
+  importance: RunEventImportanceSchema,
+  message: z.string().min(1).optional(),
+  payload: z.unknown().optional(),
+  sourcePointer: ContextPointerSchema.optional()
+});
+
+export const ArtifactKindSchema = z.enum([
+  "root_cause_note",
+  "suggested_changes_snapshot",
+  "verification_summary",
+  "patch",
+  "pull_request",
+  "risk_note",
+  "follow_up_task",
+  "audit_trail",
+  "decision_record"
+]);
+
+export const ActionHintSchema = z.object({
+  kind: z.enum([
+    "apply_suggested_changes",
+    "generate_patch",
+    "request_human_decision",
+    "link_to_work_item",
+    "request_review",
+    "create_pull_request",
+    "none"
+  ]),
+  targetId: z.string().min(1).optional(),
+  selectedIntentIds: z.array(z.string().min(1)).optional(),
+  metadata: z.record(z.unknown()).optional()
+});
+
+export const NextActionSchema = z.union([
+  z.string().min(1),
+  z.object({
+    summary: z.string().min(1),
+    hint: ActionHintSchema
+  })
+]);
+
+export const CanonicalMutationDomainSchema = z.enum(["status", "assignee", "priority", "labels", "schedule", "review", "artifact_links"]);
+
+export const MutationIntentSchema = z.object({
+  intentId: z.string().min(1),
+  domain: CanonicalMutationDomainSchema,
+  action: z.string().min(1),
+  summary: z.string().min(1),
+  params: z.record(z.unknown()).optional(),
+  supersedesIntentIds: z.array(z.string().min(1)).optional(),
+  sourcePointer: ContextPointerSchema.optional()
+});
+
+export const SuggestedChangesSnapshotSchema = z.object({
+  proposalId: z.string().min(1),
+  createdAt: z.string().datetime(),
+  sourceRunId: z.string().min(1).optional(),
+  workThread: WorkThreadSchema.optional(),
+  summary: z.string().min(1),
+  intents: z.array(MutationIntentSchema).min(1),
+  preconditions: z.array(z.string().min(1)).optional(),
+  supersedesProposalIds: z.array(z.string().min(1)).optional(),
+  metadata: z.record(z.unknown()).optional()
+});
+
+export const MutationIntentActionabilitySchema = z.object({
+  proposalId: z.string().min(1),
+  intentId: z.string().min(1),
+  domain: CanonicalMutationDomainSchema,
+  status: z.enum(["current", "superseded", "stale", "conflicted"]),
+  supersededByProposalId: z.string().min(1).optional(),
+  supersededByIntentId: z.string().min(1).optional(),
+  reason: z.string().min(1).optional()
+});
+
+export const ProposalLineageSchema = z.object({
+  scopeKey: z.string().min(1),
+  entries: z.array(MutationIntentActionabilitySchema)
+});
+
+export const ApprovalDecisionSchema = z.object({
+  id: z.string().min(1),
+  proposalId: z.string().min(1),
+  approvedIntentIds: z.array(z.string().min(1)),
+  rejectedIntentIds: z.array(z.string().min(1)).optional(),
+  approvedBy: ActorIdentitySchema,
+  approvedAt: z.string().datetime(),
+  scope: z.enum(["manual", "policy"])
+});
+
+export const ApplyIntentOutcomeSchema = z.object({
+  intentId: z.string().min(1),
+  outcome: z.enum(["applied", "skipped", "failed", "stale", "unsupported"]),
+  message: z.string().min(1).optional(),
+  externalUri: z.string().min(1).optional(),
+  error: z.string().min(1).optional()
+});
+
+export const ApplyPlanSchema = z.object({
+  id: z.string().min(1),
+  proposalId: z.string().min(1),
+  approvalDecisionId: z.string().min(1),
+  selectedIntentIds: z.array(z.string().min(1)),
+  mode: z.enum(["preflight_then_per_intent", "atomic"]).default("preflight_then_per_intent"),
+  adapter: z.string().min(1).optional(),
+  adapterPlan: z.unknown().optional(),
+  outcomes: z.array(ApplyIntentOutcomeSchema).optional()
 });
 
 export const OpenTagEventSchema = z.object({
@@ -75,12 +309,22 @@ export const OpenTagEventSchema = z.object({
   metadata: z.record(z.unknown())
 });
 
+export const ResultArtifactSchema = z.object({
+  kind: ArtifactKindSchema.optional(),
+  title: z.string(),
+  uri: z.string(),
+  metadata: z.record(z.unknown()).optional()
+});
+
 export const OpenTagRunResultSchema = z.object({
   conclusion: z.enum(["success", "failure", "cancelled", "needs_human"]),
   summary: z.string(),
   changedFiles: z.array(z.string()).optional(),
   createdPullRequestUrl: z.string().url().optional(),
-  artifacts: z.array(z.object({ title: z.string(), uri: z.string() })).optional(),
+  artifacts: z.array(ResultArtifactSchema).optional(),
+  suggestedChanges: z.array(SuggestedChangesSnapshotSchema).optional(),
+  approvalDecision: ApprovalDecisionSchema.optional(),
+  applyPlan: ApplyPlanSchema.optional(),
   verification: z
     .array(
       z.object({
@@ -90,13 +334,19 @@ export const OpenTagRunResultSchema = z.object({
       })
     )
     .optional(),
-  nextAction: z.string().optional()
+  nextAction: NextActionSchema.optional()
 });
 
 export const OpenTagRunSchema = z.object({
   id: z.string().min(1),
   eventId: z.string().min(1),
   status: z.enum(["queued", "assigned", "running", "needs_approval", "succeeded", "failed", "cancelled"]),
+  thread: WorkThreadSchema.optional(),
+  parentRunId: z.string().min(1).optional(),
+  triggeredByAction: ActionHintSchema.optional(),
+  sourceProposalId: z.string().min(1).optional(),
+  sourceApplyPlanId: z.string().min(1).optional(),
+  contextPacket: ContextPacketSchema.optional(),
   assignedRunnerId: z.string().min(1).optional(),
   executor: z.string().min(1).optional(),
   createdAt: z.string().datetime(),
@@ -108,8 +358,35 @@ export type ActorIdentity = z.infer<typeof ActorIdentitySchema>;
 export type AgentTarget = z.infer<typeof AgentTargetSchema>;
 export type OpenTagCommand = z.infer<typeof OpenTagCommandSchema>;
 export type ContextPointer = z.infer<typeof ContextPointerSchema>;
+export type ContextPacketAssemblyStage = z.infer<typeof ContextPacketAssemblyStageSchema>;
+export type ContextPacket = z.infer<typeof ContextPacketSchema>;
 export type PermissionGrant = z.infer<typeof PermissionGrantSchema>;
+export type CapabilityClass = z.infer<typeof CapabilityClassSchema>;
+export type CapabilityContract = z.infer<typeof CapabilityContractSchema>;
+export type PolicyScope = z.infer<typeof PolicyScopeSchema>;
+export type PolicyEffect = z.infer<typeof PolicyEffectSchema>;
+export type PolicyRule = z.infer<typeof PolicyRuleSchema>;
+export type PolicyResolution = z.infer<typeof PolicyResolutionSchema>;
+export type SuccessMetricName = z.infer<typeof SuccessMetricNameSchema>;
 export type CallbackRoute = z.infer<typeof CallbackRouteSchema>;
+export type WorkItemReference = z.infer<typeof WorkItemReferenceSchema>;
+export type ConversationAnchor = z.infer<typeof ConversationAnchorSchema>;
+export type WorkThread = z.infer<typeof WorkThreadSchema>;
+export type RunEventVisibility = z.infer<typeof RunEventVisibilitySchema>;
+export type RunEventImportance = z.infer<typeof RunEventImportanceSchema>;
+export type RunEvent = z.infer<typeof RunEventSchema>;
+export type ArtifactKind = z.infer<typeof ArtifactKindSchema>;
+export type ActionHint = z.infer<typeof ActionHintSchema>;
+export type NextAction = z.infer<typeof NextActionSchema>;
+export type CanonicalMutationDomain = z.infer<typeof CanonicalMutationDomainSchema>;
+export type MutationIntent = z.infer<typeof MutationIntentSchema>;
+export type SuggestedChangesSnapshot = z.infer<typeof SuggestedChangesSnapshotSchema>;
+export type MutationIntentActionability = z.infer<typeof MutationIntentActionabilitySchema>;
+export type ProposalLineage = z.infer<typeof ProposalLineageSchema>;
+export type ApprovalDecision = z.infer<typeof ApprovalDecisionSchema>;
+export type ApplyIntentOutcome = z.infer<typeof ApplyIntentOutcomeSchema>;
+export type ApplyPlan = z.infer<typeof ApplyPlanSchema>;
+export type ResultArtifact = z.infer<typeof ResultArtifactSchema>;
 export type OpenTagEvent = z.infer<typeof OpenTagEventSchema>;
 export type OpenTagRun = z.infer<typeof OpenTagRunSchema>;
 export type OpenTagRunResult = z.infer<typeof OpenTagRunResultSchema>;

--- a/packages/core/test/json-schema.test.ts
+++ b/packages/core/test/json-schema.test.ts
@@ -16,6 +16,7 @@ describe("OpenTagJsonSchemas", () => {
     expect(OpenTagJsonSchemas.WorkThread).toHaveProperty("definitions.WorkThread");
     expect(OpenTagJsonSchemas.ContextPacket).toHaveProperty("definitions.ContextPacket");
     expect(OpenTagJsonSchemas.RunEvent).toHaveProperty("definitions.RunEvent");
+    expect(OpenTagJsonSchemas.AdapterMutationMapping).toHaveProperty("definitions.AdapterMutationMapping");
     expect(OpenTagJsonSchemas.CapabilityContract).toHaveProperty("definitions.CapabilityContract");
     expect(OpenTagJsonSchemas.PolicyResolution).toHaveProperty("definitions.PolicyResolution");
     expect(OpenTagJsonSchemas.ProposalLineage).toHaveProperty("definitions.ProposalLineage");

--- a/packages/core/test/json-schema.test.ts
+++ b/packages/core/test/json-schema.test.ts
@@ -13,5 +13,15 @@ describe("OpenTagJsonSchemas", () => {
     });
     expect(OpenTagJsonSchemas.OpenTagRun).toHaveProperty("definitions.OpenTagRun");
     expect(OpenTagJsonSchemas.OpenTagRunResult).toHaveProperty("definitions.OpenTagRunResult");
+    expect(OpenTagJsonSchemas.WorkThread).toHaveProperty("definitions.WorkThread");
+    expect(OpenTagJsonSchemas.ContextPacket).toHaveProperty("definitions.ContextPacket");
+    expect(OpenTagJsonSchemas.RunEvent).toHaveProperty("definitions.RunEvent");
+    expect(OpenTagJsonSchemas.CapabilityContract).toHaveProperty("definitions.CapabilityContract");
+    expect(OpenTagJsonSchemas.PolicyResolution).toHaveProperty("definitions.PolicyResolution");
+    expect(OpenTagJsonSchemas.ProposalLineage).toHaveProperty("definitions.ProposalLineage");
+    expect(OpenTagJsonSchemas.SuccessMetricName).toHaveProperty("definitions.SuccessMetricName");
+    expect(OpenTagJsonSchemas.SuggestedChangesSnapshot).toHaveProperty("definitions.SuggestedChangesSnapshot");
+    expect(OpenTagJsonSchemas.ApprovalDecision).toHaveProperty("definitions.ApprovalDecision");
+    expect(OpenTagJsonSchemas.ApplyPlan).toHaveProperty("definitions.ApplyPlan");
   });
 });

--- a/packages/core/test/protocol.test.ts
+++ b/packages/core/test/protocol.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   assembleContextPacketFromEvent,
   contextPacketFromEvent,
+  createAdapterMutationCompilerRegistry,
   preflightMutationIntent,
   protocolRunFieldsFromEvent,
   workThreadFromEvent
@@ -101,6 +102,57 @@ describe("protocol helpers", () => {
     expect(packet.sourcePointers).toHaveLength(1);
     expect(packet.assembly?.budgetTokens).toBe(500);
     expect(packet.assembly?.stages).toContain("budget");
+  });
+
+  it("allows context packet assembly hooks to customize stages", () => {
+    const packet = assembleContextPacketFromEvent(githubEvent, "2026-06-24T00:00:00.000Z", {
+      hooks: {
+        collect({ pointers }) {
+          return pointers.slice(0, 1);
+        },
+        summarize({ summary }) {
+          return `Hooked: ${summary}`;
+        },
+        preserve({ facts }) {
+          return [...facts, { text: "hook-added fact" }];
+        }
+      }
+    });
+
+    expect(packet.summary).toBe("Hooked: fix the flaky test");
+    expect(packet.sourcePointers).toHaveLength(1);
+    expect(packet.facts?.map((fact) => fact.text)).toContain("hook-added fact");
+  });
+
+  it("compiles mutation intents through adapter compiler registry", () => {
+    const registry = createAdapterMutationCompilerRegistry([
+      {
+        adapter: "test",
+        compile(intent) {
+          return {
+            ok: true,
+            adapter: "test",
+            intentId: intent.intentId,
+            operation: { action: intent.action }
+          };
+        }
+      }
+    ]);
+
+    expect(
+      registry.compile("test", [{ intentId: "intent_1", domain: "labels", action: "add_label", summary: "Add label." }])
+    ).toEqual([{ ok: true, adapter: "test", intentId: "intent_1", operation: { action: "add_label" } }]);
+    expect(registry.compile("missing", [{ intentId: "intent_2", domain: "labels", action: "add_label", summary: "Add label." }])).toEqual([
+      {
+        ok: false,
+        adapter: "missing",
+        outcome: {
+          intentId: "intent_2",
+          outcome: "unsupported",
+          message: "No adapter mutation compiler is registered for missing."
+        }
+      }
+    ]);
   });
 
   it("preflights mutation intents through platform permission and OpenTag policy", () => {

--- a/packages/core/test/protocol.test.ts
+++ b/packages/core/test/protocol.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { contextPacketFromEvent, preflightMutationIntent, protocolRunFieldsFromEvent, workThreadFromEvent } from "../src/protocol.js";
+import {
+  assembleContextPacketFromEvent,
+  contextPacketFromEvent,
+  preflightMutationIntent,
+  protocolRunFieldsFromEvent,
+  workThreadFromEvent
+} from "../src/protocol.js";
 import type { OpenTagEvent } from "../src/schema.js";
 
 const githubEvent: OpenTagEvent = {
@@ -76,6 +82,25 @@ describe("protocol helpers", () => {
     expect(packet.assembly?.stages).toEqual(["collect", "classify", "filter", "preserve", "summarize", "budget", "emit"]);
     expect(packet.risks?.[0]).toContain("repo:write");
     expect(packet.exclusions?.[0]).toContain("explicit capability");
+  });
+
+  it("applies context packet budget as an explicit assembly stage", () => {
+    const packet = assembleContextPacketFromEvent(
+      {
+        ...githubEvent,
+        context: [
+          ...githubEvent.context,
+          { kind: "github.repo", uri: "https://github.com/acme/demo", visibility: "public" },
+          { kind: "url", uri: "https://example.com/background", visibility: "public" }
+        ]
+      },
+      "2026-06-24T00:00:00.000Z",
+      { budgetTokens: 500 }
+    );
+
+    expect(packet.sourcePointers).toHaveLength(1);
+    expect(packet.assembly?.budgetTokens).toBe(500);
+    expect(packet.assembly?.stages).toContain("budget");
   });
 
   it("preflights mutation intents through platform permission and OpenTag policy", () => {

--- a/packages/core/test/protocol.test.ts
+++ b/packages/core/test/protocol.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { contextPacketFromEvent, preflightMutationIntent, protocolRunFieldsFromEvent, workThreadFromEvent } from "../src/protocol.js";
+import type { OpenTagEvent } from "../src/schema.js";
+
+const githubEvent: OpenTagEvent = {
+  id: "evt_github_comment_1",
+  source: "github",
+  sourceEventId: "comment_1",
+  receivedAt: "2026-06-24T00:00:00.000Z",
+  actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+  target: { mention: "@opentag", agentId: "opentag" },
+  command: { rawText: "fix the flaky test", intent: "fix", args: {} },
+  context: [
+    { kind: "github.issue", uri: "https://github.com/acme/demo/issues/7", visibility: "public" },
+    { kind: "github.comment", uri: "https://github.com/acme/demo/issues/7#issuecomment-1", visibility: "public" }
+  ],
+  permissions: [
+    { scope: "issue:comment", reason: "reply to source thread" },
+    { scope: "repo:write", reason: "commit on isolated branch" },
+    { scope: "pr:create", reason: "open a pull request" }
+  ],
+  callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/7/comments", threadKey: "acme/demo" },
+  metadata: { owner: "acme", repo: "demo", issueNumber: 7 }
+};
+
+describe("protocol helpers", () => {
+  it("derives a work thread for a canonical GitHub issue event", () => {
+    const thread = workThreadFromEvent(githubEvent);
+
+    expect(thread).toMatchObject({
+      workItemReference: {
+        provider: "github",
+        kind: "issue",
+        externalId: "acme/demo#7"
+      },
+      primaryAnchor: {
+        provider: "github",
+        controlPlane: true,
+        canApprove: true
+      }
+    });
+  });
+
+  it("does not invent a canonical work item when only a Slack thread is known", () => {
+    const slackEvent: OpenTagEvent = {
+      ...githubEvent,
+      id: "evt_slack_1",
+      source: "slack",
+      sourceEventId: "Ev123",
+      actor: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
+      context: [
+        { kind: "url", uri: "slack://team/T123/channel/C123/message/1710000000.000100", visibility: "organization" },
+        { kind: "text", uri: "<@U999> fix this", visibility: "organization" }
+      ],
+      permissions: [{ scope: "chat:postMessage", reason: "reply in Slack thread" }],
+      callback: {
+        provider: "slack",
+        uri: "https://slack.com/api/chat.postMessage",
+        threadKey: "T123|C123|1710000000.000100"
+      },
+      metadata: { owner: "acme", repo: "demo", repoProvider: "github" }
+    };
+
+    expect(workThreadFromEvent(slackEvent)).toBeUndefined();
+    expect(protocolRunFieldsFromEvent(slackEvent)).toMatchObject({
+      contextPacket: {
+        summary: "fix the flaky test"
+      }
+    });
+  });
+
+  it("builds a context packet with assembly metadata and write-scope risk", () => {
+    const packet = contextPacketFromEvent(githubEvent);
+
+    expect(packet.sourcePointers).toHaveLength(2);
+    expect(packet.assembly?.stages).toEqual(["collect", "classify", "filter", "preserve", "summarize", "budget", "emit"]);
+    expect(packet.risks?.[0]).toContain("repo:write");
+    expect(packet.exclusions?.[0]).toContain("explicit capability");
+  });
+
+  it("preflights mutation intents through platform permission and OpenTag policy", () => {
+    const intent = {
+      intentId: "intent_label_1",
+      domain: "labels" as const,
+      action: "add_label",
+      summary: "Add the bug label.",
+      params: { label: "bug" }
+    };
+
+    const denied = preflightMutationIntent({
+      intent,
+      permissions: githubEvent.permissions,
+      policyRules: []
+    });
+    expect(denied.outcome).toMatchObject({
+      intentId: "intent_label_1",
+      outcome: "unsupported"
+    });
+    expect(denied.outcome.message).toContain("policy denied");
+
+    const allowed = preflightMutationIntent({
+      intent,
+      permissions: githubEvent.permissions,
+      policyRules: [
+        {
+          id: "manual_approval",
+          scope: "primary_anchor_override",
+          effect: "allow",
+          capabilityId: "set_labels",
+          reason: "Manual approval selected this label intent."
+        }
+      ]
+    });
+    expect(allowed.policyResolution?.decision).toBe("allow");
+    expect(allowed.outcome).toMatchObject({
+      intentId: "intent_label_1",
+      outcome: "skipped"
+    });
+  });
+});

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { OpenTagEventSchema } from "../src/schema.js";
+import {
+  ApprovalDecisionSchema,
+  ApplyPlanSchema,
+  CapabilityContractSchema,
+  ContextPacketSchema,
+  OpenTagEventSchema,
+  OpenTagRunResultSchema,
+  OpenTagRunSchema,
+  PolicyResolutionSchema,
+  RunEventSchema,
+  SuccessMetricNameSchema,
+  SuggestedChangesSnapshotSchema,
+  WorkThreadSchema
+} from "../src/schema.js";
 
 describe("OpenTagEventSchema", () => {
   it("accepts a valid GitHub event", () => {
@@ -89,5 +102,224 @@ describe("OpenTagEventSchema", () => {
         metadata: { owner: "acme", repo: "demo" }
       })
     ).toThrow();
+  });
+});
+
+describe("Agent Work Protocol schemas", () => {
+  it("accepts a work item thread with one primary control anchor", () => {
+    const thread = WorkThreadSchema.parse({
+      id: "thread_github_1",
+      workItemReference: {
+        provider: "github",
+        kind: "issue",
+        externalId: "acme/demo#123",
+        uri: "https://github.com/acme/demo/issues/123",
+        ownerContainer: {
+          provider: "github",
+          id: "acme/demo",
+          uri: "https://github.com/acme/demo"
+        }
+      },
+      primaryAnchor: {
+        provider: "github",
+        kind: "issue_comment_thread",
+        externalId: "comment_456",
+        uri: "https://github.com/acme/demo/issues/123#issuecomment-456",
+        controlPlane: true,
+        canApprove: true
+      },
+      secondaryAnchors: [
+        {
+          provider: "slack",
+          kind: "thread",
+          externalId: "T123:C123:1710000000.000100",
+          uri: "https://slack.com/app_redirect?channel=C123",
+          threadKey: "T123|C123|1710000000.000100",
+          controlPlane: false,
+          canApprove: false
+        }
+      ]
+    });
+
+    expect(thread.workItemReference.provider).toBe("github");
+    expect(thread.primaryAnchor.canApprove).toBe(true);
+    expect(thread.secondaryAnchors?.[0]?.controlPlane).toBe(false);
+  });
+
+  it("accepts a minimal context packet with assembly stages", () => {
+    const packet = ContextPacketSchema.parse({
+      summary: "Investigate the failing test on the linked issue.",
+      sourcePointers: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/123", visibility: "public" }],
+      facts: [{ text: "The issue reports a flaky test in CI.", sourceUri: "https://github.com/acme/demo/issues/123" }],
+      risks: ["The executor should not push directly to the default branch."],
+      exclusions: ["Do not change unrelated Slack callback presentation work."],
+      assembly: {
+        stages: ["collect", "classify", "filter", "preserve", "summarize", "budget", "emit"],
+        budgetTokens: 4000,
+        emittedAt: "2026-06-24T00:00:00.000Z"
+      }
+    });
+
+    expect(packet.assembly?.stages).toContain("budget");
+  });
+
+  it("accepts run events with visibility and importance", () => {
+    const event = RunEventSchema.parse({
+      runId: "run_1",
+      type: "run.waiting_for_permission",
+      createdAt: "2026-06-24T00:00:00.000Z",
+      visibility: "human",
+      importance: "blocking",
+      message: "Approval is required before applying suggested changes.",
+      payload: { proposalId: "proposal_1" }
+    });
+
+    expect(event.visibility).toBe("human");
+    expect(event.importance).toBe("blocking");
+  });
+
+  it("models capability contracts and policy resolution separately from platform permissions", () => {
+    const capability = CapabilityContractSchema.parse({
+      id: "create_pr",
+      semanticAction: "create_pull_request",
+      capabilityClass: "external_write",
+      requiresExplicitIntent: true,
+      mayAutoApplyByPolicy: true,
+      adapterTargets: ["github"],
+      requiredPermissionScopes: ["pr:create"],
+      requiredExecutorConditions: ["local runner completed on isolated branch"]
+    });
+
+    const resolution = PolicyResolutionSchema.parse({
+      capabilityId: capability.id,
+      decision: "allow",
+      resolvedBy: "work_context_owner_container",
+      rules: [
+        {
+          id: "repo_allows_pr_creation",
+          scope: "work_context_owner_container",
+          effect: "allow",
+          capabilityId: "create_pr",
+          reason: "Repository policy allows explicit PR creation."
+        }
+      ],
+      reason: "Platform permission and OpenTag repo policy both allow PR creation."
+    });
+
+    expect(capability.capabilityClass).toBe("external_write");
+    expect(resolution.decision).toBe("allow");
+  });
+
+  it("exposes protocol success metric names", () => {
+    expect(SuccessMetricNameSchema.parse("thread_noise_ratio")).toBe("thread_noise_ratio");
+  });
+
+  it("models immutable suggested changes, subset approval, and apply outcomes", () => {
+    const proposal = SuggestedChangesSnapshotSchema.parse({
+      proposalId: "proposal_1",
+      createdAt: "2026-06-24T00:00:00.000Z",
+      sourceRunId: "run_1",
+      summary: "Move the issue forward with owner and label updates.",
+      intents: [
+        {
+          intentId: "intent_assignee_1",
+          domain: "assignee",
+          action: "set_assignee",
+          summary: "Assign the issue to Alice.",
+          params: { assignee: "alice" }
+        },
+        {
+          intentId: "intent_label_1",
+          domain: "labels",
+          action: "add_label",
+          summary: "Add the bug label.",
+          params: { label: "bug" }
+        }
+      ],
+      preconditions: ["Issue updated_at matched 2026-06-24T00:00:00.000Z"]
+    });
+
+    const decision = ApprovalDecisionSchema.parse({
+      id: "approval_1",
+      proposalId: proposal.proposalId,
+      approvedIntentIds: ["intent_label_1"],
+      rejectedIntentIds: ["intent_assignee_1"],
+      approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+      approvedAt: "2026-06-24T00:01:00.000Z",
+      scope: "manual"
+    });
+
+    const applyPlan = ApplyPlanSchema.parse({
+      id: "apply_1",
+      proposalId: proposal.proposalId,
+      approvalDecisionId: decision.id,
+      selectedIntentIds: decision.approvedIntentIds,
+      adapter: "github",
+      outcomes: [{ intentId: "intent_label_1", outcome: "applied", externalUri: "https://github.com/acme/demo/issues/123" }]
+    });
+
+    expect(proposal.intents).toHaveLength(2);
+    expect(decision.approvedIntentIds).toEqual(["intent_label_1"]);
+    expect(applyPlan.mode).toBe("preflight_then_per_intent");
+    expect(applyPlan.outcomes?.[0]?.outcome).toBe("applied");
+  });
+
+  it("accepts structured next actions while preserving legacy string next actions", () => {
+    const structured = OpenTagRunResultSchema.parse({
+      conclusion: "needs_human",
+      summary: "I prepared a suggested change snapshot.",
+      suggestedChanges: [
+        {
+          proposalId: "proposal_1",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Add the bug label.",
+          intents: [
+            {
+              intentId: "intent_label_1",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ],
+      nextAction: {
+        summary: "Approve intent_label_1 to add the bug label.",
+        hint: {
+          kind: "apply_suggested_changes",
+          targetId: "proposal_1",
+          selectedIntentIds: ["intent_label_1"]
+        }
+      }
+    });
+
+    const legacy = OpenTagRunResultSchema.parse({
+      conclusion: "success",
+      summary: "Done.",
+      nextAction: "Review the branch."
+    });
+
+    expect(typeof structured.nextAction).toBe("object");
+    expect(legacy.nextAction).toBe("Review the branch.");
+  });
+
+  it("adds optional run lineage without changing the existing run contract", () => {
+    const run = OpenTagRunSchema.parse({
+      id: "run_2",
+      eventId: "evt_2",
+      status: "queued",
+      parentRunId: "run_1",
+      triggeredByAction: {
+        kind: "generate_patch",
+        targetId: "proposal_1"
+      },
+      sourceProposalId: "proposal_1",
+      createdAt: "2026-06-24T00:00:00.000Z",
+      updatedAt: "2026-06-24T00:00:00.000Z"
+    });
+
+    expect(run.parentRunId).toBe("run_1");
+    expect(run.triggeredByAction?.kind).toBe("generate_patch");
   });
 });

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -63,6 +63,9 @@ export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: Fe
           commentUriByKey.set(statusKey, commentUri);
         }
       }
+      if (message.kind === "final") {
+        commentUriByKey.delete(statusKey);
+      }
     }
   };
 }

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -7,6 +7,14 @@ function slackUpdateUriFrom(postMessageUri: string): string {
   return postMessageUri.replace(/\/chat\.postMessage$/, "/chat.update");
 }
 
+function githubCommentUriFrom(input: { commentsUri: string; responseBody: { id?: number; url?: string } }): string | undefined {
+  if (input.responseBody.url) return input.responseBody.url;
+  if (typeof input.responseBody.id === "number") {
+    return input.commentsUri.replace(/\/comments$/, `/comments/${input.responseBody.id}`);
+  }
+  return undefined;
+}
+
 function slackBotTokenFor(input: {
   botToken?: string;
   botTokensByAgentId?: Record<string, string>;
@@ -25,14 +33,17 @@ function slackBotTokenFor(input: {
 
 export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: FetchLike }): CallbackSink {
   const fetchImpl = input.fetchImpl ?? fetch;
+  const commentUriByKey = new Map<string, string>();
 
   return {
     async deliver(message: CallbackMessage): Promise<void> {
       if (message.provider !== "github") return;
       if (!input.token) return;
 
-      const response = await fetchImpl(message.uri, {
-        method: "POST",
+      const statusKey = message.statusMessageKey ?? `${message.runId}:status`;
+      const existingCommentUri = commentUriByKey.get(statusKey);
+      const response = await fetchImpl(existingCommentUri ?? message.uri, {
+        method: existingCommentUri ? "PATCH" : "POST",
         headers: {
           accept: "application/vnd.github+json",
           authorization: `Bearer ${input.token}`,
@@ -44,6 +55,13 @@ export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: Fe
 
       if (!response.ok) {
         throw new Error(`deliver GitHub callback failed: ${response.status} ${await response.text()}`);
+      }
+      if (!existingCommentUri) {
+        const body = (await response.json()) as { id?: number; url?: string };
+        const commentUri = githubCommentUriFrom({ commentsUri: message.uri, responseBody: body });
+        if (commentUri) {
+          commentUriByKey.set(statusKey, commentUri);
+        }
       }
     }
   };

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -34,6 +34,7 @@ function slackBotTokenFor(input: {
 export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: FetchLike }): CallbackSink {
   const fetchImpl = input.fetchImpl ?? fetch;
   const commentUriByKey = new Map<string, string>();
+  const deliveryByKey = new Map<string, Promise<void>>();
 
   return {
     async deliver(message: CallbackMessage): Promise<void> {
@@ -41,31 +42,40 @@ export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: Fe
       if (!input.token) return;
 
       const statusKey = message.statusMessageKey ?? `${message.runId}:status`;
-      const existingCommentUri = commentUriByKey.get(statusKey);
-      const response = await fetchImpl(existingCommentUri ?? message.uri, {
-        method: existingCommentUri ? "PATCH" : "POST",
-        headers: {
-          accept: "application/vnd.github+json",
-          authorization: `Bearer ${input.token}`,
-          "content-type": "application/json",
-          "x-github-api-version": "2022-11-28"
-        },
-        body: JSON.stringify({ body: message.body })
-      });
+      const previous = deliveryByKey.get(statusKey) ?? Promise.resolve();
+      const current = previous.then(async () => {
+        const existingCommentUri = commentUriByKey.get(statusKey);
+        const response = await fetchImpl(existingCommentUri ?? message.uri, {
+          method: existingCommentUri ? "PATCH" : "POST",
+          headers: {
+            accept: "application/vnd.github+json",
+            authorization: `Bearer ${input.token}`,
+            "content-type": "application/json",
+            "x-github-api-version": "2022-11-28"
+          },
+          body: JSON.stringify({ body: message.body })
+        });
 
-      if (!response.ok) {
-        throw new Error(`deliver GitHub callback failed: ${response.status} ${await response.text()}`);
-      }
-      if (!existingCommentUri) {
-        const body = (await response.json()) as { id?: number; url?: string };
-        const commentUri = githubCommentUriFrom({ commentsUri: message.uri, responseBody: body });
-        if (commentUri) {
-          commentUriByKey.set(statusKey, commentUri);
+        if (!response.ok) {
+          throw new Error(`deliver GitHub callback failed: ${response.status} ${await response.text()}`);
         }
-      }
-      if (message.kind === "final") {
-        commentUriByKey.delete(statusKey);
-      }
+        if (!existingCommentUri) {
+          const body = (await response.json()) as { id?: number; url?: string };
+          const commentUri = githubCommentUriFrom({ commentsUri: message.uri, responseBody: body });
+          if (commentUri) {
+            commentUriByKey.set(statusKey, commentUri);
+          }
+        }
+        if (message.kind === "final") {
+          commentUriByKey.delete(statusKey);
+        }
+      });
+      deliveryByKey.set(statusKey, current);
+      await current.finally(() => {
+        if (deliveryByKey.get(statusKey) === current) {
+          deliveryByKey.delete(statusKey);
+        }
+      });
     }
   };
 }

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -2,6 +2,7 @@ import {
   AdapterMutationMappingSchema,
   ActorIdentitySchema,
   ActionHintSchema,
+  createAdapterMutationCompilerRegistry,
   type OpenTagEvent,
   OpenTagEventSchema,
   OpenTagRunResultSchema,
@@ -11,9 +12,10 @@ import {
 } from "@opentag/core";
 import {
   applyGitHubIssueMutationOperation,
-  compileGitHubIssueMutationIntents,
+  createGitHubIssueMutationCompiler,
   type FetchLike as GitHubFetchLike
 } from "@opentag/github";
+import type { GitHubIssueMutationOperation } from "@opentag/github";
 import type { SlackBlock } from "@opentag/slack";
 import { createOpenTagRepository, migrateSchema } from "@opentag/store";
 import Database from "better-sqlite3";
@@ -285,6 +287,22 @@ export function createDispatcherApp(input: {
     return c.json({ mappings });
   });
 
+  app.get("/v1/repo-bindings/:provider/:owner/:repo/metrics", async (c) => {
+    const metrics = await repo.getRepoMetrics({
+      provider: c.req.param("provider"),
+      owner: c.req.param("owner"),
+      repo: c.req.param("repo")
+    });
+    return c.json({ metrics });
+  });
+
+  app.get("/v1/work-thread-metrics", async (c) => {
+    const threadId = c.req.query("threadId");
+    if (!threadId) return c.json({ error: "thread_id_required" }, 422);
+    const metrics = await repo.getWorkThreadMetrics({ threadId });
+    return c.json({ metrics });
+  });
+
   app.post("/v1/slack-channel-bindings", async (c) => {
     const parsed = CreateSlackChannelBindingSchema.parse(await c.req.json());
     await repo.createSlackChannelBinding(parsed);
@@ -487,9 +505,10 @@ export function createDispatcherApp(input: {
         issueNumber
       };
       const executedOutcomes = [];
-      for (const compilation of compileGitHubIssueMutationIntents(executableIntents, {
-        mappings: mappingsFromAdapterPlan(plan.adapterPlan)
-      })) {
+      const compilerRegistry = createAdapterMutationCompilerRegistry([
+        createGitHubIssueMutationCompiler({ mappings: mappingsFromAdapterPlan(plan.adapterPlan) })
+      ]);
+      for (const compilation of compilerRegistry.compile("github", executableIntents)) {
         if (!compilation.ok) {
           executedOutcomes.push(compilation.outcome);
           continue;
@@ -497,7 +516,7 @@ export function createDispatcherApp(input: {
         executedOutcomes.push(
           await applyGitHubIssueMutationOperation({
             target,
-            operation: compilation.operation,
+            operation: compilation.operation as GitHubIssueMutationOperation,
             ...(input.githubApply.fetchImpl ? { fetchImpl: input.githubApply.fetchImpl } : {})
           })
         );

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -4,6 +4,7 @@ import {
   type OpenTagEvent,
   OpenTagEventSchema,
   OpenTagRunResultSchema,
+  PolicyRuleSchema,
   RunEventImportanceSchema,
   RunEventVisibilitySchema
 } from "@opentag/core";
@@ -36,6 +37,10 @@ const CreateSlackChannelBindingSchema = z.object({
   channelId: z.string().min(1),
   owner: z.string().min(1),
   repo: z.string().min(1)
+});
+
+const UpsertPolicyRuleSchema = z.object({
+  rule: PolicyRuleSchema
 });
 
 const CreateRunSchema = z.object({
@@ -222,6 +227,26 @@ export function createDispatcherApp(input: {
     });
     if (!binding) return c.json({ error: "repo_binding_not_found" }, 404);
     return c.json({ binding });
+  });
+
+  app.post("/v1/repo-bindings/:provider/:owner/:repo/policy-rules", async (c) => {
+    const parsed = UpsertPolicyRuleSchema.parse(await c.req.json());
+    const rule = await repo.upsertRepoPolicyRule({
+      provider: c.req.param("provider"),
+      owner: c.req.param("owner"),
+      repo: c.req.param("repo"),
+      rule: parsed.rule
+    });
+    return c.json({ rule }, 201);
+  });
+
+  app.get("/v1/repo-bindings/:provider/:owner/:repo/policy-rules", async (c) => {
+    const rules = await repo.listRepoPolicyRules({
+      provider: c.req.param("provider"),
+      owner: c.req.param("owner"),
+      repo: c.req.param("repo")
+    });
+    return c.json({ rules });
   });
 
   app.post("/v1/slack-channel-bindings", async (c) => {
@@ -475,6 +500,14 @@ export function createDispatcherApp(input: {
     const stored = await repo.getRun({ runId: c.req.param("runId") });
     if (!stored) return c.json({ error: "run_not_found" }, 404);
     return c.json(stored);
+  });
+
+  app.get("/v1/runs/:runId/metrics", async (c) => {
+    const runId = c.req.param("runId");
+    const stored = await repo.getRun({ runId });
+    if (!stored) return c.json({ error: "run_not_found" }, 404);
+    const metrics = await repo.getRunMetrics({ runId });
+    return c.json({ metrics });
   });
 
   app.get("/v1/runs/:runId/events", async (c) => {

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -1,4 +1,5 @@
 import {
+  AdapterMutationMappingSchema,
   ActorIdentitySchema,
   ActionHintSchema,
   type OpenTagEvent,
@@ -8,7 +9,11 @@ import {
   RunEventImportanceSchema,
   RunEventVisibilitySchema
 } from "@opentag/core";
-import { applyGitHubIssueMutationIntents, type FetchLike as GitHubFetchLike } from "@opentag/github";
+import {
+  applyGitHubIssueMutationOperation,
+  compileGitHubIssueMutationIntents,
+  type FetchLike as GitHubFetchLike
+} from "@opentag/github";
 import type { SlackBlock } from "@opentag/slack";
 import { createOpenTagRepository, migrateSchema } from "@opentag/store";
 import Database from "better-sqlite3";
@@ -41,6 +46,10 @@ const CreateSlackChannelBindingSchema = z.object({
 
 const UpsertPolicyRuleSchema = z.object({
   rule: PolicyRuleSchema
+});
+
+const UpsertMutationMappingSchema = z.object({
+  mapping: AdapterMutationMappingSchema
 });
 
 const CreateRunSchema = z.object({
@@ -126,6 +135,13 @@ function childEventFromParent(input: {
       }
     }
   };
+}
+
+function mappingsFromAdapterPlan(adapterPlan: unknown) {
+  if (!adapterPlan || typeof adapterPlan !== "object" || Array.isArray(adapterPlan)) return [];
+  const mappings = (adapterPlan as { mappings?: unknown }).mappings;
+  if (!Array.isArray(mappings)) return [];
+  return mappings.map((mapping) => AdapterMutationMappingSchema.parse(mapping));
 }
 
 export type CallbackMessage = {
@@ -247,6 +263,26 @@ export function createDispatcherApp(input: {
       repo: c.req.param("repo")
     });
     return c.json({ rules });
+  });
+
+  app.post("/v1/repo-bindings/:provider/:owner/:repo/mutation-mappings", async (c) => {
+    const parsed = UpsertMutationMappingSchema.parse(await c.req.json());
+    const mapping = await repo.upsertRepoMutationMapping({
+      provider: c.req.param("provider"),
+      owner: c.req.param("owner"),
+      repo: c.req.param("repo"),
+      mapping: parsed.mapping
+    });
+    return c.json({ mapping }, 201);
+  });
+
+  app.get("/v1/repo-bindings/:provider/:owner/:repo/mutation-mappings", async (c) => {
+    const mappings = await repo.listRepoMutationMappings({
+      provider: c.req.param("provider"),
+      owner: c.req.param("owner"),
+      repo: c.req.param("repo")
+    });
+    return c.json({ mappings });
   });
 
   app.post("/v1/slack-channel-bindings", async (c) => {
@@ -444,16 +480,28 @@ export function createDispatcherApp(input: {
         const outcome = preflightOutcomeByIntentId.get(intent.intentId);
         return outcome?.outcome === "skipped" && outcome.message?.startsWith("Preflight passed");
       });
-      const executedOutcomes = await applyGitHubIssueMutationIntents({
-        target: {
-          token: input.githubApply.token,
-          owner,
-          repo: repoName,
-          issueNumber
-        },
-        intents: executableIntents,
-        ...(input.githubApply.fetchImpl ? { fetchImpl: input.githubApply.fetchImpl } : {})
-      });
+      const target = {
+        token: input.githubApply.token,
+        owner,
+        repo: repoName,
+        issueNumber
+      };
+      const executedOutcomes = [];
+      for (const compilation of compileGitHubIssueMutationIntents(executableIntents, {
+        mappings: mappingsFromAdapterPlan(plan.adapterPlan)
+      })) {
+        if (!compilation.ok) {
+          executedOutcomes.push(compilation.outcome);
+          continue;
+        }
+        executedOutcomes.push(
+          await applyGitHubIssueMutationOperation({
+            target,
+            operation: compilation.operation,
+            ...(input.githubApply.fetchImpl ? { fetchImpl: input.githubApply.fetchImpl } : {})
+          })
+        );
+      }
       const executedOutcomeByIntentId = new Map(executedOutcomes.map((outcome) => [outcome.intentId, outcome]));
       const mergedOutcomes = (plan.outcomes ?? []).map((outcome) => executedOutcomeByIntentId.get(outcome.intentId) ?? outcome);
       const executedPlan = await repo.updateApplyPlanOutcomes({

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -468,14 +468,15 @@ export function createDispatcherApp(input: {
   app.post("/v1/proposals/:proposalId/apply-plans", async (c) => {
     const proposalId = c.req.param("proposalId");
     const body = ApplyPlanInputSchema.parse(await c.req.json());
-    const plan = await repo.createApplyPlan({
-      id: body.id ?? `apply_${proposalId}_${Date.now()}`,
-      proposalId,
-      approvalDecisionId: body.approvalDecisionId,
-      ...(body.selectedIntentIds?.length ? { selectedIntentIds: body.selectedIntentIds } : {}),
-      ...(body.adapter ? { adapter: body.adapter } : {})
-    });
-    if (!plan) return c.json({ error: "proposal_or_approval_not_found" }, 404);
+    let executableTarget:
+      | {
+          proposal: NonNullable<Awaited<ReturnType<typeof repo.getSuggestedChanges>>>;
+          owner: string;
+          repoName: string;
+          issueNumber: number;
+        }
+      | undefined;
+
     if (body.execute) {
       if (body.adapter !== "github") {
         return c.json({ error: "apply_execution_adapter_not_supported" }, 422);
@@ -493,16 +494,32 @@ export function createDispatcherApp(input: {
       if (typeof owner !== "string" || typeof repoName !== "string" || typeof issueNumber !== "number") {
         return c.json({ error: "github_issue_target_missing" }, 422);
       }
+      executableTarget = { proposal, owner, repoName, issueNumber };
+    }
+
+    const plan = await repo.createApplyPlan({
+      id: body.id ?? `apply_${proposalId}_${Date.now()}`,
+      proposalId,
+      approvalDecisionId: body.approvalDecisionId,
+      ...(body.selectedIntentIds?.length ? { selectedIntentIds: body.selectedIntentIds } : {}),
+      ...(body.adapter ? { adapter: body.adapter } : {})
+    });
+    if (!plan) return c.json({ error: "proposal_or_approval_not_found" }, 404);
+    if (body.execute && executableTarget) {
+      const githubApply = input.githubApply;
+      if (!githubApply) {
+        return c.json({ error: "github_apply_not_configured" }, 422);
+      }
       const preflightOutcomeByIntentId = new Map((plan.outcomes ?? []).map((outcome) => [outcome.intentId, outcome]));
-      const executableIntents = proposal.snapshot.intents.filter((intent) => {
+      const executableIntents = executableTarget.proposal.snapshot.intents.filter((intent) => {
         const outcome = preflightOutcomeByIntentId.get(intent.intentId);
         return outcome?.outcome === "skipped" && outcome.message?.startsWith("Preflight passed");
       });
       const target = {
-        token: input.githubApply.token,
-        owner,
-        repo: repoName,
-        issueNumber
+        token: githubApply.token,
+        owner: executableTarget.owner,
+        repo: executableTarget.repoName,
+        issueNumber: executableTarget.issueNumber
       };
       const executedOutcomes = [];
       const compilerRegistry = createAdapterMutationCompilerRegistry([
@@ -517,7 +534,7 @@ export function createDispatcherApp(input: {
           await applyGitHubIssueMutationOperation({
             target,
             operation: compilation.operation as GitHubIssueMutationOperation,
-            ...(input.githubApply.fetchImpl ? { fetchImpl: input.githubApply.fetchImpl } : {})
+            ...(githubApply.fetchImpl ? { fetchImpl: githubApply.fetchImpl } : {})
           })
         );
       }

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -70,6 +70,11 @@ const ApprovalDecisionInputSchema = z.object({
   approvedBy: ActorIdentitySchema,
   approvedAt: z.string().datetime().optional(),
   scope: z.enum(["manual", "policy"]).default("manual")
+}).refine((value) => {
+  const rejected = new Set(value.rejectedIntentIds ?? []);
+  return value.approvedIntentIds.every((intentId) => !rejected.has(intentId));
+}, {
+  message: "approvedIntentIds and rejectedIntentIds must not overlap"
 });
 
 const ApplyPlanInputSchema = z.object({
@@ -445,7 +450,9 @@ export function createDispatcherApp(input: {
 
   app.post("/v1/proposals/:proposalId/approvals", async (c) => {
     const proposalId = c.req.param("proposalId");
-    const body = ApprovalDecisionInputSchema.parse(await c.req.json());
+    const parsedBody = ApprovalDecisionInputSchema.safeParse(await c.req.json());
+    if (!parsedBody.success) return c.json({ error: "invalid_approval_decision" }, 400);
+    const body = parsedBody.data;
     const decision = await repo.recordApprovalDecision({
       id: body.id ?? `approval_${proposalId}_${Date.now()}`,
       proposalId,
@@ -501,7 +508,7 @@ export function createDispatcherApp(input: {
       id: body.id ?? `apply_${proposalId}_${Date.now()}`,
       proposalId,
       approvalDecisionId: body.approvalDecisionId,
-      ...(body.selectedIntentIds?.length ? { selectedIntentIds: body.selectedIntentIds } : {}),
+      ...(body.selectedIntentIds !== undefined ? { selectedIntentIds: body.selectedIntentIds } : {}),
       ...(body.adapter ? { adapter: body.adapter } : {})
     });
     if (!plan) return c.json({ error: "proposal_or_approval_not_found" }, 404);

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -1,4 +1,13 @@
-import { OpenTagEventSchema, OpenTagRunResultSchema } from "@opentag/core";
+import {
+  ActorIdentitySchema,
+  ActionHintSchema,
+  type OpenTagEvent,
+  OpenTagEventSchema,
+  OpenTagRunResultSchema,
+  RunEventImportanceSchema,
+  RunEventVisibilitySchema
+} from "@opentag/core";
+import { applyGitHubIssueMutationIntents, type FetchLike as GitHubFetchLike } from "@opentag/github";
 import type { SlackBlock } from "@opentag/slack";
 import { createOpenTagRepository, migrateSchema } from "@opentag/store";
 import Database from "better-sqlite3";
@@ -38,10 +47,37 @@ const CompleteRunSchema = z.object({
   result: OpenTagRunResultSchema
 });
 
+const ApprovalDecisionInputSchema = z.object({
+  id: z.string().min(1).optional(),
+  approvedIntentIds: z.array(z.string().min(1)),
+  rejectedIntentIds: z.array(z.string().min(1)).optional(),
+  approvedBy: ActorIdentitySchema,
+  approvedAt: z.string().datetime().optional(),
+  scope: z.enum(["manual", "policy"]).default("manual")
+});
+
+const ApplyPlanInputSchema = z.object({
+  id: z.string().min(1).optional(),
+  approvalDecisionId: z.string().min(1),
+  selectedIntentIds: z.array(z.string().min(1)).optional(),
+  adapter: z.string().min(1).optional(),
+  execute: z.boolean().optional()
+});
+
+const ChildRunInputSchema = z.object({
+  runId: z.string().min(1),
+  action: ActionHintSchema,
+  commandText: z.string().min(1).optional(),
+  sourceProposalId: z.string().min(1).optional(),
+  sourceApplyPlanId: z.string().min(1).optional()
+});
+
 const ProgressSchema = z.object({
   type: z.string().min(1).optional(),
   message: z.string().min(1),
-  at: z.string().datetime().optional()
+  at: z.string().datetime().optional(),
+  visibility: RunEventVisibilitySchema.optional(),
+  importance: RunEventImportanceSchema.optional()
 });
 
 function repoKeyFromEvent(event: z.infer<typeof OpenTagEventSchema>): { provider: string; owner: string; repo: string } | null {
@@ -64,6 +100,29 @@ function actorIsAllowed(event: z.infer<typeof OpenTagEventSchema>, allowedActors
   return allowedActors.includes(event.actor.handle ?? "") || allowedActors.includes(event.actor.providerUserId);
 }
 
+function childEventFromParent(input: {
+  parentEvent: OpenTagEvent;
+  childRunId: string;
+  commandText?: string;
+  actionKind: string;
+  receivedAt: string;
+}): OpenTagEvent {
+  return {
+    ...input.parentEvent,
+    id: `evt_${input.childRunId}`,
+    sourceEventId: `${input.parentEvent.sourceEventId}:${input.childRunId}`,
+    receivedAt: input.receivedAt,
+    command: {
+      rawText: input.commandText ?? `Execute next action: ${input.actionKind}`,
+      intent: "run",
+      args: {
+        parentSourceEventId: input.parentEvent.sourceEventId,
+        actionKind: input.actionKind
+      }
+    }
+  };
+}
+
 export type CallbackMessage = {
   runId: string;
   kind: "acknowledgement" | "progress" | "final";
@@ -78,6 +137,11 @@ export type CallbackMessage = {
 
 export type CallbackSink = {
   deliver(message: CallbackMessage): Promise<void>;
+};
+
+export type GitHubApplyOptions = {
+  token: string;
+  fetchImpl?: GitHubFetchLike;
 };
 
 const noopCallbackSink: CallbackSink = {
@@ -95,7 +159,10 @@ async function deliverAndAudit(input: {
   await input.repo.appendRunEvent({
     runId: input.message.runId,
     type: `callback.${input.message.kind}.delivered`,
-    payload: input.message
+    payload: input.message,
+    visibility: "human",
+    importance: input.message.kind === "final" ? "high" : "normal",
+    message: input.message.body
   });
 }
 
@@ -104,7 +171,13 @@ function isAuthorized(request: Request, pairingToken: string | undefined): boole
   return request.headers.get("authorization") === `Bearer ${pairingToken}`;
 }
 
-export function createDispatcherApp(input: { databasePath: string; callbackSink?: CallbackSink; pairingToken?: string; presentation?: CallbackPresentation }) {
+export function createDispatcherApp(input: {
+  databasePath: string;
+  callbackSink?: CallbackSink;
+  pairingToken?: string;
+  presentation?: CallbackPresentation;
+  githubApply?: GitHubApplyOptions;
+}) {
   const sqlite = new Database(input.databasePath);
   migrateSchema(sqlite);
   const repo = createOpenTagRepository(drizzle(sqlite));
@@ -225,7 +298,9 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
       runId,
       message: body.message,
       ...(body.type ? { type: body.type } : {}),
-      ...(body.at ? { at: body.at } : {})
+      ...(body.at ? { at: body.at } : {}),
+      ...(body.visibility ? { visibility: body.visibility } : {}),
+      ...(body.importance ? { importance: body.importance } : {})
     });
     if (presentation.shouldDeliverProgress(stored.event.callback.provider)) {
       await deliverAndAudit({
@@ -269,6 +344,131 @@ export function createDispatcherApp(input: { databasePath: string; callbackSink?
       }
     });
     return c.json({ ok: true });
+  });
+
+  app.get("/v1/proposals/:proposalId", async (c) => {
+    const proposal = await repo.getSuggestedChanges({ proposalId: c.req.param("proposalId") });
+    if (!proposal) return c.json({ error: "proposal_not_found" }, 404);
+    return c.json(proposal);
+  });
+
+  app.get("/v1/proposals/:proposalId/lineage", async (c) => {
+    const lineage = await repo.getProposalLineage({ proposalId: c.req.param("proposalId") });
+    if (!lineage) return c.json({ error: "proposal_not_found" }, 404);
+    return c.json({ lineage });
+  });
+
+  app.get("/v1/proposals/:proposalId/current-intents", async (c) => {
+    const intents = await repo.listCurrentMutationIntents({ proposalId: c.req.param("proposalId") });
+    if (!intents) return c.json({ error: "proposal_not_found" }, 404);
+    return c.json({ intents });
+  });
+
+  app.post("/v1/proposals/:proposalId/approvals", async (c) => {
+    const proposalId = c.req.param("proposalId");
+    const body = ApprovalDecisionInputSchema.parse(await c.req.json());
+    const decision = await repo.recordApprovalDecision({
+      id: body.id ?? `approval_${proposalId}_${Date.now()}`,
+      proposalId,
+      approvedIntentIds: body.approvedIntentIds,
+      ...(body.rejectedIntentIds?.length ? { rejectedIntentIds: body.rejectedIntentIds } : {}),
+      approvedBy: body.approvedBy,
+      approvedAt: body.approvedAt ?? new Date().toISOString(),
+      scope: body.scope
+    });
+    if (!decision) return c.json({ error: "proposal_not_found" }, 404);
+    return c.json({ decision }, 201);
+  });
+
+  app.get("/v1/approvals/:approvalDecisionId", async (c) => {
+    const decision = await repo.getApprovalDecision({ id: c.req.param("approvalDecisionId") });
+    if (!decision) return c.json({ error: "approval_decision_not_found" }, 404);
+    return c.json({ decision });
+  });
+
+  app.post("/v1/proposals/:proposalId/apply-plans", async (c) => {
+    const proposalId = c.req.param("proposalId");
+    const body = ApplyPlanInputSchema.parse(await c.req.json());
+    const plan = await repo.createApplyPlan({
+      id: body.id ?? `apply_${proposalId}_${Date.now()}`,
+      proposalId,
+      approvalDecisionId: body.approvalDecisionId,
+      ...(body.selectedIntentIds?.length ? { selectedIntentIds: body.selectedIntentIds } : {}),
+      ...(body.adapter ? { adapter: body.adapter } : {})
+    });
+    if (!plan) return c.json({ error: "proposal_or_approval_not_found" }, 404);
+    if (body.execute) {
+      if (body.adapter !== "github") {
+        return c.json({ error: "apply_execution_adapter_not_supported" }, 422);
+      }
+      if (!input.githubApply) {
+        return c.json({ error: "github_apply_not_configured" }, 422);
+      }
+      const proposal = await repo.getSuggestedChanges({ proposalId });
+      if (!proposal) return c.json({ error: "proposal_not_found" }, 404);
+      const stored = await repo.getRun({ runId: proposal.runId });
+      if (!stored) return c.json({ error: "run_not_found" }, 404);
+      const owner = stored.event.metadata["owner"];
+      const repoName = stored.event.metadata["repo"];
+      const issueNumber = stored.event.metadata["issueNumber"];
+      if (typeof owner !== "string" || typeof repoName !== "string" || typeof issueNumber !== "number") {
+        return c.json({ error: "github_issue_target_missing" }, 422);
+      }
+      const preflightOutcomeByIntentId = new Map((plan.outcomes ?? []).map((outcome) => [outcome.intentId, outcome]));
+      const executableIntents = proposal.snapshot.intents.filter((intent) => {
+        const outcome = preflightOutcomeByIntentId.get(intent.intentId);
+        return outcome?.outcome === "skipped" && outcome.message?.startsWith("Preflight passed");
+      });
+      const executedOutcomes = await applyGitHubIssueMutationIntents({
+        target: {
+          token: input.githubApply.token,
+          owner,
+          repo: repoName,
+          issueNumber
+        },
+        intents: executableIntents,
+        ...(input.githubApply.fetchImpl ? { fetchImpl: input.githubApply.fetchImpl } : {})
+      });
+      const executedOutcomeByIntentId = new Map(executedOutcomes.map((outcome) => [outcome.intentId, outcome]));
+      const mergedOutcomes = (plan.outcomes ?? []).map((outcome) => executedOutcomeByIntentId.get(outcome.intentId) ?? outcome);
+      const executedPlan = await repo.updateApplyPlanOutcomes({
+        id: plan.id,
+        outcomes: mergedOutcomes,
+        externalWritesExecuted: true
+      });
+      return c.json({ plan: executedPlan ?? plan }, 201);
+    }
+    return c.json({ plan }, 201);
+  });
+
+  app.get("/v1/apply-plans/:applyPlanId", async (c) => {
+    const plan = await repo.getApplyPlan({ id: c.req.param("applyPlanId") });
+    if (!plan) return c.json({ error: "apply_plan_not_found" }, 404);
+    return c.json({ plan });
+  });
+
+  app.post("/v1/runs/:runId/child-runs", async (c) => {
+    const parentRunId = c.req.param("runId");
+    const body = ChildRunInputSchema.parse(await c.req.json());
+    const parent = await repo.getRun({ runId: parentRunId });
+    if (!parent) return c.json({ error: "parent_run_not_found" }, 404);
+    const receivedAt = new Date().toISOString();
+    const sourceProposalId = body.sourceProposalId ?? body.action.targetId;
+    const run = await repo.createRun({
+      id: body.runId,
+      event: childEventFromParent({
+        parentEvent: parent.event,
+        childRunId: body.runId,
+        ...(body.commandText ? { commandText: body.commandText } : {}),
+        actionKind: body.action.kind,
+        receivedAt
+      }),
+      parentRunId,
+      triggeredByAction: body.action,
+      ...(sourceProposalId ? { sourceProposalId } : {}),
+      ...(body.sourceApplyPlanId ? { sourceApplyPlanId: body.sourceApplyPlanId } : {})
+    });
+    return c.json({ run }, 201);
   });
 
   app.get("/v1/runs/:runId", async (c) => {

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -71,6 +71,13 @@ describe("createGitHubCallbackSink", () => {
       uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
       body: "Done"
     });
+    await sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "github",
+      uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      body: "Starting again"
+    });
 
     expect(requests).toEqual([
       {
@@ -90,6 +97,12 @@ describe("createGitHubCallbackSink", () => {
         method: "PATCH",
         authorization: "Bearer ghs_test",
         body: { body: "Done" }
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        method: "POST",
+        authorization: "Bearer ghs_test",
+        body: { body: "Starting again" }
       }
     ]);
   });

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -3,16 +3,17 @@ import { createCompositeCallbackSink, createGitHubCallbackSink, createSlackCallb
 
 describe("createGitHubCallbackSink", () => {
   it("posts GitHub callback messages to the callback URI", async () => {
-    const requests: { url: string; body: unknown; authorization: string | null }[] = [];
+    const requests: { url: string; method: string; body: unknown; authorization: string | null }[] = [];
     const sink = createGitHubCallbackSink({
       token: "ghs_test",
       fetchImpl: (async (url, init) => {
         requests.push({
           url: String(url),
+          method: init?.method ?? "GET",
           body: JSON.parse(String(init?.body)),
           authorization: new Headers(init?.headers).get("authorization")
         });
-        return Response.json({ id: 1 });
+        return Response.json({ id: 1, url: "https://api.github.com/repos/acme/demo/issues/comments/1" });
       }) as typeof fetch
     });
 
@@ -27,8 +28,68 @@ describe("createGitHubCallbackSink", () => {
     expect(requests).toEqual([
       {
         url: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        method: "POST",
         authorization: "Bearer ghs_test",
         body: { body: "done" }
+      }
+    ]);
+  });
+
+  it("updates the same GitHub callback comment for a run", async () => {
+    const requests: { url: string; method: string; body: unknown; authorization: string | null }[] = [];
+    const sink = createGitHubCallbackSink({
+      token: "ghs_test",
+      fetchImpl: (async (url, init) => {
+        requests.push({
+          url: String(url),
+          method: init?.method ?? "GET",
+          body: JSON.parse(String(init?.body)),
+          authorization: new Headers(init?.headers).get("authorization")
+        });
+        return Response.json({ id: 123, url: "https://api.github.com/repos/acme/demo/issues/comments/123" });
+      }) as typeof fetch
+    });
+
+    await sink.deliver({
+      runId: "run_1",
+      kind: "acknowledgement",
+      provider: "github",
+      uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      body: "OpenTag picked this up."
+    });
+    await sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "github",
+      uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      body: "Still working"
+    });
+    await sink.deliver({
+      runId: "run_1",
+      kind: "final",
+      provider: "github",
+      uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      body: "Done"
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        method: "POST",
+        authorization: "Bearer ghs_test",
+        body: { body: "OpenTag picked this up." }
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/comments/123",
+        method: "PATCH",
+        authorization: "Bearer ghs_test",
+        body: { body: "Still working" }
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/comments/123",
+        method: "PATCH",
+        authorization: "Bearer ghs_test",
+        body: { body: "Done" }
       }
     ]);
   });

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -107,6 +107,59 @@ describe("createGitHubCallbackSink", () => {
     ]);
   });
 
+  it("serializes concurrent GitHub callback deliveries for the same run", async () => {
+    const requests: { url: string; method: string; body: unknown }[] = [];
+    let resolveFirst: (() => void) | undefined;
+    const firstRequest = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const sink = createGitHubCallbackSink({
+      token: "ghs_test",
+      fetchImpl: (async (url, init) => {
+        requests.push({
+          url: String(url),
+          method: init?.method ?? "GET",
+          body: JSON.parse(String(init?.body))
+        });
+        if (requests.length === 1) {
+          await firstRequest;
+          return Response.json({ id: 123, url: "https://api.github.com/repos/acme/demo/issues/comments/123" });
+        }
+        return Response.json({ id: 123, url: "https://api.github.com/repos/acme/demo/issues/comments/123" });
+      }) as typeof fetch
+    });
+
+    const first = sink.deliver({
+      runId: "run_1",
+      kind: "acknowledgement",
+      provider: "github",
+      uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      body: "Starting"
+    });
+    const second = sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "github",
+      uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      body: "Still working"
+    });
+    resolveFirst?.();
+    await Promise.all([first, second]);
+
+    expect(requests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        method: "POST",
+        body: { body: "Starting" }
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/comments/123",
+        method: "PATCH",
+        body: { body: "Still working" }
+      }
+    ]);
+  });
+
   it("ignores non-GitHub callback messages", async () => {
     const sink = createGitHubCallbackSink({
       token: "ghs_test",

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -61,6 +61,22 @@ describe("default callback presentation", () => {
 
     expect(presentation.final({ provider: "github", result }).body).toContain("Next action: Approve intent_label_1");
     expect(presentation.final({ provider: "slack", result }).body).toContain("*Next action*: Approve intent_label_1");
+    expect(presentation.final({ provider: "slack", result }).blocks).toEqual([
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Finished with needs_human.*\nPrepared a suggested change snapshot."
+        }
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Next action*: Approve intent_label_1 to add the bug label."
+        }
+      }
+    ]);
     expect(presentation.final({ provider: "github", result }).body).not.toContain("[object Object]");
   });
 });

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -43,4 +43,24 @@ describe("default callback presentation", () => {
       ]
     });
   });
+
+  it("renders structured next actions by summary", () => {
+    const presentation = createDefaultCallbackPresentation();
+    const result = {
+      conclusion: "needs_human" as const,
+      summary: "Prepared a suggested change snapshot.",
+      nextAction: {
+        summary: "Approve intent_label_1 to add the bug label.",
+        hint: {
+          kind: "apply_suggested_changes" as const,
+          targetId: "proposal_1",
+          selectedIntentIds: ["intent_label_1"]
+        }
+      }
+    };
+
+    expect(presentation.final({ provider: "github", result }).body).toContain("Next action: Approve intent_label_1");
+    expect(presentation.final({ provider: "slack", result }).body).toContain("*Next action*: Approve intent_label_1");
+    expect(presentation.final({ provider: "github", result }).body).not.toContain("[object Object]");
+  });
 });

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -437,6 +437,29 @@ describe("dispatcher API", () => {
         applyOutcomeCounts: { skipped: 1 }
       }
     });
+    const repoMetricsResponse = await app.request("/v1/repo-bindings/github/acme/demo/metrics");
+    expect(repoMetricsResponse.status).toBe(200);
+    await expect(repoMetricsResponse.json()).resolves.toMatchObject({
+      metrics: {
+        scope: "repo",
+        scopeId: "github:acme/demo",
+        runCount: 1,
+        suggestedChangesCount: 1
+      }
+    });
+    const proposalAgainResponse = await app.request("/v1/proposals/proposal_protocol");
+    const proposalAgain = await proposalAgainResponse.json();
+    const threadId = proposalAgain.snapshot.workThread.id;
+    const threadMetricsResponse = await app.request(`/v1/work-thread-metrics?threadId=${encodeURIComponent(threadId)}`);
+    expect(threadMetricsResponse.status).toBe(200);
+    await expect(threadMetricsResponse.json()).resolves.toMatchObject({
+      metrics: {
+        scope: "work_thread",
+        scopeId: threadId,
+        runCount: 1,
+        suggestedChangesCount: 1
+      }
+    });
   });
 
   it("creates child runs from next action hints with lineage fields", async () => {

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -133,12 +133,26 @@ describe("dispatcher API", () => {
     const { events } = await eventsResponse.json();
     expect(events.map((event: { type: string }) => event.type)).toEqual([
       "run.created",
+      "context_packet.generated",
       "callback.acknowledgement.delivered",
       "run.progress",
       "callback.progress.delivered",
       "run.completed",
       "callback.final.delivered"
     ]);
+    expect(events.find((event: { type: string }) => event.type === "run.progress")).toMatchObject({
+      visibility: "audit",
+      importance: "normal",
+      message: "running tests"
+    });
+    expect(events.find((event: { type: string }) => event.type === "context_packet.generated")).toMatchObject({
+      visibility: "audit",
+      importance: "normal"
+    });
+    expect(events.find((event: { type: string }) => event.type === "callback.final.delivered")).toMatchObject({
+      visibility: "human",
+      importance: "high"
+    });
   });
 
   it("renders Slack callbacks with Slack mrkdwn and keeps progress audit-only", async () => {
@@ -236,11 +250,321 @@ describe("dispatcher API", () => {
     const { events } = await eventsResponse.json();
     expect(events.map((event: { type: string }) => event.type)).toEqual([
       "run.created",
+      "context_packet.generated",
       "callback.acknowledgement.delivered",
       "run.progress",
       "run.completed",
       "callback.final.delivered"
     ]);
+    expect(events.find((event: { type: string }) => event.type === "run.progress")).toMatchObject({
+      visibility: "audit",
+      importance: "normal",
+      message: "Echo executor started"
+    });
+  });
+
+  it("records proposal approval decisions and creates apply plans", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        allowedActors: ["octocat"]
+      })
+    });
+
+    const event = {
+      ...validEvent,
+      id: "evt_protocol",
+      sourceEventId: "comment_protocol",
+      permissions: [
+        ...validEvent.permissions,
+        { scope: "repo:write", reason: "mutate labels after approval" }
+      ],
+      metadata: { owner: "acme", repo: "demo", issueNumber: 2 }
+    };
+    const createResponse = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_protocol", event })
+    });
+    expect(createResponse.status).toBe(201);
+
+    await app.request("/v1/runs/run_protocol/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        result: {
+          conclusion: "needs_human",
+          summary: "Prepared proposal.",
+          suggestedChanges: [
+            {
+              proposalId: "proposal_protocol",
+              createdAt: "2026-06-24T00:00:01.000Z",
+              sourceRunId: "run_protocol",
+              summary: "Add bug label.",
+              intents: [
+                {
+                  intentId: "intent_label_bug",
+                  domain: "labels",
+                  action: "add_label",
+                  summary: "Add the bug label.",
+                  params: { label: "bug" }
+                }
+              ]
+            }
+          ]
+        }
+      })
+    });
+
+    const proposalResponse = await app.request("/v1/proposals/proposal_protocol");
+    expect(proposalResponse.status).toBe(200);
+    await expect(proposalResponse.json()).resolves.toMatchObject({
+      runId: "run_protocol",
+      snapshot: { proposalId: "proposal_protocol" }
+    });
+    const lineageResponse = await app.request("/v1/proposals/proposal_protocol/lineage");
+    expect(lineageResponse.status).toBe(200);
+    await expect(lineageResponse.json()).resolves.toMatchObject({
+      lineage: {
+        entries: [{ proposalId: "proposal_protocol", intentId: "intent_label_bug", status: "current" }]
+      }
+    });
+    const currentIntentsResponse = await app.request("/v1/proposals/proposal_protocol/current-intents");
+    expect(currentIntentsResponse.status).toBe(200);
+    await expect(currentIntentsResponse.json()).resolves.toMatchObject({
+      intents: [{ intentId: "intent_label_bug", status: "current" }]
+    });
+
+    const approvalResponse = await app.request("/v1/proposals/proposal_protocol/approvals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "approval_protocol",
+        approvedIntentIds: ["intent_label_bug"],
+        approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+        approvedAt: "2026-06-24T00:00:02.000Z"
+      })
+    });
+    expect(approvalResponse.status).toBe(201);
+
+    const applyResponse = await app.request("/v1/proposals/proposal_protocol/apply-plans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "apply_protocol",
+        approvalDecisionId: "approval_protocol",
+        adapter: "github"
+      })
+    });
+    expect(applyResponse.status).toBe(201);
+    await expect(applyResponse.json()).resolves.toMatchObject({
+      plan: {
+        id: "apply_protocol",
+        outcomes: [{ intentId: "intent_label_bug", outcome: "skipped" }]
+      }
+    });
+
+    const eventsResponse = await app.request("/v1/runs/run_protocol/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toEqual(
+      expect.arrayContaining(["proposal.snapshot.created", "approval.decision.recorded", "apply_plan.created"])
+    );
+  });
+
+  it("creates child runs from next action hints with lineage fields", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1"
+      })
+    });
+    await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_parent", event: { ...validEvent, id: "evt_parent", sourceEventId: "comment_parent" } })
+    });
+
+    const childResponse = await app.request("/v1/runs/run_parent/child-runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        runId: "run_child",
+        action: {
+          kind: "apply_suggested_changes",
+          targetId: "proposal_parent",
+          selectedIntentIds: ["intent_label_bug"]
+        },
+        commandText: "Apply approved label change"
+      })
+    });
+    expect(childResponse.status).toBe(201);
+    await expect(childResponse.json()).resolves.toMatchObject({
+      run: {
+        id: "run_child",
+        parentRunId: "run_parent",
+        sourceProposalId: "proposal_parent",
+        triggeredByAction: {
+          kind: "apply_suggested_changes",
+          targetId: "proposal_parent"
+        }
+      }
+    });
+
+    const claimedResponse = await app.request("/v1/runners/runner_1/claim", { method: "POST" });
+    const claimed = await claimedResponse.json();
+    expect(claimed.run.id).toBe("run_parent");
+
+    const parentEventsResponse = await app.request("/v1/runs/run_parent/events");
+    const { events } = await parentEventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toContain("run.child_created");
+  });
+
+  it("executes approved GitHub label and assignee apply plans when explicitly requested", async () => {
+    const githubRequests: Array<{ url: string; method: string; body: unknown; authorization: string | null }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      githubApply: {
+        token: "ghs_test",
+        fetchImpl: (async (url, init) => {
+          githubRequests.push({
+            url: String(url),
+            method: init?.method ?? "GET",
+            body: init?.body ? JSON.parse(String(init.body)) : undefined,
+            authorization: new Headers(init?.headers).get("authorization")
+          });
+          return Response.json({});
+        }) as typeof fetch
+      }
+    });
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        allowedActors: ["octocat"]
+      })
+    });
+
+    const event = {
+      ...validEvent,
+      id: "evt_execute",
+      sourceEventId: "comment_execute",
+      permissions: [...validEvent.permissions, { scope: "repo:write", reason: "mutate issue fields after approval" }],
+      metadata: { owner: "acme", repo: "demo", issueNumber: 7 }
+    };
+    await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_execute", event })
+    });
+    await app.request("/v1/runs/run_execute/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        result: {
+          conclusion: "needs_human",
+          summary: "Prepared proposal.",
+          suggestedChanges: [
+            {
+              proposalId: "proposal_execute",
+              createdAt: "2026-06-24T00:00:01.000Z",
+              sourceRunId: "run_execute",
+              summary: "Add bug label and assign owner.",
+              intents: [
+                {
+                  intentId: "intent_label_bug",
+                  domain: "labels",
+                  action: "add_label",
+                  summary: "Add the bug label.",
+                  params: { label: "bug" }
+                },
+                {
+                  intentId: "intent_assignee_alice",
+                  domain: "assignee",
+                  action: "set_assignee",
+                  summary: "Assign the issue to Alice.",
+                  params: { assignee: "alice" }
+                }
+              ]
+            }
+          ]
+        }
+      })
+    });
+    await app.request("/v1/proposals/proposal_execute/approvals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "approval_execute",
+        approvedIntentIds: ["intent_label_bug", "intent_assignee_alice"],
+        approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+        approvedAt: "2026-06-24T00:00:02.000Z"
+      })
+    });
+
+    const applyResponse = await app.request("/v1/proposals/proposal_execute/apply-plans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "apply_execute",
+        approvalDecisionId: "approval_execute",
+        adapter: "github",
+        execute: true
+      })
+    });
+    expect(applyResponse.status).toBe(201);
+    await expect(applyResponse.json()).resolves.toMatchObject({
+      plan: {
+        id: "apply_execute",
+        outcomes: [
+          { intentId: "intent_label_bug", outcome: "applied", externalUri: "https://github.com/acme/demo/issues/7" },
+          { intentId: "intent_assignee_alice", outcome: "applied", externalUri: "https://github.com/acme/demo/issues/7" }
+        ]
+      }
+    });
+    expect(githubRequests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7/labels",
+        method: "POST",
+        authorization: "Bearer ghs_test",
+        body: { labels: ["bug"] }
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7",
+        method: "PATCH",
+        authorization: "Bearer ghs_test",
+        body: { assignees: ["alice"] }
+      }
+    ]);
+
+    const storedPlanResponse = await app.request("/v1/apply-plans/apply_execute");
+    await expect(storedPlanResponse.json()).resolves.toMatchObject({
+      plan: {
+        adapterPlan: { externalWritesExecuted: true },
+        outcomes: [
+          { intentId: "intent_label_bug", outcome: "applied" },
+          { intentId: "intent_assignee_alice", outcome: "applied" }
+        ]
+      }
+    });
+
+    const eventsResponse = await app.request("/v1/runs/run_execute/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toContain("apply_plan.executed");
   });
 
   it("adds a stable statusMessageKey when progress callbacks are delivered", async () => {

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -652,6 +652,89 @@ describe("dispatcher API", () => {
     expect(events.map((event: { type: string }) => event.type)).toContain("apply_plan.executed");
   });
 
+  it("does not persist apply plans when execution prerequisites fail", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        allowedActors: ["octocat"]
+      })
+    });
+    await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        runId: "run_apply_prevalidation",
+        event: {
+          ...validEvent,
+          id: "evt_apply_prevalidation",
+          sourceEventId: "comment_apply_prevalidation",
+          permissions: [...validEvent.permissions, { scope: "repo:write", reason: "mutate labels after approval" }],
+          metadata: { owner: "acme", repo: "demo", issueNumber: 9 }
+        }
+      })
+    });
+    await app.request("/v1/runs/run_apply_prevalidation/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        result: {
+          conclusion: "needs_human",
+          summary: "Prepared proposal.",
+          suggestedChanges: [
+            {
+              proposalId: "proposal_apply_prevalidation",
+              createdAt: "2026-06-24T00:00:01.000Z",
+              sourceRunId: "run_apply_prevalidation",
+              summary: "Add bug label.",
+              intents: [
+                {
+                  intentId: "intent_label_bug",
+                  domain: "labels",
+                  action: "add_label",
+                  summary: "Add the bug label.",
+                  params: { label: "bug" }
+                }
+              ]
+            }
+          ]
+        }
+      })
+    });
+    await app.request("/v1/proposals/proposal_apply_prevalidation/approvals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "approval_apply_prevalidation",
+        approvedIntentIds: ["intent_label_bug"],
+        approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+        approvedAt: "2026-06-24T00:00:02.000Z"
+      })
+    });
+
+    const applyResponse = await app.request("/v1/proposals/proposal_apply_prevalidation/apply-plans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "apply_prevalidation",
+        approvalDecisionId: "approval_apply_prevalidation",
+        adapter: "github",
+        execute: true
+      })
+    });
+    expect(applyResponse.status).toBe(422);
+    await expect(applyResponse.json()).resolves.toEqual({ error: "github_apply_not_configured" });
+
+    const eventsResponse = await app.request("/v1/runs/run_apply_prevalidation/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).not.toContain("apply_plan.created");
+  });
+
   it("executes approved GitHub status intents through label mappings", async () => {
     const githubRequests: Array<{ url: string; method: string; body: unknown; authorization: string | null }> = [];
     const app = createDispatcherApp({

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -462,6 +462,21 @@ describe("dispatcher API", () => {
     });
   });
 
+  it("rejects approval decisions with overlapping approved and rejected intents", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+    const response = await app.request("/v1/proposals/proposal_overlap/approvals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        approvedIntentIds: ["intent_1"],
+        rejectedIntentIds: ["intent_1"],
+        approvedBy: { provider: "github", providerUserId: "42" }
+      })
+    });
+
+    expect(response.status).toBe(400);
+  });
+
   it("creates child runs from next action hints with lineage fields", async () => {
     const app = createDispatcherApp({ databasePath: ":memory:" });
     await app.request("/v1/repo-bindings", {

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -102,6 +102,31 @@ describe("dispatcher API", () => {
     });
   });
 
+  it("stores and returns repo mutation mappings", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+    const response = await app.request("/v1/repo-bindings/github/acme/demo/mutation-mappings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mapping: {
+          id: "github_status_labels",
+          adapter: "github",
+          domain: "status",
+          strategy: "label",
+          values: { blocked: "status/blocked" }
+        }
+      })
+    });
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({ mapping: { id: "github_status_labels" } });
+
+    const listResponse = await app.request("/v1/repo-bindings/github/acme/demo/mutation-mappings");
+    expect(listResponse.status).toBe(200);
+    await expect(listResponse.json()).resolves.toMatchObject({
+      mappings: [{ id: "github_status_labels", domain: "status" }]
+    });
+  });
+
   it("delivers acknowledgement, progress, and final callback messages with audit events", async () => {
     const delivered: { kind: string; body: string; blocks?: unknown[] }[] = [];
     const app = createDispatcherApp({
@@ -602,6 +627,126 @@ describe("dispatcher API", () => {
     const eventsResponse = await app.request("/v1/runs/run_execute/events");
     const { events } = await eventsResponse.json();
     expect(events.map((event: { type: string }) => event.type)).toContain("apply_plan.executed");
+  });
+
+  it("executes approved GitHub status intents through label mappings", async () => {
+    const githubRequests: Array<{ url: string; method: string; body: unknown; authorization: string | null }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      githubApply: {
+        token: "ghs_test",
+        fetchImpl: (async (url, init) => {
+          githubRequests.push({
+            url: String(url),
+            method: init?.method ?? "GET",
+            body: init?.body ? JSON.parse(String(init.body)) : undefined,
+            authorization: new Headers(init?.headers).get("authorization")
+          });
+          return Response.json({});
+        }) as typeof fetch
+      }
+    });
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        allowedActors: ["octocat"]
+      })
+    });
+    await app.request("/v1/repo-bindings/github/acme/demo/mutation-mappings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mapping: {
+          id: "github_status_labels",
+          adapter: "github",
+          domain: "status",
+          strategy: "label",
+          values: { blocked: "status/blocked" }
+        }
+      })
+    });
+
+    await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        runId: "run_status_mapping",
+        event: {
+          ...validEvent,
+          id: "evt_status_mapping",
+          sourceEventId: "comment_status_mapping",
+          permissions: [...validEvent.permissions, { scope: "repo:write", reason: "mutate issue status after approval" }],
+          metadata: { owner: "acme", repo: "demo", issueNumber: 8 }
+        }
+      })
+    });
+    await app.request("/v1/runs/run_status_mapping/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        result: {
+          conclusion: "needs_human",
+          summary: "Prepared status proposal.",
+          suggestedChanges: [
+            {
+              proposalId: "proposal_status_mapping",
+              createdAt: "2026-06-24T00:00:01.000Z",
+              sourceRunId: "run_status_mapping",
+              summary: "Mark blocked.",
+              intents: [
+                {
+                  intentId: "intent_status_blocked",
+                  domain: "status",
+                  action: "transition_status",
+                  summary: "Mark blocked.",
+                  params: { status: "blocked" }
+                }
+              ]
+            }
+          ]
+        }
+      })
+    });
+    await app.request("/v1/proposals/proposal_status_mapping/approvals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "approval_status_mapping",
+        approvedIntentIds: ["intent_status_blocked"],
+        approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+        approvedAt: "2026-06-24T00:00:02.000Z"
+      })
+    });
+
+    const applyResponse = await app.request("/v1/proposals/proposal_status_mapping/apply-plans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "apply_status_mapping",
+        approvalDecisionId: "approval_status_mapping",
+        adapter: "github",
+        execute: true
+      })
+    });
+    expect(applyResponse.status).toBe(201);
+    await expect(applyResponse.json()).resolves.toMatchObject({
+      plan: {
+        outcomes: [{ intentId: "intent_status_blocked", outcome: "applied" }]
+      }
+    });
+    expect(githubRequests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/8/labels",
+        method: "POST",
+        authorization: "Bearer ghs_test",
+        body: { labels: ["status/blocked"] }
+      }
+    ]);
   });
 
   it("adds a stable statusMessageKey when progress callbacks are delivered", async () => {

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -77,6 +77,31 @@ describe("dispatcher API", () => {
     expect(binding.binding).toMatchObject({ runnerId: "runner_1", workspacePath: "/Users/test/demo" });
   });
 
+  it("stores and returns repo policy rules", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+    const response = await app.request("/v1/repo-bindings/github/acme/demo/policy-rules", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        rule: {
+          id: "repo_allows_labels",
+          scope: "work_context_owner_container",
+          effect: "allow",
+          capabilityId: "set_labels",
+          reason: "Repo allows approved label changes."
+        }
+      })
+    });
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({ rule: { id: "repo_allows_labels" } });
+
+    const listResponse = await app.request("/v1/repo-bindings/github/acme/demo/policy-rules");
+    expect(listResponse.status).toBe(200);
+    await expect(listResponse.json()).resolves.toMatchObject({
+      rules: [{ id: "repo_allows_labels", effect: "allow" }]
+    });
+  });
+
   it("delivers acknowledgement, progress, and final callback messages with audit events", async () => {
     const delivered: { kind: string; body: string; blocks?: unknown[] }[] = [];
     const app = createDispatcherApp({
@@ -375,6 +400,18 @@ describe("dispatcher API", () => {
     expect(events.map((event: { type: string }) => event.type)).toEqual(
       expect.arrayContaining(["proposal.snapshot.created", "approval.decision.recorded", "apply_plan.created"])
     );
+
+    const metricsResponse = await app.request("/v1/runs/run_protocol/metrics");
+    expect(metricsResponse.status).toBe(200);
+    await expect(metricsResponse.json()).resolves.toMatchObject({
+      metrics: {
+        runId: "run_protocol",
+        suggestedChangesCount: 1,
+        approvalDecisionCount: 1,
+        applyPlanCount: 1,
+        applyOutcomeCounts: { skipped: 1 }
+      }
+    });
   });
 
   it("creates child runs from next action hints with lineage fields", async () => {

--- a/packages/github/src/apply.ts
+++ b/packages/github/src/apply.ts
@@ -1,4 +1,4 @@
-import type { AdapterMutationMapping, ApplyIntentOutcome, MutationIntent } from "@opentag/core";
+import type { AdapterMutationCompiler, AdapterMutationMapping, ApplyIntentOutcome, MutationIntent } from "@opentag/core";
 import type { FetchLike } from "./pull-request.js";
 
 export type GitHubIssueMutationTarget = {
@@ -226,6 +226,30 @@ export function compileGitHubIssueMutationIntents(
   options: { mappings?: AdapterMutationMapping[] } = {}
 ): GitHubIssueMutationCompilation[] {
   return intents.map((intent) => compileGitHubIssueMutationIntent(intent, options));
+}
+
+export function createGitHubIssueMutationCompiler(options: {
+  mappings?: AdapterMutationMapping[];
+} = {}): AdapterMutationCompiler<GitHubIssueMutationOperation> {
+  return {
+    adapter: "github",
+    compile(intent) {
+      const compilation = compileGitHubIssueMutationIntent(intent, options);
+      if (!compilation.ok) {
+        return {
+          ok: false,
+          adapter: "github",
+          outcome: compilation.outcome
+        };
+      }
+      return {
+        ok: true,
+        adapter: "github",
+        intentId: compilation.intentId,
+        operation: compilation.operation
+      };
+    }
+  };
 }
 
 export async function applyGitHubIssueMutationOperation(input: {

--- a/packages/github/src/apply.ts
+++ b/packages/github/src/apply.ts
@@ -1,0 +1,224 @@
+import type { ApplyIntentOutcome, MutationIntent } from "@opentag/core";
+import type { FetchLike } from "./pull-request.js";
+
+export type GitHubIssueMutationTarget = {
+  token: string;
+  owner: string;
+  repo: string;
+  issueNumber: number;
+};
+
+function labelFromIntent(intent: MutationIntent): string | undefined {
+  const value = intent.params?.["label"];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function labelsFromIntent(intent: MutationIntent): string[] | undefined {
+  const value = intent.params?.["labels"];
+  if (!Array.isArray(value)) return undefined;
+  const labels = value.filter((label): label is string => typeof label === "string" && label.length > 0);
+  return labels.length > 0 ? labels : undefined;
+}
+
+function assigneeFromIntent(intent: MutationIntent): string | undefined {
+  const value = intent.params?.["assignee"];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function assigneesFromIntent(intent: MutationIntent): string[] | undefined {
+  const value = intent.params?.["assignees"];
+  if (!Array.isArray(value)) return undefined;
+  const assignees = value.filter((assignee): assignee is string => typeof assignee === "string" && assignee.length > 0);
+  return assignees.length > 0 ? assignees : undefined;
+}
+
+async function githubJson(input: {
+  target: GitHubIssueMutationTarget;
+  fetchImpl: FetchLike;
+  method: "POST" | "PUT" | "PATCH" | "DELETE";
+  path: string;
+  body?: unknown;
+}): Promise<string | undefined> {
+  const response = await input.fetchImpl(`https://api.github.com/repos/${input.target.owner}/${input.target.repo}${input.path}`, {
+    method: input.method,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${input.target.token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28"
+    },
+    ...(input.body ? { body: JSON.stringify(input.body) } : {})
+  });
+
+  if (!response.ok) {
+    throw new Error(`${input.method} ${input.path} failed: ${response.status} ${await response.text()}`);
+  }
+  return `https://github.com/${input.target.owner}/${input.target.repo}/issues/${input.target.issueNumber}`;
+}
+
+export async function applyGitHubIssueMutationIntent(input: {
+  target: GitHubIssueMutationTarget;
+  intent: MutationIntent;
+  fetchImpl?: FetchLike;
+}): Promise<ApplyIntentOutcome> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  try {
+    if (input.intent.domain === "status") {
+      return {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: "GitHub status writes require an explicit Project field or label mapping policy."
+      };
+    }
+    if (input.intent.domain === "priority") {
+      return {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: "GitHub priority writes require an explicit label or Project field mapping policy."
+      };
+    }
+    if (input.intent.domain !== "labels" && input.intent.domain !== "assignee") {
+      return {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: `GitHub apply supports labels and assignee only, not ${input.intent.domain}.`
+      };
+    }
+
+    if (input.intent.domain === "assignee") {
+      if (input.intent.action === "set_assignee") {
+        const assignee = assigneeFromIntent(input.intent);
+        if (!assignee) {
+          return { intentId: input.intent.intentId, outcome: "failed", message: "set_assignee requires params.assignee." };
+        }
+        const externalUri = await githubJson({
+          target: input.target,
+          fetchImpl,
+          method: "PATCH",
+          path: `/issues/${input.target.issueNumber}`,
+          body: { assignees: [assignee] }
+        });
+        return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+      }
+
+      if (input.intent.action === "set_assignees") {
+        const assignees = assigneesFromIntent(input.intent);
+        if (!assignees) {
+          return { intentId: input.intent.intentId, outcome: "failed", message: "set_assignees requires params.assignees." };
+        }
+        const externalUri = await githubJson({
+          target: input.target,
+          fetchImpl,
+          method: "PATCH",
+          path: `/issues/${input.target.issueNumber}`,
+          body: { assignees }
+        });
+        return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+      }
+
+      if (input.intent.action === "add_assignee") {
+        const assignee = assigneeFromIntent(input.intent);
+        if (!assignee) {
+          return { intentId: input.intent.intentId, outcome: "failed", message: "add_assignee requires params.assignee." };
+        }
+        const externalUri = await githubJson({
+          target: input.target,
+          fetchImpl,
+          method: "POST",
+          path: `/issues/${input.target.issueNumber}/assignees`,
+          body: { assignees: [assignee] }
+        });
+        return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+      }
+
+      if (input.intent.action === "remove_assignee") {
+        const assignee = assigneeFromIntent(input.intent);
+        if (!assignee) {
+          return { intentId: input.intent.intentId, outcome: "failed", message: "remove_assignee requires params.assignee." };
+        }
+        const externalUri = await githubJson({
+          target: input.target,
+          fetchImpl,
+          method: "DELETE",
+          path: `/issues/${input.target.issueNumber}/assignees`,
+          body: { assignees: [assignee] }
+        });
+        return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+      }
+
+      return {
+        intentId: input.intent.intentId,
+        outcome: "unsupported",
+        message: `GitHub apply does not support assignee action ${input.intent.action}.`
+      };
+    }
+
+    if (input.intent.action === "add_label") {
+      const label = labelFromIntent(input.intent);
+      if (!label) {
+        return { intentId: input.intent.intentId, outcome: "failed", message: "add_label requires params.label." };
+      }
+      const externalUri = await githubJson({
+        target: input.target,
+        fetchImpl,
+        method: "POST",
+        path: `/issues/${input.target.issueNumber}/labels`,
+        body: { labels: [label] }
+      });
+      return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+    }
+
+    if (input.intent.action === "remove_label") {
+      const label = labelFromIntent(input.intent);
+      if (!label) {
+        return { intentId: input.intent.intentId, outcome: "failed", message: "remove_label requires params.label." };
+      }
+      const externalUri = await githubJson({
+        target: input.target,
+        fetchImpl,
+        method: "DELETE",
+        path: `/issues/${input.target.issueNumber}/labels/${encodeURIComponent(label)}`
+      });
+      return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+    }
+
+    if (input.intent.action === "set_labels") {
+      const labels = labelsFromIntent(input.intent);
+      if (!labels) {
+        return { intentId: input.intent.intentId, outcome: "failed", message: "set_labels requires params.labels." };
+      }
+      const externalUri = await githubJson({
+        target: input.target,
+        fetchImpl,
+        method: "PUT",
+        path: `/issues/${input.target.issueNumber}/labels`,
+        body: { labels }
+      });
+      return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+    }
+
+    return {
+      intentId: input.intent.intentId,
+      outcome: "unsupported",
+      message: `GitHub apply does not support labels action ${input.intent.action}.`
+    };
+  } catch (error) {
+    return {
+      intentId: input.intent.intentId,
+      outcome: "failed",
+      error: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
+export async function applyGitHubIssueMutationIntents(input: {
+  target: GitHubIssueMutationTarget;
+  intents: MutationIntent[];
+  fetchImpl?: FetchLike;
+}): Promise<ApplyIntentOutcome[]> {
+  const outcomes: ApplyIntentOutcome[] = [];
+  for (const intent of input.intents) {
+    outcomes.push(await applyGitHubIssueMutationIntent({ target: input.target, intent, ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {}) }));
+  }
+  return outcomes;
+}

--- a/packages/github/src/apply.ts
+++ b/packages/github/src/apply.ts
@@ -365,9 +365,12 @@ export async function applyGitHubIssueMutationOperation(input: {
 export async function applyGitHubIssueMutationIntent(input: {
   target: GitHubIssueMutationTarget;
   intent: MutationIntent;
+  mappings?: AdapterMutationMapping[];
   fetchImpl?: FetchLike;
 }): Promise<ApplyIntentOutcome> {
-  const compiled = compileGitHubIssueMutationIntent(input.intent);
+  const compiled = compileGitHubIssueMutationIntent(input.intent, {
+    ...(input.mappings ? { mappings: input.mappings } : {})
+  });
   if (!compiled.ok) return compiled.outcome;
   return applyGitHubIssueMutationOperation({
     target: input.target,
@@ -379,11 +382,19 @@ export async function applyGitHubIssueMutationIntent(input: {
 export async function applyGitHubIssueMutationIntents(input: {
   target: GitHubIssueMutationTarget;
   intents: MutationIntent[];
+  mappings?: AdapterMutationMapping[];
   fetchImpl?: FetchLike;
 }): Promise<ApplyIntentOutcome[]> {
   const outcomes: ApplyIntentOutcome[] = [];
   for (const intent of input.intents) {
-    outcomes.push(await applyGitHubIssueMutationIntent({ target: input.target, intent, ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {}) }));
+    outcomes.push(
+      await applyGitHubIssueMutationIntent({
+        target: input.target,
+        intent,
+        ...(input.mappings ? { mappings: input.mappings } : {}),
+        ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {})
+      })
+    );
   }
   return outcomes;
 }

--- a/packages/github/src/apply.ts
+++ b/packages/github/src/apply.ts
@@ -1,4 +1,4 @@
-import type { ApplyIntentOutcome, MutationIntent } from "@opentag/core";
+import type { AdapterMutationMapping, ApplyIntentOutcome, MutationIntent } from "@opentag/core";
 import type { FetchLike } from "./pull-request.js";
 
 export type GitHubIssueMutationTarget = {
@@ -7,6 +7,49 @@ export type GitHubIssueMutationTarget = {
   repo: string;
   issueNumber: number;
 };
+
+export type GitHubIssueMutationOperation =
+  | {
+      kind: "add_label";
+      intentId: string;
+      label: string;
+    }
+  | {
+      kind: "remove_label";
+      intentId: string;
+      label: string;
+    }
+  | {
+      kind: "set_labels";
+      intentId: string;
+      labels: string[];
+    }
+  | {
+      kind: "set_assignees";
+      intentId: string;
+      assignees: string[];
+    }
+  | {
+      kind: "add_assignee";
+      intentId: string;
+      assignee: string;
+    }
+  | {
+      kind: "remove_assignee";
+      intentId: string;
+      assignee: string;
+    };
+
+export type GitHubIssueMutationCompilation =
+  | {
+      ok: true;
+      intentId: string;
+      operation: GitHubIssueMutationOperation;
+    }
+  | {
+      ok: false;
+      outcome: ApplyIntentOutcome;
+    };
 
 function labelFromIntent(intent: MutationIntent): string | undefined {
   const value = intent.params?.["label"];
@@ -30,6 +73,21 @@ function assigneesFromIntent(intent: MutationIntent): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const assignees = value.filter((assignee): assignee is string => typeof assignee === "string" && assignee.length > 0);
   return assignees.length > 0 ? assignees : undefined;
+}
+
+function mappedValueFromIntent(intent: MutationIntent): string | undefined {
+  const key = intent.domain === "status" ? "status" : "priority";
+  const value = intent.params?.[key] ?? intent.params?.["value"];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function labelMappingForIntent(input: { intent: MutationIntent; mappings: AdapterMutationMapping[] }): string | undefined {
+  const semanticValue = mappedValueFromIntent(input.intent);
+  if (!semanticValue) return undefined;
+  const mapping = input.mappings.find(
+    (candidate) => candidate.adapter === "github" && candidate.domain === input.intent.domain && candidate.strategy === "label"
+  );
+  return mapping?.values[semanticValue];
 }
 
 async function githubJson(input: {
@@ -56,159 +114,210 @@ async function githubJson(input: {
   return `https://github.com/${input.target.owner}/${input.target.repo}/issues/${input.target.issueNumber}`;
 }
 
-export async function applyGitHubIssueMutationIntent(input: {
+export function compileGitHubIssueMutationIntent(
+  intent: MutationIntent,
+  options: { mappings?: AdapterMutationMapping[] } = {}
+): GitHubIssueMutationCompilation {
+  if (intent.domain === "status") {
+    const label = labelMappingForIntent({ intent, mappings: options.mappings ?? [] });
+    if (label) {
+      return { ok: true, intentId: intent.intentId, operation: { kind: "add_label", intentId: intent.intentId, label } };
+    }
+    return {
+      ok: false,
+      outcome: {
+        intentId: intent.intentId,
+        outcome: "unsupported",
+        message: "GitHub status writes require an explicit Project field or label mapping policy."
+      }
+    };
+  }
+  if (intent.domain === "priority") {
+    const label = labelMappingForIntent({ intent, mappings: options.mappings ?? [] });
+    if (label) {
+      return { ok: true, intentId: intent.intentId, operation: { kind: "add_label", intentId: intent.intentId, label } };
+    }
+    return {
+      ok: false,
+      outcome: {
+        intentId: intent.intentId,
+        outcome: "unsupported",
+        message: "GitHub priority writes require an explicit label or Project field mapping policy."
+      }
+    };
+  }
+  if (intent.domain !== "labels" && intent.domain !== "assignee") {
+    return {
+      ok: false,
+      outcome: {
+        intentId: intent.intentId,
+        outcome: "unsupported",
+        message: `GitHub apply supports labels and assignee only, not ${intent.domain}.`
+      }
+    };
+  }
+
+  if (intent.domain === "assignee") {
+    if (intent.action === "set_assignee") {
+      const assignee = assigneeFromIntent(intent);
+      return assignee
+        ? { ok: true, intentId: intent.intentId, operation: { kind: "set_assignees", intentId: intent.intentId, assignees: [assignee] } }
+        : { ok: false, outcome: { intentId: intent.intentId, outcome: "failed", message: "set_assignee requires params.assignee." } };
+    }
+    if (intent.action === "set_assignees") {
+      const assignees = assigneesFromIntent(intent);
+      return assignees
+        ? { ok: true, intentId: intent.intentId, operation: { kind: "set_assignees", intentId: intent.intentId, assignees } }
+        : { ok: false, outcome: { intentId: intent.intentId, outcome: "failed", message: "set_assignees requires params.assignees." } };
+    }
+    if (intent.action === "add_assignee") {
+      const assignee = assigneeFromIntent(intent);
+      return assignee
+        ? { ok: true, intentId: intent.intentId, operation: { kind: "add_assignee", intentId: intent.intentId, assignee } }
+        : { ok: false, outcome: { intentId: intent.intentId, outcome: "failed", message: "add_assignee requires params.assignee." } };
+    }
+    if (intent.action === "remove_assignee") {
+      const assignee = assigneeFromIntent(intent);
+      return assignee
+        ? { ok: true, intentId: intent.intentId, operation: { kind: "remove_assignee", intentId: intent.intentId, assignee } }
+        : { ok: false, outcome: { intentId: intent.intentId, outcome: "failed", message: "remove_assignee requires params.assignee." } };
+    }
+    return {
+      ok: false,
+      outcome: {
+        intentId: intent.intentId,
+        outcome: "unsupported",
+        message: `GitHub apply does not support assignee action ${intent.action}.`
+      }
+    };
+  }
+
+  if (intent.action === "add_label") {
+    const label = labelFromIntent(intent);
+    return label
+      ? { ok: true, intentId: intent.intentId, operation: { kind: "add_label", intentId: intent.intentId, label } }
+      : { ok: false, outcome: { intentId: intent.intentId, outcome: "failed", message: "add_label requires params.label." } };
+  }
+  if (intent.action === "remove_label") {
+    const label = labelFromIntent(intent);
+    return label
+      ? { ok: true, intentId: intent.intentId, operation: { kind: "remove_label", intentId: intent.intentId, label } }
+      : { ok: false, outcome: { intentId: intent.intentId, outcome: "failed", message: "remove_label requires params.label." } };
+  }
+  if (intent.action === "set_labels") {
+    const labels = labelsFromIntent(intent);
+    return labels
+      ? { ok: true, intentId: intent.intentId, operation: { kind: "set_labels", intentId: intent.intentId, labels } }
+      : { ok: false, outcome: { intentId: intent.intentId, outcome: "failed", message: "set_labels requires params.labels." } };
+  }
+
+  return {
+    ok: false,
+    outcome: {
+      intentId: intent.intentId,
+      outcome: "unsupported",
+      message: `GitHub apply does not support labels action ${intent.action}.`
+    }
+  };
+}
+
+export function compileGitHubIssueMutationIntents(
+  intents: MutationIntent[],
+  options: { mappings?: AdapterMutationMapping[] } = {}
+): GitHubIssueMutationCompilation[] {
+  return intents.map((intent) => compileGitHubIssueMutationIntent(intent, options));
+}
+
+export async function applyGitHubIssueMutationOperation(input: {
   target: GitHubIssueMutationTarget;
-  intent: MutationIntent;
+  operation: GitHubIssueMutationOperation;
   fetchImpl?: FetchLike;
 }): Promise<ApplyIntentOutcome> {
   const fetchImpl = input.fetchImpl ?? fetch;
   try {
-    if (input.intent.domain === "status") {
-      return {
-        intentId: input.intent.intentId,
-        outcome: "unsupported",
-        message: "GitHub status writes require an explicit Project field or label mapping policy."
-      };
-    }
-    if (input.intent.domain === "priority") {
-      return {
-        intentId: input.intent.intentId,
-        outcome: "unsupported",
-        message: "GitHub priority writes require an explicit label or Project field mapping policy."
-      };
-    }
-    if (input.intent.domain !== "labels" && input.intent.domain !== "assignee") {
-      return {
-        intentId: input.intent.intentId,
-        outcome: "unsupported",
-        message: `GitHub apply supports labels and assignee only, not ${input.intent.domain}.`
-      };
+    if (input.operation.kind === "set_assignees") {
+      const externalUri = await githubJson({
+        target: input.target,
+        fetchImpl,
+        method: "PATCH",
+        path: `/issues/${input.target.issueNumber}`,
+        body: { assignees: input.operation.assignees }
+      });
+      return { intentId: input.operation.intentId, outcome: "applied", externalUri };
     }
 
-    if (input.intent.domain === "assignee") {
-      if (input.intent.action === "set_assignee") {
-        const assignee = assigneeFromIntent(input.intent);
-        if (!assignee) {
-          return { intentId: input.intent.intentId, outcome: "failed", message: "set_assignee requires params.assignee." };
-        }
-        const externalUri = await githubJson({
-          target: input.target,
-          fetchImpl,
-          method: "PATCH",
-          path: `/issues/${input.target.issueNumber}`,
-          body: { assignees: [assignee] }
-        });
-        return { intentId: input.intent.intentId, outcome: "applied", externalUri };
-      }
-
-      if (input.intent.action === "set_assignees") {
-        const assignees = assigneesFromIntent(input.intent);
-        if (!assignees) {
-          return { intentId: input.intent.intentId, outcome: "failed", message: "set_assignees requires params.assignees." };
-        }
-        const externalUri = await githubJson({
-          target: input.target,
-          fetchImpl,
-          method: "PATCH",
-          path: `/issues/${input.target.issueNumber}`,
-          body: { assignees }
-        });
-        return { intentId: input.intent.intentId, outcome: "applied", externalUri };
-      }
-
-      if (input.intent.action === "add_assignee") {
-        const assignee = assigneeFromIntent(input.intent);
-        if (!assignee) {
-          return { intentId: input.intent.intentId, outcome: "failed", message: "add_assignee requires params.assignee." };
-        }
-        const externalUri = await githubJson({
-          target: input.target,
-          fetchImpl,
-          method: "POST",
-          path: `/issues/${input.target.issueNumber}/assignees`,
-          body: { assignees: [assignee] }
-        });
-        return { intentId: input.intent.intentId, outcome: "applied", externalUri };
-      }
-
-      if (input.intent.action === "remove_assignee") {
-        const assignee = assigneeFromIntent(input.intent);
-        if (!assignee) {
-          return { intentId: input.intent.intentId, outcome: "failed", message: "remove_assignee requires params.assignee." };
-        }
-        const externalUri = await githubJson({
-          target: input.target,
-          fetchImpl,
-          method: "DELETE",
-          path: `/issues/${input.target.issueNumber}/assignees`,
-          body: { assignees: [assignee] }
-        });
-        return { intentId: input.intent.intentId, outcome: "applied", externalUri };
-      }
-
-      return {
-        intentId: input.intent.intentId,
-        outcome: "unsupported",
-        message: `GitHub apply does not support assignee action ${input.intent.action}.`
-      };
+    if (input.operation.kind === "add_assignee") {
+      const externalUri = await githubJson({
+        target: input.target,
+        fetchImpl,
+        method: "POST",
+        path: `/issues/${input.target.issueNumber}/assignees`,
+        body: { assignees: [input.operation.assignee] }
+      });
+      return { intentId: input.operation.intentId, outcome: "applied", externalUri };
     }
 
-    if (input.intent.action === "add_label") {
-      const label = labelFromIntent(input.intent);
-      if (!label) {
-        return { intentId: input.intent.intentId, outcome: "failed", message: "add_label requires params.label." };
-      }
+    if (input.operation.kind === "remove_assignee") {
+      const externalUri = await githubJson({
+        target: input.target,
+        fetchImpl,
+        method: "DELETE",
+        path: `/issues/${input.target.issueNumber}/assignees`,
+        body: { assignees: [input.operation.assignee] }
+      });
+      return { intentId: input.operation.intentId, outcome: "applied", externalUri };
+    }
+
+    if (input.operation.kind === "add_label") {
       const externalUri = await githubJson({
         target: input.target,
         fetchImpl,
         method: "POST",
         path: `/issues/${input.target.issueNumber}/labels`,
-        body: { labels: [label] }
+        body: { labels: [input.operation.label] }
       });
-      return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+      return { intentId: input.operation.intentId, outcome: "applied", externalUri };
     }
 
-    if (input.intent.action === "remove_label") {
-      const label = labelFromIntent(input.intent);
-      if (!label) {
-        return { intentId: input.intent.intentId, outcome: "failed", message: "remove_label requires params.label." };
-      }
+    if (input.operation.kind === "remove_label") {
       const externalUri = await githubJson({
         target: input.target,
         fetchImpl,
         method: "DELETE",
-        path: `/issues/${input.target.issueNumber}/labels/${encodeURIComponent(label)}`
+        path: `/issues/${input.target.issueNumber}/labels/${encodeURIComponent(input.operation.label)}`
       });
-      return { intentId: input.intent.intentId, outcome: "applied", externalUri };
+      return { intentId: input.operation.intentId, outcome: "applied", externalUri };
     }
 
-    if (input.intent.action === "set_labels") {
-      const labels = labelsFromIntent(input.intent);
-      if (!labels) {
-        return { intentId: input.intent.intentId, outcome: "failed", message: "set_labels requires params.labels." };
-      }
-      const externalUri = await githubJson({
-        target: input.target,
-        fetchImpl,
-        method: "PUT",
-        path: `/issues/${input.target.issueNumber}/labels`,
-        body: { labels }
-      });
-      return { intentId: input.intent.intentId, outcome: "applied", externalUri };
-    }
-
-    return {
-      intentId: input.intent.intentId,
-      outcome: "unsupported",
-      message: `GitHub apply does not support labels action ${input.intent.action}.`
-    };
+    const externalUri = await githubJson({
+      target: input.target,
+      fetchImpl,
+      method: "PUT",
+      path: `/issues/${input.target.issueNumber}/labels`,
+      body: { labels: input.operation.labels }
+    });
+    return { intentId: input.operation.intentId, outcome: "applied", externalUri };
   } catch (error) {
     return {
-      intentId: input.intent.intentId,
+      intentId: input.operation.intentId,
       outcome: "failed",
       error: error instanceof Error ? error.message : String(error)
     };
   }
+}
+
+export async function applyGitHubIssueMutationIntent(input: {
+  target: GitHubIssueMutationTarget;
+  intent: MutationIntent;
+  fetchImpl?: FetchLike;
+}): Promise<ApplyIntentOutcome> {
+  const compiled = compileGitHubIssueMutationIntent(input.intent);
+  if (!compiled.ok) return compiled.outcome;
+  return applyGitHubIssueMutationOperation({
+    target: input.target,
+    operation: compiled.operation,
+    ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {})
+  });
 }
 
 export async function applyGitHubIssueMutationIntents(input: {

--- a/packages/github/src/apply.ts
+++ b/packages/github/src/apply.ts
@@ -20,6 +20,12 @@ export type GitHubIssueMutationOperation =
       label: string;
     }
   | {
+      kind: "replace_mapped_label";
+      intentId: string;
+      label: string;
+      removeLabels: string[];
+    }
+  | {
       kind: "set_labels";
       intentId: string;
       labels: string[];
@@ -81,13 +87,18 @@ function mappedValueFromIntent(intent: MutationIntent): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function labelMappingForIntent(input: { intent: MutationIntent; mappings: AdapterMutationMapping[] }): string | undefined {
+function labelMappingForIntent(input: { intent: MutationIntent; mappings: AdapterMutationMapping[] }): { label: string; removeLabels: string[] } | undefined {
   const semanticValue = mappedValueFromIntent(input.intent);
   if (!semanticValue) return undefined;
   const mapping = input.mappings.find(
     (candidate) => candidate.adapter === "github" && candidate.domain === input.intent.domain && candidate.strategy === "label"
   );
-  return mapping?.values[semanticValue];
+  const label = mapping?.values[semanticValue];
+  if (!label || !mapping) return undefined;
+  return {
+    label,
+    removeLabels: Object.values(mapping.values).filter((mappedLabel) => mappedLabel !== label)
+  };
 }
 
 async function githubJson(input: {
@@ -96,6 +107,7 @@ async function githubJson(input: {
   method: "POST" | "PUT" | "PATCH" | "DELETE";
   path: string;
   body?: unknown;
+  okStatuses?: number[];
 }): Promise<string | undefined> {
   const response = await input.fetchImpl(`https://api.github.com/repos/${input.target.owner}/${input.target.repo}${input.path}`, {
     method: input.method,
@@ -108,7 +120,7 @@ async function githubJson(input: {
     ...(input.body ? { body: JSON.stringify(input.body) } : {})
   });
 
-  if (!response.ok) {
+  if (!response.ok && !(input.okStatuses ?? []).includes(response.status)) {
     throw new Error(`${input.method} ${input.path} failed: ${response.status} ${await response.text()}`);
   }
   return `https://github.com/${input.target.owner}/${input.target.repo}/issues/${input.target.issueNumber}`;
@@ -119,9 +131,9 @@ export function compileGitHubIssueMutationIntent(
   options: { mappings?: AdapterMutationMapping[] } = {}
 ): GitHubIssueMutationCompilation {
   if (intent.domain === "status") {
-    const label = labelMappingForIntent({ intent, mappings: options.mappings ?? [] });
-    if (label) {
-      return { ok: true, intentId: intent.intentId, operation: { kind: "add_label", intentId: intent.intentId, label } };
+    const mapped = labelMappingForIntent({ intent, mappings: options.mappings ?? [] });
+    if (mapped) {
+      return { ok: true, intentId: intent.intentId, operation: { kind: "replace_mapped_label", intentId: intent.intentId, ...mapped } };
     }
     return {
       ok: false,
@@ -133,9 +145,9 @@ export function compileGitHubIssueMutationIntent(
     };
   }
   if (intent.domain === "priority") {
-    const label = labelMappingForIntent({ intent, mappings: options.mappings ?? [] });
-    if (label) {
-      return { ok: true, intentId: intent.intentId, operation: { kind: "add_label", intentId: intent.intentId, label } };
+    const mapped = labelMappingForIntent({ intent, mappings: options.mappings ?? [] });
+    if (mapped) {
+      return { ok: true, intentId: intent.intentId, operation: { kind: "replace_mapped_label", intentId: intent.intentId, ...mapped } };
     }
     return {
       ok: false,
@@ -288,6 +300,26 @@ export async function applyGitHubIssueMutationOperation(input: {
         method: "DELETE",
         path: `/issues/${input.target.issueNumber}/assignees`,
         body: { assignees: [input.operation.assignee] }
+      });
+      return { intentId: input.operation.intentId, outcome: "applied", externalUri };
+    }
+
+    if (input.operation.kind === "replace_mapped_label") {
+      for (const label of input.operation.removeLabels) {
+        await githubJson({
+          target: input.target,
+          fetchImpl,
+          method: "DELETE",
+          path: `/issues/${input.target.issueNumber}/labels/${encodeURIComponent(label)}`,
+          okStatuses: [200, 404]
+        });
+      }
+      const externalUri = await githubJson({
+        target: input.target,
+        fetchImpl,
+        method: "POST",
+        path: `/issues/${input.target.issueNumber}/labels`,
+        body: { labels: [input.operation.label] }
       });
       return { intentId: input.operation.intentId, outcome: "applied", externalUri };
     }

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./apply.js";
 export * from "./normalize.js";
 export * from "./pull-request.js";
 export * from "./render.js";

--- a/packages/github/src/render.ts
+++ b/packages/github/src/render.ts
@@ -1,5 +1,11 @@
 import type { OpenTagRunResult } from "@opentag/core";
 
+function nextActionSummary(result: OpenTagRunResult): string | undefined {
+  if (!result.nextAction) return undefined;
+  if (typeof result.nextAction === "string") return result.nextAction;
+  return result.nextAction.summary;
+}
+
 export function renderAcknowledgement(runId: string): string {
   return `OpenTag picked this up. Run: \`${runId}\``;
 }
@@ -18,8 +24,9 @@ export function renderFinalResult(result: OpenTagRunResult): string {
     }
   }
 
-  if (result.nextAction) {
-    lines.push("", `Next action: ${result.nextAction}`);
+  const nextAction = nextActionSummary(result);
+  if (nextAction) {
+    lines.push("", `Next action: ${nextAction}`);
   }
 
   return lines.join("\n");

--- a/packages/github/test/apply.test.ts
+++ b/packages/github/test/apply.test.ts
@@ -1,7 +1,109 @@
 import { describe, expect, it } from "vitest";
-import { applyGitHubIssueMutationIntent } from "../src/apply.js";
+import { applyGitHubIssueMutationIntent, compileGitHubIssueMutationIntent } from "../src/apply.js";
 
 describe("GitHub apply helpers", () => {
+  it("compiles semantic mutation intents into GitHub issue operations", () => {
+    expect(
+      compileGitHubIssueMutationIntent({
+        intentId: "intent_add",
+        domain: "labels",
+        action: "add_label",
+        summary: "Add label.",
+        params: { label: "bug" }
+      })
+    ).toEqual({
+      ok: true,
+      intentId: "intent_add",
+      operation: {
+        kind: "add_label",
+        intentId: "intent_add",
+        label: "bug"
+      }
+    });
+
+    expect(
+      compileGitHubIssueMutationIntent({
+        intentId: "intent_assignee",
+        domain: "assignee",
+        action: "set_assignee",
+        summary: "Set assignee.",
+        params: { assignee: "alice" }
+      })
+    ).toEqual({
+      ok: true,
+      intentId: "intent_assignee",
+      operation: {
+        kind: "set_assignees",
+        intentId: "intent_assignee",
+        assignees: ["alice"]
+      }
+    });
+  });
+
+  it("compiles status and priority through explicit GitHub label mappings", () => {
+    expect(
+      compileGitHubIssueMutationIntent(
+        {
+          intentId: "intent_status",
+          domain: "status",
+          action: "transition_status",
+          summary: "Mark blocked.",
+          params: { status: "blocked" }
+        },
+        {
+          mappings: [
+            {
+              id: "github_status_labels",
+              adapter: "github",
+              domain: "status",
+              strategy: "label",
+              values: { blocked: "status/blocked" }
+            }
+          ]
+        }
+      )
+    ).toEqual({
+      ok: true,
+      intentId: "intent_status",
+      operation: {
+        kind: "add_label",
+        intentId: "intent_status",
+        label: "status/blocked"
+      }
+    });
+
+    expect(
+      compileGitHubIssueMutationIntent(
+        {
+          intentId: "intent_priority",
+          domain: "priority",
+          action: "set_priority",
+          summary: "Set P1.",
+          params: { priority: "P1" }
+        },
+        {
+          mappings: [
+            {
+              id: "github_priority_labels",
+              adapter: "github",
+              domain: "priority",
+              strategy: "label",
+              values: { P1: "priority/P1" }
+            }
+          ]
+        }
+      )
+    ).toEqual({
+      ok: true,
+      intentId: "intent_priority",
+      operation: {
+        kind: "add_label",
+        intentId: "intent_priority",
+        label: "priority/P1"
+      }
+    });
+  });
+
   it("applies label mutation intents through GitHub issue APIs", async () => {
     const requests: Array<{ url: string; method: string; body?: unknown; authorization: string | null }> = [];
     const fetchImpl = (async (url, init) => {

--- a/packages/github/test/apply.test.ts
+++ b/packages/github/test/apply.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyGitHubIssueMutationIntent, applyGitHubIssueMutationOperation, compileGitHubIssueMutationIntent } from "../src/apply.js";
+import { applyGitHubIssueMutationIntent, compileGitHubIssueMutationIntent } from "../src/apply.js";
 
 describe("GitHub apply helpers", () => {
   it("compiles semantic mutation intents into GitHub issue operations", () => {
@@ -125,6 +125,7 @@ describe("GitHub apply helpers", () => {
       applyGitHubIssueMutationIntent({
         target: { token: "ghs_test", owner: "acme", repo: "demo", issueNumber: 7 },
         fetchImpl,
+        mappings: [{ id: "priority", adapter: "github", domain: "priority", strategy: "label", values: { P0: "priority/P0", P1: "priority/P1" } }],
         intent: {
           intentId: "intent_priority",
           domain: "priority",
@@ -132,28 +133,6 @@ describe("GitHub apply helpers", () => {
           summary: "Set P1.",
           params: { priority: "P1" }
         }
-      })
-    ).resolves.toMatchObject({ intentId: "intent_priority", outcome: "unsupported" });
-
-    requests.length = 0;
-    const compiled = compileGitHubIssueMutationIntent(
-      {
-        intentId: "intent_priority",
-        domain: "priority",
-        action: "set_priority",
-        summary: "Set P1.",
-        params: { priority: "P1" }
-      },
-      {
-        mappings: [{ id: "priority", adapter: "github", domain: "priority", strategy: "label", values: { P0: "priority/P0", P1: "priority/P1" } }]
-      }
-    );
-    if (!compiled.ok) throw new Error("expected compilation success");
-    await expect(
-      applyGitHubIssueMutationOperation({
-        target: { token: "ghs_test", owner: "acme", repo: "demo", issueNumber: 7 },
-        fetchImpl,
-        operation: compiled.operation
       })
     ).resolves.toMatchObject({ intentId: "intent_priority", outcome: "applied" });
 

--- a/packages/github/test/apply.test.ts
+++ b/packages/github/test/apply.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyGitHubIssueMutationIntent, compileGitHubIssueMutationIntent } from "../src/apply.js";
+import { applyGitHubIssueMutationIntent, applyGitHubIssueMutationOperation, compileGitHubIssueMutationIntent } from "../src/apply.js";
 
 describe("GitHub apply helpers", () => {
   it("compiles semantic mutation intents into GitHub issue operations", () => {
@@ -66,9 +66,10 @@ describe("GitHub apply helpers", () => {
       ok: true,
       intentId: "intent_status",
       operation: {
-        kind: "add_label",
+        kind: "replace_mapped_label",
         intentId: "intent_status",
-        label: "status/blocked"
+        label: "status/blocked",
+        removeLabels: []
       }
     });
 
@@ -88,7 +89,7 @@ describe("GitHub apply helpers", () => {
               adapter: "github",
               domain: "priority",
               strategy: "label",
-              values: { P1: "priority/P1" }
+              values: { P0: "priority/P0", P1: "priority/P1" }
             }
           ]
         }
@@ -97,11 +98,78 @@ describe("GitHub apply helpers", () => {
       ok: true,
       intentId: "intent_priority",
       operation: {
-        kind: "add_label",
+        kind: "replace_mapped_label",
         intentId: "intent_priority",
-        label: "priority/P1"
+        label: "priority/P1",
+        removeLabels: ["priority/P0"]
       }
     });
+  });
+
+  it("applies mapped label transitions by removing conflicting mapped labels first", async () => {
+    const requests: Array<{ url: string; method: string; body?: unknown; authorization: string | null }> = [];
+    const fetchImpl = (async (url, init) => {
+      requests.push({
+        url: String(url),
+        method: init?.method ?? "GET",
+        ...(init?.body ? { body: JSON.parse(String(init.body)) } : {}),
+        authorization: new Headers(init?.headers).get("authorization")
+      });
+      if (init?.method === "DELETE") {
+        return new Response("", { status: 404 });
+      }
+      return Response.json({});
+    }) as typeof fetch;
+
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target: { token: "ghs_test", owner: "acme", repo: "demo", issueNumber: 7 },
+        fetchImpl,
+        intent: {
+          intentId: "intent_priority",
+          domain: "priority",
+          action: "set_priority",
+          summary: "Set P1.",
+          params: { priority: "P1" }
+        }
+      })
+    ).resolves.toMatchObject({ intentId: "intent_priority", outcome: "unsupported" });
+
+    requests.length = 0;
+    const compiled = compileGitHubIssueMutationIntent(
+      {
+        intentId: "intent_priority",
+        domain: "priority",
+        action: "set_priority",
+        summary: "Set P1.",
+        params: { priority: "P1" }
+      },
+      {
+        mappings: [{ id: "priority", adapter: "github", domain: "priority", strategy: "label", values: { P0: "priority/P0", P1: "priority/P1" } }]
+      }
+    );
+    if (!compiled.ok) throw new Error("expected compilation success");
+    await expect(
+      applyGitHubIssueMutationOperation({
+        target: { token: "ghs_test", owner: "acme", repo: "demo", issueNumber: 7 },
+        fetchImpl,
+        operation: compiled.operation
+      })
+    ).resolves.toMatchObject({ intentId: "intent_priority", outcome: "applied" });
+
+    expect(requests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7/labels/priority%2FP0",
+        method: "DELETE",
+        authorization: "Bearer ghs_test"
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7/labels",
+        method: "POST",
+        authorization: "Bearer ghs_test",
+        body: { labels: ["priority/P1"] }
+      }
+    ]);
   });
 
   it("applies label mutation intents through GitHub issue APIs", async () => {

--- a/packages/github/test/apply.test.ts
+++ b/packages/github/test/apply.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { applyGitHubIssueMutationIntent } from "../src/apply.js";
+
+describe("GitHub apply helpers", () => {
+  it("applies label mutation intents through GitHub issue APIs", async () => {
+    const requests: Array<{ url: string; method: string; body?: unknown; authorization: string | null }> = [];
+    const fetchImpl = (async (url, init) => {
+      requests.push({
+        url: String(url),
+        method: init?.method ?? "GET",
+        ...(init?.body ? { body: JSON.parse(String(init.body)) } : {}),
+        authorization: new Headers(init?.headers).get("authorization")
+      });
+      return Response.json({});
+    }) as typeof fetch;
+
+    const target = { token: "ghs_test", owner: "acme", repo: "demo", issueNumber: 7 };
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target,
+        fetchImpl,
+        intent: {
+          intentId: "intent_add",
+          domain: "labels",
+          action: "add_label",
+          summary: "Add label.",
+          params: { label: "bug" }
+        }
+      })
+    ).resolves.toMatchObject({ intentId: "intent_add", outcome: "applied" });
+
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target,
+        fetchImpl,
+        intent: {
+          intentId: "intent_remove",
+          domain: "labels",
+          action: "remove_label",
+          summary: "Remove label.",
+          params: { label: "needs triage" }
+        }
+      })
+    ).resolves.toMatchObject({ intentId: "intent_remove", outcome: "applied" });
+
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target,
+        fetchImpl,
+        intent: {
+          intentId: "intent_set",
+          domain: "labels",
+          action: "set_labels",
+          summary: "Set labels.",
+          params: { labels: ["bug", "p1"] }
+        }
+      })
+    ).resolves.toMatchObject({ intentId: "intent_set", outcome: "applied" });
+
+    expect(requests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7/labels",
+        method: "POST",
+        authorization: "Bearer ghs_test",
+        body: { labels: ["bug"] }
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7/labels/needs%20triage",
+        method: "DELETE",
+        authorization: "Bearer ghs_test"
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7/labels",
+        method: "PUT",
+        authorization: "Bearer ghs_test",
+        body: { labels: ["bug", "p1"] }
+      }
+    ]);
+  });
+
+  it("returns unsupported for non-label domains", async () => {
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target: { token: "ghs_test", owner: "acme", repo: "demo", issueNumber: 7 },
+        intent: {
+          intentId: "intent_status",
+          domain: "status",
+          action: "transition_status",
+          summary: "Move status.",
+          params: { status: "in_progress" }
+        }
+      })
+    ).resolves.toMatchObject({
+      intentId: "intent_status",
+      outcome: "unsupported",
+      message: "GitHub status writes require an explicit Project field or label mapping policy."
+    });
+
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target: { token: "ghs_test", owner: "acme", repo: "demo", issueNumber: 7 },
+        intent: {
+          intentId: "intent_priority",
+          domain: "priority",
+          action: "set_priority",
+          summary: "Set priority.",
+          params: { priority: "P1" }
+        }
+      })
+    ).resolves.toMatchObject({
+      intentId: "intent_priority",
+      outcome: "unsupported",
+      message: "GitHub priority writes require an explicit label or Project field mapping policy."
+    });
+  });
+
+  it("applies assignee mutation intents through GitHub issue APIs", async () => {
+    const requests: Array<{ url: string; method: string; body?: unknown; authorization: string | null }> = [];
+    const fetchImpl = (async (url, init) => {
+      requests.push({
+        url: String(url),
+        method: init?.method ?? "GET",
+        ...(init?.body ? { body: JSON.parse(String(init.body)) } : {}),
+        authorization: new Headers(init?.headers).get("authorization")
+      });
+      return Response.json({});
+    }) as typeof fetch;
+
+    const target = { token: "ghs_test", owner: "acme", repo: "demo", issueNumber: 7 };
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target,
+        fetchImpl,
+        intent: {
+          intentId: "intent_set_assignee",
+          domain: "assignee",
+          action: "set_assignee",
+          summary: "Set assignee.",
+          params: { assignee: "alice" }
+        }
+      })
+    ).resolves.toMatchObject({ intentId: "intent_set_assignee", outcome: "applied" });
+
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target,
+        fetchImpl,
+        intent: {
+          intentId: "intent_add_assignee",
+          domain: "assignee",
+          action: "add_assignee",
+          summary: "Add assignee.",
+          params: { assignee: "bob" }
+        }
+      })
+    ).resolves.toMatchObject({ intentId: "intent_add_assignee", outcome: "applied" });
+
+    await expect(
+      applyGitHubIssueMutationIntent({
+        target,
+        fetchImpl,
+        intent: {
+          intentId: "intent_remove_assignee",
+          domain: "assignee",
+          action: "remove_assignee",
+          summary: "Remove assignee.",
+          params: { assignee: "carol" }
+        }
+      })
+    ).resolves.toMatchObject({ intentId: "intent_remove_assignee", outcome: "applied" });
+
+    expect(requests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7",
+        method: "PATCH",
+        authorization: "Bearer ghs_test",
+        body: { assignees: ["alice"] }
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7/assignees",
+        method: "POST",
+        authorization: "Bearer ghs_test",
+        body: { assignees: ["bob"] }
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/7/assignees",
+        method: "DELETE",
+        authorization: "Bearer ghs_test",
+        body: { assignees: ["carol"] }
+      }
+    ]);
+  });
+});

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -1,0 +1,176 @@
+import type { ContextPointer } from "@opentag/core";
+import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
+import type { ExecutorAdapter } from "./executor.js";
+import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
+
+export type ClaudeCodeExecutorOptions = {
+  runner?: CommandRunner;
+  claudeCommand?: string;
+  model?: string;
+  permissionMode?: "acceptEdits" | "auto" | "bypassPermissions" | "default" | "plan";
+  dangerouslySkipPermissions?: boolean;
+};
+
+function contextLines(context: ContextPointer[]): string {
+  if (!context.length) return "No additional context pointers were provided.";
+  return context.map((pointer) => `- ${pointer.kind}: ${pointer.uri}`).join("\n");
+}
+
+function buildPrompt(input: {
+  runId: string;
+  rawText: string;
+  context: ContextPointer[];
+}): string {
+  return [
+    "You are executing an OpenTag run in a local checkout.",
+    `Run ID: ${input.runId}`,
+    "",
+    "User request:",
+    input.rawText,
+    "",
+    "Context pointers:",
+    contextLines(input.context),
+    "",
+    "Work autonomously but keep the change narrow. Run relevant verification if you modify files.",
+    "End with a concise summary of what changed, what was verified, and the recommended next action."
+  ].join("\n");
+}
+
+export function createClaudeCodeExecutor(options: ClaudeCodeExecutorOptions = {}): ExecutorAdapter {
+  const runner = options.runner ?? nodeCommandRunner;
+  const claudeCommand = options.claudeCommand ?? "claude";
+
+  return {
+    id: "claude-code",
+    displayName: "Claude Code Executor",
+    async canRun(input) {
+      const claudeVersion = await runner.run(claudeCommand, ["--version"], { cwd: input.workspacePath });
+      if (claudeVersion.exitCode !== 0) {
+        return { ready: false, reason: `Claude Code CLI is not available: ${claudeVersion.stderr || claudeVersion.stdout}` };
+      }
+      const gitStatus = await runner.run("git", ["status", "--porcelain"], { cwd: input.workspacePath });
+      if (gitStatus.exitCode !== 0) {
+        return { ready: false, reason: `Workspace is not a git checkout: ${gitStatus.stderr || gitStatus.stdout}` };
+      }
+      if (gitStatus.stdout.trim().length > 0) {
+        return { ready: false, reason: "Workspace has uncommitted changes; refusing to run Claude Code executor." };
+      }
+      return { ready: true };
+    },
+    async run(input, sink) {
+      const branchName = branchNameForRun(input.runId);
+      await sink.emit({
+        type: "executor.started",
+        message: `Creating isolated branch ${branchName}`,
+        at: new Date().toISOString()
+      });
+      await createRunBranch({ runner, workspacePath: input.workspacePath, branchName });
+
+      await sink.emit({
+        type: "executor.progress",
+        message: "Starting claude --print",
+        at: new Date().toISOString()
+      });
+
+      const args = [
+        "--print",
+        "--input-format",
+        "text",
+        "--output-format",
+        "text",
+        "--no-session-persistence",
+        ...(options.model ? ["--model", options.model] : []),
+        ...(options.permissionMode ? ["--permission-mode", options.permissionMode] : []),
+        ...(options.dangerouslySkipPermissions ? ["--dangerously-skip-permissions"] : [])
+      ];
+      const claudeResult = await runner.run(claudeCommand, args, {
+        cwd: input.workspacePath,
+        input: buildPrompt({
+          runId: input.runId,
+          rawText: input.command.rawText,
+          context: input.context
+        })
+      });
+      await assertCommandSucceeded(claudeResult, "claude --print");
+
+      const cleanedArtifacts = await cleanupInternalArtifacts({ runner, workspacePath: input.workspacePath });
+      if (cleanedArtifacts.length > 0) {
+        await sink.emit({
+          type: "executor.progress",
+          message: `Cleaned internal artifacts: ${cleanedArtifacts.join(", ")}`,
+          at: new Date().toISOString()
+        });
+      }
+
+      const files = await changedFiles({ runner, workspacePath: input.workspacePath });
+      await sink.emit({
+        type: "executor.completed",
+        message: `Claude Code executor completed with ${files.length} changed file(s)`,
+        at: new Date().toISOString()
+      });
+
+      const output = claudeResult.stdout.trim() || claudeResult.stderr.trim() || "Claude Code completed without textual output.";
+      const proposalId = `proposal_${input.runId}`;
+      const suggestedChanges =
+        files.length > 0
+          ? [
+              {
+                proposalId,
+                createdAt: new Date().toISOString(),
+                sourceRunId: input.runId,
+                summary: `Claude Code changed ${files.length} file(s) on branch ${branchName}.`,
+                intents: [
+                  {
+                    intentId: `${proposalId}_link_branch`,
+                    domain: "artifact_links" as const,
+                    action: "link_artifact",
+                    summary: `Link the run branch ${branchName} to the work item.`,
+                    params: { title: "Run branch", uri: branchName }
+                  },
+                  {
+                    intentId: `${proposalId}_request_review`,
+                    domain: "review" as const,
+                    action: "request_review",
+                    summary: "Request human review of the generated code changes.",
+                    params: { changedFiles: files }
+                  }
+                ],
+                preconditions: ["The local branch was generated from the checkout state available to the runner."]
+              }
+            ]
+          : undefined;
+
+      return {
+        conclusion: "success",
+        summary: output.slice(-4000),
+        changedFiles: files,
+        artifacts: [{ kind: files.length > 0 ? "patch" : "audit_trail", title: "Run branch", uri: branchName }],
+        ...(suggestedChanges ? { suggestedChanges } : {}),
+        verification: [
+          {
+            command: "claude --print",
+            outcome: "passed",
+            excerpt: output.slice(-1000)
+          }
+        ],
+        nextAction:
+          files.length > 0
+            ? {
+                summary: "Review the local branch and explicitly create a pull request if the proposal is acceptable.",
+                hint: {
+                  kind: "create_pull_request",
+                  targetId: proposalId,
+                  selectedIntentIds: [`${proposalId}_link_branch`, `${proposalId}_request_review`]
+                }
+              }
+            : {
+                summary: "No file changes were detected.",
+                hint: { kind: "none" }
+              }
+      };
+    },
+    async cancel() {
+      return;
+    }
+  };
+}

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -44,9 +44,13 @@ export function createClaudeCodeExecutor(options: ClaudeCodeExecutorOptions = {}
     id: "claude-code",
     displayName: "Claude Code Executor",
     async canRun(input) {
-      const claudeVersion = await runner.run(claudeCommand, ["--version"], { cwd: input.workspacePath });
-      if (claudeVersion.exitCode !== 0) {
-        return { ready: false, reason: `Claude Code CLI is not available: ${claudeVersion.stderr || claudeVersion.stdout}` };
+      try {
+        const claudeVersion = await runner.run(claudeCommand, ["--version"], { cwd: input.workspacePath });
+        if (claudeVersion.exitCode !== 0) {
+          return { ready: false, reason: `Claude Code CLI is not available: ${claudeVersion.stderr || claudeVersion.stdout}` };
+        }
+      } catch (error) {
+        return { ready: false, reason: `Claude Code CLI is not available: ${error instanceof Error ? error.message : String(error)}` };
       }
       const gitStatus = await runner.run("git", ["status", "--porcelain"], { cwd: input.workspacePath });
       if (gitStatus.exitCode !== 0) {

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -2,6 +2,7 @@ import type { ContextPointer } from "@opentag/core";
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
 import type { ExecutorAdapter } from "./executor.js";
 import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
+import { createExecutorRunResult } from "./result.js";
 
 export type ClaudeCodeExecutorOptions = {
   runner?: CommandRunner;
@@ -68,7 +69,12 @@ export function createClaudeCodeExecutor(options: ClaudeCodeExecutorOptions = {}
         message: `Creating isolated branch ${branchName}`,
         at: new Date().toISOString()
       });
-      await createRunBranch({ runner, workspacePath: input.workspacePath, branchName });
+      await createRunBranch({
+        runner,
+        workspacePath: input.workspacePath,
+        branchName,
+        ...(input.baseBranch ? { startPoint: input.baseBranch } : {})
+      });
 
       await sink.emit({
         type: "executor.progress",
@@ -114,64 +120,14 @@ export function createClaudeCodeExecutor(options: ClaudeCodeExecutorOptions = {}
       });
 
       const output = claudeResult.stdout.trim() || claudeResult.stderr.trim() || "Claude Code completed without textual output.";
-      const proposalId = `proposal_${input.runId}`;
-      const suggestedChanges =
-        files.length > 0
-          ? [
-              {
-                proposalId,
-                createdAt: new Date().toISOString(),
-                sourceRunId: input.runId,
-                summary: `Claude Code changed ${files.length} file(s) on branch ${branchName}.`,
-                intents: [
-                  {
-                    intentId: `${proposalId}_link_branch`,
-                    domain: "artifact_links" as const,
-                    action: "link_artifact",
-                    summary: `Link the run branch ${branchName} to the work item.`,
-                    params: { title: "Run branch", uri: branchName }
-                  },
-                  {
-                    intentId: `${proposalId}_request_review`,
-                    domain: "review" as const,
-                    action: "request_review",
-                    summary: "Request human review of the generated code changes.",
-                    params: { changedFiles: files }
-                  }
-                ],
-                preconditions: ["The local branch was generated from the checkout state available to the runner."]
-              }
-            ]
-          : undefined;
-
-      return {
-        conclusion: "success",
-        summary: output.slice(-4000),
+      return createExecutorRunResult({
+        executorName: "Claude Code",
+        runId: input.runId,
+        branchName,
+        output,
         changedFiles: files,
-        artifacts: [{ kind: files.length > 0 ? "patch" : "audit_trail", title: "Run branch", uri: branchName }],
-        ...(suggestedChanges ? { suggestedChanges } : {}),
-        verification: [
-          {
-            command: "claude --print",
-            outcome: "passed",
-            excerpt: output.slice(-1000)
-          }
-        ],
-        nextAction:
-          files.length > 0
-            ? {
-                summary: "Review the local branch and explicitly create a pull request if the proposal is acceptable.",
-                hint: {
-                  kind: "create_pull_request",
-                  targetId: proposalId,
-                  selectedIntentIds: [`${proposalId}_link_branch`, `${proposalId}_request_review`]
-                }
-              }
-            : {
-                summary: "No file changes were detected.",
-                hint: { kind: "none" }
-              }
-      };
+        verificationCommand: "claude --print"
+      });
     },
     async cancel() {
       return;

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -105,11 +105,41 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
       });
 
       const output = codexResult.stdout.trim() || codexResult.stderr.trim() || "Codex completed without textual output.";
+      const proposalId = `proposal_${input.runId}`;
+      const suggestedChanges =
+        files.length > 0
+          ? [
+              {
+                proposalId,
+                createdAt: new Date().toISOString(),
+                sourceRunId: input.runId,
+                summary: `Codex changed ${files.length} file(s) on branch ${branchName}.`,
+                intents: [
+                  {
+                    intentId: `${proposalId}_link_branch`,
+                    domain: "artifact_links" as const,
+                    action: "link_artifact",
+                    summary: `Link the run branch ${branchName} to the work item.`,
+                    params: { title: "Run branch", uri: branchName }
+                  },
+                  {
+                    intentId: `${proposalId}_request_review`,
+                    domain: "review" as const,
+                    action: "request_review",
+                    summary: "Request human review of the generated code changes.",
+                    params: { changedFiles: files }
+                  }
+                ],
+                preconditions: ["The local branch was generated from the checkout state available to the runner."]
+              }
+            ]
+          : undefined;
       return {
         conclusion: "success",
         summary: output.slice(-4000),
         changedFiles: files,
-        artifacts: [{ title: "Run branch", uri: branchName }],
+        artifacts: [{ kind: files.length > 0 ? "patch" : "audit_trail", title: "Run branch", uri: branchName }],
+        ...(suggestedChanges ? { suggestedChanges } : {}),
         verification: [
           {
             command: "codex exec",
@@ -117,7 +147,20 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
             excerpt: output.slice(-1000)
           }
         ],
-        nextAction: files.length > 0 ? "Review the local branch and create a pull request." : "No file changes were detected."
+        nextAction:
+          files.length > 0
+            ? {
+                summary: "Review the local branch and explicitly create a pull request if the proposal is acceptable.",
+                hint: {
+                  kind: "create_pull_request",
+                  targetId: proposalId,
+                  selectedIntentIds: [`${proposalId}_link_branch`, `${proposalId}_request_review`]
+                }
+              }
+            : {
+                summary: "No file changes were detected.",
+                hint: { kind: "none" }
+              }
       };
     },
     async cancel() {

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -2,6 +2,7 @@ import type { ContextPointer } from "@opentag/core";
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
 import type { ExecutorAdapter } from "./executor.js";
 import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
+import { createExecutorRunResult } from "./result.js";
 
 export type CodexExecutorOptions = {
   runner?: CommandRunner;
@@ -61,7 +62,12 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
         message: `Creating isolated branch ${branchName}`,
         at: new Date().toISOString()
       });
-      await createRunBranch({ runner, workspacePath: input.workspacePath, branchName });
+      await createRunBranch({
+        runner,
+        workspacePath: input.workspacePath,
+        branchName,
+        ...(input.baseBranch ? { startPoint: input.baseBranch } : {})
+      });
 
       await sink.emit({
         type: "executor.progress",
@@ -105,63 +111,14 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
       });
 
       const output = codexResult.stdout.trim() || codexResult.stderr.trim() || "Codex completed without textual output.";
-      const proposalId = `proposal_${input.runId}`;
-      const suggestedChanges =
-        files.length > 0
-          ? [
-              {
-                proposalId,
-                createdAt: new Date().toISOString(),
-                sourceRunId: input.runId,
-                summary: `Codex changed ${files.length} file(s) on branch ${branchName}.`,
-                intents: [
-                  {
-                    intentId: `${proposalId}_link_branch`,
-                    domain: "artifact_links" as const,
-                    action: "link_artifact",
-                    summary: `Link the run branch ${branchName} to the work item.`,
-                    params: { title: "Run branch", uri: branchName }
-                  },
-                  {
-                    intentId: `${proposalId}_request_review`,
-                    domain: "review" as const,
-                    action: "request_review",
-                    summary: "Request human review of the generated code changes.",
-                    params: { changedFiles: files }
-                  }
-                ],
-                preconditions: ["The local branch was generated from the checkout state available to the runner."]
-              }
-            ]
-          : undefined;
-      return {
-        conclusion: "success",
-        summary: output.slice(-4000),
+      return createExecutorRunResult({
+        executorName: "Codex",
+        runId: input.runId,
+        branchName,
+        output,
         changedFiles: files,
-        artifacts: [{ kind: files.length > 0 ? "patch" : "audit_trail", title: "Run branch", uri: branchName }],
-        ...(suggestedChanges ? { suggestedChanges } : {}),
-        verification: [
-          {
-            command: "codex exec",
-            outcome: "passed",
-            excerpt: output.slice(-1000)
-          }
-        ],
-        nextAction:
-          files.length > 0
-            ? {
-                summary: "Review the local branch and explicitly create a pull request if the proposal is acceptable.",
-                hint: {
-                  kind: "create_pull_request",
-                  targetId: proposalId,
-                  selectedIntentIds: [`${proposalId}_link_branch`, `${proposalId}_request_review`]
-                }
-              }
-            : {
-                summary: "No file changes were detected.",
-                hint: { kind: "none" }
-              }
-      };
+        verificationCommand: "codex exec"
+      });
     },
     async cancel() {
       return;

--- a/packages/runner/src/echo.ts
+++ b/packages/runner/src/echo.ts
@@ -31,7 +31,11 @@ export function createEchoExecutor(): ExecutorAdapter {
             outcome: "passed",
             excerpt: input.command.rawText
           }
-        ]
+        ],
+        nextAction: {
+          summary: "No external state change is suggested for the echo executor result.",
+          hint: { kind: "none" }
+        }
       };
     },
     async cancel() {

--- a/packages/runner/src/executor.ts
+++ b/packages/runner/src/executor.ts
@@ -15,6 +15,7 @@ export type ExecutorRunInput = {
   workspacePath: string;
   command: OpenTagCommand;
   context: ContextPointer[];
+  baseBranch?: string;
 };
 
 export type ExecutorReadiness = {

--- a/packages/runner/src/git.ts
+++ b/packages/runner/src/git.ts
@@ -39,8 +39,9 @@ export async function createRunBranch(input: {
   runner: CommandRunner;
   workspacePath: string;
   branchName: string;
+  startPoint?: string;
 }): Promise<void> {
-  const result = await input.runner.run("git", ["checkout", "-B", input.branchName], { cwd: input.workspacePath });
+  const result = await input.runner.run("git", ["checkout", "-B", input.branchName, ...(input.startPoint ? [input.startPoint] : [])], { cwd: input.workspacePath });
   await assertCommandSucceeded(result, "create run branch");
 }
 

--- a/packages/runner/src/git.ts
+++ b/packages/runner/src/git.ts
@@ -50,6 +50,19 @@ export async function changedFiles(input: { runner: CommandRunner; workspacePath
   return parseChangedFiles(result.stdout);
 }
 
+export async function commitChangedFiles(input: {
+  runner: CommandRunner;
+  workspacePath: string;
+  files: string[];
+  message: string;
+}): Promise<void> {
+  if (input.files.length === 0) return;
+  const addResult = await input.runner.run("git", ["add", "--", ...input.files], { cwd: input.workspacePath });
+  await assertCommandSucceeded(addResult, "stage changed files");
+  const commitResult = await input.runner.run("git", ["commit", "-m", input.message], { cwd: input.workspacePath });
+  await assertCommandSucceeded(commitResult, "commit changed files");
+}
+
 export async function cleanupInternalArtifacts(input: { runner: CommandRunner; workspacePath: string }): Promise<string[]> {
   const statusResult = await input.runner.run("git", ["status", "--porcelain"], { cwd: input.workspacePath });
   await assertCommandSucceeded(statusResult, "scan internal artifacts");

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./claude-code.js";
 export * from "./codex.js";
 export * from "./command.js";
 export * from "./echo.js";

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -4,3 +4,4 @@ export * from "./command.js";
 export * from "./echo.js";
 export * from "./executor.js";
 export * from "./git.js";
+export * from "./result.js";

--- a/packages/runner/src/result.ts
+++ b/packages/runner/src/result.ts
@@ -1,0 +1,69 @@
+import type { OpenTagRunResult } from "@opentag/core";
+
+export function createExecutorRunResult(input: {
+  executorName: string;
+  runId: string;
+  branchName: string;
+  output: string;
+  changedFiles: string[];
+  verificationCommand: string;
+}): OpenTagRunResult {
+  const proposalId = `proposal_${input.runId}`;
+  const suggestedChanges =
+    input.changedFiles.length > 0
+      ? [
+          {
+            proposalId,
+            createdAt: new Date().toISOString(),
+            sourceRunId: input.runId,
+            summary: `${input.executorName} changed ${input.changedFiles.length} file(s) on branch ${input.branchName}.`,
+            intents: [
+              {
+                intentId: `${proposalId}_link_branch`,
+                domain: "artifact_links" as const,
+                action: "link_artifact",
+                summary: `Link the run branch ${input.branchName} to the work item.`,
+                params: { title: "Run branch", uri: input.branchName }
+              },
+              {
+                intentId: `${proposalId}_request_review`,
+                domain: "review" as const,
+                action: "request_review",
+                summary: "Request human review of the generated code changes.",
+                params: { changedFiles: input.changedFiles }
+              }
+            ],
+            preconditions: ["The local branch was generated from the checkout state available to the runner."]
+          }
+        ]
+      : undefined;
+
+  return {
+    conclusion: "success",
+    summary: input.output.slice(-4000),
+    changedFiles: input.changedFiles,
+    artifacts: [{ kind: input.changedFiles.length > 0 ? "patch" : "audit_trail", title: "Run branch", uri: input.branchName }],
+    ...(suggestedChanges ? { suggestedChanges } : {}),
+    verification: [
+      {
+        command: input.verificationCommand,
+        outcome: "passed",
+        excerpt: input.output.slice(-1000)
+      }
+    ],
+    nextAction:
+      input.changedFiles.length > 0
+        ? {
+            summary: "Review the local branch and explicitly create a pull request if the proposal is acceptable.",
+            hint: {
+              kind: "create_pull_request",
+              targetId: proposalId,
+              selectedIntentIds: [`${proposalId}_link_branch`, `${proposalId}_request_review`]
+            }
+          }
+        : {
+            summary: "No file changes were detected.",
+            hint: { kind: "none" }
+          }
+  };
+}

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -56,7 +56,8 @@ describe("Claude Code executor", () => {
         runId: "run_1",
         workspacePath: "/tmp/demo",
         command: { rawText: "fix this", intent: "fix", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }]
+        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+        baseBranch: "main"
       },
       {
         emit: async (event) => {
@@ -66,7 +67,7 @@ describe("Claude Code executor", () => {
     );
 
     const claudePrintCall = calls.find((call) => call.command === "claude" && call.args.includes("--print"));
-    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "checkout -B opentag/run_1")).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "checkout -B opentag/run_1 main")).toBe(true);
     expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .claude")).toBe(true);
     expect(claudePrintCall?.args).toContain("--input-format");
     expect(claudePrintCall?.args).toContain("text");

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { createClaudeCodeExecutor } from "../src/claude-code.js";
+import type { CommandRunner } from "../src/command.js";
+
+describe("Claude Code executor", () => {
+  it("creates an isolated branch, runs claude print mode, and reports changed files", async () => {
+    const calls: { command: string; args: string[]; input?: string }[] = [];
+    const runner: CommandRunner = {
+      async run(command, args, options) {
+        calls.push({ command, args, input: options?.input });
+        if (command === "claude" && args.includes("--version")) {
+          return { exitCode: 0, stdout: "1.0.0", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "status --porcelain") {
+          return calls.length < 4
+            ? { exitCode: 0, stdout: "", stderr: "" }
+            : {
+                exitCode: 0,
+                stdout:
+                  calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .claude")
+                    ? " M src/demo.ts\n?? test/demo.test.ts\n"
+                    : "?? .claude/\n M src/demo.ts\n?? test/demo.test.ts\n",
+                stderr: ""
+              };
+        }
+        if (command === "git" && args[0] === "checkout") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "clean -fd -- .claude") {
+          return { exitCode: 0, stdout: "Removing .claude/\n", stderr: "" };
+        }
+        if (command === "claude" && args.includes("--print")) {
+          return { exitCode: 0, stdout: "Implemented the requested Claude Code change.", stderr: "" };
+        }
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+
+    const executor = createClaudeCodeExecutor({
+      runner,
+      permissionMode: "acceptEdits",
+      model: "sonnet"
+    });
+    await expect(
+      executor.canRun({
+        runId: "run_1",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: []
+      })
+    ).resolves.toEqual({ ready: true });
+
+    const events: string[] = [];
+    const result = await executor.run(
+      {
+        runId: "run_1",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }]
+      },
+      {
+        emit: async (event) => {
+          events.push(event.type);
+        }
+      }
+    );
+
+    const claudePrintCall = calls.find((call) => call.command === "claude" && call.args.includes("--print"));
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "checkout -B opentag/run_1")).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .claude")).toBe(true);
+    expect(claudePrintCall?.args).toContain("--input-format");
+    expect(claudePrintCall?.args).toContain("text");
+    expect(claudePrintCall?.args).toContain("--output-format");
+    expect(claudePrintCall?.args).toContain("--no-session-persistence");
+    expect(claudePrintCall?.args).toContain("--permission-mode");
+    expect(claudePrintCall?.args).toContain("acceptEdits");
+    expect(claudePrintCall?.args).toContain("--model");
+    expect(claudePrintCall?.args).toContain("sonnet");
+    expect(claudePrintCall?.input).toContain("fix this");
+    expect(events).toEqual(["executor.started", "executor.progress", "executor.progress", "executor.completed"]);
+    expect(result.changedFiles).toEqual(["src/demo.ts", "test/demo.test.ts"]);
+    expect(result.summary).toContain("Implemented the requested Claude Code change.");
+    expect(result.suggestedChanges?.[0]).toMatchObject({
+      proposalId: "proposal_run_1",
+      sourceRunId: "run_1",
+      intents: [
+        { intentId: "proposal_run_1_link_branch", domain: "artifact_links", action: "link_artifact" },
+        { intentId: "proposal_run_1_request_review", domain: "review", action: "request_review" }
+      ]
+    });
+  });
+
+  it("refuses to run when the workspace has uncommitted changes", async () => {
+    const runner: CommandRunner = {
+      async run(command, args) {
+        if (command === "claude" && args.includes("--version")) {
+          return { exitCode: 0, stdout: "1.0.0", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "status --porcelain") {
+          return { exitCode: 0, stdout: " M dirty.ts\n", stderr: "" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+    };
+
+    await expect(
+      createClaudeCodeExecutor({ runner }).canRun({
+        runId: "run_1",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: []
+      })
+    ).resolves.toEqual({ ready: false, reason: "Workspace has uncommitted changes; refusing to run Claude Code executor." });
+  });
+});

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -112,4 +112,24 @@ describe("Claude Code executor", () => {
       })
     ).resolves.toEqual({ ready: false, reason: "Workspace has uncommitted changes; refusing to run Claude Code executor." });
   });
+
+  it("returns not ready when the Claude Code CLI is missing", async () => {
+    const runner: CommandRunner = {
+      async run(command) {
+        if (command === "claude") {
+          throw new Error("spawn claude ENOENT");
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+    };
+
+    await expect(
+      createClaudeCodeExecutor({ runner }).canRun({
+        runId: "run_1",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: []
+      })
+    ).resolves.toEqual({ ready: false, reason: "Claude Code CLI is not available: spawn claude ENOENT" });
+  });
 });

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -71,6 +71,23 @@ describe("Codex executor", () => {
     expect(events).toEqual(["executor.started", "executor.progress", "executor.progress", "executor.completed"]);
     expect(result.changedFiles).toEqual(["src/demo.ts", "test/demo.test.ts"]);
     expect(result.summary).toContain("Implemented the requested fix.");
+    expect(result.artifacts?.[0]).toMatchObject({ kind: "patch", title: "Run branch", uri: "opentag/run_1" });
+    expect(result.suggestedChanges?.[0]).toMatchObject({
+      proposalId: "proposal_run_1",
+      sourceRunId: "run_1",
+      intents: [
+        { intentId: "proposal_run_1_link_branch", domain: "artifact_links", action: "link_artifact" },
+        { intentId: "proposal_run_1_request_review", domain: "review", action: "request_review" }
+      ]
+    });
+    expect(result.nextAction).toMatchObject({
+      summary: "Review the local branch and explicitly create a pull request if the proposal is acceptable.",
+      hint: {
+        kind: "create_pull_request",
+        targetId: "proposal_run_1",
+        selectedIntentIds: ["proposal_run_1_link_branch", "proposal_run_1_request_review"]
+      }
+    });
   });
 
   it("refuses to run when the workspace has uncommitted changes", async () => {

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -53,7 +53,8 @@ describe("Codex executor", () => {
         runId: "run_1",
         workspacePath: "/tmp/demo",
         command: { rawText: "fix this", intent: "fix", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }]
+        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+        baseBranch: "main"
       },
       {
         emit: async (event) => {
@@ -62,7 +63,7 @@ describe("Codex executor", () => {
       }
     );
 
-    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "checkout -B opentag/run_1")).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "checkout -B opentag/run_1 main")).toBe(true);
     expect(calls.some((call) => call.command === "codex" && call.args[0] === "exec")).toBe(true);
     expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .omx")).toBe(true);
     expect(calls.find((call) => call.command === "codex" && call.args[0] === "exec")?.args).toContain("--full-auto");

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createCodexExecutor } from "../src/codex.js";
 import type { CommandRunner } from "../src/command.js";
-import { branchNameForRun, parseChangedFiles } from "../src/git.js";
+import { branchNameForRun, commitChangedFiles, parseChangedFiles } from "../src/git.js";
 
 describe("Codex executor", () => {
   it("creates an isolated branch, runs codex exec, and reports changed files", async () => {
@@ -121,5 +121,24 @@ describe("git helpers", () => {
 
   it("sanitizes branch names", () => {
     expect(branchNameForRun("run/with spaces")).toBe("opentag/run-with-spaces");
+  });
+
+  it("stages and commits selected changed files", async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        calls.push(`${command} ${args.join(" ")}`);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+    };
+
+    await commitChangedFiles({
+      runner,
+      workspacePath: "/tmp/demo",
+      files: ["README.md", "src/demo.ts"],
+      message: "OpenTag run run_1"
+    });
+
+    expect(calls).toEqual(["git add -- README.md src/demo.ts", "git commit -m OpenTag run run_1"]);
   });
 });

--- a/packages/runner/test/echo.test.ts
+++ b/packages/runner/test/echo.test.ts
@@ -22,5 +22,9 @@ describe("echo executor", () => {
     expect(events).toContain("executor.started");
     expect(result.conclusion).toBe("success");
     expect(result.summary).toContain("fix this");
+    expect(result.nextAction).toEqual({
+      summary: "No external state change is suggested for the echo executor result.",
+      hint: { kind: "none" }
+    });
   });
 });

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -43,6 +43,12 @@ export function renderSlackAcknowledgement(runId: string): string {
   return `I picked this up: \`${runId}\``;
 }
 
+function nextActionSummary(result: OpenTagRunResult): string | undefined {
+  if (!result.nextAction) return undefined;
+  if (typeof result.nextAction === "string") return result.nextAction;
+  return result.nextAction.summary;
+}
+
 export function renderSlackFinalResult(result: OpenTagRunResult): string {
   const lines = [`Finished with *${result.conclusion}*.`, "", markdownToSlackMrkdwn(result.summary)];
 
@@ -53,8 +59,9 @@ export function renderSlackFinalResult(result: OpenTagRunResult): string {
     }
   }
 
-  if (result.nextAction) {
-    lines.push("", `*Next action*: ${markdownToSlackMrkdwn(result.nextAction)}`);
+  const nextAction = nextActionSummary(result);
+  if (nextAction) {
+    lines.push("", `*Next action*: ${markdownToSlackMrkdwn(nextAction)}`);
   }
 
   return lines.join("\n");
@@ -82,12 +89,13 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlo
     });
   }
 
-  if (result.nextAction) {
+  const nextAction = nextActionSummary(result);
+  if (nextAction) {
     blocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Next action*: ${markdownToSlackMrkdwn(result.nextAction)}`
+        text: `*Next action*: ${markdownToSlackMrkdwn(nextAction)}`
       }
     });
   }

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -105,6 +105,24 @@ export type OpenTagRunMetrics = {
   staleIntentCount: number;
 };
 
+export type OpenTagAggregateMetrics = {
+  scope: "repo" | "work_thread";
+  scopeId: string;
+  runCount: number;
+  totalEventCount: number;
+  humanEventCount: number;
+  auditEventCount: number;
+  debugEventCount: number;
+  humanCallbackCount: number;
+  threadNoiseRatio: number;
+  suggestedChangesCount: number;
+  approvalDecisionCount: number;
+  applyPlanCount: number;
+  childRunCount: number;
+  applyOutcomeCounts: ApplyOutcomeCounts;
+  staleIntentCount: number;
+};
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -295,6 +313,40 @@ function metricsFromEvents(runId: string, events: OpenTagAuditEvent[]): OpenTagR
     childRunCount: events.filter((event) => event.type === "run.child_created").length,
     applyOutcomeCounts,
     staleIntentCount: applyOutcomeCounts.stale
+  };
+}
+
+function aggregateMetrics(input: {
+  scope: OpenTagAggregateMetrics["scope"];
+  scopeId: string;
+  runs: OpenTagRunMetrics[];
+}): OpenTagAggregateMetrics {
+  const applyOutcomeCounts = emptyApplyOutcomeCounts();
+  for (const run of input.runs) {
+    applyOutcomeCounts.applied += run.applyOutcomeCounts.applied;
+    applyOutcomeCounts.skipped += run.applyOutcomeCounts.skipped;
+    applyOutcomeCounts.failed += run.applyOutcomeCounts.failed;
+    applyOutcomeCounts.stale += run.applyOutcomeCounts.stale;
+    applyOutcomeCounts.unsupported += run.applyOutcomeCounts.unsupported;
+  }
+  const auditEventCount = input.runs.reduce((sum, run) => sum + run.auditEventCount, 0);
+  const humanCallbackCount = input.runs.reduce((sum, run) => sum + run.humanCallbackCount, 0);
+  return {
+    scope: input.scope,
+    scopeId: input.scopeId,
+    runCount: input.runs.length,
+    totalEventCount: input.runs.reduce((sum, run) => sum + run.totalEventCount, 0),
+    humanEventCount: input.runs.reduce((sum, run) => sum + run.humanEventCount, 0),
+    auditEventCount,
+    debugEventCount: input.runs.reduce((sum, run) => sum + run.debugEventCount, 0),
+    humanCallbackCount,
+    threadNoiseRatio: auditEventCount === 0 ? humanCallbackCount : humanCallbackCount / auditEventCount,
+    suggestedChangesCount: input.runs.reduce((sum, run) => sum + run.suggestedChangesCount, 0),
+    approvalDecisionCount: input.runs.reduce((sum, run) => sum + run.approvalDecisionCount, 0),
+    applyPlanCount: input.runs.reduce((sum, run) => sum + run.applyPlanCount, 0),
+    childRunCount: input.runs.reduce((sum, run) => sum + run.childRunCount, 0),
+    applyOutcomeCounts,
+    staleIntentCount: input.runs.reduce((sum, run) => sum + run.staleIntentCount, 0)
   };
 }
 
@@ -1102,6 +1154,75 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         createdAt: row.createdAt
       }));
       return metricsFromEvents(input.runId, events);
+    },
+
+    async getRepoMetrics(input: { provider: string; owner: string; repo: string }): Promise<OpenTagAggregateMetrics> {
+      const runRows = await db.select().from(runs).orderBy(asc(runs.createdAt));
+      const matchingRunIds = runRows
+        .filter((row) => {
+          const event = OpenTagEventSchema.parse(JSON.parse(row.eventJson));
+          const key = repoKeyFromEvent(event);
+          return key?.provider === input.provider && key.owner === input.owner && key.repo === input.repo;
+        })
+        .map((row) => row.id);
+      const runMetrics = [];
+      for (const runId of matchingRunIds) {
+        const rows = await db.select().from(runEvents).where(eq(runEvents.runId, runId)).orderBy(asc(runEvents.id));
+        runMetrics.push(
+          metricsFromEvents(
+            runId,
+            rows.map((row) => ({
+              id: row.id,
+              runId: row.runId,
+              type: row.type,
+              visibility: RunEventVisibilitySchema.parse(row.visibility),
+              importance: RunEventImportanceSchema.parse(row.importance),
+              ...(row.message ? { message: row.message } : {}),
+              payload: JSON.parse(row.payloadJson) as unknown,
+              createdAt: row.createdAt
+            }))
+          )
+        );
+      }
+      return aggregateMetrics({
+        scope: "repo",
+        scopeId: `${input.provider}:${input.owner}/${input.repo}`,
+        runs: runMetrics
+      });
+    },
+
+    async getWorkThreadMetrics(input: { threadId: string }): Promise<OpenTagAggregateMetrics> {
+      const runRows = await db.select().from(runs).orderBy(asc(runs.createdAt));
+      const matchingRunIds = runRows
+        .filter((row) => {
+          const event = OpenTagEventSchema.parse(JSON.parse(row.eventJson));
+          return protocolRunFieldsFromEvent(event, row.createdAt).thread?.id === input.threadId;
+        })
+        .map((row) => row.id);
+      const runMetrics = [];
+      for (const runId of matchingRunIds) {
+        const rows = await db.select().from(runEvents).where(eq(runEvents.runId, runId)).orderBy(asc(runEvents.id));
+        runMetrics.push(
+          metricsFromEvents(
+            runId,
+            rows.map((row) => ({
+              id: row.id,
+              runId: row.runId,
+              type: row.type,
+              visibility: RunEventVisibilitySchema.parse(row.visibility),
+              importance: RunEventImportanceSchema.parse(row.importance),
+              ...(row.message ? { message: row.message } : {}),
+              payload: JSON.parse(row.payloadJson) as unknown,
+              createdAt: row.createdAt
+            }))
+          )
+        );
+      }
+      return aggregateMetrics({
+        scope: "work_thread",
+        scopeId: input.threadId,
+        runs: runMetrics
+      });
     }
   };
 }

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -5,6 +5,7 @@ import {
   ActionHintSchema,
   OpenTagEventSchema,
   OpenTagRunResultSchema,
+  PolicyRuleSchema,
   ProposalLineageSchema,
   preflightMutationIntent,
   protocolRunFieldsFromEvent,
@@ -27,7 +28,17 @@ import {
 } from "@opentag/core";
 import { and, asc, eq } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
-import { applyPlans, approvalDecisions, repoBindings, runEvents, runners, runs, slackChannelBindings, suggestedChanges } from "./schema.js";
+import {
+  applyPlans,
+  approvalDecisions,
+  repoBindings,
+  repoPolicyRules,
+  runEvents,
+  runners,
+  runs,
+  slackChannelBindings,
+  suggestedChanges
+} from "./schema.js";
 
 export type ClaimedOpenTagRun = {
   run: OpenTagRun;
@@ -65,6 +76,30 @@ export type SlackChannelBinding = {
 export type StoredSuggestedChangesSnapshot = {
   runId: string;
   snapshot: SuggestedChangesSnapshot;
+};
+
+export type ApplyOutcomeCounts = {
+  applied: number;
+  skipped: number;
+  failed: number;
+  stale: number;
+  unsupported: number;
+};
+
+export type OpenTagRunMetrics = {
+  runId: string;
+  totalEventCount: number;
+  humanEventCount: number;
+  auditEventCount: number;
+  debugEventCount: number;
+  humanCallbackCount: number;
+  threadNoiseRatio: number;
+  suggestedChangesCount: number;
+  approvalDecisionCount: number;
+  applyPlanCount: number;
+  childRunCount: number;
+  applyOutcomeCounts: ApplyOutcomeCounts;
+  staleIntentCount: number;
 };
 
 function nowIso(): string {
@@ -204,6 +239,62 @@ function computeProposalLineage(snapshots: StoredSuggestedChangesSnapshot[], tar
   return ProposalLineageSchema.parse({ scopeKey: targetScopeKey, entries });
 }
 
+function emptyApplyOutcomeCounts(): ApplyOutcomeCounts {
+  return {
+    applied: 0,
+    skipped: 0,
+    failed: 0,
+    stale: 0,
+    unsupported: 0
+  };
+}
+
+function recordFromUnknown(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function metricsFromEvents(runId: string, events: OpenTagAuditEvent[]): OpenTagRunMetrics {
+  const latestApplyPlans = new Map<string, ApplyPlan>();
+  for (const event of events) {
+    if (event.type !== "apply_plan.created" && event.type !== "apply_plan.executed") continue;
+    const parsed = ApplyPlanSchema.safeParse(event.payload);
+    if (parsed.success) {
+      latestApplyPlans.set(parsed.data.id, parsed.data);
+    }
+  }
+
+  const applyOutcomeCounts = emptyApplyOutcomeCounts();
+  for (const plan of latestApplyPlans.values()) {
+    for (const outcome of plan.outcomes ?? []) {
+      applyOutcomeCounts[outcome.outcome] += 1;
+    }
+  }
+
+  const humanCallbackCount = events.filter((event) => event.visibility === "human" && event.type.startsWith("callback.")).length;
+  const auditEventCount = events.filter((event) => event.visibility === "audit").length;
+  return {
+    runId,
+    totalEventCount: events.length,
+    humanEventCount: events.filter((event) => event.visibility === "human").length,
+    auditEventCount,
+    debugEventCount: events.filter((event) => event.visibility === "debug").length,
+    humanCallbackCount,
+    threadNoiseRatio: auditEventCount === 0 ? humanCallbackCount : humanCallbackCount / auditEventCount,
+    suggestedChangesCount: events
+      .filter((event) => event.type === "proposal.snapshot.created")
+      .reduce((count, event) => {
+        const payload = recordFromUnknown(event.payload);
+        const intents = payload?.["intents"];
+        return count + (Array.isArray(intents) ? intents.length : 1);
+      }, 0),
+    approvalDecisionCount: events.filter((event) => event.type === "approval.decision.recorded").length,
+    applyPlanCount: latestApplyPlans.size,
+    childRunCount: events.filter((event) => event.type === "run.child_created").length,
+    applyOutcomeCounts,
+    staleIntentCount: applyOutcomeCounts.stale
+  };
+}
+
 export function createOpenTagRepository(db: BetterSQLite3Database) {
   async function appendRunEvent(input: {
     runId: string;
@@ -260,6 +351,41 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
             allowedActorsJson: input.allowedActors ? JSON.stringify(input.allowedActors) : null
           }
         });
+    },
+
+    async upsertRepoPolicyRule(input: { provider: string; owner: string; repo: string; rule: PolicyRule }): Promise<PolicyRule> {
+      const rule = PolicyRuleSchema.parse(input.rule);
+      const createdAt = nowIso();
+      await db
+        .insert(repoPolicyRules)
+        .values({
+          id: rule.id,
+          provider: input.provider,
+          owner: input.owner,
+          repo: input.repo,
+          ruleJson: JSON.stringify(rule),
+          createdAt
+        })
+        .onConflictDoUpdate({
+          target: repoPolicyRules.id,
+          set: {
+            provider: input.provider,
+            owner: input.owner,
+            repo: input.repo,
+            ruleJson: JSON.stringify(rule),
+            createdAt
+          }
+        });
+      return rule;
+    },
+
+    async listRepoPolicyRules(input: { provider: string; owner: string; repo: string }): Promise<PolicyRule[]> {
+      const rows = await db
+        .select()
+        .from(repoPolicyRules)
+        .where(and(eq(repoPolicyRules.provider, input.provider), eq(repoPolicyRules.owner, input.owner), eq(repoPolicyRules.repo, input.repo)))
+        .orderBy(asc(repoPolicyRules.createdAt));
+      return rows.map((row) => PolicyRuleSchema.parse(JSON.parse(row.ruleJson)));
     },
 
     async createSlackChannelBinding(input: SlackChannelBinding): Promise<void> {
@@ -717,6 +843,15 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const runRow = await db.select().from(runs).where(eq(runs.id, storedProposal.runId)).limit(1).get();
       if (!runRow) return null;
       const event = OpenTagEventSchema.parse(JSON.parse(runRow.eventJson));
+      const repoKey = repoKeyFromEvent(event);
+      const storedPolicyRuleRows = repoKey
+        ? await db
+            .select()
+            .from(repoPolicyRules)
+            .where(and(eq(repoPolicyRules.provider, repoKey.provider), eq(repoPolicyRules.owner, repoKey.owner), eq(repoPolicyRules.repo, repoKey.repo)))
+            .orderBy(asc(repoPolicyRules.createdAt))
+        : [];
+      const storedPolicyRules = storedPolicyRuleRows.map((row) => PolicyRuleSchema.parse(JSON.parse(row.ruleJson)));
       const selectedIntentIds = input.selectedIntentIds ?? decision.approvedIntentIds;
       const approvedIntentIds = new Set(decision.approvedIntentIds);
       const proposalIntents = new Map(storedProposal.snapshot.intents.map((intent) => [intent.intentId, intent]));
@@ -729,7 +864,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         lineageScopeKey(storedProposal)
       );
       const actionabilityByIntentId = new Map(lineage.entries.map((entry) => [entry.intentId, entry]));
-      const policyRules = [...(input.policyRules ?? []), ...syntheticManualApprovalPolicyRules(decision)];
+      const policyRules = [...storedPolicyRules, ...(input.policyRules ?? []), ...syntheticManualApprovalPolicyRules(decision)];
 
       const outcomes = selectedIntentIds.map((intentId) => {
         if (!approvedIntentIds.has(intentId)) {
@@ -894,6 +1029,21 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         payload: JSON.parse(row.payloadJson) as unknown,
         createdAt: row.createdAt
       }));
+    },
+
+    async getRunMetrics(input: { runId: string }): Promise<OpenTagRunMetrics> {
+      const rows = await db.select().from(runEvents).where(eq(runEvents.runId, input.runId)).orderBy(asc(runEvents.id));
+      const events = rows.map((row) => ({
+        id: row.id,
+        runId: row.runId,
+        type: row.type,
+        visibility: RunEventVisibilitySchema.parse(row.visibility),
+        importance: RunEventImportanceSchema.parse(row.importance),
+        ...(row.message ? { message: row.message } : {}),
+        payload: JSON.parse(row.payloadJson) as unknown,
+        createdAt: row.createdAt
+      }));
+      return metricsFromEvents(input.runId, events);
     }
   };
 }

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -1,7 +1,33 @@
-import { OpenTagEventSchema, OpenTagRunResultSchema, type OpenTagEvent, type OpenTagRun, type OpenTagRunResult } from "@opentag/core";
+import {
+  ApprovalDecisionSchema,
+  ApplyIntentOutcomeSchema,
+  ApplyPlanSchema,
+  ActionHintSchema,
+  OpenTagEventSchema,
+  OpenTagRunResultSchema,
+  ProposalLineageSchema,
+  preflightMutationIntent,
+  protocolRunFieldsFromEvent,
+  RunEventImportanceSchema,
+  RunEventVisibilitySchema,
+  SuggestedChangesSnapshotSchema,
+  type ApprovalDecision,
+  type ApplyIntentOutcome,
+  type ApplyPlan,
+  type ActionHint,
+  type MutationIntentActionability,
+  type OpenTagEvent,
+  type OpenTagRun,
+  type OpenTagRunResult,
+  type PolicyRule,
+  type ProposalLineage,
+  type RunEventImportance,
+  type RunEventVisibility,
+  type SuggestedChangesSnapshot
+} from "@opentag/core";
 import { and, asc, eq } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
-import { repoBindings, runEvents, runners, runs, slackChannelBindings } from "./schema.js";
+import { applyPlans, approvalDecisions, repoBindings, runEvents, runners, runs, slackChannelBindings, suggestedChanges } from "./schema.js";
 
 export type ClaimedOpenTagRun = {
   run: OpenTagRun;
@@ -12,6 +38,9 @@ export type OpenTagAuditEvent = {
   id: number;
   runId: string;
   type: string;
+  visibility: RunEventVisibility;
+  importance: RunEventImportance;
+  message?: string;
   payload: unknown;
   createdAt: string;
 };
@@ -33,6 +62,11 @@ export type SlackChannelBinding = {
   repo: string;
 };
 
+export type StoredSuggestedChangesSnapshot = {
+  runId: string;
+  snapshot: SuggestedChangesSnapshot;
+};
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -42,12 +76,34 @@ function isIsoExpired(iso: string | null, now: Date): boolean {
   return new Date(iso).getTime() <= now.getTime();
 }
 
+function defaultRunEventVisibility(type: string): RunEventVisibility {
+  if (type.startsWith("callback.")) return "human";
+  if (type.startsWith("executor.log")) return "debug";
+  if (type === "run.progress") return "audit";
+  return "audit";
+}
+
+function defaultRunEventImportance(type: string): RunEventImportance {
+  if (type === "run.waiting_for_permission") return "blocking";
+  if (type === "run.completed" || type.startsWith("callback.final")) return "high";
+  if (type === "run.created") return "low";
+  return "normal";
+}
+
 function runFromRow(row: typeof runs.$inferSelect): OpenTagRun {
+  const event = OpenTagEventSchema.parse(JSON.parse(row.eventJson));
   const result = row.resultJson ? OpenTagRunResultSchema.parse(JSON.parse(row.resultJson)) : undefined;
+  const triggeredByAction = row.triggeredByActionJson ? ActionHintSchema.parse(JSON.parse(row.triggeredByActionJson)) : undefined;
+  const protocolFields = protocolRunFieldsFromEvent(event, row.createdAt);
   return {
     id: row.id,
     eventId: row.eventId,
     status: row.status as OpenTagRun["status"],
+    ...protocolFields,
+    ...(row.parentRunId ? { parentRunId: row.parentRunId } : {}),
+    ...(triggeredByAction ? { triggeredByAction } : {}),
+    ...(row.sourceProposalId ? { sourceProposalId: row.sourceProposalId } : {}),
+    ...(row.sourceApplyPlanId ? { sourceApplyPlanId: row.sourceApplyPlanId } : {}),
     assignedRunnerId: row.assignedRunnerId ?? undefined,
     executor: row.executor ?? undefined,
     createdAt: row.createdAt,
@@ -67,11 +123,103 @@ function repoKeyFromEvent(event: OpenTagEvent): { provider: string; owner: strin
   };
 }
 
+function syntheticManualApprovalPolicyRules(decision: ApprovalDecision): PolicyRule[] {
+  return [
+    {
+      id: `manual_approval_${decision.id}`,
+      scope: "primary_anchor_override",
+      effect: "allow",
+      reason: "Manual approval decision authorized selected proposal intents."
+    }
+  ];
+}
+
+function lineageScopeKey(input: { runId: string; snapshot: SuggestedChangesSnapshot }): string {
+  return input.snapshot.workThread?.id ?? `run:${input.runId}`;
+}
+
+function computeProposalLineage(snapshots: StoredSuggestedChangesSnapshot[], targetScopeKey: string): ProposalLineage {
+  const scoped = snapshots
+    .filter((snapshot) => lineageScopeKey(snapshot) === targetScopeKey)
+    .sort((left, right) => {
+      const timeDelta = new Date(left.snapshot.createdAt).getTime() - new Date(right.snapshot.createdAt).getTime();
+      if (timeDelta !== 0) return timeDelta;
+      return left.snapshot.proposalId.localeCompare(right.snapshot.proposalId);
+    });
+
+  const latestProposalByDomain = new Map<string, string>();
+  const explicitSupersession = new Map<string, { proposalId: string; intentId: string }>();
+  for (const stored of scoped) {
+    const domainsInProposal = new Set<string>();
+    for (const intent of stored.snapshot.intents) {
+      domainsInProposal.add(intent.domain);
+      for (const supersededIntentId of intent.supersedesIntentIds ?? []) {
+        explicitSupersession.set(supersededIntentId, { proposalId: stored.snapshot.proposalId, intentId: intent.intentId });
+      }
+    }
+    for (const domain of domainsInProposal) {
+      latestProposalByDomain.set(domain, stored.snapshot.proposalId);
+    }
+  }
+
+  const entries: MutationIntentActionability[] = [];
+  for (const stored of scoped) {
+    for (const intent of stored.snapshot.intents) {
+      const explicit = explicitSupersession.get(intent.intentId);
+      const latestProposalId = latestProposalByDomain.get(intent.domain);
+      if (explicit) {
+        entries.push({
+          proposalId: stored.snapshot.proposalId,
+          intentId: intent.intentId,
+          domain: intent.domain,
+          status: "superseded",
+          supersededByProposalId: explicit.proposalId,
+          supersededByIntentId: explicit.intentId,
+          reason: "A later intent explicitly superseded this intent."
+        });
+      } else if (latestProposalId && latestProposalId !== stored.snapshot.proposalId) {
+        const supersedingIntent = scoped
+          .find((candidate) => candidate.snapshot.proposalId === latestProposalId)
+          ?.snapshot.intents.find((candidateIntent) => candidateIntent.domain === intent.domain);
+        entries.push({
+          proposalId: stored.snapshot.proposalId,
+          intentId: intent.intentId,
+          domain: intent.domain,
+          status: "superseded",
+          supersededByProposalId: latestProposalId,
+          ...(supersedingIntent ? { supersededByIntentId: supersedingIntent.intentId } : {}),
+          reason: `A newer proposal superseded the ${intent.domain} domain.`
+        });
+      } else {
+        entries.push({
+          proposalId: stored.snapshot.proposalId,
+          intentId: intent.intentId,
+          domain: intent.domain,
+          status: "current"
+        });
+      }
+    }
+  }
+
+  return ProposalLineageSchema.parse({ scopeKey: targetScopeKey, entries });
+}
+
 export function createOpenTagRepository(db: BetterSQLite3Database) {
-  async function appendRunEvent(input: { runId: string; type: string; payload: unknown; createdAt?: string }): Promise<void> {
+  async function appendRunEvent(input: {
+    runId: string;
+    type: string;
+    payload: unknown;
+    createdAt?: string;
+    visibility?: RunEventVisibility;
+    importance?: RunEventImportance;
+    message?: string;
+  }): Promise<void> {
     await db.insert(runEvents).values({
       runId: input.runId,
       type: input.type,
+      visibility: input.visibility ?? defaultRunEventVisibility(input.type),
+      importance: input.importance ?? defaultRunEventImportance(input.type),
+      message: input.message ?? null,
       payloadJson: JSON.stringify(input.payload),
       createdAt: input.createdAt ?? nowIso()
     });
@@ -133,14 +281,27 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         });
     },
 
-    async createRun(input: { id: string; event: OpenTagEvent }): Promise<OpenTagRun> {
+    async createRun(input: {
+      id: string;
+      event: OpenTagEvent;
+      parentRunId?: string;
+      triggeredByAction?: ActionHint;
+      sourceProposalId?: string;
+      sourceApplyPlanId?: string;
+    }): Promise<OpenTagRun> {
       const event = OpenTagEventSchema.parse(input.event);
+      const triggeredByAction = input.triggeredByAction ? ActionHintSchema.parse(input.triggeredByAction) : undefined;
       const createdAt = nowIso();
+      const protocolFields = protocolRunFieldsFromEvent(event, createdAt);
       await db.insert(runs).values({
         id: input.id,
         eventId: event.id,
         status: "queued",
         eventJson: JSON.stringify(event),
+        parentRunId: input.parentRunId ?? null,
+        triggeredByActionJson: triggeredByAction ? JSON.stringify(triggeredByAction) : null,
+        sourceProposalId: input.sourceProposalId ?? null,
+        sourceApplyPlanId: input.sourceApplyPlanId ?? null,
         createdAt,
         updatedAt: createdAt
       });
@@ -148,12 +309,47 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         runId: input.id,
         type: "run.created",
         payload: { eventId: event.id },
+        visibility: "audit",
+        importance: "low",
         createdAt
       });
+      await appendRunEvent({
+        runId: input.id,
+        type: "context_packet.generated",
+        payload: {
+          contextPacket: protocolFields.contextPacket,
+          ...(protocolFields.thread ? { thread: protocolFields.thread } : {})
+        },
+        visibility: "audit",
+        importance: "normal",
+        message: protocolFields.contextPacket.summary,
+        createdAt
+      });
+      if (input.parentRunId) {
+        await appendRunEvent({
+          runId: input.parentRunId,
+          type: "run.child_created",
+          payload: {
+            childRunId: input.id,
+            ...(triggeredByAction ? { triggeredByAction } : {}),
+            ...(input.sourceProposalId ? { sourceProposalId: input.sourceProposalId } : {}),
+            ...(input.sourceApplyPlanId ? { sourceApplyPlanId: input.sourceApplyPlanId } : {})
+          },
+          visibility: "audit",
+          importance: "normal",
+          message: `Created child run ${input.id}.`,
+          createdAt
+        });
+      }
       return {
         id: input.id,
         eventId: event.id,
         status: "queued",
+        ...protocolFields,
+        ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
+        ...(triggeredByAction ? { triggeredByAction } : {}),
+        ...(input.sourceProposalId ? { sourceProposalId: input.sourceProposalId } : {}),
+        ...(input.sourceApplyPlanId ? { sourceApplyPlanId: input.sourceApplyPlanId } : {}),
         createdAt,
         updatedAt: createdAt
       };
@@ -180,6 +376,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           runId: activeRow.id,
           type: "run.lease_expired",
           payload: { previousRunnerId: activeRow.assignedRunnerId, previousLeaseExpiresAt: activeRow.leaseExpiresAt },
+          visibility: "audit",
+          importance: "normal",
           createdAt: updatedAt
         });
       }
@@ -224,6 +422,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         runId: row.id,
         type: "run.claimed",
         payload: { runnerId: input.runnerId, leasedAt, leaseExpiresAt },
+        visibility: "audit",
+        importance: "normal",
         createdAt: updatedAt
       });
 
@@ -232,6 +432,11 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           id: row.id,
           eventId: row.eventId,
           status: "assigned",
+          ...protocolRunFieldsFromEvent(OpenTagEventSchema.parse(JSON.parse(row.eventJson)), row.createdAt),
+          ...(row.parentRunId ? { parentRunId: row.parentRunId } : {}),
+          ...(row.triggeredByActionJson ? { triggeredByAction: ActionHintSchema.parse(JSON.parse(row.triggeredByActionJson)) } : {}),
+          ...(row.sourceProposalId ? { sourceProposalId: row.sourceProposalId } : {}),
+          ...(row.sourceApplyPlanId ? { sourceApplyPlanId: row.sourceApplyPlanId } : {}),
           assignedRunnerId: input.runnerId,
           executor: row.executor ?? undefined,
           createdAt: row.createdAt,
@@ -297,6 +502,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         runId: input.runId,
         type: "run.heartbeat",
         payload: { runnerId: input.runnerId, heartbeatAt: updatedAt, leaseExpiresAt },
+        visibility: "debug",
+        importance: "low",
         createdAt: updatedAt
       });
       return true;
@@ -309,6 +516,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         runId: input.runId,
         type: "run.running",
         payload: { executor: input.executor },
+        visibility: "audit",
+        importance: "normal",
         createdAt: updatedAt
       });
     },
@@ -317,16 +526,339 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const result = OpenTagRunResultSchema.parse(input.result);
       const updatedAt = nowIso();
       const status = result.conclusion === "success" ? "succeeded" : result.conclusion === "cancelled" ? "cancelled" : "failed";
+      const runRow = await db.select().from(runs).where(eq(runs.id, input.runId)).limit(1).get();
+      const runThread = runRow ? protocolRunFieldsFromEvent(OpenTagEventSchema.parse(JSON.parse(runRow.eventJson)), runRow.createdAt).thread : undefined;
       await db.update(runs).set({ status, resultJson: JSON.stringify(result), updatedAt }).where(eq(runs.id, input.runId));
+      for (const snapshot of result.suggestedChanges ?? []) {
+        const parsedSnapshot = SuggestedChangesSnapshotSchema.parse({
+          ...snapshot,
+          sourceRunId: snapshot.sourceRunId ?? input.runId,
+          ...(snapshot.workThread || !runThread ? {} : { workThread: runThread })
+        });
+        await db
+          .insert(suggestedChanges)
+          .values({
+            proposalId: parsedSnapshot.proposalId,
+            runId: input.runId,
+            snapshotJson: JSON.stringify(parsedSnapshot),
+            createdAt: parsedSnapshot.createdAt
+          })
+          .onConflictDoUpdate({
+            target: suggestedChanges.proposalId,
+            set: {
+              runId: input.runId,
+              snapshotJson: JSON.stringify(parsedSnapshot),
+              createdAt: parsedSnapshot.createdAt
+            }
+          });
+        await appendRunEvent({
+          runId: input.runId,
+          type: "proposal.snapshot.created",
+          payload: parsedSnapshot,
+          visibility: "audit",
+          importance: "high",
+          message: parsedSnapshot.summary,
+          createdAt: updatedAt
+        });
+      }
       await appendRunEvent({
         runId: input.runId,
         type: "run.completed",
         payload: result,
+        visibility: "audit",
+        importance: "high",
+        message: result.summary,
         createdAt: updatedAt
       });
+      if ((result.suggestedChanges?.length ?? 0) > 0 || (result.artifacts?.length ?? 0) > 0) {
+        await appendRunEvent({
+          runId: input.runId,
+          type: "success_metric.observed",
+          payload: {
+            metric: "time_to_first_useful_artifact",
+            artifactCount: result.artifacts?.length ?? 0,
+            suggestedChangesCount: result.suggestedChanges?.length ?? 0
+          },
+          visibility: "audit",
+          importance: "normal",
+          createdAt: updatedAt
+        });
+      }
     },
 
-    async recordProgress(input: { runId: string; message: string; type?: string; at?: string }): Promise<void> {
+    async getSuggestedChanges(input: { proposalId: string }): Promise<StoredSuggestedChangesSnapshot | null> {
+      const row = await db.select().from(suggestedChanges).where(eq(suggestedChanges.proposalId, input.proposalId)).limit(1).get();
+      if (!row) return null;
+      return {
+        runId: row.runId,
+        snapshot: SuggestedChangesSnapshotSchema.parse(JSON.parse(row.snapshotJson))
+      };
+    },
+
+    async listSuggestedChangesForRun(input: { runId: string }): Promise<SuggestedChangesSnapshot[]> {
+      const rows = await db.select().from(suggestedChanges).where(eq(suggestedChanges.runId, input.runId)).orderBy(asc(suggestedChanges.createdAt));
+      return rows.map((row) => SuggestedChangesSnapshotSchema.parse(JSON.parse(row.snapshotJson)));
+    },
+
+    async getProposalLineage(input: { proposalId: string }): Promise<ProposalLineage | null> {
+      const targetRow = await db.select().from(suggestedChanges).where(eq(suggestedChanges.proposalId, input.proposalId)).limit(1).get();
+      if (!targetRow) return null;
+      const target = {
+        runId: targetRow.runId,
+        snapshot: SuggestedChangesSnapshotSchema.parse(JSON.parse(targetRow.snapshotJson))
+      };
+      const rows = await db.select().from(suggestedChanges).orderBy(asc(suggestedChanges.createdAt));
+      const snapshots = rows.map((row) => ({
+        runId: row.runId,
+        snapshot: SuggestedChangesSnapshotSchema.parse(JSON.parse(row.snapshotJson))
+      }));
+      return computeProposalLineage(snapshots, lineageScopeKey(target));
+    },
+
+    async listCurrentMutationIntents(input: { proposalId: string }): Promise<MutationIntentActionability[] | null> {
+      const targetRow = await db.select().from(suggestedChanges).where(eq(suggestedChanges.proposalId, input.proposalId)).limit(1).get();
+      if (!targetRow) return null;
+      const rows = await db.select().from(suggestedChanges).orderBy(asc(suggestedChanges.createdAt));
+      const lineage = computeProposalLineage(
+        rows.map((row) => ({
+          runId: row.runId,
+          snapshot: SuggestedChangesSnapshotSchema.parse(JSON.parse(row.snapshotJson))
+        })),
+        lineageScopeKey({
+          runId: targetRow.runId,
+          snapshot: SuggestedChangesSnapshotSchema.parse(JSON.parse(targetRow.snapshotJson))
+        })
+      );
+      if (!lineage) return null;
+      return lineage.entries.filter((entry) => entry.status === "current");
+    },
+
+    async recordApprovalDecision(input: ApprovalDecision): Promise<ApprovalDecision | null> {
+      const decision = ApprovalDecisionSchema.parse(input);
+      const storedProposalRow = await db
+        .select()
+        .from(suggestedChanges)
+        .where(eq(suggestedChanges.proposalId, decision.proposalId))
+        .limit(1)
+        .get();
+      if (!storedProposalRow) return null;
+      await db
+        .insert(approvalDecisions)
+        .values({
+          id: decision.id,
+          proposalId: decision.proposalId,
+          decisionJson: JSON.stringify(decision),
+          createdAt: decision.approvedAt
+        })
+        .onConflictDoUpdate({
+          target: approvalDecisions.id,
+          set: {
+            proposalId: decision.proposalId,
+            decisionJson: JSON.stringify(decision),
+            createdAt: decision.approvedAt
+          }
+        });
+      await appendRunEvent({
+        runId: storedProposalRow.runId,
+        type: "approval.decision.recorded",
+        payload: decision,
+        visibility: "audit",
+        importance: "high",
+        message: `Approved ${decision.approvedIntentIds.length} intent(s).`,
+        createdAt: decision.approvedAt
+      });
+      await appendRunEvent({
+        runId: storedProposalRow.runId,
+        type: "success_metric.observed",
+        payload: {
+          metric: "external_write_approval_rate",
+          proposalId: decision.proposalId,
+          approvedIntentCount: decision.approvedIntentIds.length
+        },
+        visibility: "audit",
+        importance: "normal",
+        createdAt: decision.approvedAt
+      });
+      return decision;
+    },
+
+    async getApprovalDecision(input: { id: string }): Promise<ApprovalDecision | null> {
+      const row = await db.select().from(approvalDecisions).where(eq(approvalDecisions.id, input.id)).limit(1).get();
+      return row ? ApprovalDecisionSchema.parse(JSON.parse(row.decisionJson)) : null;
+    },
+
+    async createApplyPlan(input: {
+      id: string;
+      proposalId: string;
+      approvalDecisionId: string;
+      selectedIntentIds?: string[];
+      adapter?: string;
+      policyRules?: PolicyRule[];
+    }): Promise<ApplyPlan | null> {
+      const storedProposalRow = await db
+        .select()
+        .from(suggestedChanges)
+        .where(eq(suggestedChanges.proposalId, input.proposalId))
+        .limit(1)
+        .get();
+      const decisionRow = await db
+        .select()
+        .from(approvalDecisions)
+        .where(eq(approvalDecisions.id, input.approvalDecisionId))
+        .limit(1)
+        .get();
+      const decision = decisionRow ? ApprovalDecisionSchema.parse(JSON.parse(decisionRow.decisionJson)) : null;
+      if (!storedProposalRow || !decision || decision.proposalId !== input.proposalId) return null;
+      const storedProposal = {
+        runId: storedProposalRow.runId,
+        snapshot: SuggestedChangesSnapshotSchema.parse(JSON.parse(storedProposalRow.snapshotJson))
+      };
+
+      const runRow = await db.select().from(runs).where(eq(runs.id, storedProposal.runId)).limit(1).get();
+      if (!runRow) return null;
+      const event = OpenTagEventSchema.parse(JSON.parse(runRow.eventJson));
+      const selectedIntentIds = input.selectedIntentIds ?? decision.approvedIntentIds;
+      const approvedIntentIds = new Set(decision.approvedIntentIds);
+      const proposalIntents = new Map(storedProposal.snapshot.intents.map((intent) => [intent.intentId, intent]));
+      const lineageRows = await db.select().from(suggestedChanges).orderBy(asc(suggestedChanges.createdAt));
+      const lineage = computeProposalLineage(
+        lineageRows.map((row) => ({
+          runId: row.runId,
+          snapshot: SuggestedChangesSnapshotSchema.parse(JSON.parse(row.snapshotJson))
+        })),
+        lineageScopeKey(storedProposal)
+      );
+      const actionabilityByIntentId = new Map(lineage.entries.map((entry) => [entry.intentId, entry]));
+      const policyRules = [...(input.policyRules ?? []), ...syntheticManualApprovalPolicyRules(decision)];
+
+      const outcomes = selectedIntentIds.map((intentId) => {
+        if (!approvedIntentIds.has(intentId)) {
+          return {
+            intentId,
+            outcome: "skipped" as const,
+            message: "Intent was not approved by the approval decision."
+          };
+        }
+        const intent = proposalIntents.get(intentId);
+        if (!intent) {
+          return {
+            intentId,
+            outcome: "failed" as const,
+            message: "Intent does not exist on the referenced proposal."
+          };
+        }
+        const actionability = actionabilityByIntentId.get(intentId);
+        if (actionability?.status !== "current") {
+          return {
+            intentId,
+            outcome: "stale" as const,
+            message: actionability?.reason ?? "Intent is no longer current for its mutation domain."
+          };
+        }
+        return preflightMutationIntent({
+          intent,
+          permissions: event.permissions,
+          policyRules
+        }).outcome;
+      });
+
+      const plan = ApplyPlanSchema.parse({
+        id: input.id,
+        proposalId: input.proposalId,
+        approvalDecisionId: input.approvalDecisionId,
+        selectedIntentIds,
+        ...(input.adapter ? { adapter: input.adapter } : {}),
+        adapterPlan: {
+          semantics: "preflight first, then per-intent outcome",
+          externalWritesExecuted: false
+        },
+        outcomes
+      });
+      const createdAt = nowIso();
+      await db
+        .insert(applyPlans)
+        .values({
+          id: plan.id,
+          proposalId: plan.proposalId,
+          approvalDecisionId: plan.approvalDecisionId,
+          planJson: JSON.stringify(plan),
+          createdAt
+        })
+        .onConflictDoUpdate({
+          target: applyPlans.id,
+          set: {
+            proposalId: plan.proposalId,
+            approvalDecisionId: plan.approvalDecisionId,
+            planJson: JSON.stringify(plan),
+            createdAt
+          }
+        });
+      await appendRunEvent({
+        runId: storedProposal.runId,
+        type: "apply_plan.created",
+        payload: plan,
+        visibility: "audit",
+        importance: "high",
+        message: `Created apply plan for ${selectedIntentIds.length} intent(s).`,
+        createdAt
+      });
+      return plan;
+    },
+
+    async getApplyPlan(input: { id: string }): Promise<ApplyPlan | null> {
+      const row = await db.select().from(applyPlans).where(eq(applyPlans.id, input.id)).limit(1).get();
+      return row ? ApplyPlanSchema.parse(JSON.parse(row.planJson)) : null;
+    },
+
+    async updateApplyPlanOutcomes(input: { id: string; outcomes: ApplyIntentOutcome[]; externalWritesExecuted: boolean }): Promise<ApplyPlan | null> {
+      const row = await db.select().from(applyPlans).where(eq(applyPlans.id, input.id)).limit(1).get();
+      if (!row) return null;
+      const currentPlan = ApplyPlanSchema.parse(JSON.parse(row.planJson));
+      const outcomes = input.outcomes.map((outcome) => ApplyIntentOutcomeSchema.parse(outcome));
+      const updatedPlan = ApplyPlanSchema.parse({
+        ...currentPlan,
+        adapterPlan: {
+          ...(currentPlan.adapterPlan && typeof currentPlan.adapterPlan === "object" && !Array.isArray(currentPlan.adapterPlan)
+            ? currentPlan.adapterPlan
+            : {}),
+          externalWritesExecuted: input.externalWritesExecuted
+        },
+        outcomes
+      });
+      const updatedAt = nowIso();
+      await db
+        .update(applyPlans)
+        .set({ planJson: JSON.stringify(updatedPlan), createdAt: row.createdAt })
+        .where(eq(applyPlans.id, input.id));
+
+      const storedProposalRow = await db
+        .select()
+        .from(suggestedChanges)
+        .where(eq(suggestedChanges.proposalId, updatedPlan.proposalId))
+        .limit(1)
+        .get();
+      if (storedProposalRow) {
+        await appendRunEvent({
+          runId: storedProposalRow.runId,
+          type: "apply_plan.executed",
+          payload: updatedPlan,
+          visibility: "audit",
+          importance: "high",
+          message: `Executed apply plan with ${outcomes.length} outcome(s).`,
+          createdAt: updatedAt
+        });
+      }
+      return updatedPlan;
+    },
+
+    async recordProgress(input: {
+      runId: string;
+      message: string;
+      type?: string;
+      at?: string;
+      visibility?: RunEventVisibility;
+      importance?: RunEventImportance;
+    }): Promise<void> {
       await appendRunEvent({
         runId: input.runId,
         type: "run.progress",
@@ -334,7 +866,10 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           type: input.type ?? "progress",
           message: input.message,
           at: input.at ?? nowIso()
-        }
+        },
+        visibility: input.visibility ?? "audit",
+        importance: input.importance ?? "normal",
+        message: input.message
       });
     },
 
@@ -353,6 +888,9 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         id: row.id,
         runId: row.runId,
         type: row.type,
+        visibility: RunEventVisibilitySchema.parse(row.visibility),
+        importance: RunEventImportanceSchema.parse(row.importance),
+        ...(row.message ? { message: row.message } : {}),
         payload: JSON.parse(row.payloadJson) as unknown,
         createdAt: row.createdAt
       }));

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -3,6 +3,7 @@ import {
   ApplyIntentOutcomeSchema,
   ApplyPlanSchema,
   ActionHintSchema,
+  AdapterMutationMappingSchema,
   OpenTagEventSchema,
   OpenTagRunResultSchema,
   PolicyRuleSchema,
@@ -16,6 +17,7 @@ import {
   type ApplyIntentOutcome,
   type ApplyPlan,
   type ActionHint,
+  type AdapterMutationMapping,
   type MutationIntentActionability,
   type OpenTagEvent,
   type OpenTagRun,
@@ -32,6 +34,7 @@ import {
   applyPlans,
   approvalDecisions,
   repoBindings,
+  repoMutationMappings,
   repoPolicyRules,
   runEvents,
   runners,
@@ -386,6 +389,46 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         .where(and(eq(repoPolicyRules.provider, input.provider), eq(repoPolicyRules.owner, input.owner), eq(repoPolicyRules.repo, input.repo)))
         .orderBy(asc(repoPolicyRules.createdAt));
       return rows.map((row) => PolicyRuleSchema.parse(JSON.parse(row.ruleJson)));
+    },
+
+    async upsertRepoMutationMapping(input: {
+      provider: string;
+      owner: string;
+      repo: string;
+      mapping: AdapterMutationMapping;
+    }): Promise<AdapterMutationMapping> {
+      const mapping = AdapterMutationMappingSchema.parse(input.mapping);
+      const createdAt = nowIso();
+      await db
+        .insert(repoMutationMappings)
+        .values({
+          id: mapping.id,
+          provider: input.provider,
+          owner: input.owner,
+          repo: input.repo,
+          mappingJson: JSON.stringify(mapping),
+          createdAt
+        })
+        .onConflictDoUpdate({
+          target: repoMutationMappings.id,
+          set: {
+            provider: input.provider,
+            owner: input.owner,
+            repo: input.repo,
+            mappingJson: JSON.stringify(mapping),
+            createdAt
+          }
+        });
+      return mapping;
+    },
+
+    async listRepoMutationMappings(input: { provider: string; owner: string; repo: string }): Promise<AdapterMutationMapping[]> {
+      const rows = await db
+        .select()
+        .from(repoMutationMappings)
+        .where(and(eq(repoMutationMappings.provider, input.provider), eq(repoMutationMappings.owner, input.owner), eq(repoMutationMappings.repo, input.repo)))
+        .orderBy(asc(repoMutationMappings.createdAt));
+      return rows.map((row) => AdapterMutationMappingSchema.parse(JSON.parse(row.mappingJson)));
     },
 
     async createSlackChannelBinding(input: SlackChannelBinding): Promise<void> {
@@ -852,6 +895,20 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
             .orderBy(asc(repoPolicyRules.createdAt))
         : [];
       const storedPolicyRules = storedPolicyRuleRows.map((row) => PolicyRuleSchema.parse(JSON.parse(row.ruleJson)));
+      const storedMappingRows = repoKey
+        ? await db
+            .select()
+            .from(repoMutationMappings)
+            .where(
+              and(
+                eq(repoMutationMappings.provider, repoKey.provider),
+                eq(repoMutationMappings.owner, repoKey.owner),
+                eq(repoMutationMappings.repo, repoKey.repo)
+              )
+            )
+            .orderBy(asc(repoMutationMappings.createdAt))
+        : [];
+      const storedMappings = storedMappingRows.map((row) => AdapterMutationMappingSchema.parse(JSON.parse(row.mappingJson)));
       const selectedIntentIds = input.selectedIntentIds ?? decision.approvedIntentIds;
       const approvedIntentIds = new Set(decision.approvedIntentIds);
       const proposalIntents = new Map(storedProposal.snapshot.intents.map((intent) => [intent.intentId, intent]));
@@ -905,7 +962,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         ...(input.adapter ? { adapter: input.adapter } : {}),
         adapterPlan: {
           semantics: "preflight first, then per-intent outcome",
-          externalWritesExecuted: false
+          externalWritesExecuted: false,
+          mappings: storedMappings
         },
         outcomes
       });

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -514,6 +514,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const triggeredByAction = input.triggeredByAction ? ActionHintSchema.parse(input.triggeredByAction) : undefined;
       const createdAt = nowIso();
       const protocolFields = protocolRunFieldsFromEvent(event, createdAt);
+      const repoKey = repoKeyFromEvent(event);
       await db.insert(runs).values({
         id: input.id,
         eventId: event.id,
@@ -523,6 +524,10 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         triggeredByActionJson: triggeredByAction ? JSON.stringify(triggeredByAction) : null,
         sourceProposalId: input.sourceProposalId ?? null,
         sourceApplyPlanId: input.sourceApplyPlanId ?? null,
+        repoProvider: repoKey?.provider ?? null,
+        repoOwner: repoKey?.owner ?? null,
+        repoName: repoKey?.repo ?? null,
+        workThreadId: protocolFields.thread?.id ?? null,
         createdAt,
         updatedAt: createdAt
       });
@@ -1157,14 +1162,12 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
     },
 
     async getRepoMetrics(input: { provider: string; owner: string; repo: string }): Promise<OpenTagAggregateMetrics> {
-      const runRows = await db.select().from(runs).orderBy(asc(runs.createdAt));
-      const matchingRunIds = runRows
-        .filter((row) => {
-          const event = OpenTagEventSchema.parse(JSON.parse(row.eventJson));
-          const key = repoKeyFromEvent(event);
-          return key?.provider === input.provider && key.owner === input.owner && key.repo === input.repo;
-        })
-        .map((row) => row.id);
+      const runRows = await db
+        .select()
+        .from(runs)
+        .where(and(eq(runs.repoProvider, input.provider), eq(runs.repoOwner, input.owner), eq(runs.repoName, input.repo)))
+        .orderBy(asc(runs.createdAt));
+      const matchingRunIds = runRows.map((row) => row.id);
       const runMetrics = [];
       for (const runId of matchingRunIds) {
         const rows = await db.select().from(runEvents).where(eq(runEvents.runId, runId)).orderBy(asc(runEvents.id));
@@ -1192,13 +1195,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
     },
 
     async getWorkThreadMetrics(input: { threadId: string }): Promise<OpenTagAggregateMetrics> {
-      const runRows = await db.select().from(runs).orderBy(asc(runs.createdAt));
-      const matchingRunIds = runRows
-        .filter((row) => {
-          const event = OpenTagEventSchema.parse(JSON.parse(row.eventJson));
-          return protocolRunFieldsFromEvent(event, row.createdAt).thread?.id === input.threadId;
-        })
-        .map((row) => row.id);
+      const runRows = await db.select().from(runs).where(eq(runs.workThreadId, input.threadId)).orderBy(asc(runs.createdAt));
+      const matchingRunIds = runRows.map((row) => row.id);
       const runMetrics = [];
       for (const runId of matchingRunIds) {
         const rows = await db.select().from(runEvents).where(eq(runEvents.runId, runId)).orderBy(asc(runEvents.id));

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -754,6 +754,9 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
               ? "needs_approval"
               : "failed";
       const runRow = await db.select().from(runs).where(eq(runs.id, input.runId)).limit(1).get();
+      if (!runRow) {
+        throw new Error(`Run not found: ${input.runId}`);
+      }
       const runThread = runRow ? protocolRunFieldsFromEvent(OpenTagEventSchema.parse(JSON.parse(runRow.eventJson)), runRow.createdAt).thread : undefined;
       await db.update(runs).set({ status, resultJson: JSON.stringify(result), updatedAt }).where(eq(runs.id, input.runId));
       for (const snapshot of result.suggestedChanges ?? []) {
@@ -1008,7 +1011,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         return preflightMutationIntent({
           intent,
           permissions: event.permissions,
-          policyRules
+          policyRules,
+          ...(input.adapter ? { adapter: input.adapter } : {})
         }).outcome;
       });
 
@@ -1120,7 +1124,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         },
         visibility: input.visibility ?? "audit",
         importance: input.importance ?? "normal",
-        message: input.message
+        message: input.message,
+        createdAt: input.at ?? nowIso()
       });
     },
 

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -422,11 +422,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           createdAt
         })
         .onConflictDoUpdate({
-          target: repoPolicyRules.id,
+          target: [repoPolicyRules.provider, repoPolicyRules.owner, repoPolicyRules.repo, repoPolicyRules.id],
           set: {
-            provider: input.provider,
-            owner: input.owner,
-            repo: input.repo,
             ruleJson: JSON.stringify(rule),
             createdAt
           }
@@ -462,11 +459,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           createdAt
         })
         .onConflictDoUpdate({
-          target: repoMutationMappings.id,
+          target: [repoMutationMappings.provider, repoMutationMappings.owner, repoMutationMappings.repo, repoMutationMappings.id],
           set: {
-            provider: input.provider,
-            owner: input.owner,
-            repo: input.repo,
             mappingJson: JSON.stringify(mapping),
             createdAt
           }
@@ -751,7 +745,14 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
     async completeRun(input: { runId: string; result: OpenTagRunResult }): Promise<void> {
       const result = OpenTagRunResultSchema.parse(input.result);
       const updatedAt = nowIso();
-      const status = result.conclusion === "success" ? "succeeded" : result.conclusion === "cancelled" ? "cancelled" : "failed";
+      const status =
+        result.conclusion === "success"
+          ? "succeeded"
+          : result.conclusion === "cancelled"
+            ? "cancelled"
+            : result.conclusion === "needs_human"
+              ? "needs_approval"
+              : "failed";
       const runRow = await db.select().from(runs).where(eq(runs.id, input.runId)).limit(1).get();
       const runThread = runRow ? protocolRunFieldsFromEvent(OpenTagEventSchema.parse(JSON.parse(runRow.eventJson)), runRow.createdAt).thread : undefined;
       await db.update(runs).set({ status, resultJson: JSON.stringify(result), updatedAt }).where(eq(runs.id, input.runId));

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -33,16 +33,22 @@ export const runs = sqliteTable(
   })
 );
 
-export const runEvents = sqliteTable("run_events", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  runId: text("run_id").notNull(),
-  type: text("type").notNull(),
-  visibility: text("visibility").notNull().default("audit"),
-  importance: text("importance").notNull().default("normal"),
-  message: text("message"),
-  payloadJson: text("payload_json").notNull(),
-  createdAt: text("created_at").notNull()
-});
+export const runEvents = sqliteTable(
+  "run_events",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    runId: text("run_id").notNull(),
+    type: text("type").notNull(),
+    visibility: text("visibility").notNull().default("audit"),
+    importance: text("importance").notNull().default("normal"),
+    message: text("message"),
+    payloadJson: text("payload_json").notNull(),
+    createdAt: text("created_at").notNull()
+  },
+  (table) => ({
+    runIdx: index("run_events_run_idx").on(table.runId)
+  })
+);
 
 export const suggestedChanges = sqliteTable("suggested_changes", {
   proposalId: text("proposal_id").primaryKey(),
@@ -174,6 +180,7 @@ export function migrateSchema(sqlite: Database.Database): void {
       payload_json TEXT NOT NULL,
       created_at TEXT NOT NULL
     );
+    CREATE INDEX IF NOT EXISTS run_events_run_idx ON run_events(run_id);
     CREATE TABLE IF NOT EXISTS suggested_changes (
       proposal_id TEXT PRIMARY KEY,
       run_id TEXT NOT NULL,
@@ -221,6 +228,8 @@ export function migrateSchema(sqlite: Database.Database): void {
       created_at TEXT NOT NULL,
       PRIMARY KEY (provider, owner, repo, id)
     );
+    CREATE UNIQUE INDEX IF NOT EXISTS repo_policy_rules_repo_id_idx
+      ON repo_policy_rules(provider, owner, repo, id);
     CREATE TABLE IF NOT EXISTS repo_mutation_mappings (
       id TEXT NOT NULL,
       provider TEXT NOT NULL,
@@ -230,6 +239,8 @@ export function migrateSchema(sqlite: Database.Database): void {
       created_at TEXT NOT NULL,
       PRIMARY KEY (provider, owner, repo, id)
     );
+    CREATE UNIQUE INDEX IF NOT EXISTS repo_mutation_mappings_repo_id_idx
+      ON repo_mutation_mappings(provider, owner, repo, id);
     CREATE TABLE IF NOT EXISTS slack_channel_bindings (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       team_id TEXT NOT NULL,
@@ -297,4 +308,7 @@ export function migrateSchema(sqlite: Database.Database): void {
   if (!runEventColumnNames.has("message")) {
     sqlite.exec("ALTER TABLE run_events ADD COLUMN message TEXT");
   }
+  sqlite.exec("CREATE INDEX IF NOT EXISTS run_events_run_idx ON run_events(run_id)");
+  sqlite.exec("CREATE UNIQUE INDEX IF NOT EXISTS repo_policy_rules_repo_id_idx ON repo_policy_rules(provider, owner, repo, id)");
+  sqlite.exec("CREATE UNIQUE INDEX IF NOT EXISTS repo_mutation_mappings_repo_id_idx ON repo_mutation_mappings(provider, owner, repo, id)");
 }

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -15,6 +15,10 @@ export const runs = sqliteTable(
     triggeredByActionJson: text("triggered_by_action_json"),
     sourceProposalId: text("source_proposal_id"),
     sourceApplyPlanId: text("source_apply_plan_id"),
+    repoProvider: text("repo_provider"),
+    repoOwner: text("repo_owner"),
+    repoName: text("repo_name"),
+    workThreadId: text("work_thread_id"),
     leasedAt: text("leased_at"),
     leaseExpiresAt: text("lease_expires_at"),
     heartbeatAt: text("heartbeat_at"),
@@ -23,7 +27,9 @@ export const runs = sqliteTable(
   },
   (table) => ({
     statusIdx: index("runs_status_idx").on(table.status),
-    runnerIdx: index("runs_runner_idx").on(table.assignedRunnerId)
+    runnerIdx: index("runs_runner_idx").on(table.assignedRunnerId),
+    repoIdx: index("runs_repo_idx").on(table.repoProvider, table.repoOwner, table.repoName),
+    workThreadIdx: index("runs_work_thread_idx").on(table.workThreadId)
   })
 );
 
@@ -132,6 +138,10 @@ export function migrateSchema(sqlite: Database.Database): void {
       triggered_by_action_json TEXT,
       source_proposal_id TEXT,
       source_apply_plan_id TEXT,
+      repo_provider TEXT,
+      repo_owner TEXT,
+      repo_name TEXT,
+      work_thread_id TEXT,
       leased_at TEXT,
       lease_expires_at TEXT,
       heartbeat_at TEXT,
@@ -140,6 +150,8 @@ export function migrateSchema(sqlite: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS runs_status_idx ON runs(status);
     CREATE INDEX IF NOT EXISTS runs_runner_idx ON runs(assigned_runner_id);
+    CREATE INDEX IF NOT EXISTS runs_repo_idx ON runs(repo_provider, repo_owner, repo_name);
+    CREATE INDEX IF NOT EXISTS runs_work_thread_idx ON runs(work_thread_id);
     CREATE TABLE IF NOT EXISTS run_events (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       run_id TEXT NOT NULL,
@@ -246,6 +258,20 @@ export function migrateSchema(sqlite: Database.Database): void {
   if (!runColumnNames.has("source_apply_plan_id")) {
     sqlite.exec("ALTER TABLE runs ADD COLUMN source_apply_plan_id TEXT");
   }
+  if (!runColumnNames.has("repo_provider")) {
+    sqlite.exec("ALTER TABLE runs ADD COLUMN repo_provider TEXT");
+  }
+  if (!runColumnNames.has("repo_owner")) {
+    sqlite.exec("ALTER TABLE runs ADD COLUMN repo_owner TEXT");
+  }
+  if (!runColumnNames.has("repo_name")) {
+    sqlite.exec("ALTER TABLE runs ADD COLUMN repo_name TEXT");
+  }
+  if (!runColumnNames.has("work_thread_id")) {
+    sqlite.exec("ALTER TABLE runs ADD COLUMN work_thread_id TEXT");
+  }
+  sqlite.exec("CREATE INDEX IF NOT EXISTS runs_repo_idx ON runs(repo_provider, repo_owner, repo_name)");
+  sqlite.exec("CREATE INDEX IF NOT EXISTS runs_work_thread_idx ON runs(work_thread_id)");
   const runEventColumns = sqlite.prepare("PRAGMA table_info(run_events)").all() as { name: string }[];
   const runEventColumnNames = new Set(runEventColumns.map((column) => column.name));
   if (!runEventColumnNames.has("visibility")) {

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -85,6 +85,15 @@ export const repoBindings = sqliteTable(
   })
 );
 
+export const repoPolicyRules = sqliteTable("repo_policy_rules", {
+  id: text("id").primaryKey(),
+  provider: text("provider").notNull(),
+  owner: text("owner").notNull(),
+  repo: text("repo").notNull(),
+  ruleJson: text("rule_json").notNull(),
+  createdAt: text("created_at").notNull()
+});
+
 export const slackChannelBindings = sqliteTable(
   "slack_channel_bindings",
   {
@@ -170,6 +179,14 @@ export function migrateSchema(sqlite: Database.Database): void {
     );
     CREATE UNIQUE INDEX IF NOT EXISTS repo_bindings_provider_owner_repo_idx
       ON repo_bindings(provider, owner, repo);
+    CREATE TABLE IF NOT EXISTS repo_policy_rules (
+      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      owner TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      rule_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
     CREATE TABLE IF NOT EXISTS slack_channel_bindings (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       team_id TEXT NOT NULL,

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { index, integer, primaryKey, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const runs = sqliteTable(
   "runs",
@@ -91,23 +91,35 @@ export const repoBindings = sqliteTable(
   })
 );
 
-export const repoPolicyRules = sqliteTable("repo_policy_rules", {
-  id: text("id").primaryKey(),
-  provider: text("provider").notNull(),
-  owner: text("owner").notNull(),
-  repo: text("repo").notNull(),
-  ruleJson: text("rule_json").notNull(),
-  createdAt: text("created_at").notNull()
-});
+export const repoPolicyRules = sqliteTable(
+  "repo_policy_rules",
+  {
+    id: text("id").notNull(),
+    provider: text("provider").notNull(),
+    owner: text("owner").notNull(),
+    repo: text("repo").notNull(),
+    ruleJson: text("rule_json").notNull(),
+    createdAt: text("created_at").notNull()
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.provider, table.owner, table.repo, table.id] })
+  })
+);
 
-export const repoMutationMappings = sqliteTable("repo_mutation_mappings", {
-  id: text("id").primaryKey(),
-  provider: text("provider").notNull(),
-  owner: text("owner").notNull(),
-  repo: text("repo").notNull(),
-  mappingJson: text("mapping_json").notNull(),
-  createdAt: text("created_at").notNull()
-});
+export const repoMutationMappings = sqliteTable(
+  "repo_mutation_mappings",
+  {
+    id: text("id").notNull(),
+    provider: text("provider").notNull(),
+    owner: text("owner").notNull(),
+    repo: text("repo").notNull(),
+    mappingJson: text("mapping_json").notNull(),
+    createdAt: text("created_at").notNull()
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.provider, table.owner, table.repo, table.id] })
+  })
+);
 
 export const slackChannelBindings = sqliteTable(
   "slack_channel_bindings",
@@ -201,20 +213,22 @@ export function migrateSchema(sqlite: Database.Database): void {
     CREATE UNIQUE INDEX IF NOT EXISTS repo_bindings_provider_owner_repo_idx
       ON repo_bindings(provider, owner, repo);
     CREATE TABLE IF NOT EXISTS repo_policy_rules (
-      id TEXT PRIMARY KEY,
+      id TEXT NOT NULL,
       provider TEXT NOT NULL,
       owner TEXT NOT NULL,
       repo TEXT NOT NULL,
       rule_json TEXT NOT NULL,
-      created_at TEXT NOT NULL
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (provider, owner, repo, id)
     );
     CREATE TABLE IF NOT EXISTS repo_mutation_mappings (
-      id TEXT PRIMARY KEY,
+      id TEXT NOT NULL,
       provider TEXT NOT NULL,
       owner TEXT NOT NULL,
       repo TEXT NOT NULL,
       mapping_json TEXT NOT NULL,
-      created_at TEXT NOT NULL
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (provider, owner, repo, id)
     );
     CREATE TABLE IF NOT EXISTS slack_channel_bindings (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -94,6 +94,15 @@ export const repoPolicyRules = sqliteTable("repo_policy_rules", {
   createdAt: text("created_at").notNull()
 });
 
+export const repoMutationMappings = sqliteTable("repo_mutation_mappings", {
+  id: text("id").primaryKey(),
+  provider: text("provider").notNull(),
+  owner: text("owner").notNull(),
+  repo: text("repo").notNull(),
+  mappingJson: text("mapping_json").notNull(),
+  createdAt: text("created_at").notNull()
+});
+
 export const slackChannelBindings = sqliteTable(
   "slack_channel_bindings",
   {
@@ -185,6 +194,14 @@ export function migrateSchema(sqlite: Database.Database): void {
       owner TEXT NOT NULL,
       repo TEXT NOT NULL,
       rule_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS repo_mutation_mappings (
+      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      owner TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      mapping_json TEXT NOT NULL,
       created_at TEXT NOT NULL
     );
     CREATE TABLE IF NOT EXISTS slack_channel_bindings (

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -11,6 +11,10 @@ export const runs = sqliteTable(
     resultJson: text("result_json"),
     assignedRunnerId: text("assigned_runner_id"),
     executor: text("executor"),
+    parentRunId: text("parent_run_id"),
+    triggeredByActionJson: text("triggered_by_action_json"),
+    sourceProposalId: text("source_proposal_id"),
+    sourceApplyPlanId: text("source_apply_plan_id"),
     leasedAt: text("leased_at"),
     leaseExpiresAt: text("lease_expires_at"),
     heartbeatAt: text("heartbeat_at"),
@@ -27,7 +31,32 @@ export const runEvents = sqliteTable("run_events", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   runId: text("run_id").notNull(),
   type: text("type").notNull(),
+  visibility: text("visibility").notNull().default("audit"),
+  importance: text("importance").notNull().default("normal"),
+  message: text("message"),
   payloadJson: text("payload_json").notNull(),
+  createdAt: text("created_at").notNull()
+});
+
+export const suggestedChanges = sqliteTable("suggested_changes", {
+  proposalId: text("proposal_id").primaryKey(),
+  runId: text("run_id").notNull(),
+  snapshotJson: text("snapshot_json").notNull(),
+  createdAt: text("created_at").notNull()
+});
+
+export const approvalDecisions = sqliteTable("approval_decisions", {
+  id: text("id").primaryKey(),
+  proposalId: text("proposal_id").notNull(),
+  decisionJson: text("decision_json").notNull(),
+  createdAt: text("created_at").notNull()
+});
+
+export const applyPlans = sqliteTable("apply_plans", {
+  id: text("id").primaryKey(),
+  proposalId: text("proposal_id").notNull(),
+  approvalDecisionId: text("approval_decision_id").notNull(),
+  planJson: text("plan_json").notNull(),
   createdAt: text("created_at").notNull()
 });
 
@@ -81,6 +110,10 @@ export function migrateSchema(sqlite: Database.Database): void {
       result_json TEXT,
       assigned_runner_id TEXT,
       executor TEXT,
+      parent_run_id TEXT,
+      triggered_by_action_json TEXT,
+      source_proposal_id TEXT,
+      source_apply_plan_id TEXT,
       leased_at TEXT,
       lease_expires_at TEXT,
       heartbeat_at TEXT,
@@ -93,7 +126,29 @@ export function migrateSchema(sqlite: Database.Database): void {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       run_id TEXT NOT NULL,
       type TEXT NOT NULL,
+      visibility TEXT NOT NULL DEFAULT 'audit',
+      importance TEXT NOT NULL DEFAULT 'normal',
+      message TEXT,
       payload_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS suggested_changes (
+      proposal_id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      snapshot_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS approval_decisions (
+      id TEXT PRIMARY KEY,
+      proposal_id TEXT NOT NULL,
+      decision_json TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS apply_plans (
+      id TEXT PRIMARY KEY,
+      proposal_id TEXT NOT NULL,
+      approval_decision_id TEXT NOT NULL,
+      plan_json TEXT NOT NULL,
       created_at TEXT NOT NULL
     );
     CREATE TABLE IF NOT EXISTS runners (
@@ -144,5 +199,28 @@ export function migrateSchema(sqlite: Database.Database): void {
   }
   if (!runColumnNames.has("heartbeat_at")) {
     sqlite.exec("ALTER TABLE runs ADD COLUMN heartbeat_at TEXT");
+  }
+  if (!runColumnNames.has("parent_run_id")) {
+    sqlite.exec("ALTER TABLE runs ADD COLUMN parent_run_id TEXT");
+  }
+  if (!runColumnNames.has("triggered_by_action_json")) {
+    sqlite.exec("ALTER TABLE runs ADD COLUMN triggered_by_action_json TEXT");
+  }
+  if (!runColumnNames.has("source_proposal_id")) {
+    sqlite.exec("ALTER TABLE runs ADD COLUMN source_proposal_id TEXT");
+  }
+  if (!runColumnNames.has("source_apply_plan_id")) {
+    sqlite.exec("ALTER TABLE runs ADD COLUMN source_apply_plan_id TEXT");
+  }
+  const runEventColumns = sqlite.prepare("PRAGMA table_info(run_events)").all() as { name: string }[];
+  const runEventColumnNames = new Set(runEventColumns.map((column) => column.name));
+  if (!runEventColumnNames.has("visibility")) {
+    sqlite.exec("ALTER TABLE run_events ADD COLUMN visibility TEXT NOT NULL DEFAULT 'audit'");
+  }
+  if (!runEventColumnNames.has("importance")) {
+    sqlite.exec("ALTER TABLE run_events ADD COLUMN importance TEXT NOT NULL DEFAULT 'normal'");
+  }
+  if (!runEventColumnNames.has("message")) {
+    sqlite.exec("ALTER TABLE run_events ADD COLUMN message TEXT");
   }
 }

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -333,6 +333,25 @@ describe("OpenTag repository", () => {
       },
       staleIntentCount: 0
     });
+    await expect(repo.getRepoMetrics({ provider: "github", owner: "acme", repo: "demo" })).resolves.toMatchObject({
+      scope: "repo",
+      scopeId: "github:acme/demo",
+      runCount: 1,
+      suggestedChangesCount: 1,
+      approvalDecisionCount: 1,
+      applyPlanCount: 1
+    });
+    const storedRun = await repo.getRun({ runId: "run_protocol" });
+    const threadId = storedRun?.run.thread?.id;
+    expect(threadId).toBeTruthy();
+    await expect(repo.getWorkThreadMetrics({ threadId: threadId! })).resolves.toMatchObject({
+      scope: "work_thread",
+      scopeId: threadId,
+      runCount: 1,
+      suggestedChangesCount: 1,
+      approvalDecisionCount: 1,
+      applyPlanCount: 1
+    });
   });
 
   it("uses repo policy rules during apply preflight", async () => {

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -224,6 +224,50 @@ describe("OpenTag repository", () => {
     expect(events[2]).toMatchObject({ visibility: "audit", importance: "high", message: "done" });
   });
 
+  it("stores needs_human results as needs_approval", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.createRun({
+      id: "run_needs_human",
+      event: {
+        id: "evt_needs_human",
+        source: "github",
+        sourceEventId: "comment_needs_human",
+        receivedAt: "2026-06-24T00:00:00.000Z",
+        actor: { provider: "github", providerUserId: "42" },
+        target: { mention: "@opentag", agentId: "opentag" },
+        command: { rawText: "propose labels", intent: "run", args: {} },
+        context: [],
+        permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
+        callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
+        metadata: { owner: "acme", repo: "demo", issueNumber: 1 }
+      }
+    });
+
+    await repo.completeRun({
+      runId: "run_needs_human",
+      result: {
+        conclusion: "needs_human",
+        summary: "Proposal ready.",
+        suggestedChanges: [
+          {
+            proposalId: "proposal_needs_human",
+            createdAt: "2026-06-24T00:00:01.000Z",
+            summary: "Add label.",
+            intents: [{ intentId: "intent_label", domain: "labels", action: "add_label", summary: "Add label.", params: { label: "bug" } }]
+          }
+        ]
+      }
+    });
+
+    await expect(repo.getRun({ runId: "run_needs_human" })).resolves.toMatchObject({
+      run: { status: "needs_approval", result: { conclusion: "needs_human" } }
+    });
+  });
+
   it("persists proposals, approvals, apply plans, and metric events", async () => {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);
@@ -375,6 +419,24 @@ describe("OpenTag repository", () => {
     await expect(repo.listRepoPolicyRules({ provider: "github", owner: "acme", repo: "demo" })).resolves.toEqual([
       expect.objectContaining({ id: "deny_labels_from_primary_anchor", effect: "deny" })
     ]);
+    await repo.upsertRepoPolicyRule({
+      provider: "github",
+      owner: "acme",
+      repo: "other",
+      rule: {
+        id: "deny_labels_from_primary_anchor",
+        scope: "primary_anchor_override",
+        effect: "allow",
+        capabilityId: "set_labels",
+        reason: "Different repo may reuse the same rule id."
+      }
+    });
+    await expect(repo.listRepoPolicyRules({ provider: "github", owner: "acme", repo: "demo" })).resolves.toEqual([
+      expect.objectContaining({ id: "deny_labels_from_primary_anchor", effect: "deny" })
+    ]);
+    await expect(repo.listRepoPolicyRules({ provider: "github", owner: "acme", repo: "other" })).resolves.toEqual([
+      expect.objectContaining({ id: "deny_labels_from_primary_anchor", effect: "allow" })
+    ]);
 
     await repo.createRun({
       id: "run_policy",
@@ -462,6 +524,21 @@ describe("OpenTag repository", () => {
     });
     await expect(repo.listRepoMutationMappings({ provider: "github", owner: "acme", repo: "demo" })).resolves.toEqual([
       expect.objectContaining({ id: "github_status_labels", domain: "status" })
+    ]);
+    await repo.upsertRepoMutationMapping({
+      provider: "github",
+      owner: "acme",
+      repo: "other",
+      mapping: {
+        id: "github_status_labels",
+        adapter: "github",
+        domain: "status",
+        strategy: "label",
+        values: { blocked: "other/blocked" }
+      }
+    });
+    await expect(repo.listRepoMutationMappings({ provider: "github", owner: "acme", repo: "demo" })).resolves.toEqual([
+      expect.objectContaining({ id: "github_status_labels", values: { blocked: "status/blocked" } })
     ]);
 
     await repo.createRun({

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -315,6 +315,112 @@ describe("OpenTag repository", () => {
         expect.objectContaining({ metric: "external_write_approval_rate" })
       ])
     );
+
+    const metrics = await repo.getRunMetrics({ runId: "run_protocol" });
+    expect(metrics).toMatchObject({
+      runId: "run_protocol",
+      humanCallbackCount: 0,
+      suggestedChangesCount: 1,
+      approvalDecisionCount: 1,
+      applyPlanCount: 1,
+      childRunCount: 0,
+      applyOutcomeCounts: {
+        applied: 0,
+        skipped: 1,
+        failed: 0,
+        stale: 0,
+        unsupported: 0
+      },
+      staleIntentCount: 0
+    });
+  });
+
+  it("uses repo policy rules during apply preflight", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.upsertRepoPolicyRule({
+      provider: "github",
+      owner: "acme",
+      repo: "demo",
+      rule: {
+        id: "deny_labels_from_primary_anchor",
+        scope: "primary_anchor_override",
+        effect: "deny",
+        capabilityId: "set_labels",
+        reason: "Repo policy denies label mutation for this anchor."
+      }
+    });
+    await expect(repo.listRepoPolicyRules({ provider: "github", owner: "acme", repo: "demo" })).resolves.toEqual([
+      expect.objectContaining({ id: "deny_labels_from_primary_anchor", effect: "deny" })
+    ]);
+
+    await repo.createRun({
+      id: "run_policy",
+      event: {
+        id: "evt_policy",
+        source: "github",
+        sourceEventId: "comment_policy",
+        receivedAt: "2026-06-24T00:00:00.000Z",
+        actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+        target: { mention: "@opentag", agentId: "opentag" },
+        command: { rawText: "label this", intent: "run", args: {} },
+        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/4", visibility: "public" }],
+        permissions: [
+          { scope: "issue:comment", reason: "reply to source thread" },
+          { scope: "repo:write", reason: "mutate labels after approval" }
+        ],
+        callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/4/comments" },
+        metadata: { owner: "acme", repo: "demo", issueNumber: 4 }
+      }
+    });
+    await repo.completeRun({
+      runId: "run_policy",
+      result: {
+        conclusion: "needs_human",
+        summary: "Prepared label proposal.",
+        suggestedChanges: [
+          {
+            proposalId: "proposal_policy",
+            createdAt: "2026-06-24T00:00:01.000Z",
+            summary: "Add blocked label.",
+            intents: [
+              {
+                intentId: "intent_label_blocked",
+                domain: "labels",
+                action: "add_label",
+                summary: "Add blocked label.",
+                params: { label: "blocked" }
+              }
+            ]
+          }
+        ]
+      }
+    });
+    await repo.recordApprovalDecision({
+      id: "approval_policy",
+      proposalId: "proposal_policy",
+      approvedIntentIds: ["intent_label_blocked"],
+      approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+      approvedAt: "2026-06-24T00:00:02.000Z",
+      scope: "manual"
+    });
+
+    const plan = await repo.createApplyPlan({
+      id: "apply_policy",
+      proposalId: "proposal_policy",
+      approvalDecisionId: "approval_policy"
+    });
+
+    expect(plan?.outcomes).toEqual([
+      expect.objectContaining({
+        intentId: "intent_label_blocked",
+        outcome: "unsupported",
+        message: "OpenTag policy denied capability set_labels: Repo policy denies label mutation for this anchor."
+      })
+    ]);
   });
 
   it("computes domain-scoped proposal supersession", async () => {

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -224,6 +224,54 @@ describe("OpenTag repository", () => {
     expect(events[2]).toMatchObject({ visibility: "audit", importance: "high", message: "done" });
   });
 
+  it("does not write completion artifacts for missing runs", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await expect(
+      repo.completeRun({
+        runId: "missing_run",
+        result: {
+          conclusion: "needs_human",
+          summary: "Proposal ready.",
+          suggestedChanges: [
+            {
+              proposalId: "proposal_missing_run",
+              createdAt: "2026-06-24T00:00:01.000Z",
+              summary: "Add label.",
+              intents: [{ intentId: "intent_label", domain: "labels", action: "add_label", summary: "Add label.", params: { label: "bug" } }]
+            }
+          ]
+        }
+      })
+    ).rejects.toThrow("Run not found: missing_run");
+    await expect(repo.listRunEvents({ runId: "missing_run" })).resolves.toEqual([]);
+    await expect(repo.getSuggestedChanges({ proposalId: "proposal_missing_run" })).resolves.toBeNull();
+  });
+
+  it("uses supplied progress timestamps as audit event timestamps", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.recordProgress({
+      runId: "run_progress_time",
+      message: "delayed progress",
+      type: "executor.progress",
+      at: "2026-06-24T00:00:01.000Z"
+    });
+
+    await expect(repo.listRunEvents({ runId: "run_progress_time" })).resolves.toEqual([
+      expect.objectContaining({
+        createdAt: "2026-06-24T00:00:01.000Z",
+        payload: expect.objectContaining({ at: "2026-06-24T00:00:01.000Z" })
+      })
+    ]);
+  });
+
   it("stores needs_human results as needs_approval", async () => {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -32,13 +32,15 @@ describe("OpenTag repository", () => {
         context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
         permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
         callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
-        metadata: { owner: "acme", repo: "demo" }
+        metadata: { owner: "acme", repo: "demo", issueNumber: 1 }
       }
     });
 
     const claimed = await repo.claimNextRun({ runnerId: "runner_1", leaseSeconds: 60 });
     expect(claimed?.run.id).toBe("run_1");
     expect(claimed?.run.status).toBe("assigned");
+    expect(claimed?.run.thread?.workItemReference).toMatchObject({ provider: "github", kind: "issue", externalId: "acme/demo#1" });
+    expect(claimed?.run.contextPacket?.summary).toBe("fix this");
     expect(claimed?.event.command.rawText).toBe("fix this");
 
     const secondClaim = await repo.claimNextRun({ runnerId: "runner_1", leaseSeconds: 60 });
@@ -123,6 +125,7 @@ describe("OpenTag repository", () => {
     expect(events.map((event) => event.type)).toContain("run.heartbeat");
     const heartbeatEvent = events.find((event) => event.type === "run.heartbeat");
     expect(heartbeatEvent?.payload).toMatchObject({ runnerId: "runner_1" });
+    expect(heartbeatEvent).toMatchObject({ visibility: "debug", importance: "low" });
   });
 
   it("requeues runs whose lease has expired", async () => {
@@ -212,8 +215,212 @@ describe("OpenTag repository", () => {
     const stored = await repo.getRun({ runId: "run_2" });
     expect(stored?.run.status).toBe("succeeded");
     expect(stored?.run.result?.summary).toBe("done");
+    expect(stored?.run.contextPacket?.assembly?.stages).toContain("emit");
 
     const events = await repo.listRunEvents({ runId: "run_2" });
-    expect(events.map((event) => event.type)).toEqual(["run.created", "run.completed"]);
+    expect(events.map((event) => event.type)).toEqual(["run.created", "context_packet.generated", "run.completed"]);
+    expect(events[0]).toMatchObject({ visibility: "audit", importance: "low" });
+    expect(events[1]).toMatchObject({ visibility: "audit", importance: "normal", message: "run echo" });
+    expect(events[2]).toMatchObject({ visibility: "audit", importance: "high", message: "done" });
+  });
+
+  it("persists proposals, approvals, apply plans, and metric events", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.createRun({
+      id: "run_protocol",
+      event: {
+        id: "evt_protocol",
+        source: "github",
+        sourceEventId: "comment_protocol",
+        receivedAt: "2026-06-24T00:00:00.000Z",
+        actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+        target: { mention: "@opentag", agentId: "opentag" },
+        command: { rawText: "label this bug", intent: "run", args: {} },
+        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/2", visibility: "public" }],
+        permissions: [
+          { scope: "issue:comment", reason: "reply to source thread" },
+          { scope: "repo:write", reason: "mutate issue labels after approval" }
+        ],
+        callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/2/comments" },
+        metadata: { owner: "acme", repo: "demo", issueNumber: 2 }
+      }
+    });
+
+    await repo.completeRun({
+      runId: "run_protocol",
+      result: {
+        conclusion: "needs_human",
+        summary: "Prepared label proposal.",
+        suggestedChanges: [
+          {
+            proposalId: "proposal_protocol",
+            createdAt: "2026-06-24T00:00:01.000Z",
+            sourceRunId: "run_protocol",
+            summary: "Add bug label.",
+            intents: [
+              {
+                intentId: "intent_label_bug",
+                domain: "labels",
+                action: "add_label",
+                summary: "Add the bug label.",
+                params: { label: "bug" }
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const storedProposal = await repo.getSuggestedChanges({ proposalId: "proposal_protocol" });
+    expect(storedProposal?.snapshot.intents[0]?.intentId).toBe("intent_label_bug");
+
+    const decision = await repo.recordApprovalDecision({
+      id: "approval_protocol",
+      proposalId: "proposal_protocol",
+      approvedIntentIds: ["intent_label_bug"],
+      approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+      approvedAt: "2026-06-24T00:00:02.000Z",
+      scope: "manual"
+    });
+    expect(decision?.approvedIntentIds).toEqual(["intent_label_bug"]);
+
+    const plan = await repo.createApplyPlan({
+      id: "apply_protocol",
+      proposalId: "proposal_protocol",
+      approvalDecisionId: "approval_protocol",
+      adapter: "github"
+    });
+    expect(plan).toMatchObject({
+      id: "apply_protocol",
+      proposalId: "proposal_protocol",
+      mode: "preflight_then_per_intent",
+      outcomes: [{ intentId: "intent_label_bug", outcome: "skipped" }]
+    });
+    expect(plan?.outcomes?.[0]?.message).toContain("adapter execution is not implemented");
+
+    await expect(repo.getApprovalDecision({ id: "approval_protocol" })).resolves.toMatchObject({ id: "approval_protocol" });
+    await expect(repo.getApplyPlan({ id: "apply_protocol" })).resolves.toMatchObject({ id: "apply_protocol" });
+
+    const events = await repo.listRunEvents({ runId: "run_protocol" });
+    expect(events.map((event) => event.type)).toContain("proposal.snapshot.created");
+    expect(events.map((event) => event.type)).toContain("approval.decision.recorded");
+    expect(events.map((event) => event.type)).toContain("apply_plan.created");
+    expect(events.filter((event) => event.type === "success_metric.observed").map((event) => event.payload)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ metric: "time_to_first_useful_artifact" }),
+        expect.objectContaining({ metric: "external_write_approval_rate" })
+      ])
+    );
+  });
+
+  it("computes domain-scoped proposal supersession", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    const baseEvent = {
+      id: "evt_lineage_1",
+      source: "github" as const,
+      sourceEventId: "comment_lineage_1",
+      receivedAt: "2026-06-24T00:00:00.000Z",
+      actor: { provider: "github" as const, providerUserId: "42", handle: "octocat" },
+      target: { mention: "@opentag", agentId: "opentag" },
+      command: { rawText: "triage this", intent: "run" as const, args: {} },
+      context: [{ kind: "github.issue" as const, uri: "https://github.com/acme/demo/issues/3", visibility: "public" as const }],
+      permissions: [
+        { scope: "issue:comment" as const, reason: "reply to source thread" },
+        { scope: "repo:write" as const, reason: "mutate issue metadata after approval" }
+      ],
+      callback: { provider: "github" as const, uri: "https://api.github.com/repos/acme/demo/issues/3/comments" },
+      metadata: { owner: "acme", repo: "demo", issueNumber: 3 }
+    };
+
+    await repo.createRun({ id: "run_lineage_1", event: baseEvent });
+    await repo.completeRun({
+      runId: "run_lineage_1",
+      result: {
+        conclusion: "needs_human",
+        summary: "Prepared initial proposal.",
+        suggestedChanges: [
+          {
+            proposalId: "proposal_lineage_1",
+            createdAt: "2026-06-24T00:00:01.000Z",
+            summary: "Set priority and assignee.",
+            intents: [
+              { intentId: "intent_priority_p1", domain: "priority", action: "set_priority", summary: "Set P1.", params: { priority: "P1" } },
+              { intentId: "intent_assignee_alice", domain: "assignee", action: "set_assignee", summary: "Assign Alice.", params: { assignee: "alice" } }
+            ]
+          }
+        ]
+      }
+    });
+
+    await repo.createRun({ id: "run_lineage_2", event: { ...baseEvent, id: "evt_lineage_2", sourceEventId: "comment_lineage_2" } });
+    await repo.completeRun({
+      runId: "run_lineage_2",
+      result: {
+        conclusion: "needs_human",
+        summary: "Prepared refined proposal.",
+        suggestedChanges: [
+          {
+            proposalId: "proposal_lineage_2",
+            createdAt: "2026-06-24T00:00:02.000Z",
+            summary: "Refine priority.",
+            intents: [
+              { intentId: "intent_priority_p0", domain: "priority", action: "set_priority", summary: "Set P0.", params: { priority: "P0" } }
+            ]
+          }
+        ]
+      }
+    });
+
+    const lineage = await repo.getProposalLineage({ proposalId: "proposal_lineage_1" });
+    expect(lineage?.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          proposalId: "proposal_lineage_1",
+          intentId: "intent_priority_p1",
+          domain: "priority",
+          status: "superseded",
+          supersededByProposalId: "proposal_lineage_2"
+        }),
+        expect.objectContaining({
+          proposalId: "proposal_lineage_1",
+          intentId: "intent_assignee_alice",
+          domain: "assignee",
+          status: "current"
+        }),
+        expect.objectContaining({
+          proposalId: "proposal_lineage_2",
+          intentId: "intent_priority_p0",
+          domain: "priority",
+          status: "current"
+        })
+      ])
+    );
+
+    await repo.recordApprovalDecision({
+      id: "approval_lineage",
+      proposalId: "proposal_lineage_1",
+      approvedIntentIds: ["intent_priority_p1", "intent_assignee_alice"],
+      approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+      approvedAt: "2026-06-24T00:00:03.000Z",
+      scope: "manual"
+    });
+    const plan = await repo.createApplyPlan({
+      id: "apply_lineage",
+      proposalId: "proposal_lineage_1",
+      approvalDecisionId: "approval_lineage"
+    });
+
+    expect(plan?.outcomes).toEqual([
+      expect.objectContaining({ intentId: "intent_priority_p1", outcome: "stale" }),
+      expect.objectContaining({ intentId: "intent_assignee_alice", outcome: "skipped" })
+    ]);
   });
 });

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -423,6 +423,92 @@ describe("OpenTag repository", () => {
     ]);
   });
 
+  it("stores repo mutation mappings and includes them in apply plans", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.upsertRepoMutationMapping({
+      provider: "github",
+      owner: "acme",
+      repo: "demo",
+      mapping: {
+        id: "github_status_labels",
+        adapter: "github",
+        domain: "status",
+        strategy: "label",
+        values: { blocked: "status/blocked" }
+      }
+    });
+    await expect(repo.listRepoMutationMappings({ provider: "github", owner: "acme", repo: "demo" })).resolves.toEqual([
+      expect.objectContaining({ id: "github_status_labels", domain: "status" })
+    ]);
+
+    await repo.createRun({
+      id: "run_mapping",
+      event: {
+        id: "evt_mapping",
+        source: "github",
+        sourceEventId: "comment_mapping",
+        receivedAt: "2026-06-24T00:00:00.000Z",
+        actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+        target: { mention: "@opentag", agentId: "opentag" },
+        command: { rawText: "mark blocked", intent: "run", args: {} },
+        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/5", visibility: "public" }],
+        permissions: [
+          { scope: "issue:comment", reason: "reply to source thread" },
+          { scope: "repo:write", reason: "mutate status after approval" }
+        ],
+        callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/5/comments" },
+        metadata: { owner: "acme", repo: "demo", issueNumber: 5 }
+      }
+    });
+    await repo.completeRun({
+      runId: "run_mapping",
+      result: {
+        conclusion: "needs_human",
+        summary: "Prepared status proposal.",
+        suggestedChanges: [
+          {
+            proposalId: "proposal_mapping",
+            createdAt: "2026-06-24T00:00:01.000Z",
+            summary: "Mark blocked.",
+            intents: [
+              {
+                intentId: "intent_status_blocked",
+                domain: "status",
+                action: "transition_status",
+                summary: "Mark blocked.",
+                params: { status: "blocked" }
+              }
+            ]
+          }
+        ]
+      }
+    });
+    await repo.recordApprovalDecision({
+      id: "approval_mapping",
+      proposalId: "proposal_mapping",
+      approvedIntentIds: ["intent_status_blocked"],
+      approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+      approvedAt: "2026-06-24T00:00:02.000Z",
+      scope: "manual"
+    });
+
+    const plan = await repo.createApplyPlan({
+      id: "apply_mapping",
+      proposalId: "proposal_mapping",
+      approvalDecisionId: "approval_mapping",
+      adapter: "github"
+    });
+
+    expect(plan?.outcomes).toEqual([expect.objectContaining({ intentId: "intent_status_blocked", outcome: "skipped" })]);
+    expect(plan?.adapterPlan).toMatchObject({
+      mappings: [{ id: "github_status_labels", domain: "status", values: { blocked: "status/blocked" } }]
+    });
+  });
+
   it("computes domain-scoped proposal supersession", async () => {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);

--- a/scripts/dev/run-gh-claude-local-test.sh
+++ b/scripts/dev/run-gh-claude-local-test.sh
@@ -66,6 +66,7 @@ cat > "$CONFIG_PATH" <<JSON
   "dispatcherUrl": "http://localhost:${OPENTAG_DISPATCHER_PORT}",
   "pairingToken": "${OPENTAG_PAIRING_TOKEN}",
   "githubToken": "${GITHUB_TOKEN}",
+  "allowAutoCreatePullRequest": ${OPENTAG_GH_CREATE_PR:-false},
   "pollIntervalMs": 1000,
   "heartbeatIntervalMs": 15000,
   "claudeCode": {

--- a/scripts/dev/run-gh-claude-local-test.sh
+++ b/scripts/dev/run-gh-claude-local-test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+: "${OPENTAG_PAIRING_TOKEN:=dev_pairing_token}"
+: "${OPENTAG_DISPATCHER_PORT:=3032}"
+: "${OPENTAG_RUNNER_ID:=runner_claude_local}"
+: "${OPENTAG_CLAUDE_PERMISSION_MODE:=acceptEdits}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found. Install and authenticate GitHub CLI first." >&2
+  exit 1
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "Claude Code CLI not found. Install/login to Claude Code first." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+TARGET_REPO="${OPENTAG_GH_REPO:-}"
+if [[ -z "$TARGET_REPO" ]]; then
+  OWNER="$(gh repo view --json owner --jq '.owner.login')"
+  REPO="$(gh repo view --json name --jq '.name')"
+  REPO_URL="$(gh repo view --json url --jq '.url')"
+else
+  OWNER="${TARGET_REPO%%/*}"
+  REPO="${TARGET_REPO#*/}"
+  REPO_URL="$(gh repo view "$TARGET_REPO" --json url --jq '.url')"
+fi
+GITHUB_TOKEN="$(gh auth token)"
+CHECKOUT_PATH="${OPENTAG_WORKSPACE_PATH:-$ROOT_DIR}"
+ISSUE_NUMBER="${OPENTAG_GH_TEST_ISSUE:-}"
+PR_CREATE_PERMISSION=""
+if [[ "${OPENTAG_GH_CREATE_PR:-false}" == "true" ]]; then
+  PR_CREATE_PERMISSION=', { scope: "pr:create", reason: "open a pull request for completed code changes" }'
+fi
+
+if [[ -z "$ISSUE_NUMBER" ]]; then
+  if [[ "${OPENTAG_GH_CREATE_ISSUE:-false}" != "true" ]]; then
+    echo "No OPENTAG_GH_TEST_ISSUE set and OPENTAG_GH_CREATE_ISSUE is not true." >&2
+    echo "Set OPENTAG_GH_TEST_ISSUE=<issue-number>, or rerun with OPENTAG_GH_CREATE_ISSUE=true to create a temporary issue." >&2
+    exit 1
+  fi
+  ISSUE_URL="$(gh issue create --repo "${OWNER}/${REPO}" \
+    --title "OpenTag Claude Code local smoke test" \
+    --body "Temporary issue for validating OpenTag -> local Claude Code -> GitHub callback.")"
+  ISSUE_NUMBER="${ISSUE_URL##*/}"
+fi
+
+ISSUE_URL="${REPO_URL}/issues/${ISSUE_NUMBER}"
+COMMENTS_API_URL="https://api.github.com/repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments"
+RUN_ID="run_gh_claude_$(date +%s)"
+EVENT_ID="evt_gh_claude_${RUN_ID}"
+ACTOR_ID="$(gh api user --jq '.id')"
+ACTOR_LOGIN="$(gh api user --jq '.login')"
+RUN_COMMAND="${OPENTAG_GH_TEST_COMMAND:-Investigate this issue and make the smallest useful local progress. If you change files, keep the change narrow and run relevant verification.}"
+CONFIG_PATH="$(mktemp "${TMPDIR:-/tmp}/opentag-gh-claude-config.XXXXXX.json")"
+DATABASE_PATH="${OPENTAG_DATABASE_PATH:-opentag.gh-claude-local-test.db}"
+
+cat > "$CONFIG_PATH" <<JSON
+{
+  "runnerId": "${OPENTAG_RUNNER_ID}",
+  "dispatcherUrl": "http://localhost:${OPENTAG_DISPATCHER_PORT}",
+  "pairingToken": "${OPENTAG_PAIRING_TOKEN}",
+  "githubToken": "${GITHUB_TOKEN}",
+  "pollIntervalMs": 1000,
+  "heartbeatIntervalMs": 15000,
+  "claudeCode": {
+    "command": "${OPENTAG_CLAUDE_COMMAND:-claude}",
+    "permissionMode": "${OPENTAG_CLAUDE_PERMISSION_MODE}"
+  },
+  "repositories": [
+    {
+      "provider": "github",
+      "owner": "${OWNER}",
+      "repo": "${REPO}",
+      "checkoutPath": "${CHECKOUT_PATH}",
+      "defaultExecutor": "claude-code",
+      "baseBranch": "${OPENTAG_BASE_BRANCH:-main}",
+      "pushRemote": "${OPENTAG_PUSH_REMOTE:-origin}"
+    }
+  ]
+}
+JSON
+
+cleanup() {
+  rm -f "$CONFIG_PATH"
+  kill "$DISPATCHER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Starting dispatcher on :${OPENTAG_DISPATCHER_PORT}"
+(
+  export PORT="$OPENTAG_DISPATCHER_PORT"
+  export OPENTAG_DATABASE_PATH="$DATABASE_PATH"
+  export OPENTAG_PAIRING_TOKEN
+  export OPENTAG_GITHUB_TOKEN="$GITHUB_TOKEN"
+  NODE_OPTIONS='--conditions=development' apps/dispatcher/node_modules/.bin/tsx apps/dispatcher/src/index.ts
+) &
+DISPATCHER_PID=$!
+
+sleep 2
+
+echo "Registering runner and binding ${OWNER}/${REPO}"
+OPENTAG_CONFIG_PATH="$CONFIG_PATH" NODE_OPTIONS='--conditions=development' apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts register-runner
+OPENTAG_CONFIG_PATH="$CONFIG_PATH" NODE_OPTIONS='--conditions=development' apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts bind-repos
+
+echo "Creating dispatcher run ${RUN_ID} for ${ISSUE_URL}"
+OPENTAG_RUN_COMMAND="$RUN_COMMAND" node <<NODE
+const body = {
+  runId: "${RUN_ID}",
+  event: {
+    id: "${EVENT_ID}",
+    source: "github",
+    sourceEventId: "gh_cli_${ISSUE_NUMBER}_${RUN_ID}",
+    receivedAt: new Date().toISOString(),
+    actor: {
+      provider: "github",
+      providerUserId: "${ACTOR_ID}",
+      handle: "${ACTOR_LOGIN}"
+    },
+    target: {
+      mention: "@opentag",
+      agentId: "opentag",
+      executorHint: "claude-code"
+    },
+    command: {
+      rawText: process.env.OPENTAG_RUN_COMMAND,
+      intent: "investigate",
+      args: {}
+    },
+    context: [
+      { kind: "github.repo", uri: "${REPO_URL}", visibility: "public" },
+      { kind: "github.issue", uri: "${ISSUE_URL}", visibility: "public" }
+    ],
+    permissions: [
+      { scope: "issue:comment", reason: "reply to the source GitHub thread" },
+      { scope: "runner:local", reason: "execute the run on a paired local daemon" },
+      { scope: "repo:read", reason: "inspect the local checkout" },
+      { scope: "repo:write", reason: "commit code changes on an isolated run branch" }${PR_CREATE_PERMISSION}
+    ],
+    callback: {
+      provider: "github",
+      uri: "${COMMENTS_API_URL}",
+      threadKey: "${OWNER}/${REPO}#${ISSUE_NUMBER}"
+    },
+    metadata: {
+      owner: "${OWNER}",
+      repo: "${REPO}",
+      issueNumber: Number("${ISSUE_NUMBER}")
+    }
+  }
+};
+
+fetch("http://localhost:${OPENTAG_DISPATCHER_PORT}/v1/runs", {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    "authorization": "Bearer ${OPENTAG_PAIRING_TOKEN}"
+  },
+  body: JSON.stringify(body)
+}).then(async (response) => {
+  if (!response.ok) {
+    throw new Error(\`create run failed: \${response.status} \${await response.text()}\`);
+  }
+  console.log(await response.text());
+});
+NODE
+
+echo "Running local daemon once with Claude Code"
+OPENTAG_CONFIG_PATH="$CONFIG_PATH" NODE_OPTIONS='--conditions=development' apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts run-once
+
+echo
+echo "GitHub-assisted Claude Code local test completed."
+echo "- Issue: ${ISSUE_URL}"
+echo "- Run ID: ${RUN_ID}"
+echo "- Workspace: ${CHECKOUT_PATH}"
+echo "- Dispatcher DB: ${DATABASE_PATH}"

--- a/scripts/dev/run-slack-claude-local-test.sh
+++ b/scripts/dev/run-slack-claude-local-test.sh
@@ -16,17 +16,12 @@ if [[ -f "$OPENTAG_ENV_FILE" ]]; then
   set +a
 fi
 
-: "${SLACK_SIGNING_SECRET:?Set SLACK_SIGNING_SECRET or OPENTAG_ENV_FILE}"
 : "${OPENTAG_SLACK_BOT_TOKEN:?Set OPENTAG_SLACK_BOT_TOKEN or OPENTAG_ENV_FILE}"
 : "${OPENTAG_CONFIG_PATH:?Set OPENTAG_CONFIG_PATH or OPENTAG_ENV_FILE}"
+: "${OPENTAG_CLAUDE_COMMAND:=claude}"
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "gh CLI not found. Install and authenticate GitHub CLI first." >&2
-  exit 1
-fi
-
-if ! command -v claude >/dev/null 2>&1; then
-  echo "Claude Code CLI not found. Install/login to Claude Code first." >&2
+if ! command -v "$OPENTAG_CLAUDE_COMMAND" >/dev/null 2>&1; then
+  echo "Claude Code CLI not found at '$OPENTAG_CLAUDE_COMMAND'. Install/login to Claude Code first." >&2
   exit 1
 fi
 
@@ -59,6 +54,10 @@ CONFIG_PATH="$(mktemp /tmp/opentag-slack-claude-config.XXXXXX)"
 DATABASE_PATH="${OPENTAG_DATABASE_PATH:-$TMP_ROOT/opentag-slack-claude.db}"
 
 if [[ ! -d "$CHECKOUT_PATH/.git" ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI not found. Set OPENTAG_WORKSPACE_PATH to an existing checkout, or install/authenticate GitHub CLI for cloning." >&2
+    exit 1
+  fi
   gh repo clone "$OWNER/$REPO" "$CHECKOUT_PATH" >/dev/null
 fi
 
@@ -70,7 +69,7 @@ cat > "$CONFIG_PATH" <<JSON
   "pollIntervalMs": 1000,
   "heartbeatIntervalMs": 15000,
   "claudeCode": {
-    "command": "${OPENTAG_CLAUDE_COMMAND:-claude}",
+    "command": "${OPENTAG_CLAUDE_COMMAND}",
     "permissionMode": "${OPENTAG_CLAUDE_PERMISSION_MODE}"
   },
   "repositories": [

--- a/scripts/dev/run-slack-claude-local-test.sh
+++ b/scripts/dev/run-slack-claude-local-test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+: "${OPENTAG_ENV_FILE:=$ROOT_DIR/.env.slack-test}"
+: "${OPENTAG_PAIRING_TOKEN:=dev_pairing_token}"
+: "${OPENTAG_DISPATCHER_PORT:=3033}"
+: "${OPENTAG_RUNNER_ID:=runner_slack_claude_real}"
+: "${OPENTAG_CLAUDE_PERMISSION_MODE:=acceptEdits}"
+
+if [[ -f "$OPENTAG_ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$OPENTAG_ENV_FILE"
+  set +a
+fi
+
+: "${SLACK_SIGNING_SECRET:?Set SLACK_SIGNING_SECRET or OPENTAG_ENV_FILE}"
+: "${OPENTAG_SLACK_BOT_TOKEN:?Set OPENTAG_SLACK_BOT_TOKEN or OPENTAG_ENV_FILE}"
+: "${OPENTAG_CONFIG_PATH:?Set OPENTAG_CONFIG_PATH or OPENTAG_ENV_FILE}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found. Install and authenticate GitHub CLI first." >&2
+  exit 1
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "Claude Code CLI not found. Install/login to Claude Code first." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+CONFIG_SUMMARY="$(python3 - <<'PY'
+import json, os
+with open(os.environ["OPENTAG_CONFIG_PATH"]) as f:
+    cfg = json.load(f)
+repo = cfg["repositories"][0]
+slack = cfg["slackChannels"][0]
+print(json.dumps({
+    "owner": repo["owner"],
+    "repo": repo["repo"],
+    "teamId": slack["teamId"],
+    "channelId": slack["channelId"],
+}))
+PY
+)"
+
+OWNER="$(node -e "console.log(JSON.parse(process.argv[1]).owner)" "$CONFIG_SUMMARY")"
+REPO="$(node -e "console.log(JSON.parse(process.argv[1]).repo)" "$CONFIG_SUMMARY")"
+TEAM_ID="$(node -e "console.log(JSON.parse(process.argv[1]).teamId)" "$CONFIG_SUMMARY")"
+CHANNEL_ID="$(node -e "console.log(JSON.parse(process.argv[1]).channelId)" "$CONFIG_SUMMARY")"
+export OWNER REPO TEAM_ID CHANNEL_ID
+
+TMP_ROOT="$(mktemp -d /tmp/opentag-slack-claude.XXXXXX)"
+CHECKOUT_PATH="${OPENTAG_WORKSPACE_PATH:-$TMP_ROOT/$REPO}"
+CONFIG_PATH="$(mktemp /tmp/opentag-slack-claude-config.XXXXXX)"
+DATABASE_PATH="${OPENTAG_DATABASE_PATH:-$TMP_ROOT/opentag-slack-claude.db}"
+
+if [[ ! -d "$CHECKOUT_PATH/.git" ]]; then
+  gh repo clone "$OWNER/$REPO" "$CHECKOUT_PATH" >/dev/null
+fi
+
+cat > "$CONFIG_PATH" <<JSON
+{
+  "runnerId": "${OPENTAG_RUNNER_ID}",
+  "dispatcherUrl": "http://localhost:${OPENTAG_DISPATCHER_PORT}",
+  "pairingToken": "${OPENTAG_PAIRING_TOKEN}",
+  "pollIntervalMs": 1000,
+  "heartbeatIntervalMs": 15000,
+  "claudeCode": {
+    "command": "${OPENTAG_CLAUDE_COMMAND:-claude}",
+    "permissionMode": "${OPENTAG_CLAUDE_PERMISSION_MODE}"
+  },
+  "repositories": [
+    {
+      "provider": "github",
+      "owner": "${OWNER}",
+      "repo": "${REPO}",
+      "checkoutPath": "${CHECKOUT_PATH}",
+      "defaultExecutor": "claude-code",
+      "baseBranch": "${OPENTAG_BASE_BRANCH:-main}",
+      "pushRemote": "${OPENTAG_PUSH_REMOTE:-origin}"
+    }
+  ],
+  "slackChannels": [
+    {
+      "teamId": "${TEAM_ID}",
+      "channelId": "${CHANNEL_ID}",
+      "owner": "${OWNER}",
+      "repo": "${REPO}"
+    }
+  ]
+}
+JSON
+
+cleanup() {
+  rm -f "$CONFIG_PATH"
+  kill "$DISPATCHER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for pid in $(lsof -ti "tcp:${OPENTAG_DISPATCHER_PORT}" 2>/dev/null); do
+  kill "$pid" 2>/dev/null || true
+done
+
+echo "Starting dispatcher on :${OPENTAG_DISPATCHER_PORT}"
+(
+  export PORT="$OPENTAG_DISPATCHER_PORT"
+  export OPENTAG_DATABASE_PATH="$DATABASE_PATH"
+  export OPENTAG_PAIRING_TOKEN
+  export OPENTAG_SLACK_BOT_TOKEN
+  NODE_OPTIONS='--conditions=development' apps/dispatcher/node_modules/.bin/tsx apps/dispatcher/src/index.ts
+) &
+DISPATCHER_PID=$!
+sleep 2
+
+export OPENTAG_CONFIG_PATH="$CONFIG_PATH"
+export OPENTAG_DISPATCHER_URL="http://localhost:${OPENTAG_DISPATCHER_PORT}"
+export OPENTAG_DISPATCHER_TOKEN="$OPENTAG_PAIRING_TOKEN"
+
+NODE_OPTIONS='--conditions=development' apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts register-runner
+NODE_OPTIONS='--conditions=development' apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts bind-repos
+NODE_OPTIONS='--conditions=development' apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts bind-slack-channels
+
+SEED_JSON="$(python3 - <<'PY'
+import json, os, urllib.request
+text = os.environ.get("OPENTAG_SLACK_TEST_TEXT", "OpenTag Slack + Claude Code E2E test: validate real callback and metrics.")
+req = urllib.request.Request(
+    "https://slack.com/api/chat.postMessage",
+    data=json.dumps({"channel": os.environ["CHANNEL_ID"], "text": text}).encode(),
+    headers={"Authorization": "Bearer " + os.environ["OPENTAG_SLACK_BOT_TOKEN"], "Content-Type": "application/json"},
+)
+with urllib.request.urlopen(req) as resp:
+    body = json.loads(resp.read())
+if not body.get("ok"):
+    raise SystemExit(body)
+print(json.dumps({"channel": body["channel"], "ts": body["ts"]}))
+PY
+)"
+echo "$SEED_JSON"
+
+RUN_ID="run_slack_claude_real_$(date +%s)"
+THREAD_TS="$(node -e "console.log(JSON.parse(process.argv[1]).ts)" "$SEED_JSON")"
+export RUN_ID THREAD_TS
+
+python3 - <<'PY'
+import json, os, urllib.request
+
+run_id = os.environ["RUN_ID"]
+thread_ts = os.environ["THREAD_TS"]
+body = {
+    "runId": run_id,
+    "event": {
+        "id": f"evt_{run_id}",
+        "source": "slack",
+        "sourceEventId": f"slack_real_{thread_ts}",
+        "receivedAt": "2026-06-24T21:55:00.000Z",
+        "actor": {"provider": "slack", "providerUserId": "U_LOCAL", "handle": "U_LOCAL", "organizationId": os.environ["TEAM_ID"]},
+        "target": {"mention": "<@opentag>", "agentId": "opentag", "executorHint": "claude-code"},
+        "command": {
+            "rawText": os.environ.get(
+                "OPENTAG_SLACK_TEST_COMMAND",
+                "Add one short sentence to README.md saying Slack can trigger local Claude Code through OpenTag. Keep the change small and do not modify anything else.",
+            ),
+            "intent": "run",
+            "args": {},
+        },
+        "context": [
+            {"kind": "url", "uri": f"slack://team/{os.environ['TEAM_ID']}/channel/{os.environ['CHANNEL_ID']}/message/{thread_ts}", "visibility": "organization"},
+            {"kind": "text", "uri": "OpenTag Slack + Claude Code E2E test: validate real callback and metrics.", "visibility": "organization"},
+        ],
+        "permissions": [
+            {"scope": "chat:postMessage", "reason": "reply in Slack thread"},
+            {"scope": "runner:local", "reason": "execute on local daemon"},
+            {"scope": "repo:read", "reason": "inspect mapped repository"},
+            {"scope": "repo:write", "reason": "modify local branch"},
+        ],
+        "callback": {"provider": "slack", "uri": "https://slack.com/api/chat.postMessage", "threadKey": f"{os.environ['TEAM_ID']}|{os.environ['CHANNEL_ID']}|{thread_ts}"},
+        "metadata": {"teamId": os.environ["TEAM_ID"], "channelId": os.environ["CHANNEL_ID"], "messageTs": thread_ts, "repoProvider": "github", "owner": os.environ["OWNER"], "repo": os.environ["REPO"]},
+    },
+}
+req = urllib.request.Request(
+    os.environ["OPENTAG_DISPATCHER_URL"] + "/v1/runs",
+    data=json.dumps(body).encode(),
+    headers={"Authorization": "Bearer " + os.environ["OPENTAG_DISPATCHER_TOKEN"], "Content-Type": "application/json"},
+)
+with urllib.request.urlopen(req) as resp:
+    print(json.dumps({"runId": run_id, "status": resp.status}))
+PY
+
+NODE_OPTIONS='--conditions=development' apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts run-once
+
+echo "Metrics:"
+curl -s -H "authorization: Bearer $OPENTAG_DISPATCHER_TOKEN" "$OPENTAG_DISPATCHER_URL/v1/runs/$RUN_ID/metrics"
+echo
+
+echo "Slack thread replies:"
+python3 - <<'PY'
+import json, os, urllib.parse, urllib.request
+url = "https://slack.com/api/conversations.replies?" + urllib.parse.urlencode({"channel": os.environ["CHANNEL_ID"], "ts": os.environ["THREAD_TS"]})
+req = urllib.request.Request(url, headers={"Authorization": "Bearer " + os.environ["OPENTAG_SLACK_BOT_TOKEN"]})
+with urllib.request.urlopen(req) as resp:
+    body = json.loads(resp.read())
+if not body.get("ok"):
+    raise SystemExit(body)
+print(json.dumps([{"ts": m.get("ts"), "text": m.get("text"), "blocks": bool(m.get("blocks"))} for m in body.get("messages", [])], ensure_ascii=False))
+PY
+
+echo
+echo "Slack + Claude Code local test completed."
+echo "- Run ID: ${RUN_ID}"
+echo "- Workspace: ${CHECKOUT_PATH}"
+echo "- Dispatcher DB: ${DATABASE_PATH}"

--- a/scripts/dev/start-github-slack-claude-test.sh
+++ b/scripts/dev/start-github-slack-claude-test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+: "${OPENTAG_CONFIG_PATH:?Set OPENTAG_CONFIG_PATH to your local runner config JSON with defaultExecutor set to claude-code}"
+: "${OPENTAG_GITHUB_TOKEN:?Set OPENTAG_GITHUB_TOKEN for GitHub callbacks and apply execution}"
+: "${SLACK_SIGNING_SECRET:?Set SLACK_SIGNING_SECRET from your Slack App}"
+: "${OPENTAG_SLACK_BOT_TOKEN:?Set OPENTAG_SLACK_BOT_TOKEN to the Slack xoxb token}"
+: "${APP_ID:?Set APP_ID to the GitHub App ID}"
+: "${WEBHOOK_SECRET:?Set WEBHOOK_SECRET to the GitHub App webhook secret}"
+: "${PRIVATE_KEY_PATH:?Set PRIVATE_KEY_PATH to the GitHub App private key path}"
+: "${OPENTAG_PAIRING_TOKEN:=dev_pairing_token}"
+: "${OPENTAG_DISPATCHER_PORT:=3031}"
+: "${OPENTAG_GITHUB_PORT:=3000}"
+: "${OPENTAG_SLACK_PORT:=3040}"
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "Claude Code CLI not found. Install/login to Claude Code before running this smoke test." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+echo "Starting dispatcher on :$OPENTAG_DISPATCHER_PORT"
+(
+  export PORT="$OPENTAG_DISPATCHER_PORT"
+  export OPENTAG_DATABASE_PATH="${OPENTAG_DATABASE_PATH:-opentag.claude-real-test.db}"
+  export OPENTAG_PAIRING_TOKEN
+  export OPENTAG_GITHUB_TOKEN
+  export OPENTAG_SLACK_BOT_TOKEN
+  apps/dispatcher/node_modules/.bin/tsx apps/dispatcher/src/index.ts
+) &
+DISPATCHER_PID=$!
+
+trap 'kill $DISPATCHER_PID $DAEMON_PID $PROBOT_PID $SLACK_PID 2>/dev/null || true' EXIT
+
+sleep 2
+
+echo "Registering runner, binding repositories, and binding Slack channels"
+export OPENTAG_CONFIG_PATH
+apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts register-runner
+apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts bind-repos
+apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts bind-slack-channels
+
+echo "Starting local daemon with configured Claude Code executor"
+(
+  export OPENTAG_CONFIG_PATH
+  apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts serve
+) &
+DAEMON_PID=$!
+
+echo "Starting GitHub Probot ingress on :$OPENTAG_GITHUB_PORT"
+(
+  export APP_ID
+  export WEBHOOK_SECRET
+  export PRIVATE_KEY_PATH
+  export PORT="$OPENTAG_GITHUB_PORT"
+  export WEBHOOK_PATH="${WEBHOOK_PATH:-/github/webhooks}"
+  export OPENTAG_DISPATCHER_URL="http://localhost:$OPENTAG_DISPATCHER_PORT"
+  export OPENTAG_DISPATCHER_TOKEN="$OPENTAG_PAIRING_TOKEN"
+  export OPENTAG_DISPATCHER_OWNS_CALLBACKS=true
+  pnpm --filter @opentag/github-probot exec probot run ./dist/index.js
+) &
+PROBOT_PID=$!
+
+echo "Starting Slack Events ingress on :$OPENTAG_SLACK_PORT"
+(
+  export SLACK_SIGNING_SECRET
+  export OPENTAG_DISPATCHER_URL="http://localhost:$OPENTAG_DISPATCHER_PORT"
+  export OPENTAG_DISPATCHER_TOKEN="$OPENTAG_PAIRING_TOKEN"
+  export PORT="$OPENTAG_SLACK_PORT"
+  apps/slack-events/node_modules/.bin/tsx apps/slack-events/src/index.ts
+) &
+SLACK_PID=$!
+
+echo
+echo "GitHub + Slack + Claude Code smoke-test stack is running."
+echo "- Dispatcher: http://localhost:$OPENTAG_DISPATCHER_PORT"
+echo "- GitHub Probot ingress: http://localhost:$OPENTAG_GITHUB_PORT/github/webhooks"
+echo "- Slack Events ingress: http://localhost:$OPENTAG_SLACK_PORT/slack/events"
+echo "- Expose GitHub and Slack ingress ports with public tunnels."
+echo "- Ensure your config repository binding uses \"defaultExecutor\": \"claude-code\"."
+echo
+wait

--- a/scripts/dev/start-github-slack-claude-test.sh
+++ b/scripts/dev/start-github-slack-claude-test.sh
@@ -32,8 +32,18 @@ echo "Starting dispatcher on :$OPENTAG_DISPATCHER_PORT"
   apps/dispatcher/node_modules/.bin/tsx apps/dispatcher/src/index.ts
 ) &
 DISPATCHER_PID=$!
+DAEMON_PID=""
+PROBOT_PID=""
+SLACK_PID=""
 
-trap 'kill $DISPATCHER_PID $DAEMON_PID $PROBOT_PID $SLACK_PID 2>/dev/null || true' EXIT
+cleanup() {
+  for pid in "$DISPATCHER_PID" "$DAEMON_PID" "$PROBOT_PID" "$SLACK_PID"; do
+    if [[ -n "$pid" ]]; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+}
+trap cleanup EXIT
 
 sleep 2
 

--- a/scripts/test/protocol-runtime-smoke.ts
+++ b/scripts/test/protocol-runtime-smoke.ts
@@ -1,0 +1,203 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createOpenTagClient } from "../../packages/client/src/index.js";
+import { createDispatcherApp } from "../../packages/dispatcher/src/server.js";
+import type { OpenTagEvent } from "../../packages/core/src/schema.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertIncludes<T>(values: T[], expected: T, message: string): void {
+  assert(values.includes(expected), `${message}: expected ${String(expected)} in ${values.map(String).join(", ")}`);
+}
+
+const tempDir = await mkdtemp(join(tmpdir(), "opentag-protocol-smoke-"));
+const databasePath = join(tempDir, "opentag-smoke.db");
+
+try {
+  const app = createDispatcherApp({ databasePath });
+  const client = createOpenTagClient({
+    dispatcherUrl: "http://opentag-smoke.local",
+    fetchImpl: async (url, init) => {
+      const parsed = new URL(String(url));
+      return app.request(`${parsed.pathname}${parsed.search}`, init);
+    }
+  });
+
+  await client.registerRunner({ runnerId: "runner_smoke", name: "Smoke Runner" });
+  await client.bindRepository({
+    provider: "github",
+    owner: "acme",
+    repo: "demo",
+    runnerId: "runner_smoke",
+    workspacePath: "/tmp/acme-demo",
+    defaultExecutor: "echo",
+    allowedActors: ["octocat"]
+  });
+  await client.upsertRepoPolicyRule({
+    provider: "github",
+    owner: "acme",
+    repo: "demo",
+    rule: {
+      id: "repo_allows_label_apply",
+      scope: "work_context_owner_container",
+      effect: "allow",
+      capabilityId: "set_labels",
+      reason: "Smoke test repo allows approved label changes."
+    }
+  });
+
+  const policyRules = await client.listRepoPolicyRules({ provider: "github", owner: "acme", repo: "demo" });
+  assert(policyRules.rules.length === 1, "repo policy rule should be stored");
+
+  const event: OpenTagEvent = {
+    id: "evt_smoke_1",
+    source: "github",
+    sourceEventId: "comment_smoke_1",
+    receivedAt: "2026-06-24T00:00:00.000Z",
+    actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+    target: { mention: "@opentag", agentId: "opentag" },
+    command: { rawText: "triage this issue", intent: "run", args: {} },
+    context: [
+      {
+        kind: "github.issue",
+        uri: "https://github.com/acme/demo/issues/9",
+        visibility: "public"
+      },
+      {
+        kind: "github.comment",
+        uri: "https://github.com/acme/demo/issues/9#issuecomment-1",
+        visibility: "public"
+      }
+    ],
+    permissions: [
+      { scope: "issue:comment", reason: "reply to source thread" },
+      { scope: "repo:write", reason: "apply approved issue metadata changes" },
+      { scope: "runner:local", reason: "execute child runs on the paired runner" }
+    ],
+    callback: {
+      provider: "github",
+      uri: "https://api.github.com/repos/acme/demo/issues/9/comments",
+      threadKey: "acme/demo"
+    },
+    metadata: { owner: "acme", repo: "demo", issueNumber: 9 }
+  };
+
+  const created = await client.createRun({ runId: "run_smoke_1", event });
+  assert(created.run.contextPacket?.summary === "triage this issue", "created run should include context packet");
+  assert(created.run.thread?.workItemReference.externalId === "acme/demo#9", "created run should include work thread");
+
+  const claimed = await client.claim({ runnerId: "runner_smoke" });
+  assert(claimed?.run.id === "run_smoke_1", "runner should claim the smoke run");
+  await client.complete({
+    runId: "run_smoke_1",
+    result: {
+      conclusion: "needs_human",
+      summary: "Prepared issue metadata proposal.",
+      suggestedChanges: [
+        {
+          proposalId: "proposal_smoke_1",
+          createdAt: "2026-06-24T00:00:01.000Z",
+          summary: "Label the issue as a bug.",
+          intents: [
+            {
+              intentId: "intent_smoke_label_bug",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ],
+      nextAction: {
+        summary: "Approve and apply the proposed label change.",
+        hint: {
+          kind: "apply_suggested_changes",
+          targetId: "proposal_smoke_1",
+          selectedIntentIds: ["intent_smoke_label_bug"]
+        }
+      }
+    }
+  });
+
+  const proposal = await client.getProposal({ proposalId: "proposal_smoke_1" });
+  assert(proposal.runId === "run_smoke_1", "proposal should point back to source run");
+  assert(proposal.snapshot.sourceRunId === "run_smoke_1", "proposal should carry sourceRunId");
+  assert(proposal.snapshot.workThread?.workItemReference.externalId === "acme/demo#9", "proposal should carry work thread");
+
+  const lineage = await client.getProposalLineage({ proposalId: "proposal_smoke_1" });
+  assert(lineage.lineage.entries[0]?.status === "current", "proposal intent should be current");
+
+  const currentIntents = await client.listCurrentMutationIntents({ proposalId: "proposal_smoke_1" });
+  assert(currentIntents.intents.some((intent) => intent.intentId === "intent_smoke_label_bug"), "current intent should be listed");
+
+  const approval = await client.approveProposal({
+    proposalId: "proposal_smoke_1",
+    id: "approval_smoke_1",
+    approvedIntentIds: ["intent_smoke_label_bug"],
+    approvedBy: { provider: "github", providerUserId: "42", handle: "octocat" },
+    approvedAt: "2026-06-24T00:00:02.000Z"
+  });
+  assert(approval.decision.id === "approval_smoke_1", "approval decision should be recorded");
+
+  const applyPlan = await client.createApplyPlan({
+    proposalId: "proposal_smoke_1",
+    id: "apply_smoke_1",
+    approvalDecisionId: "approval_smoke_1",
+    adapter: "github"
+  });
+  assert(applyPlan.plan.mode === "preflight_then_per_intent", "apply plan should use protocol default mode");
+  assert(applyPlan.plan.outcomes?.[0]?.outcome === "skipped", "preflight-passed intent should remain unexecuted without execute=true");
+
+  const childRun = await client.createChildRun({
+    parentRunId: "run_smoke_1",
+    runId: "run_smoke_child_1",
+    action: {
+      kind: "apply_suggested_changes",
+      targetId: "proposal_smoke_1",
+      selectedIntentIds: ["intent_smoke_label_bug"]
+    },
+    sourceApplyPlanId: "apply_smoke_1",
+    commandText: "Apply approved smoke proposal"
+  });
+  assert(childRun.run.parentRunId === "run_smoke_1", "child run should reference parent run");
+  assert(childRun.run.sourceProposalId === "proposal_smoke_1", "child run should reference source proposal");
+  assert(childRun.run.sourceApplyPlanId === "apply_smoke_1", "child run should reference source apply plan");
+  assert(childRun.run.triggeredByAction?.kind === "apply_suggested_changes", "child run should carry triggering action");
+
+  const events = await client.listRunEvents({ runId: "run_smoke_1" });
+  const eventTypes = events.events.map((event) => (event as { type: string }).type);
+  for (const expected of [
+    "run.created",
+    "context_packet.generated",
+    "callback.acknowledgement.delivered",
+    "proposal.snapshot.created",
+    "run.completed",
+    "callback.final.delivered",
+    "approval.decision.recorded",
+    "apply_plan.created",
+    "run.child_created"
+  ]) {
+    assertIncludes(eventTypes, expected, "parent run audit trail is incomplete");
+  }
+
+  const metrics = await client.getRunMetrics({ runId: "run_smoke_1" });
+  assert(metrics.metrics.humanCallbackCount === 2, "GitHub-shaped smoke should have ack and final human callbacks");
+  assert(metrics.metrics.auditEventCount > metrics.metrics.humanCallbackCount, "audit events should exceed human callbacks");
+  assert(metrics.metrics.threadNoiseRatio < 1, "thread noise ratio should stay below 1");
+  assert(metrics.metrics.suggestedChangesCount === 1, "metrics should count suggested changes");
+  assert(metrics.metrics.approvalDecisionCount === 1, "metrics should count approvals");
+  assert(metrics.metrics.applyPlanCount === 1, "metrics should count apply plans");
+  assert(metrics.metrics.childRunCount === 1, "metrics should count child runs");
+  assert(metrics.metrics.applyOutcomeCounts.skipped === 1, "metrics should count skipped preflight outcomes");
+  assert(metrics.metrics.staleIntentCount === 0, "metrics should count stale intents");
+
+  console.log("protocol-runtime-smoke: ok");
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}

--- a/scripts/test/slack-protocol-runtime-smoke.ts
+++ b/scripts/test/slack-protocol-runtime-smoke.ts
@@ -1,0 +1,199 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createOpenTagClient } from "../../packages/client/src/index.js";
+import { createDispatcherApp, type CallbackMessage } from "../../packages/dispatcher/src/server.js";
+import { normalizeSlackAppMention } from "../../packages/slack/src/normalize.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertIncludes<T>(values: T[], expected: T, message: string): void {
+  assert(values.includes(expected), `${message}: expected ${String(expected)} in ${values.map(String).join(", ")}`);
+}
+
+const tempDir = await mkdtemp(join(tmpdir(), "opentag-slack-protocol-smoke-"));
+const databasePath = join(tempDir, "opentag-slack-smoke.db");
+const delivered: CallbackMessage[] = [];
+
+try {
+  const app = createDispatcherApp({
+    databasePath,
+    callbackSink: {
+      async deliver(message) {
+        delivered.push(message);
+      }
+    }
+  });
+  const client = createOpenTagClient({
+    dispatcherUrl: "http://opentag-slack-smoke.local",
+    fetchImpl: async (url, init) => {
+      const parsed = new URL(String(url));
+      return app.request(`${parsed.pathname}${parsed.search}`, init);
+    }
+  });
+
+  await client.registerRunner({ runnerId: "runner_slack_smoke", name: "Slack Smoke Runner" });
+  await client.bindRepository({
+    provider: "github",
+    owner: "acme",
+    repo: "demo",
+    runnerId: "runner_slack_smoke",
+    workspacePath: "/tmp/acme-demo",
+    defaultExecutor: "echo",
+    allowedActors: ["U123"]
+  });
+
+  const event = normalizeSlackAppMention({
+    teamId: "T123",
+    channelId: "C123",
+    userId: "U123",
+    text: "<@U999> investigate the flaky smoke test",
+    ts: "1710000000.000100",
+    threadTs: "1710000000.000100",
+    eventId: "EvSlackSmoke",
+    eventTime: Math.floor(Date.parse("2026-06-24T00:00:00.000Z") / 1000),
+    appId: "A123",
+    agentId: "opentag",
+    botUserId: "U999",
+    binding: {
+      teamId: "T123",
+      channelId: "C123",
+      owner: "acme",
+      repo: "demo"
+    }
+  });
+  assert(event, "Slack mention should normalize into an OpenTag event");
+
+  const created = await client.createRun({ runId: "run_slack_smoke_1", event });
+  assert(created.run.contextPacket?.summary === "investigate the flaky smoke test", "Slack run should include context packet");
+  assert(!created.run.thread, "Slack event without canonical work item should not invent a work thread");
+  assert(delivered.length === 1, "Slack acknowledgement should be delivered");
+  assert(delivered[0]?.provider === "slack", "acknowledgement should target Slack");
+  assert(delivered[0]?.kind === "acknowledgement", "first Slack callback should be acknowledgement");
+
+  const progressResponse = await client.progress({
+    runId: "run_slack_smoke_1",
+    type: "executor.progress",
+    message: "working quietly",
+    at: "2026-06-24T00:00:01.000Z"
+  });
+  assert(progressResponse === undefined, "progress call should complete");
+  assert(delivered.length === 1, "Slack progress should remain audit-only by default");
+
+  const claimed = await client.claim({ runnerId: "runner_slack_smoke" });
+  assert(claimed?.run.id === "run_slack_smoke_1", "runner should claim the Slack smoke run");
+  assert(claimed.event.source === "slack", "claimed event should remain Slack-shaped");
+
+  await client.complete({
+    runId: "run_slack_smoke_1",
+    result: {
+      conclusion: "needs_human",
+      summary: "Prepared a Slack-originated follow-up task.",
+      suggestedChanges: [
+        {
+          proposalId: "proposal_slack_smoke_1",
+          createdAt: "2026-06-24T00:00:02.000Z",
+          summary: "Request review in the primary Slack thread.",
+          intents: [
+            {
+              intentId: "intent_slack_review",
+              domain: "review",
+              action: "request_review",
+              summary: "Ask a human to review the investigation summary.",
+              params: { surface: "slack" }
+            }
+          ]
+        }
+      ],
+      nextAction: {
+        summary: "Ask for human review in the Slack thread.",
+        hint: {
+          kind: "request_review",
+          targetId: "proposal_slack_smoke_1",
+          selectedIntentIds: ["intent_slack_review"]
+        }
+      }
+    }
+  });
+
+  assert(delivered.length === 2, "Slack final callback should be delivered");
+  assert(delivered[1]?.provider === "slack", "final callback should target Slack");
+  assert(delivered[1]?.kind === "final", "second Slack callback should be final");
+  assert(delivered[1]?.body.includes("Prepared a Slack-originated follow-up task."), "final Slack body should include summary");
+  assert(delivered[1]?.blocks && delivered[1].blocks.length > 0, "final Slack callback should include Block Kit blocks");
+
+  const proposal = await client.getProposal({ proposalId: "proposal_slack_smoke_1" });
+  assert(proposal.runId === "run_slack_smoke_1", "Slack proposal should point to source run");
+  assert(proposal.snapshot.sourceRunId === "run_slack_smoke_1", "Slack proposal should carry sourceRunId");
+  assert(!proposal.snapshot.workThread, "Slack proposal should not invent a canonical work thread");
+
+  const lineage = await client.getProposalLineage({ proposalId: "proposal_slack_smoke_1" });
+  assert(lineage.lineage.entries[0]?.status === "current", "Slack proposal intent should be current");
+
+  const approval = await client.approveProposal({
+    proposalId: "proposal_slack_smoke_1",
+    id: "approval_slack_smoke_1",
+    approvedIntentIds: ["intent_slack_review"],
+    approvedBy: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
+    approvedAt: "2026-06-24T00:00:03.000Z"
+  });
+  assert(approval.decision.id === "approval_slack_smoke_1", "Slack approval should be recorded");
+
+  const applyPlan = await client.createApplyPlan({
+    proposalId: "proposal_slack_smoke_1",
+    id: "apply_slack_smoke_1",
+    approvalDecisionId: "approval_slack_smoke_1",
+    adapter: "slack"
+  });
+  assert(applyPlan.plan.outcomes?.[0]?.outcome === "skipped", "Slack request_review should pass preflight but remain unexecuted");
+
+  const childRun = await client.createChildRun({
+    parentRunId: "run_slack_smoke_1",
+    runId: "run_slack_smoke_child_1",
+    action: {
+      kind: "request_review",
+      targetId: "proposal_slack_smoke_1",
+      selectedIntentIds: ["intent_slack_review"]
+    },
+    sourceApplyPlanId: "apply_slack_smoke_1",
+    commandText: "Request review for Slack smoke proposal"
+  });
+  assert(childRun.run.parentRunId === "run_slack_smoke_1", "Slack child run should reference parent");
+  assert(childRun.run.sourceProposalId === "proposal_slack_smoke_1", "Slack child run should reference proposal");
+  assert(childRun.run.triggeredByAction?.kind === "request_review", "Slack child run should carry request_review action");
+
+  const events = await client.listRunEvents({ runId: "run_slack_smoke_1" });
+  const eventTypes = events.events.map((event) => (event as { type: string }).type);
+  for (const expected of [
+    "run.created",
+    "context_packet.generated",
+    "callback.acknowledgement.delivered",
+    "run.progress",
+    "proposal.snapshot.created",
+    "run.completed",
+    "callback.final.delivered",
+    "approval.decision.recorded",
+    "apply_plan.created",
+    "run.child_created"
+  ]) {
+    assertIncludes(eventTypes, expected, "Slack parent run audit trail is incomplete");
+  }
+
+  const metrics = await client.getRunMetrics({ runId: "run_slack_smoke_1" });
+  assert(metrics.metrics.humanCallbackCount === 2, "Slack smoke should only deliver ack and final callbacks");
+  assert(metrics.metrics.auditEventCount > metrics.metrics.humanCallbackCount, "Slack audit events should exceed human callbacks");
+  assert(metrics.metrics.threadNoiseRatio < 1, "Slack thread noise ratio should stay below 1");
+  assert(metrics.metrics.suggestedChangesCount === 1, "Slack metrics should count suggested changes");
+  assert(metrics.metrics.approvalDecisionCount === 1, "Slack metrics should count approvals");
+  assert(metrics.metrics.applyPlanCount === 1, "Slack metrics should count apply plans");
+  assert(metrics.metrics.childRunCount === 1, "Slack metrics should count child runs");
+  assert(metrics.metrics.applyOutcomeCounts.skipped === 1, "Slack metrics should count skipped preflight outcomes");
+
+  console.log("slack-protocol-runtime-smoke: ok");
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Adds the Agent Work Protocol runtime: work threads, context packets, structured proposals, approvals, apply plans, lineage, policies, mutation mappings, and metrics.
- Wires local Claude Code/Codex execution into GitHub and Slack flows with quiet callbacks and real smoke-test helpers.
- Updates README and integration docs to reflect the current protocol, local runner, metrics, and real E2E validation paths.

## Test plan
- pnpm smoke:protocol
- pnpm smoke:slack-protocol
- pnpm test
- pnpm typecheck
- pnpm build
- pnpm lint
- Real GitHub-assisted Claude Code smoke against amplifthq/opentag-test
- Real Slack-assisted Claude Code smoke using .env.slack-test and opentag.real.json


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code as a local execution option, along with richer run results, next-action guidance, and support for creating follow-up runs.
  * Introduced proposal approval, apply-plan, metrics, and lineage features for runs and work threads.
  * Expanded GitHub and Slack integrations with improved callback handling and more complete end-to-end workflow support.
* **Bug Fixes**
  * Improved callback delivery so updates reuse the same message thread instead of creating duplicates.
  * Added safer handling for run and Slack payload fields, reducing missing-data issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->