### PR TITLE
[codex] Add example environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,79 @@
+# OpenTag example environment
+#
+# Copy this file to .env for local experiments and replace placeholder values.
+# Keep real tokens and private keys out of git.
+
+# Shared dispatcher auth
+# If set on the dispatcher, use the same value as OPENTAG_DISPATCHER_TOKEN in
+# ingress apps and as OPENTAG_PAIRING_TOKEN for daemon/client pairing.
+OPENTAG_PAIRING_TOKEN=dev_pairing_token
+OPENTAG_DISPATCHER_TOKEN=dev_pairing_token
+
+# Dispatcher app
+# apps/dispatcher defaults to PORT=3030 and OPENTAG_DATABASE_PATH=opentag.db.
+OPENTAG_DATABASE_PATH=opentag.db
+OPENTAG_GITHUB_TOKEN=ghp_replace_me
+OPENTAG_SLACK_BOT_TOKEN=xoxb-replace-me
+OPENTAG_TELEGRAM_BOT_TOKEN=0000000000:replace-me
+# OPENTAG_SLACK_BOT_TOKENS_JSON={"opentag":"xoxb-replace-me"}
+# OPENTAG_TELEGRAM_BOT_TOKENS_JSON={"opentag":"0000000000:replace-me"}
+
+# Daemon / local runner
+# Prefer OPENTAG_CONFIG_PATH for repeatable setups. The repo variables below are
+# useful for quick local env-derived binding tests.
+# OPENTAG_CONFIG_PATH=opentag.local.json
+OPENTAG_RUNNER_ID=runner_local
+OPENTAG_DISPATCHER_URL=http://localhost:3030
+OPENTAG_REPO_OWNER=amplifthq
+OPENTAG_REPO_NAME=opentag
+OPENTAG_WORKSPACE_PATH=/absolute/path/to/opentag
+OPENTAG_DEFAULT_EXECUTOR=echo
+OPENTAG_BASE_BRANCH=main
+OPENTAG_PUSH_REMOTE=origin
+# OPENTAG_WORKTREE_ROOT=/absolute/path/to/opentag-worktrees
+# OPENTAG_KEEP_WORKTREE=on_failure
+# OPENTAG_ALLOW_AUTO_CREATE_PR=false
+# OPENTAG_POLL_INTERVAL_MS=5000
+# OPENTAG_HEARTBEAT_INTERVAL_MS=15000
+
+# Optional daemon security controls
+# OPENTAG_SECURITY_MODE=enforce
+# OPENTAG_ALLOWED_WORKSPACE_ROOT=/absolute/path/to
+# OPENTAG_ALLOW_UNSAFE_PROMPTS=false
+# OPENTAG_EXTRA_SAFE_ENV=OPENTAG_DEBUG
+
+# Optional Claude Code executor controls
+# OPENTAG_CLAUDE_COMMAND=claude
+# OPENTAG_CLAUDE_MODEL=sonnet
+# OPENTAG_CLAUDE_PERMISSION_MODE=acceptEdits
+# OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=false
+
+# GitHub ingress app
+# apps/github-probot uses Probot. Set PORT and WEBHOOK_PATH per process when needed.
+# APP_ID=123456
+# WEBHOOK_SECRET=replace_me
+# PRIVATE_KEY_PATH=/absolute/path/to/github-app.private-key.pem
+# WEBHOOK_PATH=/github/webhooks
+# OPENTAG_DISPATCHER_OWNS_CALLBACKS=true
+
+# Slack ingress app
+# apps/slack-events defaults to PORT=3040.
+SLACK_SIGNING_SECRET=replace_me
+OPENTAG_SLACK_AGENT_ID=opentag
+# OPENTAG_SLACK_APP_ID=A0123456789
+# OPENTAG_SLACK_POST_MESSAGE_URL=https://slack.com/api/chat.postMessage
+# OPENTAG_SLACK_APPS_JSON=[{"agentId":"opentag","signingSecret":"replace_me","appId":"A0123456789"}]
+
+# Optional env-derived Slack channel binding for opentagd.
+OPENTAG_SLACK_TEAM_ID=T0123456789
+OPENTAG_SLACK_CHANNEL_ID=C0123456789
+OPENTAG_SLACK_REPO_PROVIDER=github
+
+# Telegram ingress app
+# apps/telegram-events defaults to PORT=3050.
+OPENTAG_TELEGRAM_BOT_ID=0000000000
+OPENTAG_TELEGRAM_AGENT_ID=opentag
+# OPENTAG_TELEGRAM_BOT_USERNAME=opentag_bot
+# OPENTAG_TELEGRAM_SECRET_TOKEN=replace_me
+# OPENTAG_TELEGRAM_CALLBACK_URI=https://api.telegram.org/sendMessage
+# OPENTAG_TELEGRAM_BOTS_JSON=[{"botId":"0000000000","agentId":"opentag","botUsername":"opentag_bot","secretToken":"replace_me"}]

--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ OPENTAG_DATABASE_PATH=opentag.db
 OPENTAG_GITHUB_TOKEN=ghp_replace_me
 OPENTAG_SLACK_BOT_TOKEN=xoxb-replace-me
 OPENTAG_TELEGRAM_BOT_TOKEN=0000000000:replace-me
-# OPENTAG_SLACK_BOT_TOKENS_JSON={"opentag":"xoxb-replace-me"}
-# OPENTAG_TELEGRAM_BOT_TOKENS_JSON={"opentag":"0000000000:replace-me"}
+# OPENTAG_SLACK_BOT_TOKENS_JSON='{"opentag":"xoxb-replace-me"}'
+# OPENTAG_TELEGRAM_BOT_TOKENS_JSON='{"opentag":"0000000000:replace-me"}'
 
 # Daemon / local runner
 # Prefer OPENTAG_CONFIG_PATH for repeatable setups. The repo variables below are
@@ -62,7 +62,7 @@ SLACK_SIGNING_SECRET=replace_me
 OPENTAG_SLACK_AGENT_ID=opentag
 # OPENTAG_SLACK_APP_ID=A0123456789
 # OPENTAG_SLACK_POST_MESSAGE_URL=https://slack.com/api/chat.postMessage
-# OPENTAG_SLACK_APPS_JSON=[{"agentId":"opentag","signingSecret":"replace_me","appId":"A0123456789"}]
+# OPENTAG_SLACK_APPS_JSON='[{"agentId":"opentag","signingSecret":"replace_me","appId":"A0123456789"}]'
 
 # Optional env-derived Slack channel binding for opentagd.
 OPENTAG_SLACK_TEAM_ID=T0123456789
@@ -76,4 +76,4 @@ OPENTAG_TELEGRAM_AGENT_ID=opentag
 # OPENTAG_TELEGRAM_BOT_USERNAME=opentag_bot
 # OPENTAG_TELEGRAM_SECRET_TOKEN=replace_me
 # OPENTAG_TELEGRAM_CALLBACK_URI=https://api.telegram.org/sendMessage
-# OPENTAG_TELEGRAM_BOTS_JSON=[{"botId":"0000000000","agentId":"opentag","botUsername":"opentag_bot","secretToken":"replace_me"}]
+# OPENTAG_TELEGRAM_BOTS_JSON='[{"botId":"0000000000","agentId":"opentag","botUsername":"opentag_bot","secretToken":"replace_me"}]'

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ pnpm smoke:slack-protocol
 pnpm build
 ```
 
+For local app and runner configuration, copy `.env.example` to `.env` and replace the placeholder values.
+
 The smoke tests start an in-process dispatcher with a temporary SQLite database and exercise the protocol chain through the client SDK. For a full local runner loop, start with [examples/github-to-echo](examples/github-to-echo/README.md).
 
 ## Why OpenTag


### PR DESCRIPTION
## Summary

Adds a root `.env.example` with placeholder configuration for local OpenTag experiments across the dispatcher, daemon, GitHub ingress, Slack ingress, and Telegram ingress. Also links the example env file from the README quick start.

## Validation

- `git diff --check`

`pnpm lint` was attempted, but current upstream `main` fails in `packages/github` TypeScript checks due to unrelated core/github type export issues. This PR only changes `.env.example` and README documentation.