### PR TITLE
Fix schema migration for existing databases

### DIFF
--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -168,8 +168,6 @@ export function migrateSchema(sqlite: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS runs_status_idx ON runs(status);
     CREATE INDEX IF NOT EXISTS runs_runner_idx ON runs(assigned_runner_id);
-    CREATE INDEX IF NOT EXISTS runs_repo_idx ON runs(repo_provider, repo_owner, repo_name);
-    CREATE INDEX IF NOT EXISTS runs_work_thread_idx ON runs(work_thread_id);
     CREATE TABLE IF NOT EXISTS run_events (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       run_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- Remove premature `runs_repo_idx` and `runs_work_thread_idx` creation from the initial `migrateSchema` DDL block
- Those indexes are already created after `ALTER TABLE` adds `repo_provider`, `repo_owner`, `repo_name`, and `work_thread_id` to older databases

## Problem
On existing SQLite databases created before the repo/thread columns were added, dispatcher startup failed with `SqliteError: no such column: repo_provider` because index creation ran before the column migrations.

## Test plan
- [x] Start dispatcher against an older local DB and confirm migration succeeds
- [x] Run `scripts/dev/run-gh-claude-local-test.sh` end-to-end
- [x] Run `scripts/dev/run-slack-claude-local-test.sh` end-to-end


Made with [Cursor](https://cursor.com)