### PR TITLE
Document OpenTag configuration and adapter authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Runnable apps live in `apps/dispatcher`, `apps/opentagd`, `apps/github-probot`, 
 - [GitHub to echo](examples/github-to-echo/README.md) - manual end-to-end GitHub-shaped local runner loop.
 - [Embedded dispatcher](examples/embedded-dispatcher/README.md) - host OpenTag inside another Node service.
 - [Custom runner](examples/custom-runner/README.md) - build a third-party runner with `@opentag/client` and `@opentag/runner`.
+- [Configuration](docs/configuration.md) - map dispatcher, daemon, ingress, callback, and runner settings.
+- [Adapter authoring](docs/adapter-authoring.md) - add new work app adapters without changing the execution model.
 - [Real integration smoke test](docs/real-integration-smoke-test.md) - real GitHub and Slack setup, trigger, and debugging order.
 - [Design](docs/design.md) - product direction, system shape, package boundaries, and v0 scope.
 - [Agent Work Protocol](docs/agent-work-protocol.md) - context packets, quiet callbacks, approvals, lineage, and governance semantics.

--- a/docs/adapter-authoring.md
+++ b/docs/adapter-authoring.md
@@ -1,0 +1,301 @@
+# Adapter Authoring
+
+OpenTag adapters bring new work apps into the same protocol loop:
+
+```text
+work app event -> OpenTagEvent -> dispatcher -> runner -> callback
+```
+
+Use this guide when adding a new GitHub-like, Slack-like, Lark-like, or webhook
+surface. For runtime configuration, see [Configuration](./configuration.md).
+
+## Adapter Types
+
+OpenTag currently uses three adapter shapes:
+
+| Adapter type | Purpose | Current examples |
+| --- | --- | --- |
+| Ingress normalizer | Converts a platform event into `OpenTagEvent` | `@opentag/github`, `@opentag/slack` |
+| Ingress app | Receives signed webhooks/events and calls the dispatcher | `apps/github-probot`, `apps/slack-events` |
+| Callback sink | Posts acknowledgement, progress, and final messages back to the source thread | `createGitHubCallbackSink`, `createSlackCallbackSink` |
+
+Future app support should arrive through these adapters, not by adding a new
+execution architecture. The dispatcher and runner contracts should stay shared.
+
+## Boundary Rules
+
+- Adapters translate platform shape into OpenTag protocol shape.
+- Adapters should ignore ambient messages unless there is an explicit mention or
+  command trigger.
+- Adapters should not choose a local checkout directly. Bindings map work app
+  containers to repositories and runners.
+- Adapters should not execute agent code. Runners and executors own execution.
+- Adapters should not bake one team's workflow method into core protocol fields.
+  Put opinionated behavior in recipes or policy.
+- Official adapters should use stable, provider-specific ids for events,
+  callbacks, and thread keys.
+
+## Core Schema Check
+
+Before writing code, check whether `@opentag/core` already supports the provider:
+
+- `SourceSchema` currently includes `github`, `slack`, `lark`, `cli`, and
+  `webhook`.
+- `ProviderSchema` currently includes `github`, `slack`, and `lark`.
+- `CallbackRouteSchema` currently includes `github`, `slack`, `lark`, and
+  `webhook`.
+- `ContextPointerSchema` includes GitHub, Slack, Lark, file, URL, and text
+  pointers.
+
+If the new app needs a new provider such as Linear, Jira, Teams, or Discord,
+extend the core enums first. Do not emit strings that fail `OpenTagEventSchema`.
+
+For prototypes that do not need a first-class provider yet, use an existing
+supported provider only when it is semantically true. Avoid pretending a Jira
+actor is a GitHub actor just to pass validation.
+
+## Normalizer Checklist
+
+An ingress normalizer should produce `OpenTagEvent | null`.
+
+Return `null` when:
+
+- the event is not a user-authored trigger;
+- the mention targets another bot or agent;
+- the command text is empty after removing the platform mention;
+- the source container is not bound to a repository or allowed work context.
+
+Populate these fields carefully:
+
+| Field | Guidance |
+| --- | --- |
+| `id` | Stable and namespaced, for example `evt_lark_message_<id>` |
+| `source` | Provider or generic source accepted by `SourceSchema` |
+| `sourceEventId` | Raw platform event id |
+| `receivedAt` | ISO timestamp from the platform event or ingress clock |
+| `actor` | Provider identity, user id, handle, and organization/team id when available |
+| `target` | Mention text, `agentId`, and optional executor hint |
+| `command` | Use `parseOpenTagMention` for literal `@opentag`; use `commandFromRawText` after stripping platform mentions |
+| `context` | Durable pointers to the issue, thread, message, file, URL, or text |
+| `permissions` | Smallest permissions implied by the command |
+| `callback` | Provider, callback URI, and stable `threadKey` when callbacks target a thread |
+| `metadata` | Provider-specific ids needed for binding, routing, or debugging |
+
+## Command Parsing
+
+Use the shared command parser instead of inventing adapter-specific commands.
+
+- Use `parseOpenTagMention(text)` when the source text contains literal
+  `@opentag`.
+- Use `commandFromRawText(text)` when the platform has already resolved the bot
+  mention and you only have the command body.
+- Preserve parser diagnostics in `command.parsed`; they help runners and audit
+  views explain weak commands.
+- Forward `executorHint` from parsed commands into `target.executorHint`.
+
+Intent defaults:
+
+| Intent | Typical permissions |
+| --- | --- |
+| `review`, `explain`, `investigate` | callback permission plus runner permission |
+| `fix`, `run` | callback, runner, repo read/write, and PR permission when the surface supports code work |
+| `unknown` | callback and runner only, unless policy upgrades it later |
+
+## Context Pointers
+
+Context pointers should point to the source material without copying more data
+than needed:
+
+- issue, PR, ticket, task, or thread URL;
+- source comment or message URL;
+- file, line, range, and URL references parsed from command flags;
+- short text context only when the source app has no durable URL.
+
+Set `visibility` to `public`, `private`, or `organization` based on the source
+container. Do not mark private work as public just because the runner is local.
+
+## Callback Routes
+
+Callbacks are part of the adapter contract. A callback route must tell the
+dispatcher where human-facing updates belong:
+
+```ts
+callback: {
+  provider: "slack",
+  uri: "https://slack.com/api/chat.postMessage",
+  threadKey: "T123|C123|1710000000.000100"
+}
+```
+
+Use `threadKey` whenever a platform needs more than a URL to route replies. The
+Slack adapter encodes `teamId`, `channelId`, and `threadTs` for this reason.
+
+Callback sinks should:
+
+- post acknowledgement and final results to the source thread;
+- keep routine progress audit-only unless the adapter policy says otherwise;
+- treat provider response bodies as authoritative when the provider can return
+  HTTP 200 with an error payload;
+- be idempotent where possible, for example by updating one run comment instead
+  of flooding a thread.
+
+## Binding Model
+
+Do not create a second execution model for chat surfaces. Chat adapters should
+resolve to the same repository and runner bindings used by GitHub-shaped runs.
+
+Current Slack behavior is the model:
+
+```json
+{
+  "teamId": "T123",
+  "channelId": "C123",
+  "owner": "acme",
+  "repo": "demo"
+}
+```
+
+That binding lets a Slack thread create a run against `acme/demo`, then the
+daemon claims it only if its repository binding allows that repo.
+
+For a new app, define the smallest binding that maps the app container to the
+work context owner. Examples:
+
+| App surface | Likely binding |
+| --- | --- |
+| Lark chat | `chatId -> owner/repo` |
+| Linear project | `teamId/projectId -> owner/repo` |
+| Jira project | `siteId/projectKey -> owner/repo` |
+| Microsoft Teams channel | `tenantId/teamId/channelId -> owner/repo` |
+
+## Package Layout
+
+Use the existing package split as the default:
+
+```text
+packages/<adapter>/
+  src/index.ts
+  src/normalize.ts
+  src/render.ts
+  test/normalize.test.ts
+  test/render.test.ts
+
+apps/<adapter>-events/
+  src/index.ts
+  src/app.ts
+  test/app.test.ts
+```
+
+Keep SDK-specific dependencies in the adapter package or ingress app. Do not add
+provider SDKs to `@opentag/core`.
+
+## Minimal Normalizer Example
+
+This example uses Lark because `lark` is already a supported provider in core.
+A new provider should first extend the core enums.
+
+```ts
+import { commandFromRawText, type OpenTagEvent } from "@opentag/core";
+
+type LarkMessageMentionInput = {
+  eventId: string;
+  messageId: string;
+  chatId: string;
+  userId: string;
+  textAfterMention: string;
+  receivedAt: string;
+  binding: {
+    owner: string;
+    repo: string;
+  };
+};
+
+export function normalizeLarkMessageMention(input: LarkMessageMentionInput): OpenTagEvent | null {
+  const rawText = input.textAfterMention.trim();
+  if (!rawText) return null;
+
+  const command = commandFromRawText(rawText);
+
+  return {
+    id: `evt_lark_message_${input.eventId}`,
+    source: "lark",
+    sourceEventId: input.eventId,
+    receivedAt: input.receivedAt,
+    actor: {
+      provider: "lark",
+      providerUserId: input.userId,
+      organizationId: input.chatId
+    },
+    target: {
+      mention: "@opentag",
+      agentId: "opentag",
+      ...(command.parsed?.executorHint ? { executorHint: command.parsed.executorHint } : {})
+    },
+    command,
+    context: [
+      {
+        kind: "lark.message",
+        uri: `lark://chat/${input.chatId}/message/${input.messageId}`,
+        visibility: "organization",
+        title: "Lark message"
+      }
+    ],
+    permissions: [
+      { scope: "chat:postMessage", reason: "reply in the originating Lark thread" },
+      { scope: "runner:local", reason: "execute the run on an approved runner" }
+    ],
+    callback: {
+      provider: "lark",
+      uri: `lark://chat/${input.chatId}/message/${input.messageId}`,
+      threadKey: `${input.chatId}|${input.messageId}`
+    },
+    metadata: {
+      chatId: input.chatId,
+      messageId: input.messageId,
+      repoProvider: "github",
+      owner: input.binding.owner,
+      repo: input.binding.repo
+    }
+  };
+}
+```
+
+## Ingress App Checklist
+
+The ingress app should:
+
+1. Verify provider signatures or tokens before parsing the event.
+2. Handle provider challenge requests, such as Slack `url_verification`.
+3. Resolve the source container to a binding.
+4. Call the normalizer.
+5. Create the run through `@opentag/client`.
+6. Return quickly to the provider.
+7. Log ignored events with enough context to debug bindings without leaking
+   secrets.
+
+If the dispatcher has `OPENTAG_PAIRING_TOKEN`, the ingress app must pass the
+same value as `OPENTAG_DISPATCHER_TOKEN`.
+
+## Test Checklist
+
+At minimum, add tests for:
+
+- non-mentions are ignored;
+- empty commands are ignored;
+- explicit mentions create a valid `OpenTagEvent`;
+- event ids and thread keys are stable;
+- write-capable intents request write permissions only when intended;
+- unbound containers do not create runs;
+- callback rendering escapes or formats provider markdown correctly;
+- provider API error payloads become failures, not silent successes.
+
+Run the normal repo gates before opening a PR:
+
+```bash
+pnpm test
+pnpm typecheck
+pnpm lint
+pnpm build
+```
+
+For real provider testing, follow [Real integration smoke test](./real-integration-smoke-test.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,235 @@
+# Configuration
+
+This guide explains which OpenTag process reads which settings. Use it as the
+configuration map, then jump to the runnable examples for end-to-end commands:
+
+- [GitHub to echo](../examples/github-to-echo/README.md)
+- [Real integration smoke test](./real-integration-smoke-test.md)
+- [Embedded dispatcher](../examples/embedded-dispatcher/README.md)
+
+## Configuration Layers
+
+OpenTag has four runtime surfaces today:
+
+| Surface | Process | Owns |
+| --- | --- | --- |
+| Dispatcher | `apps/dispatcher` | Run storage, leases, callbacks, pairing token checks |
+| Local daemon | `apps/opentagd` | Runner identity, repository bindings, workspace paths, executor settings |
+| GitHub ingress | `apps/github-probot` | GitHub App webhooks and GitHub event normalization |
+| Slack ingress | `apps/slack-events` | Slack Events API verification and Slack event normalization |
+
+Keep these boundaries separate. Ingress apps should know how to receive platform
+events and create runs. The dispatcher should coordinate runs and callbacks. The
+daemon should decide whether it can claim and execute work for a bound checkout.
+
+## Local Daemon Config
+
+`opentagd` prefers a JSON config file. Point to it with `OPENTAG_CONFIG_PATH`.
+When `OPENTAG_CONFIG_PATH` is set, the daemon reads that file and does not build
+repository bindings from the environment fallback variables.
+
+Minimal local config:
+
+```json
+{
+  "runnerId": "runner_local",
+  "dispatcherUrl": "http://localhost:3030",
+  "pairingToken": "dev_pairing_token",
+  "pollIntervalMs": 5000,
+  "heartbeatIntervalMs": 15000,
+  "repositories": [
+    {
+      "provider": "github",
+      "owner": "acme",
+      "repo": "demo",
+      "checkoutPath": "/absolute/path/to/demo",
+      "defaultExecutor": "echo",
+      "baseBranch": "main",
+      "pushRemote": "origin",
+      "keepWorktree": "on_failure"
+    }
+  ]
+}
+```
+
+Add Slack channel bindings when a chat surface should route work to a repository:
+
+```json
+{
+  "slackChannels": [
+    {
+      "teamId": "T123",
+      "channelId": "C123",
+      "owner": "acme",
+      "repo": "demo"
+    }
+  ]
+}
+```
+
+Add Claude Code settings when using the built-in `claude-code` executor:
+
+```json
+{
+  "claudeCode": {
+    "command": "claude",
+    "model": "sonnet",
+    "permissionMode": "acceptEdits"
+  }
+}
+```
+
+Use daemon security settings to keep executor runs constrained:
+
+```json
+{
+  "security": {
+    "mode": "enforce",
+    "allowedWorkspaceRoot": "/absolute/path/to/repos",
+    "allowUnsafePrompts": false,
+    "extraSafeEnv": ["OPENTAG_DEBUG"]
+  }
+}
+```
+
+## Daemon Config Fields
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `runnerId` | `runner_local` | Stable identity used by the dispatcher lease and binding tables |
+| `dispatcherUrl` | `http://localhost:3030` | Dispatcher base URL |
+| `pairingToken` | none | Shared Bearer token for dispatcher `/v1/*` calls |
+| `repositories` | `[]` | Repository bindings this daemon is allowed to claim |
+| `slackChannels` | none | Slack channel to repository mappings |
+| `claudeCode` | none | Claude Code executor settings |
+| `security` | none | Runner security policy |
+| `githubToken` | none | Optional token for PR creation from daemon-produced branches |
+| `allowAutoCreatePullRequest` | `false` | Enables PR creation when executor results include changes |
+| `pollIntervalMs` | `5000` | Poll interval for `serve` |
+| `heartbeatIntervalMs` | `15000` | Heartbeat interval for claimed runs |
+
+Repository binding fields:
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `provider` | `github` | Repo provider for the binding |
+| `owner` | required | Repository owner or organization |
+| `repo` | required | Repository name |
+| `checkoutPath` | required | Absolute path to the local checkout |
+| `defaultExecutor` | `echo` | `echo`, `codex`, or `claude-code` |
+| `baseBranch` | `main` | PR target branch |
+| `pushRemote` | `origin` | Remote used for PR branches |
+| `worktreeRoot` | none | Optional root for executor-created worktrees |
+| `keepWorktree` | `on_failure` | `always`, `on_failure`, or `never` |
+
+## Daemon Environment Fallback
+
+Use environment fallback for one-off local testing. Use `OPENTAG_CONFIG_PATH`
+for repeatable setups.
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `OPENTAG_CONFIG_PATH` | none | Path to daemon JSON config. Takes precedence over repo env fallback |
+| `OPENTAG_RUNNER_ID` | `runner_local` | Runner identity |
+| `OPENTAG_DISPATCHER_URL` | `http://localhost:3030` | Dispatcher URL |
+| `OPENTAG_REPO_OWNER` | none | Required for env-derived repository binding |
+| `OPENTAG_REPO_NAME` | none | Required for env-derived repository binding |
+| `OPENTAG_WORKSPACE_PATH` | none | Required for env-derived repository binding |
+| `OPENTAG_DEFAULT_EXECUTOR` | `echo` | `echo`, `codex`, or `claude-code` |
+| `OPENTAG_BASE_BRANCH` | `main` | PR target branch |
+| `OPENTAG_PUSH_REMOTE` | `origin` | Git remote for run branches |
+| `OPENTAG_WORKTREE_ROOT` | none | Optional worktree root |
+| `OPENTAG_KEEP_WORKTREE` | `on_failure` | `always`, `on_failure`, or `never` |
+| `OPENTAG_SLACK_TEAM_ID` | none | Creates one env-derived Slack channel binding when paired with repo env |
+| `OPENTAG_SLACK_CHANNEL_ID` | none | Creates one env-derived Slack channel binding when paired with repo env |
+| `OPENTAG_CLAUDE_COMMAND` | `claude` in executor default | Claude Code CLI command |
+| `OPENTAG_CLAUDE_MODEL` | none | Optional Claude model |
+| `OPENTAG_CLAUDE_PERMISSION_MODE` | none | `acceptEdits`, `auto`, `bypassPermissions`, `default`, or `plan` |
+| `OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` | Only for explicitly sandboxed environments |
+| `OPENTAG_SECURITY_MODE` | none | `enforce`, `audit`, or `off` |
+| `OPENTAG_ALLOWED_WORKSPACE_ROOT` | none | Restricts allowed checkout paths |
+| `OPENTAG_ALLOW_UNSAFE_PROMPTS` | `false` | Allows prompts normally rejected by runner security |
+| `OPENTAG_EXTRA_SAFE_ENV` | none | Comma-separated env names preserved for executor processes |
+| `OPENTAG_GITHUB_TOKEN` | none | Optional GitHub token for PR creation |
+| `OPENTAG_ALLOW_AUTO_CREATE_PR` | `false` | Allows daemon PR creation |
+| `OPENTAG_PAIRING_TOKEN` | none | Shared dispatcher token |
+| `OPENTAG_POLL_INTERVAL_MS` | `5000` | Poll interval |
+| `OPENTAG_HEARTBEAT_INTERVAL_MS` | `15000` | Heartbeat interval |
+
+## Dispatcher Environment
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `PORT` | `3030` | Dispatcher HTTP port |
+| `OPENTAG_DATABASE_PATH` | `opentag.db` | SQLite database path |
+| `OPENTAG_PAIRING_TOKEN` | none | Requires `Authorization: Bearer <token>` for `/v1/*` |
+| `OPENTAG_GITHUB_TOKEN` | none | Enables GitHub callback posting and GitHub apply helpers |
+| `OPENTAG_SLACK_BOT_TOKEN` | none | Single Slack bot token for callback posting |
+| `OPENTAG_SLACK_BOT_TOKENS_JSON` | none | JSON object mapping `agentId` to Slack bot token |
+
+If `OPENTAG_PAIRING_TOKEN` is set on the dispatcher, use the same value as:
+
+- daemon `pairingToken` or `OPENTAG_PAIRING_TOKEN`
+- ingress `OPENTAG_DISPATCHER_TOKEN`
+
+## GitHub Ingress Environment
+
+`apps/github-probot` uses Probot for GitHub App webhooks.
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `APP_ID` | yes | GitHub App ID expected by Probot |
+| `WEBHOOK_SECRET` | yes | GitHub App webhook secret |
+| `PRIVATE_KEY_PATH` | yes | Path to GitHub App private key |
+| `PORT` | no | Usually `3000` in local scripts |
+| `WEBHOOK_PATH` | no | Usually `/github/webhooks` |
+| `OPENTAG_DISPATCHER_URL` | yes for real dispatch | Dispatcher URL. If omitted, the app logs and does not dispatch the run |
+| `OPENTAG_DISPATCHER_TOKEN` | when dispatcher is paired | Bearer token for dispatcher `/v1/*` |
+| `OPENTAG_DISPATCHER_OWNS_CALLBACKS` | no | Set `true` when dispatcher callback sinks should own acknowledgements |
+
+Use `OPENTAG_DISPATCHER_OWNS_CALLBACKS=true` when `OPENTAG_GITHUB_TOKEN` is set
+on the dispatcher. That avoids duplicate acknowledgement comments.
+
+## Slack Ingress Environment
+
+`apps/slack-events` verifies Slack Events API requests and creates OpenTag runs.
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `OPENTAG_DISPATCHER_URL` | yes | Dispatcher URL |
+| `OPENTAG_DISPATCHER_TOKEN` | when dispatcher is paired | Bearer token for dispatcher `/v1/*` |
+| `PORT` | no | Defaults to `3040` |
+| `SLACK_SIGNING_SECRET` | yes unless using JSON config | Signing secret for a single Slack app |
+| `OPENTAG_SLACK_AGENT_ID` | no | Agent id for single-app mode. Defaults to `opentag` |
+| `OPENTAG_SLACK_APP_ID` | no | Slack app id for single-app mode |
+| `OPENTAG_SLACK_POST_MESSAGE_URL` | no | Callback URI override. Defaults to Slack `chat.postMessage` |
+| `OPENTAG_SLACK_APPS_JSON` | no | JSON array for multi-app ingress |
+
+`OPENTAG_SLACK_APPS_JSON` shape:
+
+```json
+[
+  {
+    "signingSecret": "secret",
+    "agentId": "opentag",
+    "appId": "A123",
+    "callbackUri": "https://slack.com/api/chat.postMessage"
+  }
+]
+```
+
+Set `OPENTAG_SLACK_BOT_TOKEN` or `OPENTAG_SLACK_BOT_TOKENS_JSON` on the
+dispatcher, not on the Slack ingress, when you want final replies posted back to
+Slack threads.
+
+## Secret Handling
+
+- Do not commit config files that contain real tokens, signing secrets, or private keys.
+- Prefer environment variables or a local secret manager for `OPENTAG_GITHUB_TOKEN`,
+  `OPENTAG_SLACK_BOT_TOKEN`, Slack signing secrets, and GitHub App private keys.
+- Treat `pairingToken` as a secret when the dispatcher is reachable by other
+  machines.
+- Keep `checkoutPath` pointed at a clean local checkout. Coding executors refuse
+  dirty workspaces before making changes.
+- Keep `security.mode` set to `enforce` unless you are deliberately auditing a new
+  executor or adapter path.


### PR DESCRIPTION
## Summary
- Add `docs/configuration.md` as the central map for dispatcher, daemon, GitHub ingress, Slack ingress, callback, runner, and security settings.
- Add `docs/adapter-authoring.md` for adding future work app adapters behind the shared OpenTag event, binding, dispatcher, runner, and callback model.
- Link both guides from the README `Examples And Guides` section.

## Verification
- Local markdown links/images checked.
- `git diff --check`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

## Not Tested
- GitHub-rendered Markdown preview in browser.
- Implementing a new adapter from the guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with links to new configuration and adapter-authoring guides.
  * Added a detailed configuration guide covering runtime settings, environment variables, and secret-handling recommendations.
  * Added a new adapter-authoring guide with best practices, validation checklists, and example patterns for building adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->