### PR TITLE
Generalize Slack channel bindings into a shared channel routing layer

### DIFF
--- a/apps/opentagd/src/config.ts
+++ b/apps/opentagd/src/config.ts
@@ -142,12 +142,13 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
   const owner = process.env.OPENTAG_REPO_OWNER;
   const repo = process.env.OPENTAG_REPO_NAME;
   const checkoutPath = process.env.OPENTAG_WORKSPACE_PATH;
+  const repositoryProvider = process.env.OPENTAG_SLACK_REPO_PROVIDER ?? "github";
   const claudePermissionMode = claudePermissionModeFromEnv(process.env.OPENTAG_CLAUDE_PERMISSION_MODE);
   const repositories =
     owner && repo && checkoutPath
       ? [
           {
-            provider: "github",
+            provider: repositoryProvider,
             owner,
             repo,
             checkoutPath,
@@ -170,7 +171,7 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
             {
               teamId: process.env.OPENTAG_SLACK_TEAM_ID,
               channelId: process.env.OPENTAG_SLACK_CHANNEL_ID,
-              repoProvider: process.env.OPENTAG_SLACK_REPO_PROVIDER ?? "github",
+              repoProvider: repositoryProvider,
               owner,
               repo
             }

--- a/apps/opentagd/src/config.ts
+++ b/apps/opentagd/src/config.ts
@@ -34,6 +34,7 @@ export const RepositoryBindingConfigSchema = z.object({
 export const SlackChannelBindingConfigSchema = z.object({
   teamId: z.string().min(1),
   channelId: z.string().min(1),
+  repoProvider: z.string().min(1).default("github"),
   owner: z.string().min(1),
   repo: z.string().min(1)
 });
@@ -169,6 +170,7 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
             {
               teamId: process.env.OPENTAG_SLACK_TEAM_ID,
               channelId: process.env.OPENTAG_SLACK_CHANNEL_ID,
+              repoProvider: process.env.OPENTAG_SLACK_REPO_PROVIDER ?? "github",
               owner,
               repo
             }

--- a/apps/opentagd/src/doctor.ts
+++ b/apps/opentagd/src/doctor.ts
@@ -139,22 +139,29 @@ export async function runDoctor(input: {
 
   for (const binding of input.config.slackChannels ?? []) {
     try {
-      const { binding: remoteBinding } = await client.getSlackChannelBinding({
-        teamId: binding.teamId,
-        channelId: binding.channelId
+      const { binding: remoteBinding } = await client.getChannelBinding({
+        provider: "slack",
+        accountId: binding.teamId,
+        conversationId: binding.channelId
       });
       checks.push(
-        remoteBinding.owner === binding.owner && remoteBinding.repo === binding.repo
-          ? check("ok", `${binding.teamId}/${binding.channelId} Slack binding`, `${remoteBinding.owner}/${remoteBinding.repo}`)
+        remoteBinding.owner === binding.owner &&
+        remoteBinding.repo === binding.repo &&
+        (remoteBinding.repoProvider ?? "github") === binding.repoProvider
+          ? check(
+              "ok",
+              `${binding.teamId}/${binding.channelId} Slack binding`,
+              `${remoteBinding.repoProvider ?? "github"}:${remoteBinding.owner}/${remoteBinding.repo}`
+            )
           : check(
               "fail",
               `${binding.teamId}/${binding.channelId} Slack binding`,
-              `Bound to ${remoteBinding.owner}/${remoteBinding.repo}, expected ${binding.owner}/${binding.repo}`
+              `Bound to ${(remoteBinding.repoProvider ?? "github")}:${remoteBinding.owner}/${remoteBinding.repo}, expected ${binding.repoProvider}:${binding.owner}/${binding.repo}`
             )
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      checks.push(check(message.includes("slack_channel_binding_not_found") ? "warn" : "fail", `${binding.teamId}/${binding.channelId} Slack binding`, message));
+      checks.push(check(message.includes("channel_binding_not_found") ? "warn" : "fail", `${binding.teamId}/${binding.channelId} Slack binding`, message));
     }
   }
 

--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -157,7 +157,14 @@ program
       ...(config.pairingToken ? { pairingToken: config.pairingToken } : {})
     });
     for (const binding of config.slackChannels ?? []) {
-      await client.bindSlackChannel(binding);
+      await client.bindChannel({
+        provider: "slack",
+        accountId: binding.teamId,
+        conversationId: binding.channelId,
+        repoProvider: binding.repoProvider,
+        owner: binding.owner,
+        repo: binding.repo
+      });
       console.log(`Bound Slack ${binding.teamId}/${binding.channelId} to ${binding.owner}/${binding.repo}`);
     }
     if (!(config.slackChannels?.length ?? 0)) {

--- a/apps/opentagd/test/config.test.ts
+++ b/apps/opentagd/test/config.test.ts
@@ -89,6 +89,32 @@ describe("opentagd config", () => {
     });
   });
 
+  it("propagates OPENTAG_SLACK_REPO_PROVIDER into env-derived repository and Slack bindings", () => {
+    delete process.env.OPENTAG_CONFIG_PATH;
+    process.env.OPENTAG_REPO_OWNER = "acme";
+    process.env.OPENTAG_REPO_NAME = "demo";
+    process.env.OPENTAG_WORKSPACE_PATH = "/tmp/demo";
+    process.env.OPENTAG_SLACK_TEAM_ID = "T123";
+    process.env.OPENTAG_SLACK_CHANNEL_ID = "C123";
+    process.env.OPENTAG_SLACK_REPO_PROVIDER = "gitlab";
+
+    const config = loadConfigFromEnv();
+
+    expect(config.repositories[0]).toMatchObject({
+      provider: "gitlab",
+      owner: "acme",
+      repo: "demo",
+      checkoutPath: "/tmp/demo"
+    });
+    expect(config.slackChannels?.[0]).toMatchObject({
+      teamId: "T123",
+      channelId: "C123",
+      repoProvider: "gitlab",
+      owner: "acme",
+      repo: "demo"
+    });
+  });
+
   it("formats zod config errors into a readable message", () => {
     const error = (() => {
       try {

--- a/apps/opentagd/test/config.test.ts
+++ b/apps/opentagd/test/config.test.ts
@@ -73,6 +73,22 @@ describe("opentagd config", () => {
     });
   });
 
+  it("defaults Slack channel bindings to github repoProvider", () => {
+    const parsed = parseDaemonConfig({
+      dispatcherUrl: "http://localhost:3030",
+      repositories: [],
+      slackChannels: [{ teamId: "T123", channelId: "C123", owner: "acme", repo: "demo" }]
+    });
+
+    expect(parsed.slackChannels?.[0]).toMatchObject({
+      teamId: "T123",
+      channelId: "C123",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo"
+    });
+  });
+
   it("formats zod config errors into a readable message", () => {
     const error = (() => {
       try {

--- a/apps/opentagd/test/doctor.test.ts
+++ b/apps/opentagd/test/doctor.test.ts
@@ -41,7 +41,7 @@ describe("opentagd doctor", () => {
             keepWorktree: "on_failure"
           }
         ],
-        slackChannels: [{ teamId: "T123", channelId: "C123", owner: "acme", repo: "demo" }],
+        slackChannels: [{ teamId: "T123", channelId: "C123", repoProvider: "gitlab", owner: "acme", repo: "demo" }],
         githubToken: "ghs_test",
         pollIntervalMs: 5000,
         heartbeatIntervalMs: 15000
@@ -70,11 +70,13 @@ describe("opentagd doctor", () => {
             }
           });
         }
-        if (stringUrl.endsWith("/v1/slack-channel-bindings/T123/C123")) {
+        if (stringUrl.endsWith("/v1/channel-bindings/slack/T123/C123")) {
           return Response.json({
             binding: {
-              teamId: "T123",
-              channelId: "C123",
+              provider: "slack",
+              accountId: "T123",
+              conversationId: "C123",
+              repoProvider: "gitlab",
               owner: "acme",
               repo: "demo"
             }

--- a/apps/slack-events/src/index.ts
+++ b/apps/slack-events/src/index.ts
@@ -68,10 +68,20 @@ serve({
     slackApps,
     async resolveChannelBinding(input) {
       try {
-        const { binding } = await dispatcherClient.getSlackChannelBinding(input);
-        return binding;
+        const { binding } = await dispatcherClient.getChannelBinding({
+          provider: "slack",
+          accountId: input.teamId,
+          conversationId: input.channelId
+        });
+        return {
+          teamId: binding.accountId,
+          channelId: binding.conversationId,
+          repoProvider: binding.repoProvider,
+          owner: binding.owner,
+          repo: binding.repo
+        };
       } catch (error) {
-        if (error instanceof Error && error.message.includes("slack_channel_binding_not_found")) {
+        if (error instanceof Error && error.message.includes("channel_binding_not_found")) {
           return null;
         }
         throw error;

--- a/apps/slack-events/test/app.test.ts
+++ b/apps/slack-events/test/app.test.ts
@@ -61,7 +61,7 @@ describe("Slack events app", () => {
     const app = createSlackEventsApp({
       slackApps: [{ appId: "A_GEMINI", signingSecret: "secret", agentId: "gemini" }],
       async resolveChannelBinding() {
-        return { teamId: "T123", channelId: "C123", owner: "acme", repo: "demo" };
+        return { teamId: "T123", channelId: "C123", repoProvider: "gitlab", owner: "acme", repo: "demo" };
       },
       createRun,
       now: () => now,
@@ -87,6 +87,7 @@ describe("Slack events app", () => {
     expect(createRun).toHaveBeenCalledOnce();
     const [event] = createRun.mock.calls[0] ?? [];
     expect(event.target.agentId).toBe("gemini");
+    expect(event.metadata.repoProvider).toBe("gitlab");
   });
 
   it("supports multiple Slack apps with different secrets and agent ids", async () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,7 @@ Add Slack channel bindings when a chat surface should route work to a repository
     {
       "teamId": "T123",
       "channelId": "C123",
+      "repoProvider": "github",
       "owner": "acme",
       "repo": "demo"
     }
@@ -100,7 +101,7 @@ Use daemon security settings to keep executor runs constrained:
 | `dispatcherUrl` | `http://localhost:3030` | Dispatcher base URL |
 | `pairingToken` | none | Shared Bearer token for dispatcher `/v1/*` calls |
 | `repositories` | `[]` | Repository bindings this daemon is allowed to claim |
-| `slackChannels` | none | Slack channel to repository mappings |
+| `slackChannels` | none | Slack compatibility bindings that map `teamId/channelId` into the generic channel binding table |
 | `claudeCode` | none | Claude Code executor settings |
 | `security` | none | Runner security policy |
 | `githubToken` | none | Optional token for PR creation from daemon-produced branches |
@@ -142,6 +143,7 @@ for repeatable setups.
 | `OPENTAG_KEEP_WORKTREE` | `on_failure` | `always`, `on_failure`, or `never` |
 | `OPENTAG_SLACK_TEAM_ID` | none | Creates one env-derived Slack channel binding when paired with repo env |
 | `OPENTAG_SLACK_CHANNEL_ID` | none | Creates one env-derived Slack channel binding when paired with repo env |
+| `OPENTAG_SLACK_REPO_PROVIDER` | `github` | Repo provider used for the env-derived Slack channel binding |
 | `OPENTAG_CLAUDE_COMMAND` | `claude` in executor default | Claude Code CLI command |
 | `OPENTAG_CLAUDE_MODEL` | none | Optional Claude model |
 | `OPENTAG_CLAUDE_PERMISSION_MODE` | none | `acceptEdits`, `auto`, `bypassPermissions`, `default`, or `plan` |

--- a/docs/real-integration-smoke-test.md
+++ b/docs/real-integration-smoke-test.md
@@ -61,6 +61,7 @@ Create a local runner config that binds the repository you want to test:
     {
       "teamId": "T_REAL",
       "channelId": "C_REAL",
+      "repoProvider": "github",
       "owner": "amplifthq",
       "repo": "opentag"
     }

--- a/examples/github-to-echo/README.md
+++ b/examples/github-to-echo/README.md
@@ -153,6 +153,7 @@ Example config fragment:
     {
       "teamId": "T123",
       "channelId": "C123",
+      "repoProvider": "github",
       "owner": "acme",
       "repo": "demo"
     }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -48,8 +48,19 @@ export type RepositoryBindingConfig = {
 export type SlackChannelBindingInput = {
   teamId: string;
   channelId: string;
+  repoProvider?: string;
   owner: string;
   repo: string;
+};
+
+export type ChannelBindingInput = {
+  provider: string;
+  accountId: string;
+  conversationId: string;
+  repoProvider: string;
+  owner: string;
+  repo: string;
+  metadata?: Record<string, unknown>;
 };
 
 export type RunnerRegistration = {
@@ -154,6 +165,8 @@ export type OpenTagClient = {
     mapping: AdapterMutationMapping;
   }): Promise<{ mapping: AdapterMutationMapping }>;
   listRepoMutationMappings(input: { provider: string; owner: string; repo: string }): Promise<{ mappings: AdapterMutationMapping[] }>;
+  bindChannel(input: ChannelBindingInput): Promise<void>;
+  getChannelBinding(input: { provider: string; accountId: string; conversationId: string }): Promise<{ binding: ChannelBindingInput }>;
   bindSlackChannel(input: SlackChannelBindingInput): Promise<void>;
   getSlackChannelBinding(input: { teamId: string; channelId: string }): Promise<{ binding: SlackChannelBindingInput }>;
   createRun(input: CreateRunInput): Promise<CreateRunResult>;
@@ -284,6 +297,26 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
       });
       await assertOk(response, "listRepoMutationMappings");
       return (await response.json()) as { mappings: AdapterMutationMapping[] };
+    },
+
+    async bindChannel(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/channel-bindings`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify(input)
+      });
+      await assertOk(response, "bindChannel");
+    },
+
+    async getChannelBinding(input) {
+      const response = await fetchImpl(
+        `${baseUrl}/v1/channel-bindings/${encodeURIComponent(input.provider)}/${encodeURIComponent(input.accountId)}/${encodeURIComponent(input.conversationId)}`,
+        {
+          headers: authHeaders(options.pairingToken)
+        }
+      );
+      await assertOk(response, "getChannelBinding");
+      return (await response.json()) as { binding: ChannelBindingInput };
     },
 
     async bindSlackChannel(input) {
@@ -533,6 +566,18 @@ export function createDispatcherAdminClient(options: RunnerClientOptions) {
 
     bindSlackChannel(binding: SlackChannelBindingInput): Promise<void> {
       return client.bindSlackChannel(binding);
+    },
+
+    bindChannel(binding: ChannelBindingInput): Promise<void> {
+      return client.bindChannel(binding);
+    },
+
+    getChannelBinding(input: {
+      provider: string;
+      accountId: string;
+      conversationId: string;
+    }): Promise<{ binding: ChannelBindingInput }> {
+      return client.getChannelBinding(input);
     }
   };
 }

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -42,8 +42,19 @@ const CreateRepoBindingSchema = z.object({
 const CreateSlackChannelBindingSchema = z.object({
   teamId: z.string().min(1),
   channelId: z.string().min(1),
+  repoProvider: z.string().min(1).default("github"),
   owner: z.string().min(1),
   repo: z.string().min(1)
+});
+
+const CreateChannelBindingSchema = z.object({
+  provider: z.string().min(1),
+  accountId: z.string().min(1),
+  conversationId: z.string().min(1),
+  repoProvider: z.string().min(1),
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  metadata: z.record(z.string(), z.unknown()).optional()
 });
 
 const UpsertPolicyRuleSchema = z.object({
@@ -402,6 +413,30 @@ export function createDispatcherApp(input: {
     if (!threadId) return c.json({ error: "thread_id_required" }, 422);
     const metrics = await repo.getWorkThreadMetrics({ threadId });
     return c.json({ metrics });
+  });
+
+  app.post("/v1/channel-bindings", async (c) => {
+    const parsed = CreateChannelBindingSchema.parse(await c.req.json());
+    await repo.upsertChannelBinding({
+      provider: parsed.provider,
+      accountId: parsed.accountId,
+      conversationId: parsed.conversationId,
+      repoProvider: parsed.repoProvider,
+      owner: parsed.owner,
+      repo: parsed.repo,
+      ...(parsed.metadata ? { metadata: parsed.metadata } : {})
+    });
+    return c.json({ ok: true }, 201);
+  });
+
+  app.get("/v1/channel-bindings/:provider/:accountId/:conversationId", async (c) => {
+    const binding = await repo.getChannelBinding({
+      provider: c.req.param("provider"),
+      accountId: c.req.param("accountId"),
+      conversationId: c.req.param("conversationId")
+    });
+    if (!binding) return c.json({ error: "channel_binding_not_found" }, 404);
+    return c.json({ binding });
   });
 
   app.post("/v1/slack-channel-bindings", async (c) => {

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -1111,7 +1111,39 @@ describe("dispatcher API", () => {
     expect(events.map((event: { type: string }) => event.type)).toContain("run.heartbeat");
   });
 
-  it("stores and returns Slack channel bindings", async () => {
+  it("stores and returns generic channel bindings", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:" });
+
+    const create = await app.request("/v1/channel-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "telegram",
+        accountId: "bot_123",
+        conversationId: "chat_456",
+        repoProvider: "github",
+        owner: "acme",
+        repo: "demo",
+        metadata: { title: "Ops chat" }
+      })
+    });
+    expect(create.status).toBe(201);
+
+    const get = await app.request("/v1/channel-bindings/telegram/bot_123/chat_456");
+    expect(get.status).toBe(200);
+    const body = await get.json();
+    expect(body.binding).toEqual({
+      provider: "telegram",
+      accountId: "bot_123",
+      conversationId: "chat_456",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo",
+      metadata: { title: "Ops chat" }
+    });
+  });
+
+  it("keeps Slack channel binding endpoints as compatibility wrappers", async () => {
     const app = createDispatcherApp({ databasePath: ":memory:" });
 
     const create = await app.request("/v1/slack-channel-bindings", {
@@ -1120,6 +1152,7 @@ describe("dispatcher API", () => {
       body: JSON.stringify({
         teamId: "T123",
         channelId: "C123",
+        repoProvider: "gitlab",
         owner: "acme",
         repo: "demo"
       })
@@ -1132,8 +1165,22 @@ describe("dispatcher API", () => {
     expect(body.binding).toEqual({
       teamId: "T123",
       channelId: "C123",
+      repoProvider: "gitlab",
       owner: "acme",
       repo: "demo"
+    });
+
+    const genericGet = await app.request("/v1/channel-bindings/slack/T123/C123");
+    expect(genericGet.status).toBe(200);
+    await expect(genericGet.json()).resolves.toEqual({
+      binding: {
+        provider: "slack",
+        accountId: "T123",
+        conversationId: "C123",
+        repoProvider: "gitlab",
+        owner: "acme",
+        repo: "demo"
+      }
     });
   });
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -15,7 +15,7 @@ pnpm add @opentag/slack
 - `normalizeSlackAppMention`: converts a Slack app mention into an `OpenTagEvent`.
 - `slackThreadKey`: encodes team, channel, and thread timestamp for callback routing.
 - `parseSlackThreadKey`: decodes a Slack thread key for `chat.postMessage`.
-- `SlackChannelBinding`: channel-to-repository binding contract.
+- `SlackChannelBinding`: Slack compatibility binding contract that maps into the generic channel binding layer.
 
 ## Example
 
@@ -34,6 +34,7 @@ const event = normalizeSlackAppMention({
   binding: {
     teamId: "T123",
     channelId: "C123",
+    repoProvider: "github",
     owner: "acme",
     repo: "demo"
   }

--- a/packages/slack/src/normalize.ts
+++ b/packages/slack/src/normalize.ts
@@ -3,6 +3,7 @@ import { commandFromRawText, type ContextPointer, type OpenTagCommand, type Open
 export type SlackChannelBinding = {
   teamId: string;
   channelId: string;
+  repoProvider?: string;
   owner: string;
   repo: string;
 };
@@ -183,7 +184,7 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
       ...(input.appId ? { slackAppId: input.appId } : {}),
       ...(input.botUserId ? { slackBotUserId: input.botUserId } : {}),
       ...commandMetadata(command),
-      repoProvider: "github",
+      repoProvider: input.binding.repoProvider ?? "github",
       owner: input.binding.owner,
       repo: input.binding.repo
     }

--- a/packages/slack/test/normalize.test.ts
+++ b/packages/slack/test/normalize.test.ts
@@ -22,6 +22,7 @@ describe("Slack normalization", () => {
       binding: {
         teamId: "T123",
         channelId: "C123",
+        repoProvider: "gitlab",
         owner: "acme",
         repo: "demo"
       }
@@ -34,6 +35,7 @@ describe("Slack normalization", () => {
       agentId: "gemini"
     });
     expect(event?.metadata).toMatchObject({ teamId: "T123", channelId: "C123", owner: "acme", repo: "demo" });
+    expect(event?.metadata).toMatchObject({ repoProvider: "gitlab" });
     expect(event?.metadata).toMatchObject({ slackAppId: "A123", slackBotUserId: "U_APP" });
     expect(event?.permissions.map((permission) => permission.scope)).toContain("chat:postMessage");
     expect(event?.callback.uri).toBe("http://127.0.0.1:3102/github-comment");

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -15,7 +15,7 @@ pnpm add @opentag/store
 - `migrateSchema`: creates or updates the SQLite schema.
 - `createOpenTagRepository`: repository API for runners, bindings, runs, leases, progress, completion, and audit events.
 - Drizzle table definitions from `schema.ts`.
-- Types such as `ClaimedOpenTagRun`, `OpenTagAuditEvent`, `RepoBinding`, and `SlackChannelBinding`.
+- Types such as `ClaimedOpenTagRun`, `OpenTagAuditEvent`, `RepoBinding`, `ChannelBinding`, and `SlackChannelBinding`.
 
 ## Example
 

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -249,7 +249,20 @@ function runnerFromRow(row: typeof runners.$inferSelect): RunnerRegistration {
   };
 }
 
+function recordFromJson(value: string | null): Record<string, unknown> | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function channelBindingFromRow(row: typeof channelBindings.$inferSelect): ChannelBinding {
+  const metadata = recordFromJson(row.metadataJson);
   return {
     provider: row.provider,
     accountId: row.accountId,
@@ -257,7 +270,7 @@ function channelBindingFromRow(row: typeof channelBindings.$inferSelect): Channe
     repoProvider: row.repoProvider,
     owner: row.owner,
     repo: row.repo,
-    ...(row.metadataJson ? { metadata: JSON.parse(row.metadataJson) as Record<string, unknown> } : {})
+    ...(metadata ? { metadata } : {})
   };
 }
 
@@ -618,8 +631,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           set: {
             repoProvider,
             owner: input.owner,
-            repo: input.repo,
-            metadataJson: null
+            repo: input.repo
           }
         });
     },

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -33,6 +33,7 @@ import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import {
   applyPlans,
   approvalDecisions,
+  channelBindings,
   repoBindings,
   repoMutationMappings,
   repoPolicyRules,
@@ -40,7 +41,6 @@ import {
   runEvents,
   runners,
   runs,
-  slackChannelBindings,
   suggestedChanges
 } from "./schema.js";
 
@@ -93,9 +93,20 @@ export type RepoBinding = {
   allowedActors?: string[];
 };
 
+export type ChannelBinding = {
+  provider: string;
+  accountId: string;
+  conversationId: string;
+  repoProvider: string;
+  owner: string;
+  repo: string;
+  metadata?: Record<string, unknown>;
+};
+
 export type SlackChannelBinding = {
   teamId: string;
   channelId: string;
+  repoProvider?: string;
   owner: string;
   repo: string;
 };
@@ -235,6 +246,18 @@ function runnerFromRow(row: typeof runners.$inferSelect): RunnerRegistration {
     name: row.name,
     createdAt: row.createdAt,
     ...(row.heartbeatAt ? { heartbeatAt: row.heartbeatAt } : {})
+  };
+}
+
+function channelBindingFromRow(row: typeof channelBindings.$inferSelect): ChannelBinding {
+  return {
+    provider: row.provider,
+    accountId: row.accountId,
+    conversationId: row.conversationId,
+    repoProvider: row.repoProvider,
+    owner: row.owner,
+    repo: row.repo,
+    ...(row.metadataJson ? { metadata: JSON.parse(row.metadataJson) as Record<string, unknown> } : {})
   };
 }
 
@@ -552,21 +575,51 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       return rows.map((row) => AdapterMutationMappingSchema.parse(JSON.parse(row.mappingJson)));
     },
 
-    async createSlackChannelBinding(input: SlackChannelBinding): Promise<void> {
+    async upsertChannelBinding(input: ChannelBinding): Promise<void> {
       await db
-        .insert(slackChannelBindings)
+        .insert(channelBindings)
         .values({
-          teamId: input.teamId,
-          channelId: input.channelId,
+          provider: input.provider,
+          accountId: input.accountId,
+          conversationId: input.conversationId,
+          repoProvider: input.repoProvider,
           owner: input.owner,
           repo: input.repo,
+          metadataJson: input.metadata ? JSON.stringify(input.metadata) : null,
           createdAt: nowIso()
         })
         .onConflictDoUpdate({
-          target: [slackChannelBindings.teamId, slackChannelBindings.channelId],
+          target: [channelBindings.provider, channelBindings.accountId, channelBindings.conversationId],
           set: {
+            repoProvider: input.repoProvider,
             owner: input.owner,
-            repo: input.repo
+            repo: input.repo,
+            metadataJson: input.metadata ? JSON.stringify(input.metadata) : null
+          }
+        });
+    },
+
+    async createSlackChannelBinding(input: SlackChannelBinding): Promise<void> {
+      const repoProvider = input.repoProvider ?? "github";
+      await db
+        .insert(channelBindings)
+        .values({
+          provider: "slack",
+          accountId: input.teamId,
+          conversationId: input.channelId,
+          repoProvider,
+          owner: input.owner,
+          repo: input.repo,
+          metadataJson: null,
+          createdAt: nowIso()
+        })
+        .onConflictDoUpdate({
+          target: [channelBindings.provider, channelBindings.accountId, channelBindings.conversationId],
+          set: {
+            repoProvider,
+            owner: input.owner,
+            repo: input.repo,
+            metadataJson: null
           }
         });
     },
@@ -790,19 +843,47 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       };
     },
 
+    async getChannelBinding(input: {
+      provider: string;
+      accountId: string;
+      conversationId: string;
+    }): Promise<ChannelBinding | null> {
+      const row = await db
+        .select()
+        .from(channelBindings)
+        .where(
+          and(
+            eq(channelBindings.provider, input.provider),
+            eq(channelBindings.accountId, input.accountId),
+            eq(channelBindings.conversationId, input.conversationId)
+          )
+        )
+        .limit(1)
+        .get();
+      return row ? channelBindingFromRow(row) : null;
+    },
+
     async getSlackChannelBinding(input: { teamId: string; channelId: string }): Promise<SlackChannelBinding | null> {
       const row = await db
         .select()
-        .from(slackChannelBindings)
-        .where(and(eq(slackChannelBindings.teamId, input.teamId), eq(slackChannelBindings.channelId, input.channelId)))
+        .from(channelBindings)
+        .where(
+          and(
+            eq(channelBindings.provider, "slack"),
+            eq(channelBindings.accountId, input.teamId),
+            eq(channelBindings.conversationId, input.channelId)
+          )
+        )
         .limit(1)
         .get();
       if (!row) return null;
+      const binding = channelBindingFromRow(row);
       return {
-        teamId: row.teamId,
-        channelId: row.channelId,
-        owner: row.owner,
-        repo: row.repo
+        teamId: binding.accountId,
+        channelId: binding.conversationId,
+        repoProvider: binding.repoProvider,
+        owner: binding.owner,
+        repo: binding.repo
       };
     },
 

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -127,18 +127,25 @@ export const repoMutationMappings = sqliteTable(
   })
 );
 
-export const slackChannelBindings = sqliteTable(
-  "slack_channel_bindings",
+export const channelBindings = sqliteTable(
+  "channel_bindings",
   {
     id: integer("id").primaryKey({ autoIncrement: true }),
-    teamId: text("team_id").notNull(),
-    channelId: text("channel_id").notNull(),
+    provider: text("provider").notNull(),
+    accountId: text("account_id").notNull(),
+    conversationId: text("conversation_id").notNull(),
+    repoProvider: text("repo_provider").notNull(),
     owner: text("owner").notNull(),
     repo: text("repo").notNull(),
+    metadataJson: text("metadata_json"),
     createdAt: text("created_at").notNull()
   },
   (table) => ({
-    slackChannelUniqueIdx: uniqueIndex("slack_channel_bindings_team_channel_idx").on(table.teamId, table.channelId)
+    channelBindingUniqueIdx: uniqueIndex("channel_bindings_provider_account_conversation_idx").on(
+      table.provider,
+      table.accountId,
+      table.conversationId
+    )
   })
 );
 
@@ -263,16 +270,19 @@ export function migrateSchema(sqlite: Database.Database): void {
     );
     CREATE UNIQUE INDEX IF NOT EXISTS repo_mutation_mappings_repo_id_idx
       ON repo_mutation_mappings(provider, owner, repo, id);
-    CREATE TABLE IF NOT EXISTS slack_channel_bindings (
+    CREATE TABLE IF NOT EXISTS channel_bindings (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      team_id TEXT NOT NULL,
-      channel_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      account_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      repo_provider TEXT NOT NULL,
       owner TEXT NOT NULL,
       repo TEXT NOT NULL,
+      metadata_json TEXT,
       created_at TEXT NOT NULL
     );
-    CREATE UNIQUE INDEX IF NOT EXISTS slack_channel_bindings_team_channel_idx
-      ON slack_channel_bindings(team_id, channel_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS channel_bindings_provider_account_conversation_idx
+      ON channel_bindings(provider, account_id, conversation_id);
     CREATE TABLE IF NOT EXISTS callback_deliveries (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       run_id TEXT NOT NULL,
@@ -304,6 +314,15 @@ export function migrateSchema(sqlite: Database.Database): void {
   }
   if (!columnNames.has("allowed_actors_json")) {
     sqlite.exec("ALTER TABLE repo_bindings ADD COLUMN allowed_actors_json TEXT");
+  }
+  const channelBindingColumns = sqlite.prepare("PRAGMA table_info(channel_bindings)").all() as { name: string }[];
+  const channelBindingColumnNames = new Set(channelBindingColumns.map((column) => column.name));
+  if (!channelBindingColumnNames.has("repo_provider")) {
+    sqlite.exec("ALTER TABLE channel_bindings ADD COLUMN repo_provider TEXT");
+    sqlite.exec("UPDATE channel_bindings SET repo_provider = 'github' WHERE repo_provider IS NULL");
+  }
+  if (!channelBindingColumnNames.has("metadata_json")) {
+    sqlite.exec("ALTER TABLE channel_bindings ADD COLUMN metadata_json TEXT");
   }
   const runColumns = sqlite.prepare("PRAGMA table_info(runs)").all() as { name: string }[];
   const runColumnNames = new Set(runColumns.map((column) => column.name));
@@ -376,5 +395,30 @@ export function migrateSchema(sqlite: Database.Database): void {
   }
   if (!callbackColumnNames.has("metadata_json")) {
     sqlite.exec("ALTER TABLE callback_deliveries ADD COLUMN metadata_json TEXT");
+  }
+  const legacySlackTable = sqlite
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'slack_channel_bindings'")
+    .get() as { name: string } | undefined;
+  if (legacySlackTable) {
+    sqlite.exec(`
+      INSERT OR IGNORE INTO channel_bindings (
+        provider,
+        account_id,
+        conversation_id,
+        repo_provider,
+        owner,
+        repo,
+        created_at
+      )
+      SELECT
+        'slack',
+        team_id,
+        channel_id,
+        'github',
+        owner,
+        repo,
+        created_at
+      FROM slack_channel_bindings;
+    `);
   }
 }

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -187,6 +187,44 @@ describe("OpenTag repository", () => {
     });
   });
 
+  it("ignores malformed channel binding metadata instead of throwing", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    sqlite.exec(`
+      INSERT INTO channel_bindings (
+        provider,
+        account_id,
+        conversation_id,
+        repo_provider,
+        owner,
+        repo,
+        metadata_json,
+        created_at
+      ) VALUES (
+        'telegram',
+        'bot_123',
+        'chat_456',
+        'github',
+        'acme',
+        'demo',
+        '{bad-json',
+        '2026-06-25T00:00:00.000Z'
+      );
+    `);
+
+    await expect(repo.getChannelBinding({ provider: "telegram", accountId: "bot_123", conversationId: "chat_456" })).resolves.toEqual({
+      provider: "telegram",
+      accountId: "bot_123",
+      conversationId: "chat_456",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo"
+    });
+  });
+
   it("stores Slack channel bindings through the generic channel binding table", async () => {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);
@@ -215,6 +253,41 @@ describe("OpenTag repository", () => {
       repoProvider: "gitlab",
       owner: "acme",
       repo: "demo"
+    });
+  });
+
+  it("preserves generic metadata when Slack compatibility upserts the same binding", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.upsertChannelBinding({
+      provider: "slack",
+      accountId: "T123",
+      conversationId: "C123",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo",
+      metadata: { source: "seed", labels: ["triage"] }
+    });
+
+    await repo.createSlackChannelBinding({
+      teamId: "T123",
+      channelId: "C123",
+      repoProvider: "gitlab",
+      owner: "acme",
+      repo: "demo"
+    });
+
+    await expect(repo.getChannelBinding({ provider: "slack", accountId: "T123", conversationId: "C123" })).resolves.toEqual({
+      provider: "slack",
+      accountId: "T123",
+      conversationId: "C123",
+      repoProvider: "gitlab",
+      owner: "acme",
+      repo: "demo",
+      metadata: { source: "seed", labels: ["triage"] }
     });
   });
 

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -160,7 +160,34 @@ describe("OpenTag repository", () => {
     expect(events.map((event) => event.type)).toContain("run.lease_expired");
   });
 
-  it("stores Slack channel to repo bindings", async () => {
+  it("stores generic channel to repo bindings", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+
+    await repo.upsertChannelBinding({
+      provider: "telegram",
+      accountId: "bot_123",
+      conversationId: "chat_456",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo",
+      metadata: { title: "Ops chat" }
+    });
+
+    await expect(repo.getChannelBinding({ provider: "telegram", accountId: "bot_123", conversationId: "chat_456" })).resolves.toEqual({
+      provider: "telegram",
+      accountId: "bot_123",
+      conversationId: "chat_456",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo",
+      metadata: { title: "Ops chat" }
+    });
+  });
+
+  it("stores Slack channel bindings through the generic channel binding table", async () => {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);
     migrateSchema(sqlite);
@@ -169,6 +196,7 @@ describe("OpenTag repository", () => {
     await repo.createSlackChannelBinding({
       teamId: "T123",
       channelId: "C123",
+      repoProvider: "gitlab",
       owner: "acme",
       repo: "demo"
     });
@@ -176,6 +204,15 @@ describe("OpenTag repository", () => {
     await expect(repo.getSlackChannelBinding({ teamId: "T123", channelId: "C123" })).resolves.toEqual({
       teamId: "T123",
       channelId: "C123",
+      repoProvider: "gitlab",
+      owner: "acme",
+      repo: "demo"
+    });
+    await expect(repo.getChannelBinding({ provider: "slack", accountId: "T123", conversationId: "C123" })).resolves.toEqual({
+      provider: "slack",
+      accountId: "T123",
+      conversationId: "C123",
+      repoProvider: "gitlab",
       owner: "acme",
       repo: "demo"
     });

--- a/scripts/dev/run-gh-claude-local-test.sh
+++ b/scripts/dev/run-gh-claude-local-test.sh
@@ -38,6 +38,11 @@ if [[ "${OPENTAG_GH_CREATE_PR:-false}" == "true" ]]; then
   PR_CREATE_PERMISSION=', { scope: "pr:create", reason: "open a pull request for completed code changes" }'
 fi
 
+if [[ ! -d "$CHECKOUT_PATH/.git" ]]; then
+  mkdir -p "$(dirname "$CHECKOUT_PATH")"
+  gh repo clone "${OWNER}/${REPO}" "$CHECKOUT_PATH" >/dev/null
+fi
+
 if [[ -z "$ISSUE_NUMBER" ]]; then
   if [[ "${OPENTAG_GH_CREATE_ISSUE:-false}" != "true" ]]; then
     echo "No OPENTAG_GH_TEST_ISSUE set and OPENTAG_GH_CREATE_ISSUE is not true." >&2
@@ -94,6 +99,9 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Starting dispatcher on :${OPENTAG_DISPATCHER_PORT}"
+for pid in $(lsof -ti "tcp:${OPENTAG_DISPATCHER_PORT}" 2>/dev/null); do
+  kill "$pid" 2>/dev/null || true
+done
 (
   export PORT="$OPENTAG_DISPATCHER_PORT"
   export OPENTAG_DATABASE_PATH="$DATABASE_PATH"

--- a/scripts/dev/run-gh-claude-local-test.sh
+++ b/scripts/dev/run-gh-claude-local-test.sh
@@ -8,6 +8,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 : "${OPENTAG_RUNNER_ID:=runner_claude_local}"
 : "${OPENTAG_CLAUDE_PERMISSION_MODE:=acceptEdits}"
 
+DISPATCHER_PORT="${OPENTAG_DISPATCHER_PORT}"
+
 if ! command -v gh >/dev/null 2>&1; then
   echo "gh CLI not found. Install and authenticate GitHub CLI first." >&2
   exit 1
@@ -68,7 +70,7 @@ DATABASE_PATH="${OPENTAG_DATABASE_PATH:-opentag.gh-claude-local-test.db}"
 cat > "$CONFIG_PATH" <<JSON
 {
   "runnerId": "${OPENTAG_RUNNER_ID}",
-  "dispatcherUrl": "http://localhost:${OPENTAG_DISPATCHER_PORT}",
+  "dispatcherUrl": "http://localhost:${DISPATCHER_PORT}",
   "pairingToken": "${OPENTAG_PAIRING_TOKEN}",
   "githubToken": "${GITHUB_TOKEN}",
   "allowAutoCreatePullRequest": ${OPENTAG_GH_CREATE_PR:-false},
@@ -94,16 +96,72 @@ JSON
 
 cleanup() {
   rm -f "$CONFIG_PATH"
-  kill "$DISPATCHER_PID" 2>/dev/null || true
+  if [[ -n "${DISPATCHER_PID:-}" ]]; then
+    kill "$DISPATCHER_PID" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+      if ! port_is_in_use "$DISPATCHER_PORT"; then
+        break
+      fi
+      sleep 0.25
+    done
+    if port_is_in_use "$DISPATCHER_PORT"; then
+      kill -9 "$DISPATCHER_PID" 2>/dev/null || true
+      for _ in $(seq 1 20); do
+        if ! port_is_in_use "$DISPATCHER_PORT"; then
+          break
+        fi
+        sleep 0.25
+      done
+    fi
+  fi
 }
 trap cleanup EXIT
 
-echo "Starting dispatcher on :${OPENTAG_DISPATCHER_PORT}"
-for pid in $(lsof -ti "tcp:${OPENTAG_DISPATCHER_PORT}" 2>/dev/null); do
+port_is_in_use() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -ti "tcp:${port}" >/dev/null 2>&1
+    return
+  fi
+  nc -z localhost "$port" >/dev/null 2>&1
+}
+
+dispatcher_pids_for_port() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -ti "tcp:${port}" 2>/dev/null || true
+    return
+  fi
+  pgrep -f "apps/dispatcher/src/index.ts" 2>/dev/null || true
+}
+
+echo "Starting dispatcher on :${DISPATCHER_PORT}"
+for pid in $(dispatcher_pids_for_port "${DISPATCHER_PORT}"); do
   kill "$pid" 2>/dev/null || true
 done
+for _ in $(seq 1 20); do
+  if ! port_is_in_use "${DISPATCHER_PORT}"; then
+    break
+  fi
+  sleep 0.25
+done
+if port_is_in_use "${DISPATCHER_PORT}"; then
+  for pid in $(dispatcher_pids_for_port "${DISPATCHER_PORT}"); do
+    kill -9 "$pid" 2>/dev/null || true
+  done
+  for _ in $(seq 1 20); do
+    if ! port_is_in_use "${DISPATCHER_PORT}"; then
+      break
+    fi
+    sleep 0.25
+  done
+fi
+if port_is_in_use "${DISPATCHER_PORT}"; then
+  echo "Dispatcher port ${DISPATCHER_PORT} is still in use; free it or install lsof for more reliable cleanup." >&2
+  exit 1
+fi
 (
-  export PORT="$OPENTAG_DISPATCHER_PORT"
+  export PORT="$DISPATCHER_PORT"
   export OPENTAG_DATABASE_PATH="$DATABASE_PATH"
   export OPENTAG_PAIRING_TOKEN
   export OPENTAG_GITHUB_TOKEN="$GITHUB_TOKEN"
@@ -164,7 +222,7 @@ const body = {
   }
 };
 
-fetch("http://localhost:${OPENTAG_DISPATCHER_PORT}/v1/runs", {
+fetch("http://localhost:${DISPATCHER_PORT}/v1/runs", {
   method: "POST",
   headers: {
     "content-type": "application/json",

--- a/skills/opentag/references/slack-setup.md
+++ b/skills/opentag/references/slack-setup.md
@@ -46,6 +46,7 @@ Add both repository and Slack channel bindings to `opentag.local.json`:
     {
       "teamId": "T123",
       "channelId": "C123",
+      "repoProvider": "github",
       "owner": "acme",
       "repo": "demo"
     }

--- a/skills/opentag/references/troubleshooting.md
+++ b/skills/opentag/references/troubleshooting.md
@@ -41,7 +41,7 @@ curl http://localhost:3030/v1/repo-bindings/github/acme/demo
 Slack binding:
 
 ```bash
-curl http://localhost:3030/v1/slack-channel-bindings/T123/C123
+curl http://localhost:3030/v1/channel-bindings/slack/T123/C123
 ```
 
 Run state and events:
@@ -57,7 +57,8 @@ curl http://localhost:3030/v1/runs/run_demo_1/events
 - `repo_context_missing`: run event metadata does not include `owner` and `repo`.
 - `repo_not_bound`: run repository was not bound to a runner.
 - `actor_not_allowed_for_write`: write-capable run came from an actor outside the binding allowlist.
-- `slack_channel_binding_not_found`: Slack team/channel is not bound to a repo.
+- `channel_binding_not_found`: the generic channel binding lookup did not find a route for this Slack team/channel.
+- `slack_channel_binding_not_found`: same condition through the legacy Slack compatibility endpoint.
 - `run_not_claimed_by_runner`: heartbeat came from the wrong runner or after lease loss.
 - `No OpenTag run available`: no pending run is claimable for that runner's bindings.
 


### PR DESCRIPTION
## Summary
- move Slack-specific routing onto a generic `channel_bindings(provider, accountId, conversationId -> repo)` path
- keep Slack config and `/v1/slack-channel-bindings` endpoints as compatibility wrappers, including `repoProvider` passthrough
- update docs/examples to point at `/v1/channel-bindings` and fix the GitHub Claude smoke script so missing checkouts and occupied ports do not masquerade as `claude` ENOENT

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- real GitHub echo E2E
- real Slack echo E2E
- real GitHub + Claude Code E2E
- real Slack + Claude Code E2E

## Notes
- public-tunnel GitHub/Slack webhook ingress was not re-run in this pass; the direct real callback loops were validated instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generic channel bindings, including new provider-aware binding and lookup flows.
  * Slack channel bindings now can carry repository provider details, with GitHub as the default.

* **Bug Fixes**
  * Improved binding checks and event metadata so repository provider information is preserved end to end.
  * Updated compatibility handling for legacy Slack bindings while keeping existing behavior working.

* **Documentation**
  * Refreshed setup, troubleshooting, and example config docs to reflect the new channel binding format and endpoint paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->