### PR TITLE
Add Telegram as a first-class OpenTag chat adapter

### DIFF
--- a/apps/dispatcher/src/index.ts
+++ b/apps/dispatcher/src/index.ts
@@ -1,5 +1,11 @@
 import { serve } from "@hono/node-server";
-import { createCompositeCallbackSink, createDispatcherApp, createGitHubCallbackSink, createSlackCallbackSink } from "@opentag/dispatcher";
+import {
+  createCompositeCallbackSink,
+  createDispatcherApp,
+  createGitHubCallbackSink,
+  createSlackCallbackSink,
+  createTelegramCallbackSink
+} from "@opentag/dispatcher";
 
 const port = Number(process.env.PORT ?? "3030");
 const databasePath = process.env.OPENTAG_DATABASE_PATH ?? "opentag.db";
@@ -22,6 +28,24 @@ function slackBotTokensByAgentIdFromEnv(): Record<string, string> | undefined {
 
 const slackBotTokensByAgentId = slackBotTokensByAgentIdFromEnv();
 
+function telegramBotTokensByAgentIdFromEnv(): Record<string, string> | undefined {
+  const raw = process.env.OPENTAG_TELEGRAM_BOT_TOKENS_JSON;
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Value is not a JSON object");
+    }
+    return Object.keys(parsed).length > 0 ? (parsed as Record<string, string>) : undefined;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse OPENTAG_TELEGRAM_BOT_TOKENS_JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+const telegramBotTokensByAgentId = telegramBotTokensByAgentIdFromEnv();
+
 serve({
   fetch: createDispatcherApp({
     databasePath,
@@ -34,6 +58,10 @@ serve({
       createSlackCallbackSink({
         ...(process.env.OPENTAG_SLACK_BOT_TOKEN ? { botToken: process.env.OPENTAG_SLACK_BOT_TOKEN } : {}),
         ...(slackBotTokensByAgentId ? { botTokensByAgentId: slackBotTokensByAgentId } : {})
+      }),
+      createTelegramCallbackSink({
+        ...(process.env.OPENTAG_TELEGRAM_BOT_TOKEN ? { botToken: process.env.OPENTAG_TELEGRAM_BOT_TOKEN } : {}),
+        ...(telegramBotTokensByAgentId ? { botTokensByAgentId: telegramBotTokensByAgentId } : {})
       })
     ])
   }).fetch,

--- a/apps/opentagd/src/config.ts
+++ b/apps/opentagd/src/config.ts
@@ -39,10 +39,21 @@ export const SlackChannelBindingConfigSchema = z.object({
   repo: z.string().min(1)
 });
 
+export const ChannelBindingConfigSchema = z.object({
+  provider: z.string().min(1),
+  accountId: z.string().min(1),
+  conversationId: z.string().min(1),
+  repoProvider: z.string().min(1).default("github"),
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  metadata: z.record(z.string(), z.unknown()).optional()
+});
+
 export const OpenTagDaemonConfigSchema = z.object({
   runnerId: z.string().min(1).default("runner_local"),
   dispatcherUrl: z.string().url().default("http://localhost:3030"),
   repositories: z.array(RepositoryBindingConfigSchema).default([]),
+  channelBindings: z.array(ChannelBindingConfigSchema).optional(),
   slackChannels: z.array(SlackChannelBindingConfigSchema).optional(),
   claudeCode: ClaudeCodeExecutorConfigSchema.optional(),
   security: RunnerSecurityPolicySchema.optional(),
@@ -54,6 +65,7 @@ export const OpenTagDaemonConfigSchema = z.object({
 });
 
 export type RepositoryBindingConfig = z.infer<typeof RepositoryBindingConfigSchema>;
+export type ChannelBindingConfig = z.infer<typeof ChannelBindingConfigSchema>;
 export type SlackChannelBindingConfig = z.infer<typeof SlackChannelBindingConfigSchema>;
 export type OpenTagDaemonConfig = z.infer<typeof OpenTagDaemonConfigSchema>;
 

--- a/apps/opentagd/src/doctor.ts
+++ b/apps/opentagd/src/doctor.ts
@@ -137,6 +137,40 @@ export async function runDoctor(input: {
     }
   }
 
+  for (const binding of input.config.channelBindings ?? []) {
+    try {
+      const { binding: remoteBinding } = await client.getChannelBinding({
+        provider: binding.provider,
+        accountId: binding.accountId,
+        conversationId: binding.conversationId
+      });
+      checks.push(
+        remoteBinding.repoProvider === binding.repoProvider &&
+        remoteBinding.owner === binding.owner &&
+        remoteBinding.repo === binding.repo
+          ? check(
+              "ok",
+              `${binding.provider}:${binding.accountId}/${binding.conversationId} binding`,
+              `${remoteBinding.repoProvider}:${remoteBinding.owner}/${remoteBinding.repo}`
+            )
+          : check(
+              "fail",
+              `${binding.provider}:${binding.accountId}/${binding.conversationId} binding`,
+              `Bound to ${remoteBinding.repoProvider}:${remoteBinding.owner}/${remoteBinding.repo}, expected ${binding.repoProvider}:${binding.owner}/${binding.repo}`
+            )
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      checks.push(
+        check(
+          message.includes("channel_binding_not_found") ? "warn" : "fail",
+          `${binding.provider}:${binding.accountId}/${binding.conversationId} binding`,
+          message
+        )
+      );
+    }
+  }
+
   for (const binding of input.config.slackChannels ?? []) {
     try {
       const { binding: remoteBinding } = await client.getChannelBinding({

--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -173,6 +173,35 @@ program
   });
 
 program
+  .command("bind-channels")
+  .description("Sync configured generic channel bindings to the dispatcher")
+  .action(async () => {
+    const config = loadConfigOrExit();
+    const client = createDispatcherAdminClient({
+      dispatcherUrl: config.dispatcherUrl,
+      runnerId: config.runnerId,
+      ...(config.pairingToken ? { pairingToken: config.pairingToken } : {})
+    });
+    for (const binding of config.channelBindings ?? []) {
+      await client.bindChannel({
+        provider: binding.provider,
+        accountId: binding.accountId,
+        conversationId: binding.conversationId,
+        repoProvider: binding.repoProvider,
+        owner: binding.owner,
+        repo: binding.repo,
+        ...(binding.metadata ? { metadata: binding.metadata } : {})
+      });
+      console.log(
+        `Bound ${binding.provider}:${binding.accountId}/${binding.conversationId} to ${binding.repoProvider}:${binding.owner}/${binding.repo}`
+      );
+    }
+    if (!(config.channelBindings?.length ?? 0)) {
+      console.log("No generic channel bindings configured.");
+    }
+  });
+
+program
   .command("doctor")
   .description("Check dispatcher, bindings, checkouts, and executors")
   .action(async () => {

--- a/apps/opentagd/test/config.test.ts
+++ b/apps/opentagd/test/config.test.ts
@@ -115,6 +115,34 @@ describe("opentagd config", () => {
     });
   });
 
+  it("parses generic channel bindings through the validated schema", () => {
+    const parsed = parseDaemonConfig({
+      dispatcherUrl: "http://localhost:3030",
+      repositories: [],
+      channelBindings: [
+        {
+          provider: "telegram",
+          accountId: "bot_123",
+          conversationId: "456",
+          repoProvider: "github",
+          owner: "acme",
+          repo: "demo",
+          metadata: { topic: "ops" }
+        }
+      ]
+    });
+
+    expect(parsed.channelBindings?.[0]).toMatchObject({
+      provider: "telegram",
+      accountId: "bot_123",
+      conversationId: "456",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo",
+      metadata: { topic: "ops" }
+    });
+  });
+
   it("formats zod config errors into a readable message", () => {
     const error = (() => {
       try {

--- a/apps/opentagd/test/doctor.test.ts
+++ b/apps/opentagd/test/doctor.test.ts
@@ -41,6 +41,16 @@ describe("opentagd doctor", () => {
             keepWorktree: "on_failure"
           }
         ],
+        channelBindings: [
+          {
+            provider: "telegram",
+            accountId: "bot_123",
+            conversationId: "456",
+            repoProvider: "github",
+            owner: "acme",
+            repo: "demo"
+          }
+        ],
         slackChannels: [{ teamId: "T123", channelId: "C123", repoProvider: "gitlab", owner: "acme", repo: "demo" }],
         githubToken: "ghs_test",
         pollIntervalMs: 5000,
@@ -77,6 +87,18 @@ describe("opentagd doctor", () => {
               accountId: "T123",
               conversationId: "C123",
               repoProvider: "gitlab",
+              owner: "acme",
+              repo: "demo"
+            }
+          });
+        }
+        if (stringUrl.endsWith("/v1/channel-bindings/telegram/bot_123/456")) {
+          return Response.json({
+            binding: {
+              provider: "telegram",
+              accountId: "bot_123",
+              conversationId: "456",
+              repoProvider: "github",
               owner: "acme",
               repo: "demo"
             }

--- a/apps/telegram-events/package.json
+++ b/apps/telegram-events/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@opentag/telegram-events",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsx src/index.ts",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "@opentag/client": "workspace:*",
+    "@opentag/core": "workspace:*",
+    "@opentag/telegram": "workspace:*",
+    "hono": "^4.6.15"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/telegram-events/src/app.ts
+++ b/apps/telegram-events/src/app.ts
@@ -1,0 +1,94 @@
+import type { OpenTagEvent } from "@opentag/core";
+import { type TelegramChannelBinding, normalizeTelegramMessage } from "@opentag/telegram";
+import { Hono } from "hono";
+
+type TelegramBotConfig = {
+  botId: string;
+  agentId: string;
+  botUsername?: string;
+  secretToken?: string;
+  callbackUri?: string;
+};
+
+type TelegramUpdate = {
+  update_id?: number;
+  message?: {
+    message_id?: number;
+    message_thread_id?: number;
+    text?: string;
+    from?: {
+      id?: number;
+      username?: string;
+    };
+    chat?: {
+      id?: number;
+      type?: "private" | "group" | "supergroup" | "channel";
+    };
+  };
+};
+
+export function createTelegramEventsApp(input: {
+  telegramBots: TelegramBotConfig[];
+  resolveChannelBinding(input: { botId: string; chatId: string }): Promise<TelegramChannelBinding | null>;
+  createRun(event: OpenTagEvent): Promise<{ runId: string }>;
+  now(): string;
+}) {
+  const app = new Hono();
+
+  app.post("/telegram/events/:botId", async (c) => {
+    const botId = c.req.param("botId");
+    const bot = input.telegramBots.find((candidate) => candidate.botId === botId);
+    if (!bot) {
+      return c.json({ error: "unknown_telegram_bot" }, 404);
+    }
+    if (bot.secretToken) {
+      const actual = c.req.header("x-telegram-bot-api-secret-token");
+      if (actual !== bot.secretToken) {
+        return c.json({ error: "invalid_secret_token" }, 401);
+      }
+    }
+
+    let payload: TelegramUpdate;
+    try {
+      payload = (await c.req.json()) as TelegramUpdate;
+    } catch {
+      return c.json({ error: "invalid_json" }, 400);
+    }
+
+    const message = payload.message;
+    if (!message?.message_id || !message.chat?.id || !message.chat.type || !message.from?.id || !message.text) {
+      return c.json({ ok: true, ignored: "unsupported_update" });
+    }
+
+    const chatId = String(message.chat.id);
+    const binding = await input.resolveChannelBinding({ botId, chatId });
+    if (!binding) {
+      return c.json({ ok: true, ignored: "unbound_chat" });
+    }
+
+    const event = normalizeTelegramMessage({
+      botId,
+      chatId,
+      chatType: message.chat.type,
+      userId: String(message.from.id),
+      ...(message.from.username ? { username: message.from.username } : {}),
+      ...(bot.botUsername ? { botUsername: bot.botUsername } : {}),
+      text: message.text,
+      messageId: message.message_id,
+      ...(payload.update_id ? { updateId: payload.update_id } : {}),
+      ...(message.message_thread_id ? { messageThreadId: message.message_thread_id } : {}),
+      receivedAt: input.now(),
+      agentId: bot.agentId,
+      ...(bot.callbackUri ? { callbackUri: bot.callbackUri } : {}),
+      binding
+    });
+    if (!event) {
+      return c.json({ ok: true, ignored: "empty_command" });
+    }
+
+    await input.createRun(event);
+    return c.json({ ok: true });
+  });
+
+  return app;
+}

--- a/apps/telegram-events/src/index.ts
+++ b/apps/telegram-events/src/index.ts
@@ -1,0 +1,101 @@
+import { serve } from "@hono/node-server";
+import { createOpenTagClient } from "@opentag/client";
+import { createTelegramEventsApp } from "./app.js";
+
+const dispatcherUrl = process.env.OPENTAG_DISPATCHER_URL;
+if (!dispatcherUrl) {
+  throw new Error("OPENTAG_DISPATCHER_URL is required");
+}
+
+const dispatcherToken = process.env.OPENTAG_DISPATCHER_TOKEN;
+const port = Number(process.env.PORT ?? "3050");
+const dispatcherClient = createOpenTagClient({
+  dispatcherUrl,
+  ...(dispatcherToken ? { pairingToken: dispatcherToken } : {})
+});
+
+type TelegramBotConfig = {
+  botId: string;
+  agentId: string;
+  botUsername?: string;
+  secretToken?: string;
+  callbackUri?: string;
+};
+
+function telegramBotsFromEnv(): TelegramBotConfig[] {
+  const botsJson = process.env.OPENTAG_TELEGRAM_BOTS_JSON;
+  if (botsJson) {
+    try {
+      const parsed = JSON.parse(botsJson);
+      if (!Array.isArray(parsed)) {
+        throw new Error("Value is not a JSON array");
+      }
+      return parsed.filter(
+        (candidate): candidate is TelegramBotConfig =>
+          Boolean(candidate) &&
+          typeof candidate === "object" &&
+          typeof candidate.botId === "string" &&
+          typeof candidate.agentId === "string"
+      );
+    } catch (error) {
+      throw new Error(
+        `Failed to parse OPENTAG_TELEGRAM_BOTS_JSON: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  if (!process.env.OPENTAG_TELEGRAM_BOT_ID) {
+    return [];
+  }
+
+  return [
+    {
+      botId: process.env.OPENTAG_TELEGRAM_BOT_ID,
+      agentId: process.env.OPENTAG_TELEGRAM_AGENT_ID ?? "opentag",
+      ...(process.env.OPENTAG_TELEGRAM_BOT_USERNAME ? { botUsername: process.env.OPENTAG_TELEGRAM_BOT_USERNAME } : {}),
+      ...(process.env.OPENTAG_TELEGRAM_SECRET_TOKEN ? { secretToken: process.env.OPENTAG_TELEGRAM_SECRET_TOKEN } : {}),
+      ...(process.env.OPENTAG_TELEGRAM_CALLBACK_URI ? { callbackUri: process.env.OPENTAG_TELEGRAM_CALLBACK_URI } : {})
+    }
+  ];
+}
+
+const telegramBots = telegramBotsFromEnv();
+if (telegramBots.length === 0) {
+  throw new Error("Configure OPENTAG_TELEGRAM_BOT_ID or OPENTAG_TELEGRAM_BOTS_JSON");
+}
+
+serve({
+  fetch: createTelegramEventsApp({
+    telegramBots,
+    async resolveChannelBinding(input) {
+      try {
+        const { binding } = await dispatcherClient.getChannelBinding({
+          provider: "telegram",
+          accountId: input.botId,
+          conversationId: input.chatId
+        });
+        return {
+          botId: binding.accountId,
+          chatId: binding.conversationId,
+          repoProvider: binding.repoProvider,
+          owner: binding.owner,
+          repo: binding.repo
+        };
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("channel_binding_not_found")) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    async createRun(event) {
+      const runId = `run_${Date.now()}`;
+      await dispatcherClient.createRun({ runId, event });
+      return { runId };
+    },
+    now: () => new Date().toISOString()
+  }).fetch,
+  port
+});
+
+console.log(`OpenTag Telegram events ingress listening on http://localhost:${port}`);

--- a/apps/telegram-events/test/app.test.ts
+++ b/apps/telegram-events/test/app.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramEventsApp } from "../src/app.js";
+
+describe("Telegram events app", () => {
+  const now = "2026-06-25T00:00:00.000Z";
+
+  it("creates a run for a bound Telegram private message", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_1" }));
+    const app = createTelegramEventsApp({
+      telegramBots: [{ botId: "bot_123", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return {
+          botId: "bot_123",
+          chatId: "456",
+          repoProvider: "github",
+          owner: "acme",
+          repo: "demo"
+        };
+      },
+      createRun,
+      now: () => now
+    });
+
+    const response = await app.request("/telegram/events/bot_123", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        update_id: 1,
+        message: {
+          message_id: 101,
+          from: { id: 789, username: "alice" },
+          chat: { id: 456, type: "private" },
+          text: "fix this"
+        }
+      })
+    });
+
+    expect(response.status).toBe(200);
+    expect(createRun).toHaveBeenCalledOnce();
+    const [event] = createRun.mock.calls[0] ?? [];
+    expect(event.source).toBe("telegram");
+    expect(event.target.agentId).toBe("opentag");
+  });
+});

--- a/apps/telegram-events/tsconfig.json
+++ b/apps/telegram-events/tsconfig.json
@@ -6,10 +6,8 @@
   },
   "include": ["src/**/*.ts"],
   "references": [
-    { "path": "../core" },
-    { "path": "../github" },
-    { "path": "../slack" },
-    { "path": "../telegram" },
-    { "path": "../store" }
+    { "path": "../../packages/client" },
+    { "path": "../../packages/core" },
+    { "path": "../../packages/telegram" }
   ]
 }

--- a/apps/telegram-events/tsup.config.ts
+++ b/apps/telegram-events/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  sourcemap: true,
+  clean: true
+});

--- a/docs/adapter-authoring.md
+++ b/docs/adapter-authoring.md
@@ -15,9 +15,9 @@ OpenTag currently uses three adapter shapes:
 
 | Adapter type | Purpose | Current examples |
 | --- | --- | --- |
-| Ingress normalizer | Converts a platform event into `OpenTagEvent` | `@opentag/github`, `@opentag/slack` |
-| Ingress app | Receives signed webhooks/events and calls the dispatcher | `apps/github-probot`, `apps/slack-events` |
-| Callback sink | Posts acknowledgement, progress, and final messages back to the source thread | `createGitHubCallbackSink`, `createSlackCallbackSink` |
+| Ingress normalizer | Converts a platform event into `OpenTagEvent` | `@opentag/github`, `@opentag/slack`, `@opentag/telegram` |
+| Ingress app | Receives signed webhooks/events and calls the dispatcher | `apps/github-probot`, `apps/slack-events`, `apps/telegram-events` |
+| Callback sink | Posts acknowledgement, progress, and final messages back to the source thread | `createGitHubCallbackSink`, `createSlackCallbackSink`, `createTelegramCallbackSink` |
 
 Future app support should arrive through these adapters, not by adding a new
 execution architecture. The dispatcher and runner contracts should stay shared.
@@ -39,12 +39,12 @@ execution architecture. The dispatcher and runner contracts should stay shared.
 
 Before writing code, check whether `@opentag/core` already supports the provider:
 
-- `SourceSchema` currently includes `github`, `slack`, `lark`, `cli`, and
+- `SourceSchema` currently includes `github`, `slack`, `telegram`, `lark`, `cli`, and
   `webhook`.
-- `ProviderSchema` currently includes `github`, `slack`, and `lark`.
-- `CallbackRouteSchema` currently includes `github`, `slack`, `lark`, and
+- `ProviderSchema` currently includes `github`, `slack`, `telegram`, and `lark`.
+- `CallbackRouteSchema` currently includes `github`, `slack`, `telegram`, `lark`, and
   `webhook`.
-- `ContextPointerSchema` includes GitHub, Slack, Lark, file, URL, and text
+- `ContextPointerSchema` includes GitHub, Slack, Telegram, Lark, file, URL, and text
   pointers.
 
 If the new app needs a new provider such as Linear, Jira, Teams, or Discord,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ configuration map, then jump to the runnable examples for end-to-end commands:
 
 ## Configuration Layers
 
-OpenTag has four runtime surfaces today:
+OpenTag has five runtime surfaces today:
 
 | Surface | Process | Owns |
 | --- | --- | --- |
@@ -17,6 +17,7 @@ OpenTag has four runtime surfaces today:
 | Local daemon | `apps/opentagd` | Runner identity, repository bindings, workspace paths, executor settings |
 | GitHub ingress | `apps/github-probot` | GitHub App webhooks and GitHub event normalization |
 | Slack ingress | `apps/slack-events` | Slack Events API verification and Slack event normalization |
+| Telegram ingress | `apps/telegram-events` | Telegram webhook ingestion and Telegram event normalization |
 
 Keep these boundaries separate. Ingress apps should know how to receive platform
 events and create runs. The dispatcher should coordinate runs and callbacks. The
@@ -68,6 +69,30 @@ Add Slack channel bindings when a chat surface should route work to a repository
 }
 ```
 
+Add generic channel bindings when a non-Slack chat surface should route work to
+a repository:
+
+```json
+{
+  "channelBindings": [
+    {
+      "provider": "telegram",
+      "accountId": "bot_123",
+      "conversationId": "456",
+      "repoProvider": "github",
+      "owner": "acme",
+      "repo": "demo"
+    }
+  ]
+}
+```
+
+Sync these generic bindings with:
+
+```bash
+OPENTAG_CONFIG_PATH=opentag.local.json pnpm --filter @opentag/opentagd dev -- bind-channels
+```
+
 Add Claude Code settings when using the built-in `claude-code` executor:
 
 ```json
@@ -101,6 +126,7 @@ Use daemon security settings to keep executor runs constrained:
 | `dispatcherUrl` | `http://localhost:3030` | Dispatcher base URL |
 | `pairingToken` | none | Shared Bearer token for dispatcher `/v1/*` calls |
 | `repositories` | `[]` | Repository bindings this daemon is allowed to claim |
+| `channelBindings` | none | Generic channel bindings such as Telegram `botId/chatId -> repo` |
 | `slackChannels` | none | Slack compatibility bindings that map `teamId/channelId` into the generic channel binding table |
 | `claudeCode` | none | Claude Code executor settings |
 | `security` | none | Runner security policy |
@@ -168,6 +194,8 @@ for repeatable setups.
 | `OPENTAG_GITHUB_TOKEN` | none | Enables GitHub callback posting and GitHub apply helpers |
 | `OPENTAG_SLACK_BOT_TOKEN` | none | Single Slack bot token for callback posting |
 | `OPENTAG_SLACK_BOT_TOKENS_JSON` | none | JSON object mapping `agentId` to Slack bot token |
+| `OPENTAG_TELEGRAM_BOT_TOKEN` | none | Single Telegram bot token for callback posting |
+| `OPENTAG_TELEGRAM_BOT_TOKENS_JSON` | none | JSON object mapping `agentId` to Telegram bot token |
 
 If `OPENTAG_PAIRING_TOKEN` is set on the dispatcher, use the same value as:
 
@@ -223,6 +251,40 @@ on the dispatcher. That avoids duplicate acknowledgement comments.
 Set `OPENTAG_SLACK_BOT_TOKEN` or `OPENTAG_SLACK_BOT_TOKENS_JSON` on the
 dispatcher, not on the Slack ingress, when you want final replies posted back to
 Slack threads.
+
+## Telegram Ingress Environment
+
+`apps/telegram-events` receives Telegram webhook updates and creates OpenTag runs.
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `OPENTAG_DISPATCHER_URL` | yes | Dispatcher URL |
+| `OPENTAG_DISPATCHER_TOKEN` | when dispatcher is paired | Bearer token for dispatcher `/v1/*` |
+| `PORT` | no | Defaults to `3050` |
+| `OPENTAG_TELEGRAM_BOT_ID` | yes unless using JSON config | Bot id used in the webhook path and channel binding lookup |
+| `OPENTAG_TELEGRAM_AGENT_ID` | no | Agent id for single-bot mode. Defaults to `opentag` |
+| `OPENTAG_TELEGRAM_BOT_USERNAME` | no | Used to strip mentions in group chats |
+| `OPENTAG_TELEGRAM_SECRET_TOKEN` | no | Expected `x-telegram-bot-api-secret-token` header value |
+| `OPENTAG_TELEGRAM_CALLBACK_URI` | no | Callback URI override. Defaults to `https://api.telegram.org/sendMessage` |
+| `OPENTAG_TELEGRAM_BOTS_JSON` | no | JSON array for multi-bot ingress |
+
+`OPENTAG_TELEGRAM_BOTS_JSON` shape:
+
+```json
+[
+  {
+    "botId": "bot_123",
+    "agentId": "opentag",
+    "botUsername": "opentag_bot",
+    "secretToken": "telegram-secret",
+    "callbackUri": "https://api.telegram.org/sendMessage"
+  }
+]
+```
+
+Set `OPENTAG_TELEGRAM_BOT_TOKEN` or `OPENTAG_TELEGRAM_BOT_TOKENS_JSON` on the
+dispatcher, not on the Telegram ingress, when you want final replies posted
+back to Telegram chats.
 
 ## Secret Handling
 

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -108,7 +108,15 @@ function classifyContextPointer(pointer: ContextPointer): ClassifiedContextPoint
   if (pointer.kind === "text") {
     return { pointer, classification: "primary_evidence", reason: "Original user-authored text is primary evidence." };
   }
-  if (pointer.kind === "github.issue" || pointer.kind === "github.pull_request" || pointer.kind === "github.comment" || pointer.kind === "slack.thread" || pointer.kind === "slack.message") {
+  if (
+    pointer.kind === "github.issue" ||
+    pointer.kind === "github.pull_request" ||
+    pointer.kind === "github.comment" ||
+    pointer.kind === "slack.thread" ||
+    pointer.kind === "slack.message" ||
+    pointer.kind === "telegram.thread" ||
+    pointer.kind === "telegram.message"
+  ) {
     return { pointer, classification: "primary_evidence", reason: `${pointer.kind} is directly attached to the invocation.` };
   }
   if (pointer.kind === "github.repo" || pointer.kind === "file" || pointer.kind === "url") {
@@ -203,7 +211,7 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "callback",
     requiresExplicitIntent: false,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "slack", "lark", "webhook"],
+    adapterTargets: ["github", "slack", "telegram", "lark", "webhook"],
     requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
   },
   {
@@ -212,7 +220,7 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "callback",
     requiresExplicitIntent: false,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "slack", "lark", "webhook"],
+    adapterTargets: ["github", "slack", "telegram", "lark", "webhook"],
     requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
   },
   {
@@ -267,7 +275,7 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "callback",
     requiresExplicitIntent: false,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "slack", "lark"],
+    adapterTargets: ["github", "slack", "telegram", "lark"],
     requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
   }
 ] satisfies CapabilityContract[];
@@ -325,10 +333,11 @@ export function workItemReferenceFromEvent(event: OpenTagEvent): WorkItemReferen
 }
 
 export function primaryConversationAnchorFromEvent(event: OpenTagEvent): ConversationAnchor {
-  const slackThreadKey = event.callback.provider === "slack" ? event.callback.threadKey : undefined;
+  const structuredThreadKey =
+    event.callback.provider === "slack" || event.callback.provider === "telegram" ? event.callback.threadKey : undefined;
   return {
     provider: event.callback.provider,
-    kind: event.callback.provider === "slack" ? "thread" : `${event.callback.provider}_thread`,
+    kind: event.callback.provider === "slack" || event.callback.provider === "telegram" ? "thread" : `${event.callback.provider}_thread`,
     externalId: event.callback.threadKey ?? event.callback.uri,
     uri:
       firstContextUri(event, "github.comment") ??
@@ -336,7 +345,7 @@ export function primaryConversationAnchorFromEvent(event: OpenTagEvent): Convers
       event.callback.uri,
     controlPlane: true,
     canApprove: true,
-    ...(slackThreadKey ? { threadKey: slackThreadKey } : {})
+    ...(structuredThreadKey ? { threadKey: structuredThreadKey } : {})
   };
 }
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-export const SourceSchema = z.enum(["github", "slack", "lark", "cli", "webhook"]);
-export const ProviderSchema = z.enum(["github", "slack", "lark"]);
+export const SourceSchema = z.enum(["github", "slack", "telegram", "lark", "cli", "webhook"]);
+export const ProviderSchema = z.enum(["github", "slack", "telegram", "lark"]);
 export const ExecutorHintSchema = z.enum(["claude-code", "codex", "hermes", "openclaw", "custom"]);
 export const PermissionScopeSchema = z.enum([
   "repo:read",
@@ -76,6 +76,9 @@ export const ContextPointerSchema = z.object({
     "slack.channel",
     "slack.thread",
     "slack.message",
+    "telegram.chat",
+    "telegram.thread",
+    "telegram.message",
     "lark.chat",
     "lark.thread",
     "lark.message",
@@ -192,7 +195,7 @@ export const SuccessMetricNameSchema = z.enum([
 ]);
 
 export const CallbackRouteSchema = z.object({
-  provider: z.enum(["github", "slack", "lark", "webhook"]),
+  provider: z.enum(["github", "slack", "telegram", "lark", "webhook"]),
   uri: z.string().min(1),
   threadKey: z.string().min(1).optional()
 });
@@ -214,7 +217,7 @@ export const WorkItemReferenceSchema = z.object({
 });
 
 export const ConversationAnchorSchema = z.object({
-  provider: z.enum(["github", "slack", "lark", "webhook"]),
+  provider: z.enum(["github", "slack", "telegram", "lark", "webhook"]),
   kind: z.string().min(1),
   externalId: z.string().min(1),
   uri: z.string().min(1),

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -58,6 +58,51 @@ describe("OpenTagEventSchema", () => {
     expect(parsed.source).toBe("github");
   });
 
+  it("accepts a valid Telegram event", () => {
+    const parsed = OpenTagEventSchema.parse({
+      id: "evt_tg_1",
+      source: "telegram",
+      sourceEventId: "update_123",
+      receivedAt: "2026-06-25T00:00:00.000Z",
+      actor: {
+        provider: "telegram",
+        providerUserId: "456",
+        handle: "alice"
+      },
+      target: {
+        mention: "@opentag_bot",
+        agentId: "opentag"
+      },
+      command: {
+        rawText: "fix this",
+        intent: "fix",
+        args: {}
+      },
+      context: [
+        {
+          kind: "telegram.message",
+          uri: "telegram://bot/123/chat/456/message/789",
+          visibility: "organization"
+        }
+      ],
+      permissions: [
+        {
+          scope: "chat:postMessage",
+          reason: "reply to source thread"
+        }
+      ],
+      callback: {
+        provider: "telegram",
+        uri: "https://api.telegram.org/sendMessage",
+        threadKey: "123|456|789|"
+      },
+      metadata: {}
+    });
+
+    expect(parsed.source).toBe("telegram");
+    expect(parsed.callback.provider).toBe("telegram");
+  });
+
   it("accepts the current public executor hints", () => {
     for (const executorHint of ["claude-code", "codex", "hermes", "openclaw", "custom"]) {
       expect(

--- a/packages/dispatcher/README.md
+++ b/packages/dispatcher/README.md
@@ -15,6 +15,7 @@ pnpm add @opentag/dispatcher
 - `createDispatcherApp`: creates the Hono app that exposes the OpenTag dispatcher API.
 - `createGitHubCallbackSink`: posts callback messages to GitHub issue or PR comments.
 - `createSlackCallbackSink`: posts callback messages to Slack threads through `chat.postMessage`.
+- `createTelegramCallbackSink`: posts callback messages to Telegram chats through the Bot API `sendMessage` method.
 - `createCompositeCallbackSink`: fans callback delivery out to multiple sinks.
 - `CallbackMessage`, `CallbackSink`: callback delivery contracts.
 
@@ -25,7 +26,8 @@ import {
   createCompositeCallbackSink,
   createDispatcherApp,
   createGitHubCallbackSink,
-  createSlackCallbackSink
+  createSlackCallbackSink,
+  createTelegramCallbackSink
 } from "@opentag/dispatcher";
 
 export const dispatcher = createDispatcherApp({
@@ -33,14 +35,15 @@ export const dispatcher = createDispatcherApp({
   pairingToken: process.env.OPENTAG_PAIRING_TOKEN,
   callbackSink: createCompositeCallbackSink([
     createGitHubCallbackSink({ token: process.env.OPENTAG_GITHUB_TOKEN }),
-    createSlackCallbackSink({ botToken: process.env.OPENTAG_SLACK_BOT_TOKEN })
+    createSlackCallbackSink({ botToken: process.env.OPENTAG_SLACK_BOT_TOKEN }),
+    createTelegramCallbackSink({ botToken: process.env.OPENTAG_TELEGRAM_BOT_TOKEN })
   ])
 });
 ```
 
 ## API Shape
 
-The app exposes `/healthz` and `/v1/*` dispatcher endpoints for runners, repository bindings, Slack channel bindings, runs, progress, heartbeats, completion, and audit event lookup.
+The app exposes `/healthz` and `/v1/*` dispatcher endpoints for runners, repository bindings, generic channel bindings, Slack compatibility bindings, runs, progress, heartbeats, completion, and audit event lookup.
 
 When `pairingToken` is set, every `/v1/*` endpoint requires:
 

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -1,4 +1,5 @@
 import { createSlackPostMessagePayload, createSlackUpdateMessagePayload, parseSlackThreadKey } from "@opentag/slack";
+import { createTelegramSendMessageDraftPayload, createTelegramSendMessagePayload, parseTelegramThreadKey } from "@opentag/telegram";
 import type { CallbackMessage, CallbackSink } from "./server.js";
 
 export type FetchLike = typeof fetch;
@@ -139,6 +140,69 @@ export function createSlackCallbackSink(input: {
             statusMessageTsByKey.delete(key);
           }
         }
+      }
+    }
+  };
+}
+
+export function createTelegramCallbackSink(input: {
+  botToken?: string;
+  botTokensByAgentId?: Record<string, string>;
+  fetchImpl?: FetchLike;
+}): CallbackSink {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const draftIdByKey = new Map<string, number>();
+  let nextDraftId = 1;
+
+  return {
+    async deliver(message: CallbackMessage): Promise<void> {
+      if (message.provider !== "telegram") return;
+      const botToken = slackBotTokenFor({
+        ...(input.botToken ? { botToken: input.botToken } : {}),
+        ...(input.botTokensByAgentId ? { botTokensByAgentId: input.botTokensByAgentId } : {}),
+        ...(message.agentId ? { agentId: message.agentId } : {})
+      });
+      if (!botToken) return;
+
+      const thread = parseTelegramThreadKey(message.threadKey ?? "");
+      const statusKey = message.statusMessageKey ?? `${message.runId}:status`;
+      const isDraft = message.kind === "progress";
+      const draftId = isDraft ? (draftIdByKey.get(statusKey) ?? nextDraftId++) : undefined;
+      if (isDraft && draftId && !draftIdByKey.has(statusKey)) {
+        draftIdByKey.set(statusKey, draftId);
+      }
+
+      const response = await fetchImpl(`https://api.telegram.org/bot${botToken}/${isDraft ? "sendMessageDraft" : "sendMessage"}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(
+          isDraft
+            ? createTelegramSendMessageDraftPayload({
+                chatId: thread.chatId,
+                text: message.body,
+                draftId: draftId!,
+                ...(thread.messageThreadId ? { messageThreadId: thread.messageThreadId } : {})
+              })
+            : createTelegramSendMessagePayload({
+                chatId: thread.chatId,
+                text: message.body,
+                replyToMessageId: thread.replyToMessageId,
+                ...(thread.messageThreadId ? { messageThreadId: thread.messageThreadId } : {})
+              })
+        )
+      });
+
+      if (!response.ok) {
+        throw new Error(`deliver Telegram callback failed: ${response.status} ${await response.text()}`);
+      }
+      const body = (await response.json()) as { ok?: boolean; description?: string };
+      if (body.ok === false) {
+        throw new Error(`deliver Telegram callback failed: ${body.description ?? "unknown_error"}`);
+      }
+      if (message.kind === "final") {
+        draftIdByKey.delete(statusKey);
       }
     }
   };

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -1,6 +1,7 @@
 import type { OpenTagRunResult } from "@opentag/core";
 import { renderAcknowledgement, renderFinalResult, renderProgress } from "@opentag/github";
 import { createSlackFinalResultBlocks, renderSlackAcknowledgement, renderSlackFinalResult, type SlackBlock } from "@opentag/slack";
+import { renderTelegramAcknowledgement, renderTelegramFinalResult, renderTelegramProgress } from "@opentag/telegram";
 import type { CallbackMessage } from "./server.js";
 
 export type CallbackProvider = CallbackMessage["provider"];
@@ -27,10 +28,16 @@ export function createDefaultCallbackPresentation(): CallbackPresentation {
       if (input.provider === "slack") {
         return renderSlackAcknowledgement(input.runId);
       }
+      if (input.provider === "telegram") {
+        return renderTelegramAcknowledgement(input.runId);
+      }
       return renderAcknowledgement(input.runId);
     },
 
     progress(input) {
+      if (input.provider === "telegram") {
+        return renderTelegramProgress(input.message);
+      }
       return renderProgress({ runId: input.runId, message: input.message });
     },
 
@@ -40,6 +47,9 @@ export function createDefaultCallbackPresentation(): CallbackPresentation {
           body: renderSlackFinalResult(input.result),
           blocks: createSlackFinalResultBlocks(input.result)
         };
+      }
+      if (input.provider === "telegram") {
+        return { body: renderTelegramFinalResult(input.result) };
       }
       return { body: renderFinalResult(input.result) };
     }

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -165,7 +165,7 @@ function mappingsFromAdapterPlan(adapterPlan: unknown) {
 export type CallbackMessage = {
   runId: string;
   kind: "acknowledgement" | "progress" | "final";
-  provider: "github" | "slack" | "lark" | "webhook";
+  provider: "github" | "slack" | "telegram" | "lark" | "webhook";
   uri: string;
   body: string;
   agentId?: string;

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createCompositeCallbackSink, createGitHubCallbackSink, createSlackCallbackSink } from "../src/callbacks.js";
+import { createCompositeCallbackSink, createGitHubCallbackSink, createSlackCallbackSink, createTelegramCallbackSink } from "../src/callbacks.js";
 
 describe("createGitHubCallbackSink", () => {
   it("posts GitHub callback messages to the callback URI", async () => {
@@ -210,6 +210,96 @@ describe("createGitHubCallbackSink", () => {
           channel: "C123",
           text: "done",
           thread_ts: "1710000000.000100"
+        }
+      }
+    ]);
+  });
+
+  it("posts Telegram callback messages to sendMessage", async () => {
+    const requests: { url: string; body: unknown }[] = [];
+    const sink = createTelegramCallbackSink({
+      botToken: "telegram-token",
+      fetchImpl: (async (url, init) => {
+        requests.push({
+          url: String(url),
+          body: JSON.parse(String(init?.body))
+        });
+        return Response.json({ ok: true, result: { message_id: 999 } });
+      }) as typeof fetch
+    });
+
+    await sink.deliver({
+      runId: "run_1",
+      kind: "final",
+      provider: "telegram",
+      uri: "https://api.telegram.org/sendMessage",
+      threadKey: "bot_123|-1001|789|42",
+      body: "done"
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "https://api.telegram.org/bottelegram-token/sendMessage",
+        body: {
+          chat_id: "-1001",
+          text: "done",
+          reply_to_message_id: 789,
+          message_thread_id: 42,
+          allow_sending_without_reply: true
+        }
+      }
+    ]);
+  });
+
+  it("streams Telegram progress messages through sendMessageDraft with a stable draft id", async () => {
+    const requests: { url: string; body: unknown }[] = [];
+    const sink = createTelegramCallbackSink({
+      botToken: "telegram-token",
+      fetchImpl: (async (url, init) => {
+        requests.push({
+          url: String(url),
+          body: JSON.parse(String(init?.body))
+        });
+        return Response.json({ ok: true });
+      }) as typeof fetch
+    });
+
+    await sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "telegram",
+      uri: "https://api.telegram.org/sendMessage",
+      threadKey: "bot_123|-1001|789|42",
+      statusMessageKey: "run_1:status",
+      body: "step 1"
+    });
+    await sink.deliver({
+      runId: "run_1",
+      kind: "progress",
+      provider: "telegram",
+      uri: "https://api.telegram.org/sendMessage",
+      threadKey: "bot_123|-1001|789|42",
+      statusMessageKey: "run_1:status",
+      body: "step 2"
+    });
+
+    expect(requests).toEqual([
+      {
+        url: "https://api.telegram.org/bottelegram-token/sendMessageDraft",
+        body: {
+          chat_id: "-1001",
+          text: "step 1",
+          draft_id: 1,
+          message_thread_id: 42
+        }
+      },
+      {
+        url: "https://api.telegram.org/bottelegram-token/sendMessageDraft",
+        body: {
+          chat_id: "-1001",
+          text: "step 2",
+          draft_id: 1,
+          message_thread_id: 42
         }
       }
     ]);

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -6,6 +6,7 @@ describe("default callback presentation", () => {
     const presentation = createDefaultCallbackPresentation();
 
     expect(presentation.shouldDeliverProgress("slack")).toBe(false);
+    expect(presentation.shouldDeliverProgress("telegram")).toBe(true);
     expect(presentation.shouldDeliverProgress("github")).toBe(true);
   });
 
@@ -19,6 +20,7 @@ describe("default callback presentation", () => {
 
     expect(presentation.acknowledgement({ provider: "github", runId: "run_1" })).toBe("OpenTag picked this up. Run: `run_1`");
     expect(presentation.acknowledgement({ provider: "slack", runId: "run_1" })).toBe("I picked this up: `run_1`");
+    expect(presentation.acknowledgement({ provider: "telegram", runId: "run_1" })).toBe("I picked this up: run_1");
     expect(presentation.final({ provider: "github", result })).toEqual({
       body: "OpenTag finished with **success**.\n\ndone\n\nVerification:\n- `echo`: passed"
     });
@@ -42,6 +44,24 @@ describe("default callback presentation", () => {
         }
       ]
     });
+    expect(presentation.final({ provider: "telegram", result })).toEqual({
+      body: "Finished with success.\n\ndone\n\nVerification:\n- echo: passed"
+    });
+  });
+
+  it("renders Telegram progress as concise conversational states", () => {
+    const presentation = createDefaultCallbackPresentation();
+
+    expect(presentation.progress({ provider: "telegram", runId: "run_1", message: "Starting claude --print" })).toBe(
+      "Thinking..."
+    );
+    expect(
+      presentation.progress({
+        provider: "telegram",
+        runId: "run_1",
+        message: "Creating isolated branch opentag/run_1"
+      })
+    ).toBe("Working...");
   });
 
   it("renders structured next actions by summary", () => {

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -61,7 +61,7 @@ export type OpenTagAuditEvent = {
 };
 
 export type CallbackDeliveryKind = "acknowledgement" | "progress" | "final";
-export type CallbackDeliveryProvider = "github" | "slack" | "lark" | "webhook";
+export type CallbackDeliveryProvider = "github" | "slack" | "telegram" | "lark" | "webhook";
 export type CallbackDeliveryStatus = "pending" | "delivering" | "delivered" | "failed";
 
 export type CallbackDelivery = {

--- a/packages/telegram/README.md
+++ b/packages/telegram/README.md
@@ -1,0 +1,55 @@
+# @opentag/telegram
+
+Telegram message normalization and callback helpers for OpenTag.
+
+Use this package to normalize Telegram bot messages into `OpenTagEvent` objects
+and to encode or parse Telegram callback thread keys.
+
+## Install
+
+```bash
+pnpm add @opentag/telegram
+```
+
+## Exports
+
+- `normalizeTelegramMessage`: converts a Telegram message into an `OpenTagEvent`.
+- `encodeTelegramThreadKey`: encodes bot, chat, and message coordinates for callback routing.
+- `parseTelegramThreadKey`: decodes a Telegram callback thread key.
+- `renderTelegramAcknowledgement`: renders the Telegram acknowledgement body.
+- `renderTelegramFinalResult`: renders the Telegram final result body.
+- `createTelegramSendMessagePayload`: creates a Telegram Bot API `sendMessage` payload.
+
+## Example
+
+```ts
+import { normalizeTelegramMessage } from "@opentag/telegram";
+
+const event = normalizeTelegramMessage({
+  botId: "bot_123",
+  botUsername: "opentag_bot",
+  chatId: "456",
+  chatType: "private",
+  userId: "789",
+  username: "alice",
+  text: "investigate this deploy failure",
+  messageId: 101,
+  updateId: 202,
+  binding: {
+    botId: "bot_123",
+    chatId: "456",
+    repoProvider: "github",
+    owner: "acme",
+    repo: "demo"
+  }
+});
+
+if (event) {
+  // Send the event to @opentag/client or your own OpenTag-compatible control plane.
+}
+```
+
+## Stability
+
+Telegram thread key format is public because callback sinks depend on it.
+Change it only with a migration path.

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@opentag/dispatcher",
+  "name": "@opentag/telegram",
   "version": "0.1.0",
-  "description": "Embeddable OpenTag dispatcher Hono app and callback sinks.",
+  "description": "Telegram message normalization and callback helpers for OpenTag.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -21,8 +21,8 @@
   },
   "keywords": [
     "opentag",
-    "dispatcher",
-    "hono",
+    "telegram",
+    "bots",
     "agents",
     "webhooks"
   ],
@@ -32,19 +32,10 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@opentag/core": "workspace:*",
-    "@opentag/github": "workspace:*",
-    "@opentag/slack": "workspace:*",
-    "@opentag/telegram": "workspace:*",
-    "@opentag/store": "workspace:*",
-    "better-sqlite3": "^11.7.0",
-    "drizzle-orm": "^0.45.2",
-    "hono": "^4.6.15",
-    "zod": "^3.24.1"
+    "@opentag/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.12",
-    "tsup": "^8.3.5",
-    "typescript": "^5.7.2"
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/telegram/src/index.ts
+++ b/packages/telegram/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./normalize.js";
+export * from "./render.js";

--- a/packages/telegram/src/normalize.ts
+++ b/packages/telegram/src/normalize.ts
@@ -1,0 +1,228 @@
+import { commandFromRawText, type ContextPointer, type OpenTagCommand, type OpenTagEvent, type PermissionGrant } from "@opentag/core";
+
+export type TelegramChannelBinding = {
+  botId: string;
+  chatId: string;
+  repoProvider?: string;
+  owner: string;
+  repo: string;
+};
+
+export type TelegramMessageInput = {
+  botId: string;
+  botUsername?: string;
+  chatId: string;
+  chatType: "private" | "group" | "supergroup" | "channel";
+  userId: string;
+  username?: string;
+  text: string;
+  messageId: number;
+  updateId?: number;
+  messageThreadId?: number;
+  receivedAt?: string;
+  agentId?: string;
+  callbackUri?: string;
+  binding: TelegramChannelBinding;
+};
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function stripTelegramInvocation(input: {
+  text: string;
+  chatType: TelegramMessageInput["chatType"];
+  botUsername?: string;
+}): string | null {
+  const trimmed = input.text.trim();
+  if (!trimmed) return null;
+  if (input.chatType === "private") return trimmed;
+
+  const username = input.botUsername?.replace(/^@/, "");
+  const patterns = username
+    ? [
+        new RegExp(`^@${escapeRegExp(username)}\\s+`, "i"),
+        new RegExp(`^/opentag@${escapeRegExp(username)}\\s+`, "i"),
+        /^\/opentag\s+/i
+      ]
+    : [/^\/opentag\s+/i];
+
+  for (const pattern of patterns) {
+    const stripped = trimmed.replace(pattern, "").trim();
+    if (stripped !== trimmed) {
+      return stripped.length > 0 ? stripped : null;
+    }
+  }
+
+  return null;
+}
+
+export function encodeTelegramThreadKey(input: {
+  botId: string;
+  chatId: string;
+  replyToMessageId: number;
+  messageThreadId?: number;
+}): string {
+  return [input.botId, input.chatId, String(input.replyToMessageId), input.messageThreadId ? String(input.messageThreadId) : ""].join("|");
+}
+
+export function parseTelegramThreadKey(threadKey: string): {
+  botId: string;
+  chatId: string;
+  replyToMessageId: number;
+  messageThreadId?: number;
+} {
+  const [botId, chatId, replyToMessageIdRaw, messageThreadIdRaw] = threadKey.split("|");
+  const replyToMessageId = Number(replyToMessageIdRaw);
+  if (!botId || !chatId || !Number.isInteger(replyToMessageId) || replyToMessageId <= 0) {
+    throw new Error(`Invalid Telegram thread key: ${threadKey}`);
+  }
+  const messageThreadId = messageThreadIdRaw ? Number(messageThreadIdRaw) : undefined;
+  return {
+    botId,
+    chatId,
+    replyToMessageId,
+    ...(messageThreadId && Number.isInteger(messageThreadId) && messageThreadId > 0 ? { messageThreadId } : {})
+  };
+}
+
+function permissionsForIntent(intent: OpenTagCommand["intent"]): PermissionGrant[] {
+  const permissions: PermissionGrant[] = [
+    {
+      scope: "chat:postMessage",
+      reason: "reply in the originating Telegram thread"
+    },
+    {
+      scope: "runner:local",
+      reason: "execute the run on a paired local daemon"
+    }
+  ];
+
+  if (intent === "fix" || intent === "run") {
+    permissions.push(
+      {
+        scope: "repo:read",
+        reason: "inspect the repository in the paired local checkout"
+      },
+      {
+        scope: "repo:write",
+        reason: "commit code changes on an isolated run branch"
+      },
+      {
+        scope: "pr:create",
+        reason: "open a pull request for completed code changes"
+      }
+    );
+  }
+
+  return permissions;
+}
+
+function referenceTitle(reference: NonNullable<OpenTagCommand["parsed"]>["references"][number]): string {
+  return reference.title ?? "Command file reference";
+}
+
+function contextPointersForCommand(command: OpenTagCommand): ContextPointer[] {
+  const context: ContextPointer[] = [];
+  for (const reference of command.parsed?.references ?? []) {
+    if (reference.kind === "url") {
+      context.push({
+        kind: "url",
+        uri: reference.uri,
+        visibility: "organization",
+        title: reference.title ?? "Command URL reference"
+      });
+      continue;
+    }
+    if (reference.kind === "file" || reference.kind === "path") {
+      context.push({
+        kind: "file",
+        uri: reference.uri,
+        ...(reference.line ? { line: reference.line } : {}),
+        ...(reference.startLine ? { startLine: reference.startLine } : {}),
+        ...(reference.endLine ? { endLine: reference.endLine } : {}),
+        visibility: "organization",
+        title: referenceTitle(reference)
+      });
+    }
+  }
+  return context;
+}
+
+function commandMetadata(command: OpenTagCommand): Record<string, unknown> {
+  if (!command.parsed) return {};
+  return {
+    commandParser: command.parsed.version,
+    commandDiagnostics: command.parsed.diagnostics,
+    ...(command.parsed.approval ? { approval: command.parsed.approval } : {}),
+    ...(command.parsed.network ? { network: command.parsed.network } : {})
+  };
+}
+
+export function normalizeTelegramMessage(input: TelegramMessageInput): OpenTagEvent | null {
+  const rawText = stripTelegramInvocation({
+    text: input.text,
+    chatType: input.chatType,
+    ...(input.botUsername ? { botUsername: input.botUsername } : {})
+  });
+  if (!rawText) return null;
+
+  const command = commandFromRawText(rawText);
+  const agentId = input.agentId ?? "opentag";
+
+  return {
+    id: `evt_telegram_${input.updateId ?? `${input.botId}_${input.chatId}_${input.messageId}`}`,
+    source: "telegram",
+    sourceEventId: String(input.updateId ?? input.messageId),
+    receivedAt: input.receivedAt ?? new Date().toISOString(),
+    actor: {
+      provider: "telegram",
+      providerUserId: input.userId,
+      ...(input.username ? { handle: input.username } : {})
+    },
+    target: {
+      mention: input.botUsername ? `@${input.botUsername.replace(/^@/, "")}` : "/opentag",
+      agentId,
+      ...(command.parsed?.executorHint ? { executorHint: command.parsed.executorHint } : {})
+    },
+    command,
+    context: [
+      {
+        kind: "telegram.message",
+        uri: `telegram://bot/${input.botId}/chat/${input.chatId}/message/${input.messageId}`,
+        visibility: "organization",
+        title: "Telegram message"
+      },
+      {
+        kind: "text",
+        uri: input.text,
+        visibility: "organization",
+        title: "Telegram message text"
+      },
+      ...contextPointersForCommand(command)
+    ],
+    permissions: permissionsForIntent(command.intent),
+    callback: {
+      provider: "telegram",
+      uri: input.callbackUri ?? "https://api.telegram.org/sendMessage",
+      threadKey: encodeTelegramThreadKey({
+        botId: input.botId,
+        chatId: input.chatId,
+        replyToMessageId: input.messageId,
+        ...(input.messageThreadId ? { messageThreadId: input.messageThreadId } : {})
+      })
+    },
+    metadata: {
+      botId: input.botId,
+      chatId: input.chatId,
+      messageId: input.messageId,
+      chatType: input.chatType,
+      ...(input.messageThreadId ? { messageThreadId: input.messageThreadId } : {}),
+      ...(input.botUsername ? { telegramBotUsername: input.botUsername.replace(/^@/, "") } : {}),
+      ...commandMetadata(command),
+      repoProvider: input.binding.repoProvider ?? "github",
+      owner: input.binding.owner,
+      repo: input.binding.repo
+    }
+  };
+}

--- a/packages/telegram/src/render.ts
+++ b/packages/telegram/src/render.ts
@@ -1,0 +1,80 @@
+import type { OpenTagRunResult } from "@opentag/core";
+
+function nextActionSummary(result: OpenTagRunResult): string | undefined {
+  if (!result.nextAction) return undefined;
+  if (typeof result.nextAction === "string") return result.nextAction;
+  return result.nextAction.summary;
+}
+
+export function renderTelegramAcknowledgement(runId: string): string {
+  return `I picked this up: ${runId}`;
+}
+
+export function renderTelegramProgress(message: string): string {
+  if (/starting claude --print|thinking/i.test(message)) {
+    return "Thinking...";
+  }
+
+  return "Working...";
+}
+
+export function renderTelegramFinalResult(result: OpenTagRunResult): string {
+  const lines = [`Finished with ${result.conclusion}.`, "", result.summary];
+
+  if (result.verification?.length) {
+    lines.push("", "Verification:");
+    for (const check of result.verification) {
+      lines.push(`- ${check.command}: ${check.outcome}`);
+    }
+  }
+
+  const nextAction = nextActionSummary(result);
+  if (nextAction) {
+    lines.push("", `Next action: ${nextAction}`);
+  }
+
+  return lines.join("\n");
+}
+
+export type TelegramSendMessagePayload = {
+  chat_id: string;
+  text: string;
+  reply_to_message_id?: number;
+  message_thread_id?: number;
+  allow_sending_without_reply?: boolean;
+};
+
+export type TelegramSendMessageDraftPayload = {
+  chat_id: string;
+  text: string;
+  draft_id: number;
+  message_thread_id?: number;
+};
+
+export function createTelegramSendMessagePayload(input: {
+  chatId: string;
+  text: string;
+  replyToMessageId?: number;
+  messageThreadId?: number;
+}): TelegramSendMessagePayload {
+  return {
+    chat_id: input.chatId,
+    text: input.text,
+    ...(input.replyToMessageId ? { reply_to_message_id: input.replyToMessageId, allow_sending_without_reply: true } : {}),
+    ...(input.messageThreadId ? { message_thread_id: input.messageThreadId } : {})
+  };
+}
+
+export function createTelegramSendMessageDraftPayload(input: {
+  chatId: string;
+  text: string;
+  draftId: number;
+  messageThreadId?: number;
+}): TelegramSendMessageDraftPayload {
+  return {
+    chat_id: input.chatId,
+    text: input.text,
+    draft_id: input.draftId,
+    ...(input.messageThreadId ? { message_thread_id: input.messageThreadId } : {})
+  };
+}

--- a/packages/telegram/test/normalize.test.ts
+++ b/packages/telegram/test/normalize.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { encodeTelegramThreadKey, normalizeTelegramMessage, parseTelegramThreadKey } from "../src/normalize.js";
+
+describe("Telegram normalization", () => {
+  it("normalizes a private Telegram message into an OpenTagEvent", () => {
+    const event = normalizeTelegramMessage({
+      botId: "bot_123",
+      chatId: "456",
+      chatType: "private",
+      userId: "789",
+      text: "fix this",
+      messageId: 101,
+      updateId: 202,
+      agentId: "opentag",
+      binding: {
+        botId: "bot_123",
+        chatId: "456",
+        repoProvider: "github",
+        owner: "acme",
+        repo: "demo"
+      }
+    });
+
+    expect(event?.source).toBe("telegram");
+    expect(event?.command.intent).toBe("fix");
+    expect(event?.callback.provider).toBe("telegram");
+    expect(event?.metadata).toMatchObject({
+      botId: "bot_123",
+      chatId: "456",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo"
+    });
+  });
+
+  it("encodes and decodes Telegram thread keys", () => {
+    const key = encodeTelegramThreadKey({
+      botId: "bot_123",
+      chatId: "456",
+      replyToMessageId: 101,
+      messageThreadId: 42
+    });
+
+    expect(parseTelegramThreadKey(key)).toEqual({
+      botId: "bot_123",
+      chatId: "456",
+      replyToMessageId: 101,
+      messageThreadId: 42
+    });
+  });
+});

--- a/packages/telegram/tsconfig.json
+++ b/packages/telegram/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/telegram/tsup.config.ts
+++ b/packages/telegram/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  sourcemap: true,
+  clean: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,34 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  apps/telegram-events:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.14(hono@4.12.27)
+      '@opentag/client':
+        specifier: workspace:*
+        version: link:../../packages/client
+      '@opentag/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@opentag/telegram':
+        specifier: workspace:*
+        version: link:../../packages/telegram
+      hono:
+        specifier: ^4.6.15
+        version: 4.12.27
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/custom-runner:
     dependencies:
       '@opentag/client':
@@ -214,6 +242,9 @@ importers:
       '@opentag/store':
         specifier: workspace:*
         version: link:../store
+      '@opentag/telegram':
+        specifier: workspace:*
+        version: link:../telegram
       better-sqlite3:
         specifier: ^11.7.0
         version: 11.10.0
@@ -296,6 +327,19 @@ importers:
         version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.7.2
+        version: 5.9.3
+
+  packages/telegram:
+    dependencies:
+      '@opentag/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.9.3
         version: 5.9.3
 
 packages:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,13 @@
     { "path": "packages/dispatcher" },
     { "path": "packages/github" },
     { "path": "packages/slack" },
+    { "path": "packages/telegram" },
     { "path": "packages/runner" },
     { "path": "packages/store" },
     { "path": "apps/dispatcher" },
     { "path": "apps/github-probot" },
     { "path": "apps/slack-events" },
+    { "path": "apps/telegram-events" },
     { "path": "apps/opentagd" },
     { "path": "examples/custom-runner" },
     { "path": "examples/embedded-dispatcher" }


### PR DESCRIPTION
## Summary
- add a dedicated `@opentag/telegram` adapter package plus `apps/telegram-events` ingress
- extend core/provider/dispatcher/channel-binding plumbing so Telegram runs through the shared adapter loop
- add Telegram callback delivery, draft-based progress via `sendMessageDraft`, and config/docs for generic `channelBindings`

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- real Telegram webhook capture to obtain a live `chat_id`
- real Telegram replay E2E through `apps/telegram-events -> dispatcher -> opentagd -> Telegram callback`
- real Telegram progress delivery through `sendMessageDraft`

## Notes
- the bot webhook was restored to its original staging URL after validation
- this PR does not yet add true executor content chunk streaming; Telegram progress currently streams state updates such as thinking/working via draft messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram support across the platform, including event ingestion, message normalization, and callback delivery.
  * Introduced generic channel bindings so conversations can be linked to repositories beyond the existing Slack flow.
  * Added Telegram-specific run updates and final responses for a more conversational experience.

* **Bug Fixes**
  * Improved validation and doctor checks for channel bindings to surface configuration issues earlier.

* **Documentation**
  * Updated setup and adapter docs to cover Telegram configuration, ingress, and binding sync commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->