### PR TITLE
Add Lark/Feishu connector (long-connection ingress + dispatcher sink)

### DIFF
--- a/apps/dispatcher/src/index.ts
+++ b/apps/dispatcher/src/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "@hono/node-server";
-import { createCompositeCallbackSink, createDispatcherApp, createGitHubCallbackSink, createSlackCallbackSink } from "@opentag/dispatcher";
+import { createCompositeCallbackSink, createDispatcherApp, createGitHubCallbackSink, createLarkCallbackSink, createSlackCallbackSink } from "@opentag/dispatcher";
 
 const port = Number(process.env.PORT ?? "3030");
 const databasePath = process.env.OPENTAG_DATABASE_PATH ?? "opentag.db";
@@ -34,6 +34,11 @@ serve({
       createSlackCallbackSink({
         ...(process.env.OPENTAG_SLACK_BOT_TOKEN ? { botToken: process.env.OPENTAG_SLACK_BOT_TOKEN } : {}),
         ...(slackBotTokensByAgentId ? { botTokensByAgentId: slackBotTokensByAgentId } : {})
+      }),
+      createLarkCallbackSink({
+        ...(process.env.LARK_APP_ID ? { appId: process.env.LARK_APP_ID } : {}),
+        ...(process.env.LARK_APP_SECRET ? { appSecret: process.env.LARK_APP_SECRET } : {}),
+        ...(process.env.LARK_DOMAIN === "feishu" ? { domain: "feishu" as const } : {})
       })
     ])
   }).fetch,

--- a/apps/lark-events/package.json
+++ b/apps/lark-events/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@opentag/lark-events",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsx src/index.ts",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.68.0",
+    "@opentag/client": "workspace:*",
+    "@opentag/core": "workspace:*",
+    "@opentag/lark": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -1,5 +1,5 @@
 import type { OpenTagEvent } from "@opentag/core";
-import { type LarkChannelBinding, normalizeLarkMessage } from "@opentag/lark";
+import { type LarkChannelBinding, normalizeLarkMessage, stripLarkMention } from "@opentag/lark";
 
 export type LarkMention = { key?: string; id?: { open_id?: string }; name?: string };
 
@@ -33,22 +33,32 @@ export type LarkMessageHandlerConfig = {
   callbackUri?: string;
   resolveChannelBinding(input: { tenantKey: string; chatId: string }): Promise<LarkChannelBinding | null>;
   createRun(event: OpenTagEvent): Promise<{ runId: string }>;
+  // Self-service binding from within Lark (`/bind owner/repo`); optional so tests can omit it.
+  bindChannel?(input: { tenantKey: string; chatId: string; repoProvider: string; owner: string; repo: string }): Promise<void>;
+  // Reply into the originating thread (onboarding hints, bind confirmations); optional.
+  reply?(input: { messageId: string; text: string }): Promise<void>;
   now?(): number;
 };
 
 export type LarkMessageHandlerOutcome = {
   status:
     | "created"
+    | "bound"
     | "ignored_non_text"
     | "ignored_invalid_payload"
     | "ignored_group_requires_bot_open_id"
     | "ignored_not_addressed"
+    | "ignored_bind_usage"
     | "ignored_unbound_chat"
     | "ignored_empty_command";
   runId?: string;
   tenantKey?: string;
   chatId?: string;
 };
+
+const BIND_USAGE = "Usage: /bind <owner>/<repo> — e.g. /bind amplifthq/opentag (or /bind github:amplifthq/opentag).";
+const UNBOUND_HINT =
+  "👋 This chat isn't connected to a repo yet. @-mention me with `/bind <owner>/<repo>` to connect it — e.g. /bind amplifthq/opentag.";
 
 function extractText(content: string | undefined): string {
   if (!content) return "";
@@ -64,7 +74,17 @@ function mentionsBot(mentions: LarkMention[] | undefined, botOpenId: string): bo
   return (mentions ?? []).some((mention) => mention.id?.open_id === botOpenId);
 }
 
-// Handle one inbound Lark message: group messages must @-mention the bot, then resolve binding, normalize, create a run.
+// Parse `/bind owner/repo` (or `/bind provider:owner/repo`). null = not a bind command; {ok:false} = malformed.
+function parseBindCommand(
+  command: string
+): { ok: true; repoProvider: string; owner: string; repo: string } | { ok: false } | null {
+  if (!/^\/bind(\s|$)/.test(command)) return null;
+  const match = command.match(/^\/bind\s+(?:([\w-]+):)?([\w.-]+)\/([\w.-]+)\s*$/);
+  if (!match) return { ok: false };
+  return { ok: true, repoProvider: match[1] ?? "github", owner: match[2] as string, repo: match[3] as string };
+}
+
+// Handle one inbound Lark message: group messages must @-mention the bot, then handle /bind, resolve binding, normalize, create a run.
 export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
   return async function handleLarkMessage(data: LarkInboundMessageEvent): Promise<LarkMessageHandlerOutcome> {
     const message = data.message;
@@ -92,8 +112,32 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
       }
     }
 
+    const command = stripLarkMention(extractText(message.content));
+
+    // Self-service binding: connect this chat to a repo without leaving Lark.
+    const bindRequest = parseBindCommand(command);
+    if (bindRequest && config.bindChannel) {
+      if (!bindRequest.ok) {
+        await config.reply?.({ messageId, text: BIND_USAGE });
+        return { status: "ignored_bind_usage", tenantKey, chatId };
+      }
+      await config.bindChannel({
+        tenantKey,
+        chatId,
+        repoProvider: bindRequest.repoProvider,
+        owner: bindRequest.owner,
+        repo: bindRequest.repo
+      });
+      await config.reply?.({
+        messageId,
+        text: `✅ Connected this chat to ${bindRequest.repoProvider}:${bindRequest.owner}/${bindRequest.repo}. @-mention me with a task to start a run.`
+      });
+      return { status: "bound", tenantKey, chatId };
+    }
+
     const binding = await config.resolveChannelBinding({ tenantKey, chatId });
     if (!binding) {
+      await config.reply?.({ messageId, text: UNBOUND_HINT });
       return { status: "ignored_unbound_chat", tenantKey, chatId };
     }
 

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -3,31 +3,27 @@ import { type LarkChannelBinding, normalizeLarkMessage } from "@opentag/lark";
 
 export type LarkMention = { key?: string; id?: { open_id?: string }; name?: string };
 
-// Subset of the `im.message.receive_v1` payload OpenTag needs; all optional (external input).
+// Flattened `im.message.receive_v1` payload as delivered by the SDK EventDispatcher (header fields + message/sender on the top level). All optional (external input).
 export type LarkInboundMessageEvent = {
-  header?: {
-    event_id?: string;
-    event_type?: string;
-    create_time?: string;
+  event_id?: string;
+  event_type?: string;
+  create_time?: string;
+  tenant_key?: string;
+  app_id?: string;
+  sender?: {
+    sender_id?: { open_id?: string; user_id?: string; union_id?: string };
+    sender_type?: string;
     tenant_key?: string;
-    app_id?: string;
   };
-  event?: {
-    sender?: {
-      sender_id?: { open_id?: string; user_id?: string; union_id?: string };
-      sender_type?: string;
-      tenant_key?: string;
-    };
-    message?: {
-      message_id?: string;
-      root_id?: string;
-      parent_id?: string;
-      chat_id?: string;
-      chat_type?: string;
-      message_type?: string;
-      content?: string;
-      mentions?: LarkMention[];
-    };
+  message?: {
+    message_id?: string;
+    root_id?: string;
+    parent_id?: string;
+    chat_id?: string;
+    chat_type?: string;
+    message_type?: string;
+    content?: string;
+    mentions?: LarkMention[];
   };
 };
 
@@ -71,17 +67,16 @@ function mentionsBot(mentions: LarkMention[] | undefined, botOpenId: string): bo
 // Handle one inbound Lark message: group messages must @-mention the bot, then resolve binding, normalize, create a run.
 export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
   return async function handleLarkMessage(data: LarkInboundMessageEvent): Promise<LarkMessageHandlerOutcome> {
-    const message = data.event?.message;
-    const header = data.header;
+    const message = data.message;
     if (!message || message.message_type !== "text") {
       return { status: "ignored_non_text" };
     }
 
-    const tenantKey = header?.tenant_key ?? data.event?.sender?.tenant_key;
+    const tenantKey = data.tenant_key ?? data.sender?.tenant_key;
     const chatId = message.chat_id;
     const messageId = message.message_id;
-    const eventId = header?.event_id;
-    const senderOpenId = data.event?.sender?.sender_id?.open_id;
+    const eventId = data.event_id;
+    const senderOpenId = data.sender?.sender_id?.open_id;
     if (!tenantKey || !chatId || !messageId || !eventId || !senderOpenId) {
       return { status: "ignored_invalid_payload" };
     }
@@ -102,7 +97,7 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
       return { status: "ignored_unbound_chat", tenantKey, chatId };
     }
 
-    const parsedTime = header?.create_time ? Number(header.create_time) : Number.NaN;
+    const parsedTime = data.create_time ? Number(data.create_time) : Number.NaN;
     const eventTimeMs = Number.isFinite(parsedTime) ? parsedTime : (config.now?.() ?? Date.now());
 
     const event = normalizeLarkMessage({

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -1,0 +1,130 @@
+import type { OpenTagEvent } from "@opentag/core";
+import { type LarkChannelBinding, normalizeLarkMessage } from "@opentag/lark";
+
+/**
+ * Shape of the `im.message.receive_v1` event payload delivered by
+ * @larksuiteoapi/node-sdk's EventDispatcher. Only the fields OpenTag needs are
+ * declared; everything is optional because the payload is external input.
+ */
+export type LarkMention = { key?: string; id?: { open_id?: string }; name?: string };
+
+export type LarkInboundMessageEvent = {
+  header?: {
+    event_id?: string;
+    event_type?: string;
+    create_time?: string;
+    tenant_key?: string;
+    app_id?: string;
+  };
+  event?: {
+    sender?: {
+      sender_id?: { open_id?: string; user_id?: string; union_id?: string };
+      sender_type?: string;
+      tenant_key?: string;
+    };
+    message?: {
+      message_id?: string;
+      root_id?: string;
+      parent_id?: string;
+      chat_id?: string;
+      chat_type?: string;
+      message_type?: string;
+      content?: string;
+      mentions?: LarkMention[];
+    };
+  };
+};
+
+export type LarkMessageHandlerConfig = {
+  agentId: string;
+  botOpenId?: string;
+  callbackUri?: string;
+  resolveChannelBinding(input: { tenantKey: string; chatId: string }): Promise<LarkChannelBinding | null>;
+  createRun(event: OpenTagEvent): Promise<{ runId: string }>;
+  now?(): number;
+};
+
+export type LarkMessageHandlerOutcome = {
+  status:
+    | "created"
+    | "ignored_non_text"
+    | "ignored_invalid_payload"
+    | "ignored_unbound_chat"
+    | "ignored_empty_command";
+  runId?: string;
+};
+
+function extractText(content: string | undefined): string {
+  if (!content) return "";
+  try {
+    const parsed = JSON.parse(content) as { text?: unknown };
+    return typeof parsed.text === "string" ? parsed.text : "";
+  } catch {
+    return "";
+  }
+}
+
+function findBotMentionKey(mentions: LarkMention[] | undefined, botOpenId: string | undefined): string | undefined {
+  if (!botOpenId || !mentions) return undefined;
+  for (const mention of mentions) {
+    if (mention.id?.open_id === botOpenId && mention.key) {
+      return mention.key;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build a handler for inbound Lark message events. The handler resolves the
+ * channel binding, normalizes the message into an OpenTagEvent, and creates a
+ * run. It is transport-agnostic so it can be unit-tested without a live socket.
+ */
+export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
+  return async function handleLarkMessage(data: LarkInboundMessageEvent): Promise<LarkMessageHandlerOutcome> {
+    const message = data.event?.message;
+    const header = data.header;
+    if (!message || message.message_type !== "text") {
+      return { status: "ignored_non_text" };
+    }
+
+    const tenantKey = header?.tenant_key ?? data.event?.sender?.tenant_key;
+    const chatId = message.chat_id;
+    const messageId = message.message_id;
+    const eventId = header?.event_id;
+    const senderOpenId = data.event?.sender?.sender_id?.open_id;
+    if (!tenantKey || !chatId || !messageId || !eventId || !senderOpenId) {
+      return { status: "ignored_invalid_payload" };
+    }
+
+    const binding = await config.resolveChannelBinding({ tenantKey, chatId });
+    if (!binding) {
+      return { status: "ignored_unbound_chat" };
+    }
+
+    const botMentionKey = findBotMentionKey(message.mentions, config.botOpenId);
+    const eventTimeMs = header?.create_time ? Number(header.create_time) : (config.now?.() ?? Date.now());
+
+    const event = normalizeLarkMessage({
+      tenantKey,
+      chatId,
+      chatType: message.chat_type ?? "group",
+      senderOpenId,
+      text: extractText(message.content),
+      messageId,
+      ...(message.root_id ? { rootId: message.root_id } : {}),
+      eventId,
+      eventTimeMs,
+      agentId: config.agentId,
+      ...(config.botOpenId ? { botOpenId: config.botOpenId } : {}),
+      ...(botMentionKey ? { botMentionKey } : {}),
+      ...(config.callbackUri ? { callbackUri: config.callbackUri } : {}),
+      binding
+    });
+    if (!event) {
+      return { status: "ignored_empty_command" };
+    }
+
+    const { runId } = await config.createRun(event);
+    return { status: "created", runId };
+  };
+}

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -3,11 +3,7 @@ import { type LarkChannelBinding, normalizeLarkMessage } from "@opentag/lark";
 
 export type LarkMention = { key?: string; id?: { open_id?: string }; name?: string };
 
-/**
- * Shape of the `im.message.receive_v1` event payload delivered by
- * @larksuiteoapi/node-sdk's EventDispatcher. Only the fields OpenTag needs are
- * declared; everything is optional because the payload is external input.
- */
+// Subset of the `im.message.receive_v1` payload OpenTag needs; all optional (external input).
 export type LarkInboundMessageEvent = {
   header?: {
     event_id?: string;
@@ -72,13 +68,7 @@ function mentionsBot(mentions: LarkMention[] | undefined, botOpenId: string): bo
   return (mentions ?? []).some((mention) => mention.id?.open_id === botOpenId);
 }
 
-/**
- * Build a handler for inbound Lark message events. The handler enforces that
- * group messages must @-mention the bot (only direct p2p chats are exempt),
- * resolves the channel binding, normalizes the message into an OpenTagEvent, and
- * creates a run. It is transport-agnostic so it can be unit-tested without a
- * live socket.
- */
+// Handle one inbound Lark message: group messages must @-mention the bot, then resolve binding, normalize, create a run.
 export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
   return async function handleLarkMessage(data: LarkInboundMessageEvent): Promise<LarkMessageHandlerOutcome> {
     const message = data.event?.message;
@@ -96,8 +86,7 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
       return { status: "ignored_invalid_payload" };
     }
 
-    // Group messages must explicitly @-mention the bot before they can trigger a
-    // (potentially write-capable) run. Direct p2p chats need no mention.
+    // Group messages must @-mention the bot before triggering a (write-capable) run; p2p is exempt.
     const isDirect = message.chat_type === "p2p";
     if (!isDirect) {
       if (!config.botOpenId) {

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -1,13 +1,13 @@
 import type { OpenTagEvent } from "@opentag/core";
 import { type LarkChannelBinding, normalizeLarkMessage } from "@opentag/lark";
 
+export type LarkMention = { key?: string; id?: { open_id?: string }; name?: string };
+
 /**
  * Shape of the `im.message.receive_v1` event payload delivered by
  * @larksuiteoapi/node-sdk's EventDispatcher. Only the fields OpenTag needs are
  * declared; everything is optional because the payload is external input.
  */
-export type LarkMention = { key?: string; id?: { open_id?: string }; name?: string };
-
 export type LarkInboundMessageEvent = {
   header?: {
     event_id?: string;
@@ -49,9 +49,13 @@ export type LarkMessageHandlerOutcome = {
     | "created"
     | "ignored_non_text"
     | "ignored_invalid_payload"
+    | "ignored_group_requires_bot_open_id"
+    | "ignored_not_addressed"
     | "ignored_unbound_chat"
     | "ignored_empty_command";
   runId?: string;
+  tenantKey?: string;
+  chatId?: string;
 };
 
 function extractText(content: string | undefined): string {
@@ -64,20 +68,16 @@ function extractText(content: string | undefined): string {
   }
 }
 
-function findBotMentionKey(mentions: LarkMention[] | undefined, botOpenId: string | undefined): string | undefined {
-  if (!botOpenId || !mentions) return undefined;
-  for (const mention of mentions) {
-    if (mention.id?.open_id === botOpenId && mention.key) {
-      return mention.key;
-    }
-  }
-  return undefined;
+function mentionsBot(mentions: LarkMention[] | undefined, botOpenId: string): boolean {
+  return (mentions ?? []).some((mention) => mention.id?.open_id === botOpenId);
 }
 
 /**
- * Build a handler for inbound Lark message events. The handler resolves the
- * channel binding, normalizes the message into an OpenTagEvent, and creates a
- * run. It is transport-agnostic so it can be unit-tested without a live socket.
+ * Build a handler for inbound Lark message events. The handler enforces that
+ * group messages must @-mention the bot (only direct p2p chats are exempt),
+ * resolves the channel binding, normalizes the message into an OpenTagEvent, and
+ * creates a run. It is transport-agnostic so it can be unit-tested without a
+ * live socket.
  */
 export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
   return async function handleLarkMessage(data: LarkInboundMessageEvent): Promise<LarkMessageHandlerOutcome> {
@@ -96,13 +96,25 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
       return { status: "ignored_invalid_payload" };
     }
 
-    const binding = await config.resolveChannelBinding({ tenantKey, chatId });
-    if (!binding) {
-      return { status: "ignored_unbound_chat" };
+    // Group messages must explicitly @-mention the bot before they can trigger a
+    // (potentially write-capable) run. Direct p2p chats need no mention.
+    const isDirect = message.chat_type === "p2p";
+    if (!isDirect) {
+      if (!config.botOpenId) {
+        return { status: "ignored_group_requires_bot_open_id", tenantKey, chatId };
+      }
+      if (!mentionsBot(message.mentions, config.botOpenId)) {
+        return { status: "ignored_not_addressed", tenantKey, chatId };
+      }
     }
 
-    const botMentionKey = findBotMentionKey(message.mentions, config.botOpenId);
-    const eventTimeMs = header?.create_time ? Number(header.create_time) : (config.now?.() ?? Date.now());
+    const binding = await config.resolveChannelBinding({ tenantKey, chatId });
+    if (!binding) {
+      return { status: "ignored_unbound_chat", tenantKey, chatId };
+    }
+
+    const parsedTime = header?.create_time ? Number(header.create_time) : Number.NaN;
+    const eventTimeMs = Number.isFinite(parsedTime) ? parsedTime : (config.now?.() ?? Date.now());
 
     const event = normalizeLarkMessage({
       tenantKey,
@@ -116,7 +128,6 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
       eventTimeMs,
       agentId: config.agentId,
       ...(config.botOpenId ? { botOpenId: config.botOpenId } : {}),
-      ...(botMentionKey ? { botMentionKey } : {}),
       ...(config.callbackUri ? { callbackUri: config.callbackUri } : {}),
       binding
     });

--- a/apps/lark-events/src/index.ts
+++ b/apps/lark-events/src/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as lark from "@larksuiteoapi/node-sdk";
 import { createOpenTagClient } from "@opentag/client";
+import { createLarkReplyClient, replyLarkMessage } from "@opentag/lark";
 import { createLarkMessageHandler, type LarkInboundMessageEvent, type LarkMessageHandlerOutcome } from "./app.js";
 
 const appId = process.env.LARK_APP_ID;
@@ -13,12 +14,13 @@ if (!dispatcherUrl) {
   throw new Error("OPENTAG_DISPATCHER_URL is required");
 }
 
-const domain = process.env.LARK_DOMAIN === "feishu" ? lark.Domain.Feishu : lark.Domain.Lark;
+const larkDomain = process.env.LARK_DOMAIN === "feishu" ? "feishu" : "lark";
 const dispatcherToken = process.env.OPENTAG_DISPATCHER_TOKEN;
 const dispatcherClient = createOpenTagClient({
   dispatcherUrl,
   ...(dispatcherToken ? { pairingToken: dispatcherToken } : {})
 });
+const replyClient = createLarkReplyClient({ appId, appSecret, domain: larkDomain });
 
 const handler = createLarkMessageHandler({
   agentId: process.env.OPENTAG_LARK_AGENT_ID ?? "opentag",
@@ -44,6 +46,19 @@ const handler = createLarkMessageHandler({
       throw error;
     }
   },
+  async bindChannel(input) {
+    await dispatcherClient.bindChannel({
+      provider: "lark",
+      accountId: input.tenantKey,
+      conversationId: input.chatId,
+      repoProvider: input.repoProvider,
+      owner: input.owner,
+      repo: input.repo
+    });
+  },
+  async reply(input) {
+    await replyLarkMessage(replyClient, input);
+  },
   async createRun(event) {
     const runId = `run_${randomUUID()}`;
     await dispatcherClient.createRun({ runId, event });
@@ -52,10 +67,10 @@ const handler = createLarkMessageHandler({
 });
 
 function logIgnored(outcome: LarkMessageHandlerOutcome): void {
-  if (outcome.status === "created") return;
+  if (outcome.status === "created" || outcome.status === "bound") return;
   if (outcome.status === "ignored_unbound_chat") {
     console.log(
-      `[lark] ignored unbound chat — bind it: provider=lark accountId(tenant_key)=${outcome.tenantKey} conversationId(chat_id)=${outcome.chatId} (opentagd bind-lark-channels or POST /v1/channel-bindings)`
+      `[lark] ignored unbound chat — bind it: provider=lark accountId(tenant_key)=${outcome.tenantKey} conversationId(chat_id)=${outcome.chatId} (reply '/bind owner/repo' in the chat, or POST /v1/channel-bindings)`
     );
     return;
   }
@@ -68,7 +83,11 @@ const eventDispatcher = new lark.EventDispatcher({}).register({
   }
 });
 
-const wsClient = new lark.WSClient({ appId, appSecret, domain });
+const wsClient = new lark.WSClient({
+  appId,
+  appSecret,
+  domain: larkDomain === "feishu" ? lark.Domain.Feishu : lark.Domain.Lark
+});
 wsClient.start({ eventDispatcher }).catch((error: unknown) => {
   console.error("[lark] failed to start long-connection client:", error);
   process.exit(1);

--- a/apps/lark-events/src/index.ts
+++ b/apps/lark-events/src/index.ts
@@ -1,0 +1,62 @@
+import * as lark from "@larksuiteoapi/node-sdk";
+import { createOpenTagClient } from "@opentag/client";
+import { createLarkMessageHandler, type LarkInboundMessageEvent } from "./app.js";
+
+const appId = process.env.LARK_APP_ID;
+const appSecret = process.env.LARK_APP_SECRET;
+const dispatcherUrl = process.env.OPENTAG_DISPATCHER_URL;
+if (!appId || !appSecret) {
+  throw new Error("LARK_APP_ID and LARK_APP_SECRET are required");
+}
+if (!dispatcherUrl) {
+  throw new Error("OPENTAG_DISPATCHER_URL is required");
+}
+
+const domain = process.env.LARK_DOMAIN === "feishu" ? lark.Domain.Feishu : lark.Domain.Lark;
+const dispatcherToken = process.env.OPENTAG_DISPATCHER_TOKEN;
+const dispatcherClient = createOpenTagClient({
+  dispatcherUrl,
+  ...(dispatcherToken ? { pairingToken: dispatcherToken } : {})
+});
+
+const handler = createLarkMessageHandler({
+  agentId: process.env.OPENTAG_LARK_AGENT_ID ?? "opentag",
+  ...(process.env.LARK_BOT_OPEN_ID ? { botOpenId: process.env.LARK_BOT_OPEN_ID } : {}),
+  async resolveChannelBinding(input) {
+    try {
+      const { binding } = await dispatcherClient.getChannelBinding({
+        provider: "lark",
+        accountId: input.tenantKey,
+        conversationId: input.chatId
+      });
+      return {
+        tenantKey: binding.accountId,
+        chatId: binding.conversationId,
+        repoProvider: binding.repoProvider,
+        owner: binding.owner,
+        repo: binding.repo
+      };
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("channel_binding_not_found")) {
+        return null;
+      }
+      throw error;
+    }
+  },
+  async createRun(event) {
+    const runId = `run_${Date.now()}`;
+    await dispatcherClient.createRun({ runId, event });
+    return { runId };
+  }
+});
+
+const eventDispatcher = new lark.EventDispatcher({}).register({
+  "im.message.receive_v1": async (data) => {
+    await handler(data as unknown as LarkInboundMessageEvent);
+  }
+});
+
+const wsClient = new lark.WSClient({ appId, appSecret, domain });
+void wsClient.start({ eventDispatcher });
+
+console.log("OpenTag Lark events long-connection ingress started");

--- a/apps/lark-events/src/index.ts
+++ b/apps/lark-events/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import * as lark from "@larksuiteoapi/node-sdk";
 import { createOpenTagClient } from "@opentag/client";
 import { createLarkMessageHandler, type LarkInboundMessageEvent } from "./app.js";
@@ -38,13 +39,18 @@ const handler = createLarkMessageHandler({
       };
     } catch (error) {
       if (error instanceof Error && error.message.includes("channel_binding_not_found")) {
+        console.log(
+          `[lark] message from an unbound chat — to route it to a repo, bind:\n` +
+            `      provider=lark  accountId(tenant_key)=${input.tenantKey}  conversationId(chat_id)=${input.chatId}\n` +
+            `      via "opentagd bind-lark-channels" (after setting larkChannels) or POST /v1/channel-bindings`
+        );
         return null;
       }
       throw error;
     }
   },
   async createRun(event) {
-    const runId = `run_${Date.now()}`;
+    const runId = `run_${randomUUID()}`;
     await dispatcherClient.createRun({ runId, event });
     return { runId };
   }
@@ -57,6 +63,9 @@ const eventDispatcher = new lark.EventDispatcher({}).register({
 });
 
 const wsClient = new lark.WSClient({ appId, appSecret, domain });
-void wsClient.start({ eventDispatcher });
+wsClient.start({ eventDispatcher }).catch((error: unknown) => {
+  console.error("[lark] failed to start long-connection client:", error);
+  process.exit(1);
+});
 
 console.log("OpenTag Lark events long-connection ingress started");

--- a/apps/lark-events/src/index.ts
+++ b/apps/lark-events/src/index.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as lark from "@larksuiteoapi/node-sdk";
 import { createOpenTagClient } from "@opentag/client";
-import { createLarkMessageHandler, type LarkInboundMessageEvent } from "./app.js";
+import { createLarkMessageHandler, type LarkInboundMessageEvent, type LarkMessageHandlerOutcome } from "./app.js";
 
 const appId = process.env.LARK_APP_ID;
 const appSecret = process.env.LARK_APP_SECRET;
@@ -39,11 +39,6 @@ const handler = createLarkMessageHandler({
       };
     } catch (error) {
       if (error instanceof Error && error.message.includes("channel_binding_not_found")) {
-        console.log(
-          `[lark] message from an unbound chat — to route it to a repo, bind:\n` +
-            `      provider=lark  accountId(tenant_key)=${input.tenantKey}  conversationId(chat_id)=${input.chatId}\n` +
-            `      via "opentagd bind-lark-channels" (after setting larkChannels) or POST /v1/channel-bindings`
-        );
         return null;
       }
       throw error;
@@ -56,9 +51,20 @@ const handler = createLarkMessageHandler({
   }
 });
 
+function logIgnored(outcome: LarkMessageHandlerOutcome): void {
+  if (outcome.status === "created") return;
+  if (outcome.status === "ignored_unbound_chat") {
+    console.log(
+      `[lark] ignored unbound chat — bind it: provider=lark accountId(tenant_key)=${outcome.tenantKey} conversationId(chat_id)=${outcome.chatId} (opentagd bind-lark-channels or POST /v1/channel-bindings)`
+    );
+    return;
+  }
+  console.log(`[lark] ignored event: ${outcome.status}${outcome.chatId ? ` chat_id=${outcome.chatId}` : ""}`);
+}
+
 const eventDispatcher = new lark.EventDispatcher({}).register({
   "im.message.receive_v1": async (data) => {
-    await handler(data as unknown as LarkInboundMessageEvent);
+    logIgnored(await handler(data as unknown as LarkInboundMessageEvent));
   }
 });
 

--- a/apps/lark-events/test/app.test.ts
+++ b/apps/lark-events/test/app.test.ts
@@ -1,0 +1,101 @@
+import type { OpenTagEvent } from "@opentag/core";
+import { describe, expect, it, vi } from "vitest";
+import { createLarkMessageHandler, type LarkInboundMessageEvent } from "../src/app.js";
+
+function messageEvent(overrides?: {
+  text?: string;
+  messageType?: string;
+  chatId?: string;
+  tenantKey?: string;
+  messageId?: string;
+  eventId?: string;
+  openId?: string;
+}): LarkInboundMessageEvent {
+  return {
+    header: {
+      event_id: overrides?.eventId ?? "evt_1",
+      event_type: "im.message.receive_v1",
+      create_time: "1700000000000",
+      tenant_key: overrides?.tenantKey ?? "tk_123"
+    },
+    event: {
+      sender: {
+        sender_id: { open_id: overrides?.openId ?? "ou_user" },
+        sender_type: "user",
+        tenant_key: overrides?.tenantKey ?? "tk_123"
+      },
+      message: {
+        message_id: overrides?.messageId ?? "om_msg",
+        chat_id: overrides?.chatId ?? "oc_chat",
+        chat_type: "group",
+        message_type: overrides?.messageType ?? "text",
+        content: JSON.stringify({ text: overrides?.text ?? "@_user_1 fix the bug" }),
+        mentions: [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "OpenTag" }]
+      }
+    }
+  };
+}
+
+const binding = { tenantKey: "tk_123", chatId: "oc_chat", owner: "acme", repo: "app" };
+
+describe("createLarkMessageHandler", () => {
+  it("normalizes a text message and creates a run", async () => {
+    const createRun = vi.fn(async (_event: OpenTagEvent) => ({ runId: "run_1" }));
+    const handler = createLarkMessageHandler({
+      agentId: "opentag",
+      botOpenId: "ou_bot",
+      resolveChannelBinding: async () => binding,
+      createRun
+    });
+
+    const outcome = await handler(messageEvent());
+    expect(outcome.status).toBe("created");
+    expect(outcome.runId).toBe("run_1");
+    expect(createRun).toHaveBeenCalledTimes(1);
+    const event = createRun.mock.calls[0]?.[0];
+    expect(event?.source).toBe("lark");
+    expect(event?.command.rawText).toBe("fix the bug");
+    expect(event?.callback.threadKey).toBe("tk_123|oc_chat|om_msg");
+  });
+
+  it("ignores non-text messages", async () => {
+    const handler = createLarkMessageHandler({
+      agentId: "opentag",
+      resolveChannelBinding: async () => binding,
+      createRun: async () => ({ runId: "run_x" })
+    });
+    expect((await handler(messageEvent({ messageType: "image" }))).status).toBe("ignored_non_text");
+  });
+
+  it("ignores messages from unbound chats", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_x" }));
+    const handler = createLarkMessageHandler({
+      agentId: "opentag",
+      resolveChannelBinding: async () => null,
+      createRun
+    });
+    expect((await handler(messageEvent())).status).toBe("ignored_unbound_chat");
+    expect(createRun).not.toHaveBeenCalled();
+  });
+
+  it("ignores messages whose command is empty after stripping the mention", async () => {
+    const handler = createLarkMessageHandler({
+      agentId: "opentag",
+      botOpenId: "ou_bot",
+      resolveChannelBinding: async () => binding,
+      createRun: async () => ({ runId: "run_x" })
+    });
+    expect((await handler(messageEvent({ text: "@_user_1" }))).status).toBe("ignored_empty_command");
+  });
+
+  it("ignores payloads missing required ids", async () => {
+    const handler = createLarkMessageHandler({
+      agentId: "opentag",
+      resolveChannelBinding: async () => binding,
+      createRun: async () => ({ runId: "run_x" })
+    });
+    const broken = messageEvent();
+    broken.event!.message!.chat_id = undefined;
+    expect((await handler(broken)).status).toBe("ignored_invalid_payload");
+  });
+});

--- a/apps/lark-events/test/app.test.ts
+++ b/apps/lark-events/test/app.test.ts
@@ -2,6 +2,7 @@ import type { OpenTagEvent } from "@opentag/core";
 import { describe, expect, it, vi } from "vitest";
 import { createLarkMessageHandler, type LarkInboundMessageEvent } from "../src/app.js";
 
+// Mirrors the flattened im.message.receive_v1 payload the SDK delivers.
 function messageEvent(overrides?: {
   text?: string;
   messageType?: string;
@@ -15,26 +16,22 @@ function messageEvent(overrides?: {
 }): LarkInboundMessageEvent {
   const mentionBot = overrides?.mentionBot ?? true;
   return {
-    header: {
-      event_id: overrides?.eventId ?? "evt_1",
-      event_type: "im.message.receive_v1",
-      create_time: "1700000000000",
+    event_id: overrides?.eventId ?? "evt_1",
+    event_type: "im.message.receive_v1",
+    create_time: "1700000000000",
+    tenant_key: overrides?.tenantKey ?? "tk_123",
+    sender: {
+      sender_id: { open_id: overrides?.openId ?? "ou_user" },
+      sender_type: "user",
       tenant_key: overrides?.tenantKey ?? "tk_123"
     },
-    event: {
-      sender: {
-        sender_id: { open_id: overrides?.openId ?? "ou_user" },
-        sender_type: "user",
-        tenant_key: overrides?.tenantKey ?? "tk_123"
-      },
-      message: {
-        message_id: overrides?.messageId ?? "om_msg",
-        chat_id: overrides?.chatId ?? "oc_chat",
-        chat_type: overrides?.chatType ?? "group",
-        message_type: overrides?.messageType ?? "text",
-        content: JSON.stringify({ text: overrides?.text ?? "@_user_1 fix the bug" }),
-        mentions: mentionBot ? [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "OpenTag" }] : []
-      }
+    message: {
+      message_id: overrides?.messageId ?? "om_msg",
+      chat_id: overrides?.chatId ?? "oc_chat",
+      chat_type: overrides?.chatType ?? "group",
+      message_type: overrides?.messageType ?? "text",
+      content: JSON.stringify({ text: overrides?.text ?? "@_user_1 fix the bug" }),
+      mentions: mentionBot ? [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "OpenTag" }] : []
     }
   };
 }
@@ -112,7 +109,7 @@ describe("createLarkMessageHandler", () => {
       now: () => 1_700_000_000_000
     });
     const evt = messageEvent();
-    evt.header!.create_time = "not-a-number";
+    evt.create_time = "not-a-number";
     const outcome = await handler(evt);
     expect(outcome.status).toBe("created");
     const event = createRun.mock.calls[0]?.[0];
@@ -123,7 +120,7 @@ describe("createLarkMessageHandler", () => {
   it("ignores payloads missing required ids", async () => {
     const { handler } = makeHandler();
     const broken = messageEvent();
-    broken.event!.message!.chat_id = undefined;
+    broken.message!.chat_id = undefined;
     expect((await handler(broken)).status).toBe("ignored_invalid_payload");
   });
 

--- a/apps/lark-events/test/app.test.ts
+++ b/apps/lark-events/test/app.test.ts
@@ -1,4 +1,5 @@
 import type { OpenTagEvent } from "@opentag/core";
+import type { LarkChannelBinding } from "@opentag/lark";
 import { describe, expect, it, vi } from "vitest";
 import { createLarkMessageHandler, type LarkInboundMessageEvent } from "../src/app.js";
 
@@ -36,17 +37,27 @@ function messageEvent(overrides?: {
   };
 }
 
-const binding = { tenantKey: "tk_123", chatId: "oc_chat", owner: "acme", repo: "app" };
+const binding: LarkChannelBinding = { tenantKey: "tk_123", chatId: "oc_chat", owner: "acme", repo: "app" };
 
-function makeHandler(opts?: { withBotOpenId?: boolean; createRun?: ReturnType<typeof vi.fn> }) {
+function makeHandler(opts?: {
+  withBotOpenId?: boolean;
+  binding?: LarkChannelBinding | null;
+  createRun?: ReturnType<typeof vi.fn>;
+  bindChannel?: ReturnType<typeof vi.fn>;
+  reply?: ReturnType<typeof vi.fn>;
+}) {
   const createRun = opts?.createRun ?? vi.fn(async (_event: OpenTagEvent) => ({ runId: "run_1" }));
+  const bindChannel = opts?.bindChannel ?? vi.fn(async () => {});
+  const reply = opts?.reply ?? vi.fn(async () => {});
   const handler = createLarkMessageHandler({
     agentId: "opentag",
     ...(opts?.withBotOpenId === false ? {} : { botOpenId: "ou_bot" }),
-    resolveChannelBinding: async () => binding,
-    createRun
+    resolveChannelBinding: async () => (opts && "binding" in opts ? (opts.binding ?? null) : binding),
+    createRun,
+    bindChannel,
+    reply
   });
-  return { handler, createRun };
+  return { handler, createRun, bindChannel, reply };
 }
 
 describe("createLarkMessageHandler", () => {
@@ -84,18 +95,44 @@ describe("createLarkMessageHandler", () => {
     expect((await handler(messageEvent({ messageType: "image" }))).status).toBe("ignored_non_text");
   });
 
-  it("ignores messages from unbound chats and surfaces the ids", async () => {
-    const createRun = vi.fn(async () => ({ runId: "run_x" }));
-    const handler = createLarkMessageHandler({
-      agentId: "opentag",
-      botOpenId: "ou_bot",
-      resolveChannelBinding: async () => null,
-      createRun
+  it("binds the chat via /bind owner/repo and confirms in-thread", async () => {
+    const { handler, bindChannel, reply, createRun } = makeHandler();
+    const outcome = await handler(messageEvent({ text: "@_user_1 /bind amplifthq/opentag" }));
+    expect(outcome.status).toBe("bound");
+    expect(bindChannel).toHaveBeenCalledWith({
+      tenantKey: "tk_123",
+      chatId: "oc_chat",
+      repoProvider: "github",
+      owner: "amplifthq",
+      repo: "opentag"
     });
+    expect(reply).toHaveBeenCalledTimes(1);
+    expect(createRun).not.toHaveBeenCalled();
+  });
+
+  it("accepts an explicit provider prefix in /bind", async () => {
+    const { handler, bindChannel } = makeHandler();
+    await handler(messageEvent({ text: "@_user_1 /bind github:acme/web-app" }));
+    expect(bindChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ repoProvider: "github", owner: "acme", repo: "web-app" })
+    );
+  });
+
+  it("replies with usage on a malformed /bind and does not bind", async () => {
+    const { handler, bindChannel, reply } = makeHandler();
+    const outcome = await handler(messageEvent({ text: "@_user_1 /bind not-a-repo" }));
+    expect(outcome.status).toBe("ignored_bind_usage");
+    expect(bindChannel).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("replies with an onboarding hint when the chat is unbound", async () => {
+    const { handler, reply, createRun } = makeHandler({ binding: null });
     const outcome = await handler(messageEvent());
     expect(outcome.status).toBe("ignored_unbound_chat");
     expect(outcome.tenantKey).toBe("tk_123");
     expect(outcome.chatId).toBe("oc_chat");
+    expect(reply).toHaveBeenCalledTimes(1);
     expect(createRun).not.toHaveBeenCalled();
   });
 

--- a/apps/lark-events/test/app.test.ts
+++ b/apps/lark-events/test/app.test.ts
@@ -5,12 +5,15 @@ import { createLarkMessageHandler, type LarkInboundMessageEvent } from "../src/a
 function messageEvent(overrides?: {
   text?: string;
   messageType?: string;
+  chatType?: string;
   chatId?: string;
   tenantKey?: string;
   messageId?: string;
   eventId?: string;
   openId?: string;
+  mentionBot?: boolean;
 }): LarkInboundMessageEvent {
+  const mentionBot = overrides?.mentionBot ?? true;
   return {
     header: {
       event_id: overrides?.eventId ?? "evt_1",
@@ -27,10 +30,10 @@ function messageEvent(overrides?: {
       message: {
         message_id: overrides?.messageId ?? "om_msg",
         chat_id: overrides?.chatId ?? "oc_chat",
-        chat_type: "group",
+        chat_type: overrides?.chatType ?? "group",
         message_type: overrides?.messageType ?? "text",
         content: JSON.stringify({ text: overrides?.text ?? "@_user_1 fix the bug" }),
-        mentions: [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "OpenTag" }]
+        mentions: mentionBot ? [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "OpenTag" }] : []
       }
     }
   };
@@ -38,62 +41,87 @@ function messageEvent(overrides?: {
 
 const binding = { tenantKey: "tk_123", chatId: "oc_chat", owner: "acme", repo: "app" };
 
-describe("createLarkMessageHandler", () => {
-  it("normalizes a text message and creates a run", async () => {
-    const createRun = vi.fn(async (_event: OpenTagEvent) => ({ runId: "run_1" }));
-    const handler = createLarkMessageHandler({
-      agentId: "opentag",
-      botOpenId: "ou_bot",
-      resolveChannelBinding: async () => binding,
-      createRun
-    });
+function makeHandler(opts?: { withBotOpenId?: boolean; createRun?: ReturnType<typeof vi.fn> }) {
+  const createRun = opts?.createRun ?? vi.fn(async (_event: OpenTagEvent) => ({ runId: "run_1" }));
+  const handler = createLarkMessageHandler({
+    agentId: "opentag",
+    ...(opts?.withBotOpenId === false ? {} : { botOpenId: "ou_bot" }),
+    resolveChannelBinding: async () => binding,
+    createRun
+  });
+  return { handler, createRun };
+}
 
+describe("createLarkMessageHandler", () => {
+  it("normalizes a group message that @-mentions the bot and creates a run", async () => {
+    const { handler, createRun } = makeHandler();
     const outcome = await handler(messageEvent());
     expect(outcome.status).toBe("created");
     expect(outcome.runId).toBe("run_1");
-    expect(createRun).toHaveBeenCalledTimes(1);
     const event = createRun.mock.calls[0]?.[0];
     expect(event?.source).toBe("lark");
     expect(event?.command.rawText).toBe("fix the bug");
     expect(event?.callback.threadKey).toBe("tk_123|oc_chat|om_msg");
   });
 
-  it("ignores non-text messages", async () => {
-    const handler = createLarkMessageHandler({
-      agentId: "opentag",
-      resolveChannelBinding: async () => binding,
-      createRun: async () => ({ runId: "run_x" })
-    });
-    expect((await handler(messageEvent({ messageType: "image" }))).status).toBe("ignored_non_text");
+  it("handles a direct (p2p) message without requiring a mention", async () => {
+    const { handler } = makeHandler({ withBotOpenId: false });
+    const outcome = await handler(messageEvent({ chatType: "p2p", text: "fix the bug", mentionBot: false }));
+    expect(outcome.status).toBe("created");
   });
 
-  it("ignores messages from unbound chats", async () => {
-    const createRun = vi.fn(async () => ({ runId: "run_x" }));
-    const handler = createLarkMessageHandler({
-      agentId: "opentag",
-      resolveChannelBinding: async () => null,
-      createRun
-    });
-    expect((await handler(messageEvent())).status).toBe("ignored_unbound_chat");
+  it("ignores group messages that do not @-mention the bot", async () => {
+    const { handler, createRun } = makeHandler();
+    const outcome = await handler(messageEvent({ text: "fix the bug", mentionBot: false }));
+    expect(outcome.status).toBe("ignored_not_addressed");
     expect(createRun).not.toHaveBeenCalled();
   });
 
-  it("ignores messages whose command is empty after stripping the mention", async () => {
+  it("ignores group messages when botOpenId is not configured", async () => {
+    const { handler } = makeHandler({ withBotOpenId: false });
+    expect((await handler(messageEvent())).status).toBe("ignored_group_requires_bot_open_id");
+  });
+
+  it("ignores non-text messages", async () => {
+    const { handler } = makeHandler();
+    expect((await handler(messageEvent({ messageType: "image" }))).status).toBe("ignored_non_text");
+  });
+
+  it("ignores messages from unbound chats and surfaces the ids", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_x" }));
+    const handler = createLarkMessageHandler({
+      agentId: "opentag",
+      botOpenId: "ou_bot",
+      resolveChannelBinding: async () => null,
+      createRun
+    });
+    const outcome = await handler(messageEvent());
+    expect(outcome.status).toBe("ignored_unbound_chat");
+    expect(outcome.tenantKey).toBe("tk_123");
+    expect(outcome.chatId).toBe("oc_chat");
+    expect(createRun).not.toHaveBeenCalled();
+  });
+
+  it("falls back to now() when create_time is malformed", async () => {
+    const createRun = vi.fn(async (_event: OpenTagEvent) => ({ runId: "run_1" }));
     const handler = createLarkMessageHandler({
       agentId: "opentag",
       botOpenId: "ou_bot",
       resolveChannelBinding: async () => binding,
-      createRun: async () => ({ runId: "run_x" })
+      createRun,
+      now: () => 1_700_000_000_000
     });
-    expect((await handler(messageEvent({ text: "@_user_1" }))).status).toBe("ignored_empty_command");
+    const evt = messageEvent();
+    evt.header!.create_time = "not-a-number";
+    const outcome = await handler(evt);
+    expect(outcome.status).toBe("created");
+    const event = createRun.mock.calls[0]?.[0];
+    expect(() => new Date(event!.receivedAt).toISOString()).not.toThrow();
+    expect(event?.receivedAt).toBe(new Date(1_700_000_000_000).toISOString());
   });
 
   it("ignores payloads missing required ids", async () => {
-    const handler = createLarkMessageHandler({
-      agentId: "opentag",
-      resolveChannelBinding: async () => binding,
-      createRun: async () => ({ runId: "run_x" })
-    });
+    const { handler } = makeHandler();
     const broken = messageEvent();
     broken.event!.message!.chat_id = undefined;
     expect((await handler(broken)).status).toBe("ignored_invalid_payload");

--- a/apps/lark-events/test/app.test.ts
+++ b/apps/lark-events/test/app.test.ts
@@ -126,4 +126,17 @@ describe("createLarkMessageHandler", () => {
     broken.event!.message!.chat_id = undefined;
     expect((await handler(broken)).status).toBe("ignored_invalid_payload");
   });
+
+  it("propagates createRun failure instead of silently succeeding", async () => {
+    const createRun = vi.fn(async () => {
+      throw new Error("dispatcher unreachable");
+    });
+    const handler = createLarkMessageHandler({
+      agentId: "opentag",
+      botOpenId: "ou_bot",
+      resolveChannelBinding: async () => binding,
+      createRun
+    });
+    await expect(handler(messageEvent())).rejects.toThrow(/dispatcher unreachable/);
+  });
 });

--- a/apps/lark-events/tsconfig.json
+++ b/apps/lark-events/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../../packages/client" }, { "path": "../../packages/core" }, { "path": "../../packages/lark" }]
+}

--- a/apps/lark-events/tsup.config.ts
+++ b/apps/lark-events/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  sourcemap: true,
+  clean: true
+});

--- a/apps/opentagd/src/config.ts
+++ b/apps/opentagd/src/config.ts
@@ -39,11 +39,20 @@ export const SlackChannelBindingConfigSchema = z.object({
   repo: z.string().min(1)
 });
 
+export const LarkChannelBindingConfigSchema = z.object({
+  tenantKey: z.string().min(1),
+  chatId: z.string().min(1),
+  repoProvider: z.string().min(1).default("github"),
+  owner: z.string().min(1),
+  repo: z.string().min(1)
+});
+
 export const OpenTagDaemonConfigSchema = z.object({
   runnerId: z.string().min(1).default("runner_local"),
   dispatcherUrl: z.string().url().default("http://localhost:3030"),
   repositories: z.array(RepositoryBindingConfigSchema).default([]),
   slackChannels: z.array(SlackChannelBindingConfigSchema).optional(),
+  larkChannels: z.array(LarkChannelBindingConfigSchema).optional(),
   claudeCode: ClaudeCodeExecutorConfigSchema.optional(),
   security: RunnerSecurityPolicySchema.optional(),
   githubToken: z.string().min(1).optional(),
@@ -55,6 +64,7 @@ export const OpenTagDaemonConfigSchema = z.object({
 
 export type RepositoryBindingConfig = z.infer<typeof RepositoryBindingConfigSchema>;
 export type SlackChannelBindingConfig = z.infer<typeof SlackChannelBindingConfigSchema>;
+export type LarkChannelBindingConfig = z.infer<typeof LarkChannelBindingConfigSchema>;
 export type OpenTagDaemonConfig = z.infer<typeof OpenTagDaemonConfigSchema>;
 
 export type InitConfigInput = {
@@ -171,6 +181,19 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
             {
               teamId: process.env.OPENTAG_SLACK_TEAM_ID,
               channelId: process.env.OPENTAG_SLACK_CHANNEL_ID,
+              repoProvider: repositoryProvider,
+              owner,
+              repo
+            }
+          ]
+        }
+      : {}),
+    ...(process.env.OPENTAG_LARK_TENANT_KEY && process.env.OPENTAG_LARK_CHAT_ID && owner && repo
+      ? {
+          larkChannels: [
+            {
+              tenantKey: process.env.OPENTAG_LARK_TENANT_KEY,
+              chatId: process.env.OPENTAG_LARK_CHAT_ID,
               repoProvider: repositoryProvider,
               owner,
               repo

--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -173,6 +173,32 @@ program
   });
 
 program
+  .command("bind-lark-channels")
+  .description("Sync configured Lark channel bindings to the dispatcher")
+  .action(async () => {
+    const config = loadConfigOrExit();
+    const client = createDispatcherAdminClient({
+      dispatcherUrl: config.dispatcherUrl,
+      runnerId: config.runnerId,
+      ...(config.pairingToken ? { pairingToken: config.pairingToken } : {})
+    });
+    for (const binding of config.larkChannels ?? []) {
+      await client.bindChannel({
+        provider: "lark",
+        accountId: binding.tenantKey,
+        conversationId: binding.chatId,
+        repoProvider: binding.repoProvider,
+        owner: binding.owner,
+        repo: binding.repo
+      });
+      console.log(`Bound Lark ${binding.tenantKey}/${binding.chatId} to ${binding.owner}/${binding.repo}`);
+    }
+    if (!(config.larkChannels?.length ?? 0)) {
+      console.log("No Lark channels configured.");
+    }
+  });
+
+program
   .command("doctor")
   .description("Check dispatcher, bindings, checkouts, and executors")
   .action(async () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,13 @@ Set `LARK_APP_ID` / `LARK_APP_SECRET` / `LARK_DOMAIN` on the dispatcher too, so
 the Lark callback sink can post replies. Bind a chat to a repo with
 `opentagd bind-lark-channels` (using `larkChannels`) or `POST /v1/channel-bindings`.
 
+Each chat is bound independently (one `tenantKey/chatId` → one repo), so one bot
+can serve several chats that each target a different repo. Users can also bind a
+chat from inside Lark without the CLI: @-mention the bot with `/bind <owner>/<repo>`
+(e.g. `/bind amplifthq/opentag`, or `/bind github:amplifthq/opentag`). The bot
+confirms in-thread, and an @-mention in an unbound chat replies with the same
+hint. The target repo must already be registered on a runner (`opentagd bind-repos`).
+
 ## Secret Handling
 
 - Do not commit config files that contain real tokens, signing secrets, or private keys.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,22 @@ Add Slack channel bindings when a chat surface should route work to a repository
 }
 ```
 
+Add Lark channel bindings the same way for a Lark chat or group:
+
+```json
+{
+  "larkChannels": [
+    {
+      "tenantKey": "<tenant_key>",
+      "chatId": "oc_...",
+      "repoProvider": "github",
+      "owner": "acme",
+      "repo": "demo"
+    }
+  ]
+}
+```
+
 Add Claude Code settings when using the built-in `claude-code` executor:
 
 ```json
@@ -102,6 +118,7 @@ Use daemon security settings to keep executor runs constrained:
 | `pairingToken` | none | Shared Bearer token for dispatcher `/v1/*` calls |
 | `repositories` | `[]` | Repository bindings this daemon is allowed to claim |
 | `slackChannels` | none | Slack compatibility bindings that map `teamId/channelId` into the generic channel binding table |
+| `larkChannels` | none | Lark bindings that map `tenantKey/chatId` into the generic channel binding table |
 | `claudeCode` | none | Claude Code executor settings |
 | `security` | none | Runner security policy |
 | `githubToken` | none | Optional token for PR creation from daemon-produced branches |
@@ -144,6 +161,8 @@ for repeatable setups.
 | `OPENTAG_SLACK_TEAM_ID` | none | Creates one env-derived Slack channel binding when paired with repo env |
 | `OPENTAG_SLACK_CHANNEL_ID` | none | Creates one env-derived Slack channel binding when paired with repo env |
 | `OPENTAG_SLACK_REPO_PROVIDER` | `github` | Repo provider used for the env-derived Slack channel binding |
+| `OPENTAG_LARK_TENANT_KEY` | none | Creates one env-derived Lark channel binding when paired with repo env |
+| `OPENTAG_LARK_CHAT_ID` | none | Creates one env-derived Lark channel binding when paired with repo env |
 | `OPENTAG_CLAUDE_COMMAND` | `claude` in executor default | Claude Code CLI command |
 | `OPENTAG_CLAUDE_MODEL` | none | Optional Claude model |
 | `OPENTAG_CLAUDE_PERMISSION_MODE` | none | `acceptEdits`, `auto`, `bypassPermissions`, `default`, or `plan` |
@@ -168,6 +187,9 @@ for repeatable setups.
 | `OPENTAG_GITHUB_TOKEN` | none | Enables GitHub callback posting and GitHub apply helpers |
 | `OPENTAG_SLACK_BOT_TOKEN` | none | Single Slack bot token for callback posting |
 | `OPENTAG_SLACK_BOT_TOKENS_JSON` | none | JSON object mapping `agentId` to Slack bot token |
+| `LARK_APP_ID` | none | Lark app id for the callback sink that posts replies via the Lark API |
+| `LARK_APP_SECRET` | none | Lark app secret for the callback sink |
+| `LARK_DOMAIN` | `lark` | `lark` or `feishu`; selects the Lark vs Feishu API host |
 
 If `OPENTAG_PAIRING_TOKEN` is set on the dispatcher, use the same value as:
 
@@ -223,6 +245,25 @@ on the dispatcher. That avoids duplicate acknowledgement comments.
 Set `OPENTAG_SLACK_BOT_TOKEN` or `OPENTAG_SLACK_BOT_TOKENS_JSON` on the
 dispatcher, not on the Slack ingress, when you want final replies posted back to
 Slack threads.
+
+## Lark Ingress Environment
+
+`apps/lark-events` opens a Lark/Feishu WebSocket long connection (no public
+tunnel) and creates OpenTag runs from `im.message.receive_v1` events.
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `LARK_APP_ID` | yes | Lark app id used for the long connection |
+| `LARK_APP_SECRET` | yes | Lark app secret used for the long connection |
+| `LARK_DOMAIN` | no | `lark` or `feishu`; defaults to `lark` |
+| `OPENTAG_DISPATCHER_URL` | yes | Dispatcher URL |
+| `OPENTAG_DISPATCHER_TOKEN` | when dispatcher is paired | Bearer token for dispatcher `/v1/*` |
+| `LARK_BOT_OPEN_ID` | for group chats | Bot open id; group messages must @-mention it. Direct p2p chats do not need it |
+| `OPENTAG_LARK_AGENT_ID` | no | Agent id for the ingress. Defaults to `opentag` |
+
+Set `LARK_APP_ID` / `LARK_APP_SECRET` / `LARK_DOMAIN` on the dispatcher too, so
+the Lark callback sink can post replies. Bind a chat to a repo with
+`opentagd bind-lark-channels` (using `larkChannels`) or `POST /v1/channel-bindings`.
 
 ## Secret Handling
 

--- a/packages/dispatcher/package.json
+++ b/packages/dispatcher/package.json
@@ -32,8 +32,10 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.68.0",
     "@opentag/core": "workspace:*",
     "@opentag/github": "workspace:*",
+    "@opentag/lark": "workspace:*",
     "@opentag/slack": "workspace:*",
     "@opentag/store": "workspace:*",
     "better-sqlite3": "^11.7.0",

--- a/packages/dispatcher/package.json
+++ b/packages/dispatcher/package.json
@@ -32,7 +32,6 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@larksuiteoapi/node-sdk": "^1.68.0",
     "@opentag/core": "workspace:*",
     "@opentag/github": "workspace:*",
     "@opentag/lark": "workspace:*",

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -1,3 +1,5 @@
+import * as lark from "@larksuiteoapi/node-sdk";
+import { createLarkTextMessageContent, parseLarkThreadKey } from "@opentag/lark";
 import { createSlackPostMessagePayload, createSlackUpdateMessagePayload, parseSlackThreadKey } from "@opentag/slack";
 import type { CallbackMessage, CallbackSink } from "./server.js";
 
@@ -140,6 +142,51 @@ export function createSlackCallbackSink(input: {
           }
         }
       }
+    }
+  };
+}
+
+export type LarkReplyClient = {
+  im: {
+    message: {
+      reply(payload: {
+        path: { message_id: string };
+        data: { content: string; msg_type: string; reply_in_thread?: boolean; uuid?: string };
+      }): Promise<unknown>;
+    };
+  };
+};
+
+export function createLarkCallbackSink(input: {
+  appId?: string;
+  appSecret?: string;
+  domain?: "lark" | "feishu";
+  client?: LarkReplyClient;
+}): CallbackSink {
+  const client: LarkReplyClient | undefined =
+    input.client ??
+    (input.appId && input.appSecret
+      ? new lark.Client({
+          appId: input.appId,
+          appSecret: input.appSecret,
+          domain: input.domain === "feishu" ? lark.Domain.Feishu : lark.Domain.Lark
+        })
+      : undefined);
+
+  return {
+    async deliver(message: CallbackMessage): Promise<void> {
+      if (message.provider !== "lark") return;
+      if (!client) return;
+
+      const { messageId } = parseLarkThreadKey(message.threadKey ?? "");
+      await client.im.message.reply({
+        path: { message_id: messageId },
+        data: {
+          content: createLarkTextMessageContent(message.body),
+          msg_type: "text",
+          reply_in_thread: true
+        }
+      });
     }
   };
 }

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -163,6 +163,13 @@ export function createLarkCallbackSink(input: {
   domain?: "lark" | "feishu";
   client?: LarkReplyClient;
 }): CallbackSink {
+  // Reject partial credentials up front so a misconfigured sink fails loudly at
+  // startup rather than silently dropping replies. Neither credential set is
+  // fine (Lark is simply not configured); exactly one set is a mistake.
+  if (!input.client && Boolean(input.appId) !== Boolean(input.appSecret)) {
+    throw new Error("Lark callback sink requires both appId and appSecret (or neither).");
+  }
+
   const client: LarkReplyClient | undefined =
     input.client ??
     (input.appId && input.appSecret
@@ -176,9 +183,16 @@ export function createLarkCallbackSink(input: {
   return {
     async deliver(message: CallbackMessage): Promise<void> {
       if (message.provider !== "lark") return;
-      if (!client) return;
+      // A lark run was accepted, so a missing client or threadKey is a real
+      // delivery failure that must surface — not a silent success.
+      if (!client) {
+        throw new Error("Lark callback sink received a lark message but has no client configured (missing appId/appSecret).");
+      }
+      if (!message.threadKey) {
+        throw new Error("Lark callback message is missing threadKey.");
+      }
 
-      const { messageId } = parseLarkThreadKey(message.threadKey ?? "");
+      const { messageId } = parseLarkThreadKey(message.threadKey);
       await client.im.message.reply({
         path: { message_id: messageId },
         data: {

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -1,5 +1,4 @@
-import * as lark from "@larksuiteoapi/node-sdk";
-import { createLarkTextMessageContent, parseLarkThreadKey } from "@opentag/lark";
+import { createLarkReplyClient, type LarkReplyClient, parseLarkThreadKey, replyLarkMessage } from "@opentag/lark";
 import { createSlackPostMessagePayload, createSlackUpdateMessagePayload, parseSlackThreadKey } from "@opentag/slack";
 import type { CallbackMessage, CallbackSink } from "./server.js";
 
@@ -146,26 +145,13 @@ export function createSlackCallbackSink(input: {
   };
 }
 
-export type LarkReplyClient = {
-  im: {
-    message: {
-      reply(payload: {
-        path: { message_id: string };
-        data: { content: string; msg_type: string; reply_in_thread?: boolean; uuid?: string };
-      }): Promise<unknown>;
-    };
-  };
-};
-
 export function createLarkCallbackSink(input: {
   appId?: string;
   appSecret?: string;
   domain?: "lark" | "feishu";
   client?: LarkReplyClient;
 }): CallbackSink {
-  // Reject partial credentials up front so a misconfigured sink fails loudly at
-  // startup rather than silently dropping replies. Neither credential set is
-  // fine (Lark is simply not configured); exactly one set is a mistake.
+  // Reject partial credentials so a misconfigured sink fails at startup, not silently.
   if (!input.client && Boolean(input.appId) !== Boolean(input.appSecret)) {
     throw new Error("Lark callback sink requires both appId and appSecret (or neither).");
   }
@@ -173,34 +159,21 @@ export function createLarkCallbackSink(input: {
   const client: LarkReplyClient | undefined =
     input.client ??
     (input.appId && input.appSecret
-      ? new lark.Client({
-          appId: input.appId,
-          appSecret: input.appSecret,
-          domain: input.domain === "feishu" ? lark.Domain.Feishu : lark.Domain.Lark
-        })
+      ? createLarkReplyClient({ appId: input.appId, appSecret: input.appSecret, ...(input.domain ? { domain: input.domain } : {}) })
       : undefined);
 
   return {
     async deliver(message: CallbackMessage): Promise<void> {
       if (message.provider !== "lark") return;
-      // A lark run was accepted, so a missing client or threadKey is a real
-      // delivery failure that must surface — not a silent success.
+      // A lark run was accepted, so a missing client/threadKey is a real failure, not a silent success.
       if (!client) {
         throw new Error("Lark callback sink received a lark message but has no client configured (missing appId/appSecret).");
       }
       if (!message.threadKey) {
         throw new Error("Lark callback message is missing threadKey.");
       }
-
       const { messageId } = parseLarkThreadKey(message.threadKey);
-      await client.im.message.reply({
-        path: { message_id: messageId },
-        data: {
-          content: createLarkTextMessageContent(message.body),
-          msg_type: "text",
-          reply_in_thread: true
-        }
-      });
+      await replyLarkMessage(client, { messageId, text: message.body });
     }
   };
 }

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -1,5 +1,6 @@
 import type { OpenTagRunResult } from "@opentag/core";
 import { renderAcknowledgement, renderFinalResult, renderProgress } from "@opentag/github";
+import { renderLarkAcknowledgement, renderLarkFinalResult } from "@opentag/lark";
 import { createSlackFinalResultBlocks, renderSlackAcknowledgement, renderSlackFinalResult, type SlackBlock } from "@opentag/slack";
 import type { CallbackMessage } from "./server.js";
 
@@ -27,6 +28,9 @@ export function createDefaultCallbackPresentation(): CallbackPresentation {
       if (input.provider === "slack") {
         return renderSlackAcknowledgement(input.runId);
       }
+      if (input.provider === "lark") {
+        return renderLarkAcknowledgement(input.runId);
+      }
       return renderAcknowledgement(input.runId);
     },
 
@@ -40,6 +44,9 @@ export function createDefaultCallbackPresentation(): CallbackPresentation {
           body: renderSlackFinalResult(input.result),
           blocks: createSlackFinalResultBlocks(input.result)
         };
+      }
+      if (input.provider === "lark") {
+        return { body: renderLarkFinalResult(input.result) };
       }
       return { body: renderFinalResult(input.result) };
     }

--- a/packages/dispatcher/test/lark-callback.test.ts
+++ b/packages/dispatcher/test/lark-callback.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { createLarkCallbackSink, type LarkReplyClient } from "../src/callbacks.js";
+import type { LarkReplyClient } from "@opentag/lark";
+import { createLarkCallbackSink } from "../src/callbacks.js";
 import type { CallbackMessage } from "../src/server.js";
 
 function larkMessage(overrides?: Partial<CallbackMessage>): CallbackMessage {

--- a/packages/dispatcher/test/lark-callback.test.ts
+++ b/packages/dispatcher/test/lark-callback.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLarkCallbackSink, type LarkReplyClient } from "../src/callbacks.js";
+import type { CallbackMessage } from "../src/server.js";
+
+function larkMessage(overrides?: Partial<CallbackMessage>): CallbackMessage {
+  return {
+    runId: "run_1",
+    kind: "final",
+    provider: "lark",
+    uri: "lark://im/v1/messages",
+    body: "done",
+    threadKey: "tk_123|oc_chat|om_msg",
+    ...overrides
+  };
+}
+
+function mockClient() {
+  const reply = vi.fn(async () => ({}));
+  const client: LarkReplyClient = { im: { message: { reply } } };
+  return { client, reply };
+}
+
+describe("createLarkCallbackSink", () => {
+  it("replies in-thread to the trigger message via the Lark client", async () => {
+    const { client, reply } = mockClient();
+    const sink = createLarkCallbackSink({ client });
+    await sink.deliver(larkMessage());
+    expect(reply).toHaveBeenCalledTimes(1);
+    const arg = reply.mock.calls[0]?.[0];
+    expect(arg?.path.message_id).toBe("om_msg");
+    expect(arg?.data.reply_in_thread).toBe(true);
+    expect(arg?.data.msg_type).toBe("text");
+    expect(JSON.parse(arg?.data.content ?? "{}").text).toBe("done");
+  });
+
+  it("ignores non-lark messages", async () => {
+    const { client, reply } = mockClient();
+    const sink = createLarkCallbackSink({ client });
+    await sink.deliver(larkMessage({ provider: "slack" }));
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it("throws on partial credentials (appId without appSecret)", () => {
+    expect(() => createLarkCallbackSink({ appId: "cli_x" })).toThrow(/both appId and appSecret/);
+  });
+
+  it("does not throw when neither credential is set", () => {
+    expect(() => createLarkCallbackSink({})).not.toThrow();
+  });
+
+  it("throws when a lark message arrives but no client is configured", async () => {
+    const sink = createLarkCallbackSink({});
+    await expect(sink.deliver(larkMessage())).rejects.toThrow(/no client configured/);
+  });
+
+  it("throws when threadKey is missing", async () => {
+    const { client } = mockClient();
+    const sink = createLarkCallbackSink({ client });
+    const msg: CallbackMessage = {
+      runId: "run_1",
+      kind: "final",
+      provider: "lark",
+      uri: "lark://im/v1/messages",
+      body: "done"
+    };
+    await expect(sink.deliver(msg)).rejects.toThrow(/missing threadKey/);
+  });
+});

--- a/packages/dispatcher/tsconfig.json
+++ b/packages/dispatcher/tsconfig.json
@@ -8,6 +8,7 @@
   "references": [
     { "path": "../core" },
     { "path": "../github" },
+    { "path": "../lark" },
     { "path": "../slack" },
     { "path": "../store" }
   ]

--- a/packages/lark/package.json
+++ b/packages/lark/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@opentag/lark",
+  "version": "0.1.0",
+  "description": "Lark/Feishu message normalization and callback helpers for OpenTag.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "opentag",
+    "lark",
+    "feishu",
+    "events",
+    "agents"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "build": "tsup && tsc -b tsconfig.json --emitDeclarationOnly --force",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opentag/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/lark/package.json
+++ b/packages/lark/package.json
@@ -32,6 +32,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.68.0",
     "@opentag/core": "workspace:*"
   },
   "devDependencies": {

--- a/packages/lark/src/index.ts
+++ b/packages/lark/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./normalize.js";
+export * from "./render.js";

--- a/packages/lark/src/index.ts
+++ b/packages/lark/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./normalize.js";
+export * from "./outbound.js";
 export * from "./render.js";

--- a/packages/lark/src/normalize.ts
+++ b/packages/lark/src/normalize.ts
@@ -1,0 +1,195 @@
+import { commandFromRawText, type ContextPointer, type OpenTagCommand, type OpenTagEvent, type PermissionGrant } from "@opentag/core";
+
+export type LarkChannelBinding = {
+  tenantKey: string;
+  chatId: string;
+  repoProvider?: string;
+  owner: string;
+  repo: string;
+};
+
+export type LarkMessageInput = {
+  tenantKey: string;
+  chatId: string;
+  chatType: string;
+  senderOpenId: string;
+  text: string;
+  messageId: string;
+  rootId?: string;
+  eventId: string;
+  eventTimeMs: number;
+  agentId?: string;
+  botOpenId?: string;
+  botMentionKey?: string;
+  callbackUri?: string;
+  binding: LarkChannelBinding;
+};
+
+/**
+ * Lark message text encodes @-mentions as `@_user_N` placeholders, with the
+ * mentions[] array mapping each placeholder key to a user. Strip the bot's
+ * placeholder (when known) plus any leftover `@_user_N` tokens, then collapse
+ * whitespace. Returns the bare command text.
+ */
+export function stripLarkMention(text: string, botMentionKey?: string): string {
+  let stripped = text;
+  if (botMentionKey) {
+    stripped = stripped.split(botMentionKey).join(" ");
+  }
+  return stripped
+    .replace(/@_user_\d+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function encodeLarkThreadKey(input: { tenantKey: string; chatId: string; messageId: string }): string {
+  return `${input.tenantKey}|${input.chatId}|${input.messageId}`;
+}
+
+export function parseLarkThreadKey(threadKey: string): { tenantKey: string; chatId: string; messageId: string } {
+  const [tenantKey, chatId, messageId] = threadKey.split("|");
+  if (!tenantKey || !chatId || !messageId) {
+    throw new Error(`Invalid Lark thread key: ${threadKey}`);
+  }
+  return { tenantKey, chatId, messageId };
+}
+
+function permissionsForIntent(intent: OpenTagCommand["intent"]): PermissionGrant[] {
+  const permissions: PermissionGrant[] = [
+    {
+      scope: "chat:postMessage",
+      reason: "reply in the originating Lark thread"
+    },
+    {
+      scope: "runner:local",
+      reason: "execute the run on a paired local daemon"
+    }
+  ];
+
+  if (intent === "fix" || intent === "run") {
+    permissions.push(
+      {
+        scope: "repo:read",
+        reason: "inspect the repository in the paired local checkout"
+      },
+      {
+        scope: "repo:write",
+        reason: "commit code changes on an isolated run branch"
+      },
+      {
+        scope: "pr:create",
+        reason: "open a pull request for completed code changes"
+      }
+    );
+  }
+
+  return permissions;
+}
+
+function contextPointersForCommand(command: OpenTagCommand): ContextPointer[] {
+  const context: ContextPointer[] = [];
+
+  for (const reference of command.parsed?.references ?? []) {
+    if (reference.kind === "url") {
+      context.push({
+        kind: "url",
+        uri: reference.uri,
+        visibility: "organization",
+        title: reference.title ?? "Command URL reference"
+      });
+      continue;
+    }
+
+    if (reference.kind === "file" || reference.kind === "path") {
+      context.push({
+        kind: "file",
+        uri: reference.uri,
+        ...(reference.line ? { line: reference.line } : {}),
+        ...(reference.startLine ? { startLine: reference.startLine } : {}),
+        ...(reference.endLine ? { endLine: reference.endLine } : {}),
+        visibility: "organization",
+        title: referenceTitle(reference)
+      });
+    }
+  }
+
+  return context;
+}
+
+function referenceTitle(reference: NonNullable<OpenTagCommand["parsed"]>["references"][number]): string {
+  return reference.title ?? "Command file reference";
+}
+
+function commandMetadata(command: OpenTagCommand): Record<string, unknown> {
+  if (!command.parsed) return {};
+  return {
+    commandParser: command.parsed.version,
+    commandDiagnostics: command.parsed.diagnostics,
+    ...(command.parsed.approval ? { approval: command.parsed.approval } : {}),
+    ...(command.parsed.network ? { network: command.parsed.network } : {})
+  };
+}
+
+export function normalizeLarkMessage(input: LarkMessageInput): OpenTagEvent | null {
+  const rawText = stripLarkMention(input.text, input.botMentionKey);
+  if (!rawText) return null;
+
+  const command = commandFromRawText(rawText);
+  const agentId = input.agentId ?? "opentag";
+
+  return {
+    id: `evt_lark_message_${input.eventId}`,
+    source: "lark",
+    sourceEventId: input.eventId,
+    receivedAt: new Date(input.eventTimeMs).toISOString(),
+    actor: {
+      provider: "lark",
+      providerUserId: input.senderOpenId,
+      handle: input.senderOpenId,
+      organizationId: input.tenantKey
+    },
+    target: {
+      mention: input.botOpenId ? `@${input.botOpenId}` : "@app",
+      agentId,
+      ...(command.parsed?.executorHint ? { executorHint: command.parsed.executorHint } : {})
+    },
+    command,
+    context: [
+      {
+        kind: "lark.message",
+        uri: `lark://tenant/${input.tenantKey}/chat/${input.chatId}/message/${input.messageId}`,
+        visibility: "organization",
+        title: "Lark message"
+      },
+      {
+        kind: "text",
+        uri: input.text,
+        visibility: "organization",
+        title: "Lark message text"
+      },
+      ...contextPointersForCommand(command)
+    ],
+    permissions: permissionsForIntent(command.intent),
+    callback: {
+      provider: "lark",
+      uri: input.callbackUri ?? "lark://im/v1/messages",
+      threadKey: encodeLarkThreadKey({
+        tenantKey: input.tenantKey,
+        chatId: input.chatId,
+        messageId: input.messageId
+      })
+    },
+    metadata: {
+      tenantKey: input.tenantKey,
+      chatId: input.chatId,
+      messageId: input.messageId,
+      chatType: input.chatType,
+      ...(input.rootId ? { rootId: input.rootId } : {}),
+      ...(input.botOpenId ? { larkBotOpenId: input.botOpenId } : {}),
+      ...commandMetadata(command),
+      repoProvider: input.binding.repoProvider ?? "github",
+      owner: input.binding.owner,
+      repo: input.binding.repo
+    }
+  };
+}

--- a/packages/lark/src/normalize.ts
+++ b/packages/lark/src/normalize.ts
@@ -24,14 +24,7 @@ export type LarkMessageInput = {
   binding: LarkChannelBinding;
 };
 
-/**
- * Lark message text encodes @-mentions as `@_user_N` placeholders, with the
- * mentions[] array mapping each placeholder key to a user. Strip every
- * placeholder token and collapse whitespace, returning the bare command text.
- *
- * The `\d+` match removes a whole index (so `@_user_10` is removed intact rather
- * than leaving a stray `0` from a `@_user_1` substring strip).
- */
+// Strip `@_user_N` mention placeholders (whole \d+ index) and collapse whitespace.
 export function stripLarkMention(text: string): string {
   return text
     .replace(/@_user_\d+/g, " ")

--- a/packages/lark/src/normalize.ts
+++ b/packages/lark/src/normalize.ts
@@ -20,23 +20,20 @@ export type LarkMessageInput = {
   eventTimeMs: number;
   agentId?: string;
   botOpenId?: string;
-  botMentionKey?: string;
   callbackUri?: string;
   binding: LarkChannelBinding;
 };
 
 /**
  * Lark message text encodes @-mentions as `@_user_N` placeholders, with the
- * mentions[] array mapping each placeholder key to a user. Strip the bot's
- * placeholder (when known) plus any leftover `@_user_N` tokens, then collapse
- * whitespace. Returns the bare command text.
+ * mentions[] array mapping each placeholder key to a user. Strip every
+ * placeholder token and collapse whitespace, returning the bare command text.
+ *
+ * The `\d+` match removes a whole index (so `@_user_10` is removed intact rather
+ * than leaving a stray `0` from a `@_user_1` substring strip).
  */
-export function stripLarkMention(text: string, botMentionKey?: string): string {
-  let stripped = text;
-  if (botMentionKey) {
-    stripped = stripped.split(botMentionKey).join(" ");
-  }
-  return stripped
+export function stripLarkMention(text: string): string {
+  return text
     .replace(/@_user_\d+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
@@ -131,7 +128,7 @@ function commandMetadata(command: OpenTagCommand): Record<string, unknown> {
 }
 
 export function normalizeLarkMessage(input: LarkMessageInput): OpenTagEvent | null {
-  const rawText = stripLarkMention(input.text, input.botMentionKey);
+  const rawText = stripLarkMention(input.text);
   if (!rawText) return null;
 
   const command = commandFromRawText(rawText);

--- a/packages/lark/src/outbound.ts
+++ b/packages/lark/src/outbound.ts
@@ -1,0 +1,29 @@
+import * as lark from "@larksuiteoapi/node-sdk";
+import { createLarkTextMessageContent } from "./render.js";
+
+// Minimal client surface OpenTag uses; lark.Client satisfies it structurally.
+export type LarkReplyClient = {
+  im: {
+    message: {
+      reply(payload: {
+        path: { message_id: string };
+        data: { content: string; msg_type: string; reply_in_thread?: boolean; uuid?: string };
+      }): Promise<unknown>;
+    };
+  };
+};
+
+export function createLarkReplyClient(input: { appId: string; appSecret: string; domain?: "lark" | "feishu" }): LarkReplyClient {
+  return new lark.Client({
+    appId: input.appId,
+    appSecret: input.appSecret,
+    domain: input.domain === "feishu" ? lark.Domain.Feishu : lark.Domain.Lark
+  });
+}
+
+export async function replyLarkMessage(client: LarkReplyClient, input: { messageId: string; text: string }): Promise<void> {
+  await client.im.message.reply({
+    path: { message_id: input.messageId },
+    data: { content: createLarkTextMessageContent(input.text), msg_type: "text", reply_in_thread: true }
+  });
+}

--- a/packages/lark/src/render.ts
+++ b/packages/lark/src/render.ts
@@ -1,0 +1,37 @@
+import type { OpenTagRunResult } from "@opentag/core";
+
+function nextActionSummary(result: OpenTagRunResult): string | undefined {
+  if (!result.nextAction) return undefined;
+  if (typeof result.nextAction === "string") return result.nextAction;
+  return result.nextAction.summary;
+}
+
+export function renderLarkAcknowledgement(runId: string): string {
+  return `I picked this up: ${runId}`;
+}
+
+export function renderLarkFinalResult(result: OpenTagRunResult): string {
+  const lines = [`Finished with ${result.conclusion}.`, "", result.summary];
+
+  if (result.verification?.length) {
+    lines.push("", "Verification");
+    for (const check of result.verification) {
+      lines.push(`- ${check.command}: ${check.outcome}`);
+    }
+  }
+
+  const nextAction = nextActionSummary(result);
+  if (nextAction) {
+    lines.push("", `Next action: ${nextAction}`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Lark text messages carry their body as a JSON-encoded `{ "text": "..." }`
+ * string in the `content` field. This helper produces that serialized content.
+ */
+export function createLarkTextMessageContent(text: string): string {
+  return JSON.stringify({ text });
+}

--- a/packages/lark/src/render.ts
+++ b/packages/lark/src/render.ts
@@ -28,10 +28,7 @@ export function renderLarkFinalResult(result: OpenTagRunResult): string {
   return lines.join("\n");
 }
 
-/**
- * Lark text messages carry their body as a JSON-encoded `{ "text": "..." }`
- * string in the `content` field. This helper produces that serialized content.
- */
+// Lark text message content is a JSON-encoded `{ "text": "..." }` string.
 export function createLarkTextMessageContent(text: string): string {
   return JSON.stringify({ text });
 }

--- a/packages/lark/test/normalize.test.ts
+++ b/packages/lark/test/normalize.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeLarkThreadKey,
+  type LarkMessageInput,
+  normalizeLarkMessage,
+  parseLarkThreadKey,
+  stripLarkMention
+} from "../src/index.js";
+
+const baseInput: LarkMessageInput = {
+  tenantKey: "tk_123",
+  chatId: "oc_chat",
+  chatType: "group",
+  senderOpenId: "ou_user",
+  text: "@_user_1 fix the login bug",
+  messageId: "om_msg",
+  eventId: "evt_1",
+  eventTimeMs: 1_700_000_000_000,
+  botMentionKey: "@_user_1",
+  binding: { tenantKey: "tk_123", chatId: "oc_chat", owner: "acme", repo: "app" }
+};
+
+describe("stripLarkMention", () => {
+  it("strips the bot mention placeholder and trims", () => {
+    expect(stripLarkMention("@_user_1 hello", "@_user_1")).toBe("hello");
+  });
+
+  it("strips leftover @_user_N tokens and collapses whitespace", () => {
+    expect(stripLarkMention("hey @_user_2   there")).toBe("hey there");
+  });
+
+  it("returns empty string when only a mention is present", () => {
+    expect(stripLarkMention("@_user_1", "@_user_1")).toBe("");
+  });
+});
+
+describe("lark thread key", () => {
+  it("round-trips", () => {
+    const key = encodeLarkThreadKey({ tenantKey: "tk", chatId: "oc", messageId: "om" });
+    expect(key).toBe("tk|oc|om");
+    expect(parseLarkThreadKey(key)).toEqual({ tenantKey: "tk", chatId: "oc", messageId: "om" });
+  });
+
+  it("throws on a malformed key", () => {
+    expect(() => parseLarkThreadKey("bad")).toThrow(/Invalid Lark thread key/);
+  });
+});
+
+describe("normalizeLarkMessage", () => {
+  it("maps a Lark message into an OpenTagEvent", () => {
+    const event = normalizeLarkMessage(baseInput);
+    expect(event).not.toBeNull();
+    expect(event?.source).toBe("lark");
+    expect(event?.actor.provider).toBe("lark");
+    expect(event?.actor.providerUserId).toBe("ou_user");
+    expect(event?.actor.organizationId).toBe("tk_123");
+    expect(event?.callback.provider).toBe("lark");
+    expect(event?.callback.threadKey).toBe("tk_123|oc_chat|om_msg");
+    expect(event?.command.rawText).toBe("fix the login bug");
+    expect(event?.metadata.owner).toBe("acme");
+    expect(event?.metadata.repo).toBe("app");
+    expect(event?.metadata.repoProvider).toBe("github");
+    expect(event?.metadata.chatId).toBe("oc_chat");
+    expect(event?.metadata.tenantKey).toBe("tk_123");
+  });
+
+  it("returns null when the command is empty after stripping", () => {
+    expect(normalizeLarkMessage({ ...baseInput, text: "@_user_1" })).toBeNull();
+  });
+
+  it("honors binding.repoProvider when provided", () => {
+    const event = normalizeLarkMessage({
+      ...baseInput,
+      binding: { ...baseInput.binding, repoProvider: "gitlab" }
+    });
+    expect(event?.metadata.repoProvider).toBe("gitlab");
+  });
+});

--- a/packages/lark/test/normalize.test.ts
+++ b/packages/lark/test/normalize.test.ts
@@ -16,21 +16,24 @@ const baseInput: LarkMessageInput = {
   messageId: "om_msg",
   eventId: "evt_1",
   eventTimeMs: 1_700_000_000_000,
-  botMentionKey: "@_user_1",
   binding: { tenantKey: "tk_123", chatId: "oc_chat", owner: "acme", repo: "app" }
 };
 
 describe("stripLarkMention", () => {
-  it("strips the bot mention placeholder and trims", () => {
-    expect(stripLarkMention("@_user_1 hello", "@_user_1")).toBe("hello");
+  it("strips a mention placeholder and trims", () => {
+    expect(stripLarkMention("@_user_1 hello")).toBe("hello");
   });
 
-  it("strips leftover @_user_N tokens and collapses whitespace", () => {
-    expect(stripLarkMention("hey @_user_2   there")).toBe("hey there");
+  it("removes @_user_10 intact (no leftover digit from an @_user_1 prefix strip)", () => {
+    expect(stripLarkMention("@_user_10 deploy now")).toBe("deploy now");
+  });
+
+  it("strips multiple placeholders and collapses whitespace", () => {
+    expect(stripLarkMention("@_user_1 hey @_user_2   there")).toBe("hey there");
   });
 
   it("returns empty string when only a mention is present", () => {
-    expect(stripLarkMention("@_user_1", "@_user_1")).toBe("");
+    expect(stripLarkMention("@_user_1")).toBe("");
   });
 });
 

--- a/packages/lark/test/render.test.ts
+++ b/packages/lark/test/render.test.ts
@@ -1,0 +1,41 @@
+import type { OpenTagRunResult } from "@opentag/core";
+import { describe, expect, it } from "vitest";
+import { createLarkTextMessageContent, renderLarkAcknowledgement, renderLarkFinalResult } from "../src/index.js";
+
+describe("renderLarkAcknowledgement", () => {
+  it("includes the run id", () => {
+    expect(renderLarkAcknowledgement("run_1")).toContain("run_1");
+  });
+});
+
+describe("renderLarkFinalResult", () => {
+  it("renders conclusion, summary, verification and next action", () => {
+    const result: OpenTagRunResult = {
+      conclusion: "success",
+      summary: "Did the thing.",
+      verification: [{ command: "pnpm test", outcome: "passed" }],
+      nextAction: "Review the PR."
+    };
+    const text = renderLarkFinalResult(result);
+    expect(text).toContain("success");
+    expect(text).toContain("Did the thing.");
+    expect(text).toContain("pnpm test");
+    expect(text).toContain("passed");
+    expect(text).toContain("Review the PR.");
+  });
+
+  it("handles a structured nextAction", () => {
+    const result: OpenTagRunResult = {
+      conclusion: "needs_human",
+      summary: "Need a decision.",
+      nextAction: { summary: "Pick an option", hint: { kind: "request_human_decision" } }
+    };
+    expect(renderLarkFinalResult(result)).toContain("Pick an option");
+  });
+});
+
+describe("createLarkTextMessageContent", () => {
+  it("produces JSON-encoded text content", () => {
+    expect(createLarkTextMessageContent("hi")).toBe('{"text":"hi"}');
+  });
+});

--- a/packages/lark/tsconfig.json
+++ b/packages/lark/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/lark/tsup.config.ts
+++ b/packages/lark/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  sourcemap: true,
+  clean: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,31 @@ importers:
         specifier: ^5.7.2
         version: 5.9.3
 
+  apps/lark-events:
+    dependencies:
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.68.0
+        version: 1.68.0
+      '@opentag/client':
+        specifier: workspace:*
+        version: link:../../packages/client
+      '@opentag/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@opentag/lark':
+        specifier: workspace:*
+        version: link:../../packages/lark
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/opentagd:
     dependencies:
       '@opentag/client':
@@ -202,12 +227,18 @@ importers:
 
   packages/dispatcher:
     dependencies:
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.68.0
+        version: 1.68.0
       '@opentag/core':
         specifier: workspace:*
         version: link:../core
       '@opentag/github':
         specifier: workspace:*
         version: link:../github
+      '@opentag/lark':
+        specifier: workspace:*
+        version: link:../lark
       '@opentag/slack':
         specifier: workspace:*
         version: link:../slack
@@ -248,6 +279,19 @@ importers:
         version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.7.2
+        version: 5.9.3
+
+  packages/lark:
+    dependencies:
+      '@opentag/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.9.3
         version: 5.9.3
 
   packages/runner:
@@ -787,6 +831,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@larksuiteoapi/node-sdk@1.68.0':
+    resolution: {integrity: sha512-ip14+pWAv2La3bss4oDDtee2P5xBLDXuvmzhTvkxQMcPA5jCffFsler1TvNt4MyW6pexscj72AEWektyZwU9Yw==}
+
   '@octokit/auth-app@8.2.0':
     resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
     engines: {node: '>= 20'}
@@ -901,6 +948,33 @@ packages:
     resolution: {integrity: sha512-ULNKXY9jewO1/BHME3ZmsP3yHYocJBErT5D5fWxaQnoHNS635mTqBI2NszIGZO/56/i/lRFm+J9gp2NOkM6yjQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -1083,9 +1157,15 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1118,6 +1198,14 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -1135,6 +1223,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -1182,6 +1274,10 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1279,11 +1375,31 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1336,6 +1452,19 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -1344,12 +1473,39 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -1395,11 +1551,35 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lodash.identity@3.0.0:
+    resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.pickby@4.6.0:
+    resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1438,6 +1618,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   octokit-auth-probot@4.2.2:
     resolution: {integrity: sha512-fxJ8iIu030wh6wSCpT586IIH77+qLCLv0Jofx55aNotNC+8NN6MClE4EU0+3Fez6CRSyYa1RzIh1WcryEBjgRg==}
@@ -1530,8 +1714,19 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -1578,6 +1773,22 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1806,6 +2017,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -2074,6 +2297,20 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@larksuiteoapi/node-sdk@1.68.0':
+    dependencies:
+      axios: 1.13.6
+      lodash.identity: 3.0.0
+      lodash.merge: 4.6.2
+      lodash.pickby: 4.6.0
+      protobufjs: 7.6.4
+      qs: 6.15.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
   '@octokit/auth-app@8.2.0':
     dependencies:
       '@octokit/auth-oauth-app': 9.0.3
@@ -2218,6 +2455,26 @@ snapshots:
       pump: 3.0.4
       split2: 4.2.0
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
@@ -2358,7 +2615,17 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
+
+  axios@1.13.6:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   base64-js@1.5.1: {}
 
@@ -2393,6 +2660,16 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -2410,6 +2687,10 @@ snapshots:
   chownr@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@12.1.0: {}
 
@@ -2437,6 +2718,8 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-libc@2.1.2: {}
 
   drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
@@ -2444,11 +2727,32 @@ snapshots:
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 11.10.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2563,14 +2867,56 @@ snapshots:
       mlly: 1.8.2
       rollup: 4.62.2
 
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
   github-from-package@0.0.0: {}
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   help-me@5.0.0: {}
 
@@ -2598,11 +2944,27 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  lodash.identity@3.0.0: {}
+
+  lodash.merge@4.6.2: {}
+
+  lodash.pickby@4.6.0: {}
+
+  long@5.3.2: {}
+
   loupe@3.2.1: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-response@3.1.0: {}
 
@@ -2636,6 +2998,8 @@ snapshots:
   npx-import-light@1.0.0: {}
 
   object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
 
   octokit-auth-probot@4.2.2(@octokit/core@7.0.6):
     dependencies:
@@ -2771,10 +3135,31 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.20.0
+      long: 5.3.2
+
+  proxy-from-env@1.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quick-format-unescaped@4.0.4: {}
 
@@ -2837,6 +3222,34 @@ snapshots:
   secure-json-parse@4.1.0: {}
 
   semver@7.8.5: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3064,6 +3477,8 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   yaml@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,9 +227,6 @@ importers:
 
   packages/dispatcher:
     dependencies:
-      '@larksuiteoapi/node-sdk':
-        specifier: ^1.68.0
-        version: 1.68.0
       '@opentag/core':
         specifier: workspace:*
         version: link:../core
@@ -283,6 +280,9 @@ importers:
 
   packages/lark:
     dependencies:
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.68.0
+        version: 1.68.0
       '@opentag/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

Adds a Lark/Feishu connector, mirroring the Slack adapter and reusing the generic `channel_bindings` layer from #19 — **no new binding tables or dispatcher routes, only adapter code**.

## What's included

- **`packages/lark`** — `normalizeLarkMessage` → `OpenTagEvent` (source/provider `"lark"`), text result render, threadKey `tenantKey|chatId|messageId`. Reuses the platform-neutral command/context/permission helpers from `@opentag/core`.
- **`apps/lark-events`** — long-connection ingress via `@larksuiteoapi/node-sdk` `WSClient` (`im.message.receive_v1`). Resolves the repo via `getChannelBinding({ provider: "lark", accountId: tenantKey, conversationId: chatId })`. **No public tunnel required** (long connection, unlike Slack's webhook).
- **dispatcher** — `createLarkCallbackSink` (reply-in-thread via the Lark SDK `Client`) plus a Lark `presentation` branch, registered in `apps/dispatcher`.

## Notes

- **No core changes**: the `lark` enums in the core schema were already reserved.
- **No binding-layer changes**: reuses #19's generic `getChannelBinding(provider: "lark")`; Lark maps `account_id = tenant_key`, `conversation_id = chat_id`.
- Outbound is a **text MVP**; interactive cards can follow in a later PR.
- `pnpm-lock.yaml` realigns vitest to the `^3.2.6` already declared in the root `package.json` (the lock was stale at `2.1.9`).

## Operator config

`LARK_APP_ID`, `LARK_APP_SECRET`, `LARK_DOMAIN` (`lark` | `feishu`); optional `LARK_BOT_OPEN_ID`, `OPENTAG_LARK_AGENT_ID`.

## Tests / gates

- `packages/lark`: 12 unit tests (normalize + render)
- `apps/lark-events`: 5 handler tests
- Full suite green (**172 passed**); `tsc -b` typecheck and `pnpm -r lint` clean.

> Note: `packages/store` sqlite tests require Node 22 locally (better-sqlite3 prebuilt ABI); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lark/Feishu event intake with command normalization and automated run acknowledgement/final rendering.
  * Added Lark callback-based in-thread replies and dispatcher presentation for Lark provider responses.
  * Added `opentagd bind-lark-channels`, Lark channel binding configuration, and chat `/bind` flows.
* **Bug Fixes**
  * Improved payload validation, stricter group bot addressing, and clearer “ignored” outcomes (including timestamp fallback).
* **Tests**
  * Expanded unit/integration coverage for normalization, rendering, handler outcomes, and callback delivery.
* **Documentation**
  * Updated configuration/ingress docs and environment variable guidance for Lark/Feishu bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->