### PR TITLE
Add one-command Lark local start path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .omx/
+.opentag/
 .env
 .env.*
 !.env.example

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pnpm add @opentag/core @opentag/client @opentag/dispatcher @opentag/github @open
 | [`@opentag/store`](https://www.npmjs.com/package/@opentag/store) | SQLite/Drizzle persistence for runs, audit events, leases, policy, and metrics |
 | [`@opentag/runner`](https://www.npmjs.com/package/@opentag/runner) | Executor contracts plus echo, Claude Code, and Codex adapters |
 
-Runnable apps live in `apps/dispatcher`, `apps/opentagd`, `apps/github-probot`, and `apps/slack-events`.
+Runnable apps live in `apps/dispatcher`, `apps/opentagd`, `apps/github-probot`, `apps/slack-events`, `apps/lark-events`, and `apps/telegram-events`.
 
 ## Examples and Guides
 
@@ -126,6 +126,7 @@ Runnable apps live in `apps/dispatcher`, `apps/opentagd`, `apps/github-probot`, 
 - [GitHub to PR](examples/github-to-pr/README.md) - product demo path from GitHub issue mention to local execution, pull request, callback, and audit evidence.
 - [Embedded dispatcher](examples/embedded-dispatcher/README.md) - host OpenTag inside another Node service.
 - [Custom runner](examples/custom-runner/README.md) - build a third-party runner with `@opentag/client` and `@opentag/runner`.
+- [Start OpenTag for Lark locally](docs/lark-local-start.md) - one-command local MVP path for Lark or Feishu long-connection testing.
 - [Configuration](docs/configuration.md) - map dispatcher, daemon, ingress, callback, and runner settings.
 - [Adapter authoring](docs/adapter-authoring.md) - add new work app adapters without changing the execution model.
 - [Real integration smoke test](docs/real-integration-smoke-test.md) - real GitHub and Slack setup, trigger, and debugging order.

--- a/apps/lark-events/package.json
+++ b/apps/lark-events/package.json
@@ -13,7 +13,8 @@
     "@larksuiteoapi/node-sdk": "^1.68.0",
     "@opentag/client": "workspace:*",
     "@opentag/core": "workspace:*",
-    "@opentag/lark": "workspace:*"
+    "@opentag/lark": "workspace:*",
+    "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/apps/lark-events/scripts/register-personal-agent.cjs
+++ b/apps/lark-events/scripts/register-personal-agent.cjs
@@ -87,6 +87,7 @@ async function fetchBotIdentity(input) {
 
 async function main() {
   const requestedDomain = parseDomain(process.argv[2] || process.env.LARK_DOMAIN || "lark");
+  let detectedDomain;
 
   const registration = await lark.registerApp({
     // The Personal Agent registration flow starts on Feishu and switches to Lark after scan when needed.
@@ -113,12 +114,13 @@ async function main() {
       if (info.status === "slow_down") {
         log(`Lark asked OpenTag to poll more slowly. Next check in ${info.interval ?? "a few"} seconds.`);
       } else if (info.status === "domain_switched") {
+        detectedDomain = "lark";
         log("Detected a Lark tenant. Continuing registration on larksuite.com.");
       }
     }
   });
 
-  const domain = registrationDomainFromUserInfo(requestedDomain, registration.user_info);
+  const domain = detectedDomain ?? registrationDomainFromUserInfo(requestedDomain, registration.user_info);
   const botIdentity = await fetchBotIdentity({
     appId: registration.client_id,
     appSecret: registration.client_secret,

--- a/apps/lark-events/scripts/register-personal-agent.cjs
+++ b/apps/lark-events/scripts/register-personal-agent.cjs
@@ -29,8 +29,10 @@ function sdkDomainFor(domain) {
   return domain === "feishu" ? lark.Domain.Feishu : lark.Domain.Lark;
 }
 
-function registrationDomainFromUserInfo(initialDomain, userInfo) {
-  return userInfo?.tenant_brand === "lark" ? "lark" : initialDomain;
+function registrationDomainFromUserInfo(requestedDomain, userInfo) {
+  if (userInfo?.tenant_brand === "lark") return "lark";
+  if (userInfo?.tenant_brand === "feishu") return "feishu";
+  return requestedDomain;
 }
 
 function printQrCode(info) {
@@ -84,10 +86,11 @@ async function fetchBotIdentity(input) {
 }
 
 async function main() {
-  const initialDomain = parseDomain(process.argv[2] || process.env.LARK_DOMAIN || "lark");
+  const requestedDomain = parseDomain(process.argv[2] || process.env.LARK_DOMAIN || "lark");
 
   const registration = await lark.registerApp({
-    domain: accountDomainFor(initialDomain),
+    // The Personal Agent registration flow starts on Feishu and switches to Lark after scan when needed.
+    domain: accountDomainFor("feishu"),
     larkDomain: accountDomainFor("lark"),
     source: REGISTRATION_SOURCE,
     createOnly: true,
@@ -115,7 +118,7 @@ async function main() {
     }
   });
 
-  const domain = registrationDomainFromUserInfo(initialDomain, registration.user_info);
+  const domain = registrationDomainFromUserInfo(requestedDomain, registration.user_info);
   const botIdentity = await fetchBotIdentity({
     appId: registration.client_id,
     appSecret: registration.client_secret,

--- a/apps/lark-events/scripts/register-personal-agent.cjs
+++ b/apps/lark-events/scripts/register-personal-agent.cjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+"use strict";
+
+const lark = require("@larksuiteoapi/node-sdk");
+const qrcode = require("qrcode-terminal");
+
+const REGISTRATION_SOURCE = "opentag";
+const BOT_INFO_RETRIES = 6;
+const BOT_INFO_RETRY_DELAY_MS = 2000;
+
+function log(message = "") {
+  process.stderr.write(`${message}\n`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseDomain(value) {
+  if (value === "lark" || value === "feishu") return value;
+  throw new Error("Lark domain must be lark or feishu.");
+}
+
+function accountDomainFor(domain) {
+  return domain === "feishu" ? "accounts.feishu.cn" : "accounts.larksuite.com";
+}
+
+function sdkDomainFor(domain) {
+  return domain === "feishu" ? lark.Domain.Feishu : lark.Domain.Lark;
+}
+
+function registrationDomainFromUserInfo(initialDomain, userInfo) {
+  return userInfo?.tenant_brand === "lark" ? "lark" : initialDomain;
+}
+
+function printQrCode(info) {
+  log();
+  log("Scan this QR code with Lark or Feishu, then finish creating the Personal Agent app:");
+  qrcode.generate(info.url, { small: true }, (qr) => {
+    process.stderr.write(`${qr}\n`);
+  });
+  log(`URL: ${info.url}`);
+  log(`This QR code expires in about ${Math.ceil(info.expireIn / 60)} minute(s).`);
+  log("Keep this terminal open. OpenTag will continue automatically after the app is created.");
+  log();
+}
+
+async function fetchBotIdentity(input) {
+  const client = new lark.Client({
+    appId: input.appId,
+    appSecret: input.appSecret,
+    domain: sdkDomainFor(input.domain)
+  });
+
+  let lastError;
+  for (let attempt = 1; attempt <= BOT_INFO_RETRIES; attempt += 1) {
+    try {
+      const response = await client.request({
+        url: "/open-apis/bot/v3/info",
+        method: "GET"
+      });
+      const bot = response?.bot ?? response?.data?.bot;
+      if (bot?.open_id) {
+        return {
+          botOpenId: bot.open_id,
+          botName: bot.app_name || bot.name || "OpenTag"
+        };
+      }
+      lastError = new Error(`bot/v3/info response missing bot.open_id: ${JSON.stringify(response).slice(0, 200)}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt < BOT_INFO_RETRIES) {
+      await sleep(BOT_INFO_RETRY_DELAY_MS);
+    }
+  }
+
+  log("OpenTag could not fetch the bot open_id automatically.");
+  log(`Reason: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+  log("Direct chat still works. For group chat, set LARK_BOT_OPEN_ID or enter it when prompted.");
+  log();
+  return {};
+}
+
+async function main() {
+  const initialDomain = parseDomain(process.argv[2] || process.env.LARK_DOMAIN || "lark");
+
+  const registration = await lark.registerApp({
+    domain: accountDomainFor(initialDomain),
+    larkDomain: accountDomainFor("lark"),
+    source: REGISTRATION_SOURCE,
+    createOnly: true,
+    appPreset: {
+      name: "OpenTag {user}",
+      desc: "Wake your local OpenTag agent from Lark."
+    },
+    addons: {
+      scopes: {
+        tenant: ["im:message:send_as_bot", "im:message.p2p_msg:readonly", "im:message.group_msg:readonly", "im:chat:readonly"]
+      },
+      events: {
+        items: {
+          tenant: ["im.message.receive_v1"]
+        }
+      }
+    },
+    onQRCodeReady: printQrCode,
+    onStatusChange(info) {
+      if (info.status === "slow_down") {
+        log(`Lark asked OpenTag to poll more slowly. Next check in ${info.interval ?? "a few"} seconds.`);
+      } else if (info.status === "domain_switched") {
+        log("Detected a Lark tenant. Continuing registration on larksuite.com.");
+      }
+    }
+  });
+
+  const domain = registrationDomainFromUserInfo(initialDomain, registration.user_info);
+  const botIdentity = await fetchBotIdentity({
+    appId: registration.client_id,
+    appSecret: registration.client_secret,
+    domain
+  });
+
+  log("Personal Agent app created.");
+  log(`App ID: ${registration.client_id}`);
+  log(`Domain: ${domain}`);
+  if (registration.user_info?.open_id) {
+    log(`Setup user: ${registration.user_info.open_id}`);
+  }
+  if (botIdentity.botOpenId) {
+    log(`Bot: ${botIdentity.botName} (${botIdentity.botOpenId})`);
+  }
+  log();
+
+  process.stdout.write(
+    `${JSON.stringify({
+      appId: registration.client_id,
+      appSecret: registration.client_secret,
+      domain,
+      operatorOpenId: registration.user_info?.open_id,
+      botOpenId: botIdentity.botOpenId,
+      botName: botIdentity.botName
+    })}\n`
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -31,6 +31,7 @@ export type LarkMessageHandlerConfig = {
   agentId: string;
   botOpenId?: string;
   callbackUri?: string;
+  defaultRepoBinding?: { repoProvider: string; owner: string; repo: string };
   resolveChannelBinding(input: { tenantKey: string; chatId: string }): Promise<LarkChannelBinding | null>;
   createRun(event: OpenTagEvent): Promise<{ runId: string }>;
   // Self-service binding from within Lark (`/bind owner/repo`); optional so tests can omit it.
@@ -135,10 +136,27 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
       return { status: "bound", tenantKey, chatId };
     }
 
-    const binding = await config.resolveChannelBinding({ tenantKey, chatId });
+    let binding = await config.resolveChannelBinding({ tenantKey, chatId });
     if (!binding) {
-      await config.reply?.({ messageId, text: UNBOUND_HINT });
-      return { status: "ignored_unbound_chat", tenantKey, chatId };
+      if (config.defaultRepoBinding && config.bindChannel) {
+        await config.bindChannel({
+          tenantKey,
+          chatId,
+          repoProvider: config.defaultRepoBinding.repoProvider,
+          owner: config.defaultRepoBinding.owner,
+          repo: config.defaultRepoBinding.repo
+        });
+        binding = {
+          tenantKey,
+          chatId,
+          repoProvider: config.defaultRepoBinding.repoProvider,
+          owner: config.defaultRepoBinding.owner,
+          repo: config.defaultRepoBinding.repo
+        };
+      } else {
+        await config.reply?.({ messageId, text: UNBOUND_HINT });
+        return { status: "ignored_unbound_chat", tenantKey, chatId };
+      }
     }
 
     const parsedTime = data.create_time ? Number(data.create_time) : Number.NaN;

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -136,6 +136,10 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
       return { status: "bound", tenantKey, chatId };
     }
 
+    if (command.trim().length === 0) {
+      return { status: "ignored_empty_command", tenantKey, chatId };
+    }
+
     let binding = await config.resolveChannelBinding({ tenantKey, chatId });
     if (!binding) {
       if (config.defaultRepoBinding && config.bindChannel) {

--- a/apps/lark-events/src/index.ts
+++ b/apps/lark-events/src/index.ts
@@ -22,9 +22,25 @@ const dispatcherClient = createOpenTagClient({
 });
 const replyClient = createLarkReplyClient({ appId, appSecret, domain: larkDomain });
 
+function defaultRepoBindingFromEnv(value: string | undefined) {
+  if (!value) return undefined;
+  const match = value.match(/^(?:([\w-]+):)?([\w.-]+)\/([\w.-]+)$/);
+  if (!match) {
+    throw new Error("OPENTAG_LARK_DEFAULT_REPO must be formatted as owner/repo or provider:owner/repo");
+  }
+  return {
+    repoProvider: match[1] ?? "github",
+    owner: match[2] as string,
+    repo: match[3] as string
+  };
+}
+
+const defaultRepoBinding = defaultRepoBindingFromEnv(process.env.OPENTAG_LARK_DEFAULT_REPO);
+
 const handler = createLarkMessageHandler({
   agentId: process.env.OPENTAG_LARK_AGENT_ID ?? "opentag",
   ...(process.env.LARK_BOT_OPEN_ID ? { botOpenId: process.env.LARK_BOT_OPEN_ID } : {}),
+  ...(defaultRepoBinding ? { defaultRepoBinding } : {}),
   async resolveChannelBinding(input) {
     try {
       const { binding } = await dispatcherClient.getChannelBinding({

--- a/apps/lark-events/test/app.test.ts
+++ b/apps/lark-events/test/app.test.ts
@@ -42,6 +42,7 @@ const binding: LarkChannelBinding = { tenantKey: "tk_123", chatId: "oc_chat", ow
 function makeHandler(opts?: {
   withBotOpenId?: boolean;
   binding?: LarkChannelBinding | null;
+  defaultRepoBinding?: { repoProvider: string; owner: string; repo: string };
   createRun?: ReturnType<typeof vi.fn>;
   bindChannel?: ReturnType<typeof vi.fn>;
   reply?: ReturnType<typeof vi.fn>;
@@ -52,6 +53,7 @@ function makeHandler(opts?: {
   const handler = createLarkMessageHandler({
     agentId: "opentag",
     ...(opts?.withBotOpenId === false ? {} : { botOpenId: "ou_bot" }),
+    ...(opts?.defaultRepoBinding ? { defaultRepoBinding: opts.defaultRepoBinding } : {}),
     resolveChannelBinding: async () => (opts && "binding" in opts ? (opts.binding ?? null) : binding),
     createRun,
     bindChannel,
@@ -134,6 +136,25 @@ describe("createLarkMessageHandler", () => {
     expect(outcome.chatId).toBe("oc_chat");
     expect(reply).toHaveBeenCalledTimes(1);
     expect(createRun).not.toHaveBeenCalled();
+  });
+
+  it("auto-binds an unbound chat to the configured default repo and creates a run", async () => {
+    const { handler, bindChannel, reply, createRun } = makeHandler({
+      binding: null,
+      defaultRepoBinding: { repoProvider: "github", owner: "amplifthq", repo: "opentag" }
+    });
+    const outcome = await handler(messageEvent({ text: "@_user_1 investigate this setup" }));
+    expect(outcome.status).toBe("created");
+    expect(bindChannel).toHaveBeenCalledWith({
+      tenantKey: "tk_123",
+      chatId: "oc_chat",
+      repoProvider: "github",
+      owner: "amplifthq",
+      repo: "opentag"
+    });
+    expect(reply).not.toHaveBeenCalled();
+    const event = createRun.mock.calls[0]?.[0];
+    expect(event?.metadata).toMatchObject({ repoProvider: "github", owner: "amplifthq", repo: "opentag" });
   });
 
   it("falls back to now() when create_time is malformed", async () => {

--- a/apps/lark-events/test/app.test.ts
+++ b/apps/lark-events/test/app.test.ts
@@ -157,6 +157,18 @@ describe("createLarkMessageHandler", () => {
     expect(event?.metadata).toMatchObject({ repoProvider: "github", owner: "amplifthq", repo: "opentag" });
   });
 
+  it("does not auto-bind an empty @mention", async () => {
+    const { handler, bindChannel, reply, createRun } = makeHandler({
+      binding: null,
+      defaultRepoBinding: { repoProvider: "github", owner: "amplifthq", repo: "opentag" }
+    });
+    const outcome = await handler(messageEvent({ text: "@_user_1   " }));
+    expect(outcome.status).toBe("ignored_empty_command");
+    expect(bindChannel).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+    expect(createRun).not.toHaveBeenCalled();
+  });
+
   it("falls back to now() when create_time is malformed", async () => {
     const createRun = vi.fn(async (_event: OpenTagEvent) => ({ runId: "run_1" }));
     const handler = createLarkMessageHandler({

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,6 +279,11 @@ Slack threads.
 `apps/lark-events` opens a Lark/Feishu WebSocket long connection (no public
 tunnel) and creates OpenTag runs from `im.message.receive_v1` events.
 
+For the shortest local setup, run `scripts/dev/start-lark.sh` and choose the QR
+scan path. It creates a Personal Agent app and exports these values for the
+local dispatcher and Lark ingress. Use the environment variables below for
+manual or hosted setups.
+
 | Variable | Required | Notes |
 | --- | --- | --- |
 | `LARK_APP_ID` | yes | Lark app id used for the long connection |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -280,9 +280,9 @@ Slack threads.
 tunnel) and creates OpenTag runs from `im.message.receive_v1` events.
 
 For the shortest local setup, run `scripts/dev/start-lark.sh` and choose the QR
-scan path. It creates a Personal Agent app and exports these values for the
-local dispatcher and Lark ingress. Use the environment variables below for
-manual or hosted setups.
+scan path. It creates a Personal Agent app, connects the chat to a local project
+target, and exports these values for the local dispatcher and Lark ingress. Use
+the environment variables below for manual or hosted setups.
 
 | Variable | Required | Notes |
 | --- | --- | --- |
@@ -293,20 +293,19 @@ manual or hosted setups.
 | `OPENTAG_DISPATCHER_TOKEN` | when dispatcher is paired | Bearer token for dispatcher `/v1/*` |
 | `LARK_BOT_OPEN_ID` | for group chats | Bot open id; group messages must @-mention it. Direct p2p chats do not need it |
 | `OPENTAG_LARK_AGENT_ID` | no | Agent id for the ingress. Defaults to `opentag` |
-| `OPENTAG_LARK_DEFAULT_REPO` | no | Optional default repo formatted as `owner/repo` or `provider:owner/repo`; unbound chats auto-connect to it before creating the first run |
+| `OPENTAG_LARK_DEFAULT_REPO` | no | Optional internal project target formatted as `owner/repo` or `provider:owner/repo`; unbound chats auto-connect to it before creating the first run |
 
 Set `LARK_APP_ID` / `LARK_APP_SECRET` / `LARK_DOMAIN` on the dispatcher too, so
 the Lark callback sink can post replies. Bind a chat to a repo with
 `opentagd bind-lark-channels` (using `larkChannels`) or `POST /v1/channel-bindings`.
 
-Each chat is bound independently (one `tenantKey/chatId` → one repo), so one bot
-can serve several chats that each target a different repo. Users can also bind a
-chat from inside Lark without the CLI: @-mention the bot with `/bind <owner>/<repo>`
-(e.g. `/bind amplifthq/opentag`, or `/bind github:amplifthq/opentag`). The bot
-confirms in-thread, and an @-mention in an unbound chat replies with the same
-hint. For the shortest local start path, set `OPENTAG_LARK_DEFAULT_REPO` so the
-first message from an unbound chat auto-connects to the selected repo. The target
-repo must already be registered on a runner (`opentagd bind-repos`).
+Each chat is bound independently (one `tenantKey/chatId` to one project target),
+so one bot can serve several chats that each target a different local project.
+Manual and hosted setups can still bind a chat from inside Lark with
+`/bind <owner>/<repo>` or `/bind <provider>:<owner>/<repo>`. Treat that as an
+advanced route; the local start script auto-connects the first chat to the
+selected local project. The target must already be registered on a runner
+(`opentagd bind-repos`).
 
 ## Telegram Ingress Environment
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,8 +281,11 @@ tunnel) and creates OpenTag runs from `im.message.receive_v1` events.
 
 For the shortest local setup, run `scripts/dev/start-lark.sh` and choose the QR
 scan path. It creates a Personal Agent app, connects the chat to a local project
-target, and exports these values for the local dispatcher and Lark ingress. Use
-the environment variables below for manual or hosted setups.
+target, saves the Personal Agent credentials to `.opentag/lark/lark.local.json`,
+and exports these values for the local dispatcher and Lark ingress. Rerunning
+the script reuses that saved app unless `OPENTAG_LARK_APP_SETUP=scan` or
+`OPENTAG_LARK_APP_SETUP=manual` is set explicitly. Use the environment variables
+below for manual or hosted setups.
 
 | Variable | Required | Notes |
 | --- | --- | --- |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -288,6 +288,7 @@ tunnel) and creates OpenTag runs from `im.message.receive_v1` events.
 | `OPENTAG_DISPATCHER_TOKEN` | when dispatcher is paired | Bearer token for dispatcher `/v1/*` |
 | `LARK_BOT_OPEN_ID` | for group chats | Bot open id; group messages must @-mention it. Direct p2p chats do not need it |
 | `OPENTAG_LARK_AGENT_ID` | no | Agent id for the ingress. Defaults to `opentag` |
+| `OPENTAG_LARK_DEFAULT_REPO` | no | Optional default repo formatted as `owner/repo` or `provider:owner/repo`; unbound chats auto-connect to it before creating the first run |
 
 Set `LARK_APP_ID` / `LARK_APP_SECRET` / `LARK_DOMAIN` on the dispatcher too, so
 the Lark callback sink can post replies. Bind a chat to a repo with
@@ -298,7 +299,9 @@ can serve several chats that each target a different repo. Users can also bind a
 chat from inside Lark without the CLI: @-mention the bot with `/bind <owner>/<repo>`
 (e.g. `/bind amplifthq/opentag`, or `/bind github:amplifthq/opentag`). The bot
 confirms in-thread, and an @-mention in an unbound chat replies with the same
-hint. The target repo must already be registered on a runner (`opentagd bind-repos`).
+hint. For the shortest local start path, set `OPENTAG_LARK_DEFAULT_REPO` so the
+first message from an unbound chat auto-connects to the selected repo. The target
+repo must already be registered on a runner (`opentagd bind-repos`).
 
 ## Telegram Ingress Environment
 

--- a/docs/lark-local-start.md
+++ b/docs/lark-local-start.md
@@ -33,9 +33,9 @@ The script prompts for:
 
 - local project path
 - executor: `codex`, `claude-code`, or `echo`
-- Lark domain: `lark` or `feishu`
-- Lark app setup: `scan` or `manual`
-- a QR scan when using `scan`
+- Lark domain: `lark` or `feishu`, only when no saved app exists
+- Lark app setup: `scan` or `manual`, only when no saved app exists
+- a QR scan when using `scan` for the first time
 - `LARK_APP_ID` and `LARK_APP_SECRET` only when using `manual`
 - `LARK_BOT_OPEN_ID` only when group chat support cannot be detected automatically
 
@@ -43,13 +43,26 @@ It then:
 
 1. Installs workspace dependencies if needed.
 2. Creates a Lark/Feishu Personal Agent from the QR scan, unless manual app
-   credentials are provided.
-3. Generates `.opentag/lark/opentag.local.json`.
-4. Starts the dispatcher.
-5. Registers the local runner.
-6. Binds the selected local checkout.
-7. Starts `opentagd`.
-8. Starts the Lark long-connection ingress.
+   credentials or saved local credentials are available.
+3. Saves Personal Agent credentials to `.opentag/lark/lark.local.json`.
+4. Generates `.opentag/lark/opentag.local.json`.
+5. Starts the dispatcher.
+6. Registers the local runner.
+7. Binds the selected local checkout.
+8. Starts `opentagd`.
+9. Starts the Lark long-connection ingress.
+
+## Restarting
+
+After the first successful QR or manual setup, rerun the same command:
+
+```bash
+./scripts/dev/start-lark.sh
+```
+
+The script reuses `.opentag/lark/lark.local.json`, so you do not need to scan a
+new QR code. To create a new Personal Agent app intentionally, set
+`OPENTAG_LARK_APP_SETUP=scan` or `OPENTAG_LARK_APP_SETUP=manual`.
 
 ## Project Target
 

--- a/docs/lark-local-start.md
+++ b/docs/lark-local-start.md
@@ -1,0 +1,87 @@
+# Start OpenTag For Lark Locally
+
+Use this guide when you want the shortest local loop:
+
+```text
+Lark message -> OpenTag dispatcher -> opentagd on this computer -> executor -> Lark reply
+```
+
+This is the current MVP setup path. It still uses a Lark app that you create in
+Lark/Feishu, but it avoids manually starting the dispatcher, daemon, and Lark
+ingress in separate terminals.
+
+## What You Need
+
+- Node 22.x
+- Git
+- A Lark or Feishu account
+- A Lark/Feishu app with `LARK_APP_ID` and `LARK_APP_SECRET`
+- A local git checkout for the project the agent should run in
+- Optional: Codex CLI or Claude Code CLI for real local agent execution
+
+If Codex and Claude Code are not installed, the script can still use the `echo`
+executor to prove the Lark callback loop.
+
+## Start
+
+From the OpenTag repository:
+
+```bash
+./scripts/dev/start-lark.sh
+```
+
+The script prompts for:
+
+- local project path
+- executor: `codex`, `claude-code`, or `echo`
+- Lark domain: `lark` or `feishu`
+- `LARK_APP_ID`
+- `LARK_APP_SECRET`
+- `LARK_BOT_OPEN_ID` when you want to test in a group chat
+
+It then:
+
+1. Installs workspace dependencies if needed.
+2. Generates `.opentag/lark/opentag.local.json`.
+3. Starts the dispatcher.
+4. Registers the local runner.
+5. Binds the selected local checkout.
+6. Starts `opentagd`.
+7. Starts the Lark long-connection ingress.
+
+## First Message
+
+In a direct chat with the bot, send:
+
+```text
+say hello from my local computer
+```
+
+In a group chat, send:
+
+```text
+@OpenTag say hello from my local computer
+```
+
+The first chat that messages the bot is automatically connected to the selected
+project path. This keeps the first-run path short. To point a chat at another
+repository later, send:
+
+```text
+@OpenTag /bind owner/repo
+```
+
+## Expected Result
+
+1. Lark replies with an acknowledgement.
+2. The terminal shows the local daemon claiming and running the task.
+3. Lark replies with the final result.
+
+## Current Limits
+
+- The script does not create a Lark app for you yet.
+- Group chat triggers require `LARK_BOT_OPEN_ID`.
+- Code tasks still need a git checkout because the current runner model is
+  repository-scoped.
+- The future package CLI should replace this repo-local script with
+  `npx opentag lark`.

--- a/docs/lark-local-start.md
+++ b/docs/lark-local-start.md
@@ -6,21 +6,20 @@ Use this guide when you want the shortest local loop:
 Lark message -> OpenTag dispatcher -> opentagd on this computer -> executor -> Lark reply
 ```
 
-This is the current MVP setup path. It still uses a Lark app that you create in
-Lark/Feishu, but it avoids manually starting the dispatcher, daemon, and Lark
-ingress in separate terminals.
+This is the current MVP setup path. It shows a Lark/Feishu Personal Agent QR
+code, stores the created app credentials locally, and avoids manually starting
+the dispatcher, daemon, and Lark ingress in separate terminals.
 
 ## What You Need
 
 - Node 22.x
 - Git
 - A Lark or Feishu account
-- A Lark/Feishu app with `LARK_APP_ID` and `LARK_APP_SECRET`
 - A local git checkout for the project the agent should run in
-- Optional: Codex CLI or Claude Code CLI for real local agent execution
+- Codex CLI for a real local agent run
 
-If Codex and Claude Code are not installed, the script can still use the `echo`
-executor to prove the Lark callback loop.
+The `echo` executor is still available for plumbing checks, but the real demo
+path should choose `codex`.
 
 ## Start
 
@@ -35,19 +34,30 @@ The script prompts for:
 - local project path
 - executor: `codex`, `claude-code`, or `echo`
 - Lark domain: `lark` or `feishu`
-- `LARK_APP_ID`
-- `LARK_APP_SECRET`
-- `LARK_BOT_OPEN_ID` when you want to test in a group chat
+- Lark app setup: `scan` or `manual`
+- a QR scan when using `scan`
+- `LARK_APP_ID` and `LARK_APP_SECRET` only when using `manual`
+- `LARK_BOT_OPEN_ID` only when group chat support cannot be detected automatically
 
 It then:
 
 1. Installs workspace dependencies if needed.
-2. Generates `.opentag/lark/opentag.local.json`.
-3. Starts the dispatcher.
-4. Registers the local runner.
-5. Binds the selected local checkout.
-6. Starts `opentagd`.
-7. Starts the Lark long-connection ingress.
+2. Creates a Lark/Feishu Personal Agent from the QR scan, unless manual app
+   credentials are provided.
+3. Generates `.opentag/lark/opentag.local.json`.
+4. Starts the dispatcher.
+5. Registers the local runner.
+6. Binds the selected local checkout.
+7. Starts `opentagd`.
+8. Starts the Lark long-connection ingress.
+
+## Project Target
+
+OpenTag runs are currently repository-scoped. The script asks for a local project
+path, then infers the GitHub `owner/repo` from that checkout's `origin` remote
+when it can. That repo name is not a Lark requirement; it is how the local runner
+knows which registered checkout should execute the task. If the repo cannot be
+inferred, the script asks for `owner/repo`.
 
 ## First Message
 
@@ -79,8 +89,10 @@ repository later, send:
 
 ## Current Limits
 
-- The script does not create a Lark app for you yet.
-- Group chat triggers require `LARK_BOT_OPEN_ID`.
+- The QR flow creates a Personal Agent app, but the user still finishes the app
+  creation page opened by Lark/Feishu after scanning.
+- Group chat triggers require the bot open id. The script tries to detect it
+  automatically; if detection fails, direct chat still works.
 - Code tasks still need a git checkout because the current runner model is
   repository-scoped.
 - The future package CLI should replace this repo-local script with

--- a/docs/lark-local-start.md
+++ b/docs/lark-local-start.md
@@ -53,11 +53,10 @@ It then:
 
 ## Project Target
 
-OpenTag runs are currently repository-scoped. The script asks for a local project
-path, then infers the GitHub `owner/repo` from that checkout's `origin` remote
-when it can. That repo name is not a Lark requirement; it is how the local runner
-knows which registered checkout should execute the task. If the repo cannot be
-inferred, the script asks for `owner/repo`.
+The Lark MVP path is local-project first. The script asks for the folder where
+the agent should run and connects the first Lark chat to that local project.
+OpenTag still creates an internal project target so the dispatcher and local
+daemon can route the run, but the first-run path does not require a GitHub repo.
 
 ## First Message
 
@@ -74,12 +73,14 @@ In a group chat, send:
 ```
 
 The first chat that messages the bot is automatically connected to the selected
-project path. This keeps the first-run path short. To point a chat at another
-repository later, send:
+project path. This keeps the first-run path short.
 
-```text
-@OpenTag /bind owner/repo
-```
+## Advanced GitHub Target
+
+GitHub repository settings are optional for the Lark local loop. Use them later
+when you want GitHub-specific behavior such as repository policy, branch push, or
+pull request creation. Set `OPENTAG_REPO_OWNER` and `OPENTAG_REPO_NAME` before
+starting the script to use a GitHub-style project target.
 
 ## Expected Result
 
@@ -93,7 +94,7 @@ repository later, send:
   creation page opened by Lark/Feishu after scanning.
 - Group chat triggers require the bot open id. The script tries to detect it
   automatically; if detection fails, direct chat still works.
-- Code tasks still need a git checkout because the current runner model is
-  repository-scoped.
+- Code tasks still need a local git checkout because the Codex executor creates
+  isolated worktrees for runs.
 - The future package CLI should replace this repo-local script with
   `npx opentag lark`.

--- a/docs/lark-local-start.md
+++ b/docs/lark-local-start.md
@@ -97,9 +97,8 @@ starting the script to use a GitHub-style project target.
 
 ## Expected Result
 
-1. Lark replies with an acknowledgement.
-2. The terminal shows the local daemon claiming and running the task.
-3. Lark replies with the final result.
+1. The terminal shows the local daemon claiming and running the task.
+2. Lark replies with the agent's final result.
 
 ## Current Limits
 

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -22,7 +22,7 @@ export type CallbackPresentation = {
 export function createDefaultCallbackPresentation(): CallbackPresentation {
   return {
     shouldDeliverProgress(provider) {
-      return provider !== "slack";
+      return provider !== "slack" && provider !== "lark";
     },
 
     acknowledgement(input) {

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -13,6 +13,7 @@ export type PresentedCallbackBody = {
 };
 
 export type CallbackPresentation = {
+  shouldDeliverAcknowledgement(provider: CallbackProvider): boolean;
   shouldDeliverProgress(provider: CallbackProvider): boolean;
   acknowledgement(input: { provider: CallbackProvider; runId: string }): string;
   progress(input: { provider: CallbackProvider; runId: string; message: string }): string;
@@ -21,6 +22,10 @@ export type CallbackPresentation = {
 
 export function createDefaultCallbackPresentation(): CallbackPresentation {
   return {
+    shouldDeliverAcknowledgement(provider) {
+      return provider !== "lark";
+    },
+
     shouldDeliverProgress(provider) {
       return provider !== "slack" && provider !== "lark";
     },

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -493,20 +493,22 @@ export function createDispatcherApp(input: {
       );
     }
     const { run } = createdRun;
-    await deliverAndAudit({
-      repo,
-      sink: callbackSink,
-      retry: callbackRetry,
-      message: {
-        runId: run.id,
-        kind: "acknowledgement",
-        provider: parsed.event.callback.provider,
-        uri: parsed.event.callback.uri,
-        body: presentation.acknowledgement({ provider: parsed.event.callback.provider, runId: run.id }),
-        ...(parsed.event.target.agentId ? { agentId: parsed.event.target.agentId } : {}),
-        ...(parsed.event.callback.threadKey ? { threadKey: parsed.event.callback.threadKey } : {})
-      }
-    });
+    if (presentation.shouldDeliverAcknowledgement(parsed.event.callback.provider)) {
+      await deliverAndAudit({
+        repo,
+        sink: callbackSink,
+        retry: callbackRetry,
+        message: {
+          runId: run.id,
+          kind: "acknowledgement",
+          provider: parsed.event.callback.provider,
+          uri: parsed.event.callback.uri,
+          body: presentation.acknowledgement({ provider: parsed.event.callback.provider, runId: run.id }),
+          ...(parsed.event.target.agentId ? { agentId: parsed.event.target.agentId } : {}),
+          ...(parsed.event.callback.threadKey ? { threadKey: parsed.event.callback.threadKey } : {})
+        }
+      });
+    }
     return c.json({ decision: admitted.decision, run }, 201);
   });
 
@@ -536,20 +538,22 @@ export function createDispatcherApp(input: {
     }
     const followUpRequest = promoted.followUpRequest;
     const event = followUpRequest.event;
-    await deliverAndAudit({
-      repo,
-      sink: callbackSink,
-      retry: callbackRetry,
-      message: {
-        runId: promoted.run.id,
-        kind: "acknowledgement",
-        provider: event.callback.provider,
-        uri: event.callback.uri,
-        body: presentation.acknowledgement({ provider: event.callback.provider, runId: promoted.run.id }),
-        ...(event.target.agentId ? { agentId: event.target.agentId } : {}),
-        ...(event.callback.threadKey ? { threadKey: event.callback.threadKey } : {})
-      }
-    });
+    if (presentation.shouldDeliverAcknowledgement(event.callback.provider)) {
+      await deliverAndAudit({
+        repo,
+        sink: callbackSink,
+        retry: callbackRetry,
+        message: {
+          runId: promoted.run.id,
+          kind: "acknowledgement",
+          provider: event.callback.provider,
+          uri: event.callback.uri,
+          body: presentation.acknowledgement({ provider: event.callback.provider, runId: promoted.run.id }),
+          ...(event.target.agentId ? { agentId: event.target.agentId } : {}),
+          ...(event.callback.threadKey ? { threadKey: event.callback.threadKey } : {})
+        }
+      });
+    }
     return c.json({ followUpRequest, run: promoted.run }, 201);
   });
 

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from "vitest";
 import { createDefaultCallbackPresentation } from "../src/presentation.js";
 
 describe("default callback presentation", () => {
+  it("keeps Lark acknowledgements silent while preserving other provider acknowledgements", () => {
+    const presentation = createDefaultCallbackPresentation();
+
+    expect(presentation.shouldDeliverAcknowledgement("lark")).toBe(false);
+    expect(presentation.shouldDeliverAcknowledgement("slack")).toBe(true);
+    expect(presentation.shouldDeliverAcknowledgement("telegram")).toBe(true);
+    expect(presentation.shouldDeliverAcknowledgement("github")).toBe(true);
+  });
+
   it("keeps chat progress audit-only while allowing GitHub and Telegram progress delivery", () => {
     const presentation = createDefaultCallbackPresentation();
 

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import { createDefaultCallbackPresentation } from "../src/presentation.js";
 
 describe("default callback presentation", () => {
-  it("keeps Slack progress audit-only while allowing GitHub progress delivery", () => {
+  it("keeps chat progress audit-only while allowing GitHub and Telegram progress delivery", () => {
     const presentation = createDefaultCallbackPresentation();
 
     expect(presentation.shouldDeliverProgress("slack")).toBe(false);
+    expect(presentation.shouldDeliverProgress("lark")).toBe(false);
     expect(presentation.shouldDeliverProgress("telegram")).toBe(true);
     expect(presentation.shouldDeliverProgress("github")).toBe(true);
   });

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -590,7 +590,7 @@ describe("dispatcher API", () => {
     });
   });
 
-  it("renders Lark callbacks as plain text and keeps progress audit-only", async () => {
+  it("renders Lark final callbacks as plain text while keeping acknowledgement and progress audit-only", async () => {
     const delivered: { kind: string; body: string }[] = [];
     const app = createDispatcherApp({
       databasePath: ":memory:",
@@ -657,7 +657,6 @@ describe("dispatcher API", () => {
     expect(completeResponse.status).toBe(200);
 
     expect(delivered).toEqual([
-      { kind: "acknowledgement", body: "I picked this up: run_lark_1" },
       {
         kind: "final",
         body: "Finished with success.\n\nEchoed OpenTag command: introduce yourself\n\nVerification\n- echo: passed"
@@ -670,8 +669,6 @@ describe("dispatcher API", () => {
       "admission.decided",
       "run.created",
       "context_packet.generated",
-      "callback.acknowledgement.queued",
-      "callback.acknowledgement.delivered",
       "run.claimed",
       "run.progress",
       "run.completed",
@@ -1251,6 +1248,9 @@ describe("dispatcher API", () => {
     const app = createDispatcherApp({
       databasePath: ":memory:",
       presentation: {
+        shouldDeliverAcknowledgement() {
+          return true;
+        },
         shouldDeliverProgress(provider) {
           return provider === "slack";
         },

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -590,6 +590,101 @@ describe("dispatcher API", () => {
     });
   });
 
+  it("renders Lark callbacks as plain text and keeps progress audit-only", async () => {
+    const delivered: { kind: string; body: string }[] = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        runnerId: "runner_1",
+        workspacePath: "/Users/test/demo",
+        defaultExecutor: "echo"
+      })
+    });
+
+    const larkEvent = {
+      ...validEvent,
+      id: "evt_lark_1",
+      source: "lark",
+      sourceEventId: "EvLark123",
+      actor: { provider: "lark", providerUserId: "ou_123", handle: "Felix", organizationId: "tenant_123" },
+      permissions: [{ scope: "chat:postMessage", reason: "reply in thread" }],
+      callback: {
+        provider: "lark",
+        uri: "lark://im/v1/messages",
+        threadKey: "tk_123|oc_chat|om_msg"
+      }
+    };
+
+    const createResponse = await app.request("/v1/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "run_lark_1", event: larkEvent })
+    });
+    expect(createResponse.status).toBe(201);
+
+    await app.request("/v1/runners/runner_1/claim", { method: "POST" });
+    const progressResponse = await app.request("/v1/runners/runner_1/runs/run_lark_1/progress", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "executor.progress", message: "Echo executor started", at: "2026-06-24T00:00:01.000Z" })
+    });
+    expect(progressResponse.status).toBe(200);
+
+    const completeResponse = await app.request("/v1/runners/runner_1/runs/run_lark_1/complete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        result: {
+          conclusion: "success",
+          summary: "Echoed OpenTag command: introduce yourself",
+          verification: [{ command: "echo", outcome: "passed" }]
+        }
+      })
+    });
+    expect(completeResponse.status).toBe(200);
+
+    expect(delivered).toEqual([
+      { kind: "acknowledgement", body: "I picked this up: run_lark_1" },
+      {
+        kind: "final",
+        body: "Finished with success.\n\nEchoed OpenTag command: introduce yourself\n\nVerification\n- echo: passed"
+      }
+    ]);
+
+    const eventsResponse = await app.request("/v1/runs/run_lark_1/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toEqual([
+      "admission.decided",
+      "run.created",
+      "context_packet.generated",
+      "callback.acknowledgement.queued",
+      "callback.acknowledgement.delivered",
+      "run.claimed",
+      "run.progress",
+      "run.completed",
+      "callback.final.queued",
+      "callback.final.delivered"
+    ]);
+    expect(events.find((event: { type: string }) => event.type === "run.progress")).toMatchObject({
+      visibility: "audit",
+      importance: "normal",
+      message: "Echo executor started"
+    });
+  });
+
   it("records proposal approval decisions and creates apply plans", async () => {
     const app = createDispatcherApp({ databasePath: ":memory:" });
     await app.request("/v1/repo-bindings", {

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -7,6 +7,7 @@ import {
   cleanupInternalArtifacts,
   commitRunChanges,
   createRunWorktree,
+  deleteRunBranch,
   removeRunWorktree,
   worktreePathForRun
 } from "./git.js";
@@ -106,6 +107,7 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
       const baseBranch = input.baseBranch ?? "main";
       const keepWorktree = input.keepWorktree ?? "on_failure";
       let completed = false;
+      let changedFileCount: number | undefined;
 
       await sink.emit({
         type: "executor.started",
@@ -158,6 +160,7 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
         }
 
         const files = await changedFiles({ runner, workspacePath: worktreePath });
+        changedFileCount = files.length;
         if (files.length > 0) {
           await sink.emit({
             type: "executor.progress",
@@ -184,7 +187,7 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
           summary: output.slice(-4000),
           changedFiles: files,
           artifacts: [
-            { title: "Run branch", uri: branchName },
+            ...(files.length > 0 ? [{ title: "Run branch", uri: branchName }] : []),
             ...(keepWorktree === "always" ? [{ title: "Run worktree", uri: worktreePath }] : [])
           ],
           verification: [
@@ -206,6 +209,9 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
         if (shouldRemove) {
           try {
             await removeRunWorktree({ runner, workspacePath: input.workspacePath, worktreePath });
+            if (completed && changedFileCount === 0) {
+              await deleteRunBranch({ runner, workspacePath: input.workspacePath, branchName });
+            }
           } catch (error) {
             await sink.emit({
               type: "executor.progress",

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -215,7 +215,7 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
           } catch (error) {
             await sink.emit({
               type: "executor.progress",
-              message: `Could not remove run worktree ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`,
+              message: `Could not clean up run worktree or branch for ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`,
               at: new Date().toISOString()
             });
           }

--- a/packages/runner/src/git.ts
+++ b/packages/runner/src/git.ts
@@ -84,6 +84,13 @@ export async function removeRunWorktree(input: {
   await assertCommandSucceeded(result, "remove run worktree");
 }
 
+export async function deleteRunBranch(input: { runner: CommandRunner; workspacePath: string; branchName: string }): Promise<void> {
+  const result = await input.runner.run("git", ["branch", "-D", input.branchName], {
+    cwd: input.workspacePath
+  });
+  await assertCommandSucceeded(result, "delete empty run branch");
+}
+
 export async function changedFiles(input: { runner: CommandRunner; workspacePath: string }): Promise<string[]> {
   const result = await input.runner.run("git", ["status", "--porcelain"], { cwd: input.workspacePath });
   await assertCommandSucceeded(result, "read changed files");

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -111,6 +111,7 @@ describe("Codex executor", () => {
     expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "add -- src/demo.ts test/demo.test.ts")).toBe(true);
     expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "commit -m OpenTag run run_1")).toBe(true);
     expect(calls.some((call) => call.command === "git" && call.args.join(" ") === `worktree remove --force ${worktreePath}`)).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "branch -D opentag/run_1")).toBe(false);
     const codexExecCall = calls.find((call) => call.command === "codex" && call.args[0] === "exec");
     expect(codexExecCall?.args).toContain("--full-auto");
     expect(codexExecCall?.args).toContain("--ephemeral");
@@ -125,6 +126,61 @@ describe("Codex executor", () => {
     expect(result.summary).toContain("Implemented the requested fix.");
     expect(result.artifacts?.[0]).toMatchObject({ title: "Run branch", uri: "opentag/run_1" });
     expect(result.nextAction).toBe("Review the local branch or pull request.");
+  });
+
+  it("removes the empty run branch when codex completes without changes", async () => {
+    process.env.OPENAI_API_KEY = "sk-secret";
+    const calls: { command: string; args: string[]; cwd?: string }[] = [];
+    const runner: CommandRunner = {
+      async run(command, args, options) {
+        calls.push({ command, args, cwd: options?.cwd });
+        if (command === "codex" && args.includes("--version")) {
+          return { exitCode: 0, stdout: "codex 1.0.0", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "rev-parse --show-toplevel") {
+          return { exitCode: 0, stdout: "/tmp/demo\n", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "rev-parse --verify main^{commit}") {
+          return { exitCode: 0, stdout: "abc123\n", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "status --porcelain") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && args[0] === "worktree" && args[1] === "add") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && args[0] === "worktree" && args[1] === "remove") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "branch -D opentag/run_no_change") {
+          return { exitCode: 0, stdout: "Deleted branch opentag/run_no_change\n", stderr: "" };
+        }
+        if (command === "codex" && args[0] === "exec") {
+          return { exitCode: 0, stdout: "Nothing to change.", stderr: "" };
+        }
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+
+    const result = await createCodexExecutor({ runner }).run(
+      {
+        runId: "run_no_change",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "hi", intent: "unknown", args: {} },
+        context: [],
+        permissions: [{ scope: "repo:write", reason: "write branch" }],
+        baseBranch: "main",
+        keepWorktree: "on_failure"
+      },
+      { emit: async () => undefined }
+    );
+
+    const worktreePath = worktreePathForRun({ workspacePath: "/tmp/demo", runId: "run_no_change" });
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === `worktree remove --force ${worktreePath}`)).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "branch -D opentag/run_no_change")).toBe(true);
+    expect(result.changedFiles).toEqual([]);
+    expect(result.artifacts).toEqual([]);
+    expect(result.nextAction).toBe("No file changes were detected.");
   });
 
   it("refuses to run when the workspace has uncommitted changes", async () => {

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -1,21 +1,15 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCodexExecutor } from "../src/codex.js";
 import type { CommandRunner } from "../src/command.js";
 import { branchNameForRun, commitRunChanges, parseChangedFiles, worktreePathForRun } from "../src/git.js";
 
-const ORIGINAL_OPENAI_API_KEY = process.env.OPENAI_API_KEY;
-
 afterEach(() => {
-  if (ORIGINAL_OPENAI_API_KEY === undefined) {
-    delete process.env.OPENAI_API_KEY;
-  } else {
-    process.env.OPENAI_API_KEY = ORIGINAL_OPENAI_API_KEY;
-  }
+  vi.unstubAllEnvs();
 });
 
 describe("Codex executor", () => {
   it("creates an isolated worktree, runs codex exec, and reports changed files", async () => {
-    process.env.OPENAI_API_KEY = "sk-secret";
+    vi.stubEnv("OPENAI_API_KEY", "sk-secret");
     const calls: { command: string; args: string[]; input?: string; cwd?: string; env?: Record<string, string | undefined> }[] = [];
     const runner: CommandRunner = {
       async run(command, args, options) {
@@ -129,7 +123,7 @@ describe("Codex executor", () => {
   });
 
   it("removes the empty run branch when codex completes without changes", async () => {
-    process.env.OPENAI_API_KEY = "sk-secret";
+    vi.stubEnv("OPENAI_API_KEY", "sk-secret");
     const calls: { command: string; args: string[]; cwd?: string }[] = [];
     const runner: CommandRunner = {
       async run(command, args, options) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       '@opentag/lark':
         specifier: workspace:*
         version: link:../../packages/lark
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
     devDependencies:
       tsup:
         specifier: ^8.5.1
@@ -1768,6 +1771,10 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  qrcode-terminal@0.12.0:
+    resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
+    hasBin: true
+
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
@@ -3199,6 +3206,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qrcode-terminal@0.12.0: {}
 
   qs@6.15.3:
     dependencies:

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -33,6 +33,13 @@ require_command() {
   fi
 }
 
+workspace_dependencies_installed() {
+  [[ -x "$ROOT_DIR/apps/dispatcher/node_modules/.bin/tsx" ]] &&
+    [[ -x "$ROOT_DIR/apps/opentagd/node_modules/.bin/tsx" ]] &&
+    [[ -x "$ROOT_DIR/apps/lark-events/node_modules/.bin/tsx" ]] &&
+    [[ -d "$ROOT_DIR/apps/lark-events/node_modules/qrcode-terminal" ]]
+}
+
 read_with_default() {
   local prompt="$1"
   local default_value="$2"
@@ -152,6 +159,36 @@ validate_executor() {
   esac
 }
 
+assert_executor_available() {
+  case "$1" in
+    codex)
+      require_command codex
+      ;;
+    claude-code)
+      require_command claude
+      ;;
+    echo)
+      ;;
+  esac
+}
+
+json_field() {
+  local field="$1"
+  FIELD="$field" node -e '
+const fs = require("node:fs");
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const value = data[process.env.FIELD];
+if (typeof value === "string") process.stdout.write(value);
+' <<< "$REGISTRATION_JSON"
+}
+
+register_lark_personal_agent() {
+  (
+    cd "$ROOT_DIR/apps/lark-events"
+    node scripts/register-personal-agent.cjs "$LARK_DOMAIN"
+  )
+}
+
 write_config() {
   mkdir -p "$STATE_DIR" "$STATE_DIR/worktrees"
   CONFIG_PATH="$CONFIG_PATH" \
@@ -222,7 +259,7 @@ log
 log "This starts a local OpenTag stack that lets Lark wake an agent on this computer."
 log
 
-if [[ ! -x "$ROOT_DIR/node_modules/.bin/tsx" ]]; then
+if ! workspace_dependencies_installed; then
   log "Installing workspace dependencies with corepack pnpm install..."
   (cd "$ROOT_DIR" && corepack pnpm install)
 fi
@@ -239,7 +276,8 @@ if [[ -n "${OPENTAG_REPO_OWNER:-}" && -n "${OPENTAG_REPO_NAME:-}" ]]; then
   REPO_OWNER="$OPENTAG_REPO_OWNER"
   REPO_NAME="$OPENTAG_REPO_NAME"
 elif [[ -n "$INFERRED_SLUG" && "$INFERRED_SLUG" == */* ]]; then
-  REPO_SLUG="$(read_with_default "GitHub repo for this checkout" "$INFERRED_SLUG")"
+  REPO_SLUG="$INFERRED_SLUG"
+  log "Using repo from git origin: $REPO_SLUG"
   REPO_OWNER="${REPO_SLUG%%/*}"
   REPO_NAME="${REPO_SLUG#*/}"
 else
@@ -255,8 +293,9 @@ BASE_BRANCH="${BASE_BRANCH:-main}"
 PUSH_REMOTE="${OPENTAG_PUSH_REMOTE:-origin}"
 
 DETECTED_EXECUTOR="$(detect_executor)"
-EXECUTOR="$(read_with_default "Executor for local runs (codex, claude-code, echo)" "$DETECTED_EXECUTOR")"
+EXECUTOR="$(read_with_default "Executor for local runs (codex, claude-code, echo; choose codex for a real local agent)" "$DETECTED_EXECUTOR")"
 validate_executor "$EXECUTOR"
+assert_executor_available "$EXECUTOR"
 
 LARK_DOMAIN="$(read_with_default "Lark domain (lark or feishu)" "${LARK_DOMAIN:-lark}")"
 case "$LARK_DOMAIN" in
@@ -267,27 +306,52 @@ case "$LARK_DOMAIN" in
     ;;
 esac
 
-LARK_APP_ID="$(read_with_default "LARK_APP_ID" "${LARK_APP_ID:-}")"
-[[ -n "$LARK_APP_ID" ]] || fail "LARK_APP_ID is required."
+if [[ -n "${LARK_APP_ID:-}" && -n "${LARK_APP_SECRET:-}" ]]; then
+  log "Using LARK_APP_ID and LARK_APP_SECRET from the environment."
+else
+  LARK_SETUP_MODE="$(read_with_default "Lark app setup (scan or manual)" "${OPENTAG_LARK_APP_SETUP:-scan}")"
+  case "$LARK_SETUP_MODE" in
+    scan)
+      REGISTRATION_JSON="$(register_lark_personal_agent)"
+      LARK_APP_ID="$(json_field appId)"
+      LARK_APP_SECRET="$(json_field appSecret)"
+      DETECTED_LARK_DOMAIN="$(json_field domain)"
+      DETECTED_LARK_BOT_OPEN_ID="$(json_field botOpenId)"
+      if [[ -n "$DETECTED_LARK_DOMAIN" ]]; then
+        LARK_DOMAIN="$DETECTED_LARK_DOMAIN"
+      fi
+      if [[ -n "$DETECTED_LARK_BOT_OPEN_ID" && -z "${LARK_BOT_OPEN_ID:-}" ]]; then
+        LARK_BOT_OPEN_ID="$DETECTED_LARK_BOT_OPEN_ID"
+      fi
+      ;;
+    manual)
+      LARK_APP_ID="$(read_with_default "LARK_APP_ID" "${LARK_APP_ID:-}")"
+      LARK_APP_SECRET="$(read_secret_with_default "LARK_APP_SECRET" "${LARK_APP_SECRET:-}")"
+      ;;
+    *)
+      fail "Lark app setup must be scan or manual."
+      ;;
+  esac
+fi
 
-LARK_APP_SECRET="$(read_secret_with_default "LARK_APP_SECRET" "${LARK_APP_SECRET:-}")"
+[[ -n "$LARK_APP_ID" ]] || fail "LARK_APP_ID is required."
 [[ -n "$LARK_APP_SECRET" ]] || fail "LARK_APP_SECRET is required."
 
-USE_GROUP="$(read_with_default "Will you test in a Lark group chat? (y/N)" "${OPENTAG_LARK_GROUP_CHAT:-N}")"
 LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-}"
-case "$USE_GROUP" in
-  y|Y|yes|YES)
-    LARK_BOT_OPEN_ID="$(read_with_default "LARK_BOT_OPEN_ID for group @mentions" "$LARK_BOT_OPEN_ID")"
-    [[ -n "$LARK_BOT_OPEN_ID" ]] || fail "LARK_BOT_OPEN_ID is required for group chat triggers."
-    ;;
-  *)
-    if [[ -n "$LARK_BOT_OPEN_ID" ]]; then
-      log "Using LARK_BOT_OPEN_ID from the environment for group messages."
-    else
+if [[ -n "$LARK_BOT_OPEN_ID" ]]; then
+  log "Using LARK_BOT_OPEN_ID for group @mentions."
+else
+  USE_GROUP="$(read_with_default "Will you test in a Lark group chat? (y/N)" "${OPENTAG_LARK_GROUP_CHAT:-N}")"
+  case "$USE_GROUP" in
+    y|Y|yes|YES)
+      LARK_BOT_OPEN_ID="$(read_with_default "LARK_BOT_OPEN_ID for group @mentions" "$LARK_BOT_OPEN_ID")"
+      [[ -n "$LARK_BOT_OPEN_ID" ]] || fail "LARK_BOT_OPEN_ID is required for group chat triggers."
+      ;;
+    *)
       log "Direct Lark messages can run without LARK_BOT_OPEN_ID. Group messages require it."
-    fi
-    ;;
-esac
+      ;;
+  esac
+fi
 
 PAIRING_TOKEN="${OPENTAG_PAIRING_TOKEN:-dev_pairing_token}"
 RUNNER_ID="${OPENTAG_RUNNER_ID:-runner_lark_local}"
@@ -357,9 +421,14 @@ log
 log "Try this in a direct chat with the bot:"
 log "  say hello from my local computer"
 log
-log "Try this in a group chat:"
-log "  @OpenTag say hello from my local computer"
-log
+if [[ -n "$LARK_BOT_OPEN_ID" ]]; then
+  log "Try this in a group chat:"
+  log "  @OpenTag say hello from my local computer"
+  log
+else
+  log "Group chat needs LARK_BOT_OPEN_ID. Direct chat is ready now."
+  log
+fi
 log "This script auto-connects the first Lark chat that messages the bot to $DEFAULT_REPO."
 log "To point a chat at another repo later, send:"
 log "  @OpenTag /bind owner/repo"

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STATE_DIR="$ROOT_DIR/.opentag/lark"
+CONFIG_PATH="$STATE_DIR/opentag.local.json"
+
+DISPATCHER_PID=""
+DAEMON_PID=""
+LARK_PID=""
+
+cleanup() {
+  for pid in "$LARK_PID" "$DAEMON_PID" "$DISPATCHER_PID"; do
+    if [[ -n "$pid" ]]; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+}
+trap cleanup EXIT
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    fail "$1 is required."
+  fi
+}
+
+read_with_default() {
+  local prompt="$1"
+  local default_value="$2"
+  local value
+  if [[ -n "$default_value" ]]; then
+    read -r -p "$prompt [$default_value]: " value
+    printf '%s' "${value:-$default_value}"
+  else
+    read -r -p "$prompt: " value
+    printf '%s' "$value"
+  fi
+}
+
+read_secret_with_default() {
+  local prompt="$1"
+  local default_value="$2"
+  local value
+  if [[ -n "$default_value" ]]; then
+    read -r -s -p "$prompt [already set]: " value
+    printf '\n' >&2
+    printf '%s' "${value:-$default_value}"
+  else
+    read -r -s -p "$prompt: " value
+    printf '\n' >&2
+    printf '%s' "$value"
+  fi
+}
+
+absolute_path() {
+  local raw="$1"
+  if [[ "$raw" == "~" ]]; then
+    raw="$HOME"
+  elif [[ "$raw" == ~/* ]]; then
+    raw="$HOME/${raw#~/}"
+  fi
+  node -e 'const path = require("node:path"); console.log(path.resolve(process.argv[1]));' "$raw"
+}
+
+infer_github_slug() {
+  local checkout_path="$1"
+  local remote_url
+  remote_url="$(git -C "$checkout_path" remote get-url origin 2>/dev/null || true)"
+  remote_url="${remote_url%.git}"
+  case "$remote_url" in
+    https://github.com/*)
+      printf '%s' "${remote_url#https://github.com/}"
+      ;;
+    git@github.com:*)
+      printf '%s' "${remote_url#git@github.com:}"
+      ;;
+    ssh://git@github.com/*)
+      printf '%s' "${remote_url#ssh://git@github.com/}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+port_is_in_use() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -ti "tcp:${port}" >/dev/null 2>&1
+    return
+  fi
+  nc -z 127.0.0.1 "$port" >/dev/null 2>&1
+}
+
+choose_dispatcher_port() {
+  local requested="${OPENTAG_DISPATCHER_PORT:-}"
+  local port="${requested:-3030}"
+  if [[ -n "$requested" ]]; then
+    if port_is_in_use "$port"; then
+      fail "Port $port is already in use. Set OPENTAG_DISPATCHER_PORT to a free port."
+    fi
+    printf '%s' "$port"
+    return
+  fi
+
+  while port_is_in_use "$port"; do
+    port=$((port + 1))
+  done
+  printf '%s' "$port"
+}
+
+wait_for_dispatcher() {
+  local url="$1"
+  for _ in $(seq 1 60); do
+    if node -e 'fetch(process.argv[1]).then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1));' "$url/healthz"; then
+      return
+    fi
+    sleep 0.5
+  done
+  fail "Dispatcher did not become healthy at $url."
+}
+
+detect_executor() {
+  if [[ -n "${OPENTAG_LARK_EXECUTOR:-}" ]]; then
+    printf '%s' "$OPENTAG_LARK_EXECUTOR"
+  elif command -v codex >/dev/null 2>&1; then
+    printf 'codex'
+  elif command -v claude >/dev/null 2>&1; then
+    printf 'claude-code'
+  else
+    printf 'echo'
+  fi
+}
+
+validate_executor() {
+  case "$1" in
+    echo|codex|claude-code)
+      return
+      ;;
+    *)
+      fail "Executor must be echo, codex, or claude-code."
+      ;;
+  esac
+}
+
+write_config() {
+  mkdir -p "$STATE_DIR" "$STATE_DIR/worktrees"
+  CONFIG_PATH="$CONFIG_PATH" \
+  RUNNER_ID="$RUNNER_ID" \
+  DISPATCHER_URL="$DISPATCHER_URL" \
+  PAIRING_TOKEN="$PAIRING_TOKEN" \
+  REPO_PROVIDER="$REPO_PROVIDER" \
+  REPO_OWNER="$REPO_OWNER" \
+  REPO_NAME="$REPO_NAME" \
+  CHECKOUT_PATH="$CHECKOUT_PATH" \
+  EXECUTOR="$EXECUTOR" \
+  BASE_BRANCH="$BASE_BRANCH" \
+  PUSH_REMOTE="$PUSH_REMOTE" \
+  WORKTREE_ROOT="$STATE_DIR/worktrees" \
+  node <<'NODE'
+const { writeFileSync, chmodSync } = require("node:fs");
+
+const config = {
+  runnerId: process.env.RUNNER_ID,
+  dispatcherUrl: process.env.DISPATCHER_URL,
+  pairingToken: process.env.PAIRING_TOKEN,
+  pollIntervalMs: 1000,
+  heartbeatIntervalMs: 15000,
+  repositories: [
+    {
+      provider: process.env.REPO_PROVIDER,
+      owner: process.env.REPO_OWNER,
+      repo: process.env.REPO_NAME,
+      checkoutPath: process.env.CHECKOUT_PATH,
+      defaultExecutor: process.env.EXECUTOR,
+      baseBranch: process.env.BASE_BRANCH,
+      pushRemote: process.env.PUSH_REMOTE,
+      worktreeRoot: process.env.WORKTREE_ROOT,
+      keepWorktree: "on_failure"
+    }
+  ]
+};
+
+if (process.env.EXECUTOR === "claude-code") {
+  config.claudeCode = {
+    command: process.env.OPENTAG_CLAUDE_COMMAND || "claude",
+    permissionMode: process.env.OPENTAG_CLAUDE_PERMISSION_MODE || "acceptEdits"
+  };
+}
+
+writeFileSync(process.env.CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+chmodSync(process.env.CONFIG_PATH, 0o600);
+NODE
+}
+
+run_opentagd() {
+  local command_name="$1"
+  shift || true
+  (
+    cd "$ROOT_DIR"
+    OPENTAG_CONFIG_PATH="$CONFIG_PATH" \
+    NODE_OPTIONS='--conditions=development' \
+    corepack pnpm --filter @opentag/opentagd dev -- "$command_name" "$@"
+  )
+}
+
+require_command node
+require_command git
+require_command corepack
+
+log "OpenTag for Lark"
+log
+log "This starts a local OpenTag stack that lets Lark wake an agent on this computer."
+log
+
+if [[ ! -x "$ROOT_DIR/node_modules/.bin/tsx" ]]; then
+  log "Installing workspace dependencies with corepack pnpm install..."
+  (cd "$ROOT_DIR" && corepack pnpm install)
+fi
+
+DEFAULT_CHECKOUT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$ROOT_DIR")"
+CHECKOUT_INPUT="${OPENTAG_WORKSPACE_PATH:-$(read_with_default "Local project path for this agent" "$DEFAULT_CHECKOUT")}"
+CHECKOUT_PATH="$(absolute_path "$CHECKOUT_INPUT")"
+
+[[ -d "$CHECKOUT_PATH" ]] || fail "Project path does not exist: $CHECKOUT_PATH"
+git -C "$CHECKOUT_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "Project path must be a git checkout: $CHECKOUT_PATH"
+
+INFERRED_SLUG="$(infer_github_slug "$CHECKOUT_PATH" || true)"
+if [[ -n "${OPENTAG_REPO_OWNER:-}" && -n "${OPENTAG_REPO_NAME:-}" ]]; then
+  REPO_OWNER="$OPENTAG_REPO_OWNER"
+  REPO_NAME="$OPENTAG_REPO_NAME"
+elif [[ -n "$INFERRED_SLUG" && "$INFERRED_SLUG" == */* ]]; then
+  REPO_SLUG="$(read_with_default "GitHub repo for this checkout" "$INFERRED_SLUG")"
+  REPO_OWNER="${REPO_SLUG%%/*}"
+  REPO_NAME="${REPO_SLUG#*/}"
+else
+  REPO_SLUG="$(read_with_default "GitHub repo for this checkout (owner/repo)" "")"
+  [[ "$REPO_SLUG" == */* ]] || fail "Repo must be formatted as owner/repo."
+  REPO_OWNER="${REPO_SLUG%%/*}"
+  REPO_NAME="${REPO_SLUG#*/}"
+fi
+
+REPO_PROVIDER="${OPENTAG_REPO_PROVIDER:-github}"
+BASE_BRANCH="${OPENTAG_BASE_BRANCH:-$(git -C "$CHECKOUT_PATH" branch --show-current 2>/dev/null || true)}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+PUSH_REMOTE="${OPENTAG_PUSH_REMOTE:-origin}"
+
+DETECTED_EXECUTOR="$(detect_executor)"
+EXECUTOR="$(read_with_default "Executor for local runs (codex, claude-code, echo)" "$DETECTED_EXECUTOR")"
+validate_executor "$EXECUTOR"
+
+LARK_DOMAIN="$(read_with_default "Lark domain (lark or feishu)" "${LARK_DOMAIN:-lark}")"
+case "$LARK_DOMAIN" in
+  lark|feishu)
+    ;;
+  *)
+    fail "Lark domain must be lark or feishu."
+    ;;
+esac
+
+LARK_APP_ID="$(read_with_default "LARK_APP_ID" "${LARK_APP_ID:-}")"
+[[ -n "$LARK_APP_ID" ]] || fail "LARK_APP_ID is required."
+
+LARK_APP_SECRET="$(read_secret_with_default "LARK_APP_SECRET" "${LARK_APP_SECRET:-}")"
+[[ -n "$LARK_APP_SECRET" ]] || fail "LARK_APP_SECRET is required."
+
+USE_GROUP="$(read_with_default "Will you test in a Lark group chat? (y/N)" "${OPENTAG_LARK_GROUP_CHAT:-N}")"
+LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-}"
+case "$USE_GROUP" in
+  y|Y|yes|YES)
+    LARK_BOT_OPEN_ID="$(read_with_default "LARK_BOT_OPEN_ID for group @mentions" "$LARK_BOT_OPEN_ID")"
+    [[ -n "$LARK_BOT_OPEN_ID" ]] || fail "LARK_BOT_OPEN_ID is required for group chat triggers."
+    ;;
+  *)
+    if [[ -n "$LARK_BOT_OPEN_ID" ]]; then
+      log "Using LARK_BOT_OPEN_ID from the environment for group messages."
+    else
+      log "Direct Lark messages can run without LARK_BOT_OPEN_ID. Group messages require it."
+    fi
+    ;;
+esac
+
+PAIRING_TOKEN="${OPENTAG_PAIRING_TOKEN:-dev_pairing_token}"
+RUNNER_ID="${OPENTAG_RUNNER_ID:-runner_lark_local}"
+DISPATCHER_PORT="$(choose_dispatcher_port)"
+DISPATCHER_URL="http://localhost:$DISPATCHER_PORT"
+DATABASE_PATH="${OPENTAG_DATABASE_PATH:-$STATE_DIR/opentag.db}"
+DEFAULT_REPO="$REPO_PROVIDER:$REPO_OWNER/$REPO_NAME"
+
+write_config
+
+log
+log "Starting OpenTag for Lark"
+log "- Project: $REPO_OWNER/$REPO_NAME"
+log "- Path: $CHECKOUT_PATH"
+log "- Executor: $EXECUTOR"
+log "- Dispatcher: $DISPATCHER_URL"
+log "- Config: $CONFIG_PATH"
+log
+
+(
+  cd "$ROOT_DIR"
+  export PORT="$DISPATCHER_PORT"
+  export OPENTAG_DATABASE_PATH="$DATABASE_PATH"
+  export OPENTAG_PAIRING_TOKEN="$PAIRING_TOKEN"
+  export LARK_APP_ID
+  export LARK_APP_SECRET
+  export LARK_DOMAIN
+  NODE_OPTIONS='--conditions=development' corepack pnpm --filter @opentag/dispatcher-app dev
+) &
+DISPATCHER_PID=$!
+
+wait_for_dispatcher "$DISPATCHER_URL"
+
+log "Registering local runner and binding the selected project..."
+run_opentagd register-runner
+run_opentagd bind-repos
+
+log "Starting local daemon..."
+(
+  cd "$ROOT_DIR"
+  OPENTAG_CONFIG_PATH="$CONFIG_PATH" \
+  NODE_OPTIONS='--conditions=development' \
+  corepack pnpm --filter @opentag/opentagd dev -- serve
+) &
+DAEMON_PID=$!
+
+log "Starting Lark long-connection ingress..."
+(
+  cd "$ROOT_DIR"
+  export LARK_APP_ID
+  export LARK_APP_SECRET
+  export LARK_DOMAIN
+  export OPENTAG_DISPATCHER_URL="$DISPATCHER_URL"
+  export OPENTAG_DISPATCHER_TOKEN="$PAIRING_TOKEN"
+  export OPENTAG_LARK_DEFAULT_REPO="$DEFAULT_REPO"
+  export OPENTAG_LARK_AGENT_ID="${OPENTAG_LARK_AGENT_ID:-opentag}"
+  if [[ -n "$LARK_BOT_OPEN_ID" ]]; then
+    export LARK_BOT_OPEN_ID
+  fi
+  NODE_OPTIONS='--conditions=development' corepack pnpm --filter @opentag/lark-events dev
+) &
+LARK_PID=$!
+
+log
+log "OpenTag for Lark is running."
+log
+log "Try this in a direct chat with the bot:"
+log "  say hello from my local computer"
+log
+log "Try this in a group chat:"
+log "  @OpenTag say hello from my local computer"
+log
+log "This script auto-connects the first Lark chat that messages the bot to $DEFAULT_REPO."
+log "To point a chat at another repo later, send:"
+log "  @OpenTag /bind owner/repo"
+log
+log "Expected AHA moment:"
+log "1. Lark replies with an acknowledgement."
+log "2. This terminal shows the local daemon running the executor."
+log "3. Lark replies with the final result."
+log
+log "Press Ctrl-C to stop OpenTag."
+wait

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -165,7 +165,16 @@ json_field() {
   local field="$1"
   FIELD="$field" node -e '
 const fs = require("node:fs");
-const data = JSON.parse(fs.readFileSync(0, "utf8"));
+const input = fs.readFileSync(0, "utf8");
+const jsonLine = input
+  .split(/\r?\n/)
+  .map((line) => line.trim())
+  .filter((line) => line.startsWith("{") && line.endsWith("}"))
+  .at(-1);
+if (!jsonLine) {
+  throw new Error("Lark Personal Agent registration did not return JSON credentials.");
+}
+const data = JSON.parse(jsonLine);
 const value = data[process.env.FIELD];
 if (typeof value === "string") process.stdout.write(value);
 ' <<< "$REGISTRATION_JSON"

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -78,25 +78,14 @@ absolute_path() {
   node -e 'const path = require("node:path"); console.log(path.resolve(process.argv[1]));' "$raw"
 }
 
-infer_github_slug() {
+local_project_name() {
   local checkout_path="$1"
-  local remote_url
-  remote_url="$(git -C "$checkout_path" remote get-url origin 2>/dev/null || true)"
-  remote_url="${remote_url%.git}"
-  case "$remote_url" in
-    https://github.com/*)
-      printf '%s' "${remote_url#https://github.com/}"
-      ;;
-    git@github.com:*)
-      printf '%s' "${remote_url#git@github.com:}"
-      ;;
-    ssh://git@github.com/*)
-      printf '%s' "${remote_url#ssh://git@github.com/}"
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  node -e '
+const path = require("node:path");
+const rawName = path.basename(process.argv[1]).trim() || "project";
+const safeName = rawName.replace(/[^\w.-]+/g, "-").replace(/^-+|-+$/g, "") || "project";
+process.stdout.write(safeName);
+' "$checkout_path"
 }
 
 port_is_in_use() {
@@ -271,23 +260,17 @@ CHECKOUT_PATH="$(absolute_path "$CHECKOUT_INPUT")"
 [[ -d "$CHECKOUT_PATH" ]] || fail "Project path does not exist: $CHECKOUT_PATH"
 git -C "$CHECKOUT_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "Project path must be a git checkout: $CHECKOUT_PATH"
 
-INFERRED_SLUG="$(infer_github_slug "$CHECKOUT_PATH" || true)"
 if [[ -n "${OPENTAG_REPO_OWNER:-}" && -n "${OPENTAG_REPO_NAME:-}" ]]; then
+  REPO_PROVIDER="${OPENTAG_REPO_PROVIDER:-github}"
   REPO_OWNER="$OPENTAG_REPO_OWNER"
   REPO_NAME="$OPENTAG_REPO_NAME"
-elif [[ -n "$INFERRED_SLUG" && "$INFERRED_SLUG" == */* ]]; then
-  REPO_SLUG="$INFERRED_SLUG"
-  log "Using repo from git origin: $REPO_SLUG"
-  REPO_OWNER="${REPO_SLUG%%/*}"
-  REPO_NAME="${REPO_SLUG#*/}"
+  log "Advanced repository target enabled for PR-capable workflows."
 else
-  REPO_SLUG="$(read_with_default "GitHub repo for this checkout (owner/repo)" "")"
-  [[ "$REPO_SLUG" == */* ]] || fail "Repo must be formatted as owner/repo."
-  REPO_OWNER="${REPO_SLUG%%/*}"
-  REPO_NAME="${REPO_SLUG#*/}"
+  REPO_PROVIDER="local"
+  REPO_OWNER="local"
+  REPO_NAME="$(local_project_name "$CHECKOUT_PATH")"
 fi
 
-REPO_PROVIDER="${OPENTAG_REPO_PROVIDER:-github}"
 BASE_BRANCH="${OPENTAG_BASE_BRANCH:-$(git -C "$CHECKOUT_PATH" branch --show-current 2>/dev/null || true)}"
 BASE_BRANCH="${BASE_BRANCH:-main}"
 PUSH_REMOTE="${OPENTAG_PUSH_REMOTE:-origin}"
@@ -364,7 +347,7 @@ write_config
 
 log
 log "Starting OpenTag for Lark"
-log "- Project: $REPO_OWNER/$REPO_NAME"
+log "- Project: $REPO_NAME"
 log "- Path: $CHECKOUT_PATH"
 log "- Executor: $EXECUTOR"
 log "- Dispatcher: $DISPATCHER_URL"
@@ -429,9 +412,7 @@ else
   log "Group chat needs LARK_BOT_OPEN_ID. Direct chat is ready now."
   log
 fi
-log "This script auto-connects the first Lark chat that messages the bot to $DEFAULT_REPO."
-log "To point a chat at another repo later, send:"
-log "  @OpenTag /bind owner/repo"
+log "This script auto-connects the first Lark chat that messages the bot to this local project."
 log
 log "Expected AHA moment:"
 log "1. Lark replies with an acknowledgement."

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -9,15 +9,27 @@ LARK_CONFIG_PATH="$STATE_DIR/lark.local.json"
 DISPATCHER_PID=""
 DAEMON_PID=""
 LARK_PID=""
+CLEANING_UP=""
 
 cleanup() {
+  if [[ -n "$CLEANING_UP" ]]; then
+    return
+  fi
+  CLEANING_UP=1
   for pid in "$LARK_PID" "$DAEMON_PID" "$DISPATCHER_PID"; do
     if [[ -n "$pid" ]]; then
       kill "$pid" 2>/dev/null || true
     fi
   done
+  for pid in "$LARK_PID" "$DAEMON_PID" "$DISPATCHER_PID"; do
+    if [[ -n "$pid" ]]; then
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 log() {
   printf '%s\n' "$*"
@@ -92,8 +104,10 @@ process.stdout.write(safeName);
 port_is_in_use() {
   local port="$1"
   if command -v lsof >/dev/null 2>&1; then
-    lsof -ti "tcp:${port}" >/dev/null 2>&1
-    return
+    if lsof -ti "tcp:${port}" >/dev/null 2>&1; then
+      return 0
+    fi
+    return 1
   fi
   nc -z 127.0.0.1 "$port" >/dev/null 2>&1
 }
@@ -118,12 +132,42 @@ choose_dispatcher_port() {
 wait_for_dispatcher() {
   local url="$1"
   for _ in $(seq 1 60); do
-    if node -e 'fetch(process.argv[1]).then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1));' "$url/healthz"; then
+    if node -e '
+const ctrl = new AbortController();
+setTimeout(() => ctrl.abort(), 5000).unref();
+fetch(process.argv[1], { signal: ctrl.signal })
+  .then((r) => process.exit(r.ok ? 0 : 1))
+  .catch(() => process.exit(1));
+' "$url/healthz"; then
       return
     fi
     sleep 0.5
   done
   fail "Dispatcher did not become healthy at $url."
+}
+
+ensure_process_started() {
+  local pid="$1"
+  local name="$2"
+  sleep 1
+  if ! kill -0 "$pid" 2>/dev/null; then
+    wait "$pid" 2>/dev/null || true
+    fail "$name exited before OpenTag finished starting."
+  fi
+}
+
+wait_for_stack_exit() {
+  while true; do
+    for name_and_pid in "Dispatcher:$DISPATCHER_PID" "Local daemon:$DAEMON_PID" "Lark ingress:$LARK_PID"; do
+      local name="${name_and_pid%%:*}"
+      local pid="${name_and_pid#*:}"
+      if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+        wait "$pid" 2>/dev/null || true
+        fail "$name exited. Check the log above for the underlying error."
+      fi
+    done
+    sleep 1
+  done
 }
 
 detect_executor() {
@@ -155,7 +199,7 @@ assert_executor_available() {
       require_command codex
       ;;
     claude-code)
-      require_command claude
+      require_command "${OPENTAG_CLAUDE_COMMAND:-claude}"
       ;;
     echo)
       ;;
@@ -215,7 +259,7 @@ write_lark_config() {
   LARK_DOMAIN="$LARK_DOMAIN" \
   LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-}" \
   node <<'NODE'
-const { chmodSync, writeFileSync } = require("node:fs");
+const { closeSync, chmodSync, openSync, writeFileSync } = require("node:fs");
 
 const config = {
   appId: process.env.LARK_APP_ID,
@@ -225,8 +269,9 @@ const config = {
   savedAt: new Date().toISOString()
 };
 
-writeFileSync(process.env.LARK_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+closeSync(openSync(process.env.LARK_CONFIG_PATH, "a", 0o600));
 chmodSync(process.env.LARK_CONFIG_PATH, 0o600);
+writeFileSync(process.env.LARK_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
 NODE
 }
 
@@ -245,7 +290,7 @@ write_config() {
   PUSH_REMOTE="$PUSH_REMOTE" \
   WORKTREE_ROOT="$STATE_DIR/worktrees" \
   node <<'NODE'
-const { writeFileSync, chmodSync } = require("node:fs");
+const { closeSync, chmodSync, openSync, writeFileSync } = require("node:fs");
 
 const config = {
   runnerId: process.env.RUNNER_ID,
@@ -275,14 +320,16 @@ if (process.env.EXECUTOR === "claude-code") {
   };
 }
 
-writeFileSync(process.env.CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+closeSync(openSync(process.env.CONFIG_PATH, "a", 0o600));
 chmodSync(process.env.CONFIG_PATH, 0o600);
+writeFileSync(process.env.CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
 NODE
 }
 
 run_opentagd() {
-  local command_name="$1"
-  shift || true
+  local command_name="${1:-}"
+  [[ -n "$command_name" ]] || fail "run_opentagd requires a command name."
+  shift
   (
     cd "$ROOT_DIR"
     OPENTAG_CONFIG_PATH="$CONFIG_PATH" \
@@ -340,7 +387,7 @@ EXPLICIT_LARK_SETUP="${OPENTAG_LARK_APP_SETUP:-}"
 LARK_CONFIG_SOURCE=""
 
 if [[ -n "${LARK_APP_ID:-}" && -n "${LARK_APP_SECRET:-}" ]]; then
-  LARK_DOMAIN="${LARK_DOMAIN:-${SAVED_LARK_DOMAIN:-lark}}"
+  LARK_DOMAIN="${LARK_DOMAIN:-lark}"
   log "Using LARK_APP_ID and LARK_APP_SECRET from the environment."
   LARK_CONFIG_SOURCE="environment"
 elif [[ -n "$SAVED_LARK_APP_ID" || -n "$SAVED_LARK_APP_SECRET" ]]; then
@@ -409,7 +456,11 @@ fi
 [[ -n "$LARK_APP_ID" ]] || fail "LARK_APP_ID is required."
 [[ -n "$LARK_APP_SECRET" ]] || fail "LARK_APP_SECRET is required."
 
-LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-$SAVED_LARK_BOT_OPEN_ID}"
+if [[ "$LARK_CONFIG_SOURCE" == "saved" ]]; then
+  LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-$SAVED_LARK_BOT_OPEN_ID}"
+else
+  LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-}"
+fi
 if [[ -n "$LARK_BOT_OPEN_ID" ]]; then
   log "Using LARK_BOT_OPEN_ID for group @mentions."
 else
@@ -430,7 +481,7 @@ if [[ "$LARK_CONFIG_SOURCE" != "environment" ]]; then
   log "Saved Lark app credentials to $LARK_CONFIG_PATH."
 fi
 
-PAIRING_TOKEN="${OPENTAG_PAIRING_TOKEN:-dev_pairing_token}"
+PAIRING_TOKEN="${OPENTAG_PAIRING_TOKEN:-$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')}"
 RUNNER_ID="${OPENTAG_RUNNER_ID:-runner_lark_local}"
 DISPATCHER_PORT="$(choose_dispatcher_port)"
 DISPATCHER_URL="http://localhost:$DISPATCHER_PORT"
@@ -456,10 +507,12 @@ log
   export LARK_APP_ID
   export LARK_APP_SECRET
   export LARK_DOMAIN
-  NODE_OPTIONS='--conditions=development' corepack pnpm --filter @opentag/dispatcher-app dev
+  export NODE_OPTIONS='--conditions=development'
+  exec corepack pnpm --filter @opentag/dispatcher-app dev
 ) &
 DISPATCHER_PID=$!
 
+ensure_process_started "$DISPATCHER_PID" "Dispatcher"
 wait_for_dispatcher "$DISPATCHER_URL"
 
 log "Registering local runner and binding the selected project..."
@@ -469,11 +522,12 @@ run_opentagd bind-repos
 log "Starting local daemon..."
 (
   cd "$ROOT_DIR"
-  OPENTAG_CONFIG_PATH="$CONFIG_PATH" \
-  NODE_OPTIONS='--conditions=development' \
-  corepack pnpm --filter @opentag/opentagd dev -- serve
+  export OPENTAG_CONFIG_PATH="$CONFIG_PATH"
+  export NODE_OPTIONS='--conditions=development'
+  exec corepack pnpm --filter @opentag/opentagd dev -- serve
 ) &
 DAEMON_PID=$!
+ensure_process_started "$DAEMON_PID" "Local daemon"
 
 log "Starting Lark long-connection ingress..."
 (
@@ -488,9 +542,11 @@ log "Starting Lark long-connection ingress..."
   if [[ -n "$LARK_BOT_OPEN_ID" ]]; then
     export LARK_BOT_OPEN_ID
   fi
-  NODE_OPTIONS='--conditions=development' corepack pnpm --filter @opentag/lark-events dev
+  export NODE_OPTIONS='--conditions=development'
+  exec corepack pnpm --filter @opentag/lark-events dev
 ) &
 LARK_PID=$!
+ensure_process_started "$LARK_PID" "Lark ingress"
 
 log
 log "OpenTag for Lark is running."
@@ -513,4 +569,4 @@ log "1. This terminal shows the local daemon running the executor."
 log "2. Lark replies with the agent's final result."
 log
 log "Press Ctrl-C to stop OpenTag."
-wait
+wait_for_stack_exit

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -509,9 +509,8 @@ fi
 log "This script auto-connects the first Lark chat that messages the bot to this local project."
 log
 log "Expected AHA moment:"
-log "1. Lark replies with an acknowledgement."
-log "2. This terminal shows the local daemon running the executor."
-log "3. Lark replies with the final result."
+log "1. This terminal shows the local daemon running the executor."
+log "2. Lark replies with the agent's final result."
 log
 log "Press Ctrl-C to stop OpenTag."
 wait

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 STATE_DIR="$ROOT_DIR/.opentag/lark"
 CONFIG_PATH="$STATE_DIR/opentag.local.json"
+LARK_CONFIG_PATH="$STATE_DIR/lark.local.json"
 
 DISPATCHER_PID=""
 DAEMON_PID=""
@@ -180,11 +181,53 @@ if (typeof value === "string") process.stdout.write(value);
 ' <<< "$REGISTRATION_JSON"
 }
 
+saved_lark_field() {
+  local field="$1"
+  if [[ ! -f "$LARK_CONFIG_PATH" ]]; then
+    return
+  fi
+  FIELD="$field" LARK_CONFIG_PATH="$LARK_CONFIG_PATH" node -e '
+const { readFileSync } = require("node:fs");
+let data;
+try {
+  data = JSON.parse(readFileSync(process.env.LARK_CONFIG_PATH, "utf8"));
+} catch (error) {
+  console.error(`Invalid saved Lark config at ${process.env.LARK_CONFIG_PATH}: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}
+const value = data[process.env.FIELD];
+if (typeof value === "string") process.stdout.write(value);
+'
+}
+
 register_lark_personal_agent() {
   (
     cd "$ROOT_DIR/apps/lark-events"
     node scripts/register-personal-agent.cjs "$LARK_DOMAIN"
   )
+}
+
+write_lark_config() {
+  mkdir -p "$STATE_DIR"
+  LARK_CONFIG_PATH="$LARK_CONFIG_PATH" \
+  LARK_APP_ID="$LARK_APP_ID" \
+  LARK_APP_SECRET="$LARK_APP_SECRET" \
+  LARK_DOMAIN="$LARK_DOMAIN" \
+  LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-}" \
+  node <<'NODE'
+const { chmodSync, writeFileSync } = require("node:fs");
+
+const config = {
+  appId: process.env.LARK_APP_ID,
+  appSecret: process.env.LARK_APP_SECRET,
+  domain: process.env.LARK_DOMAIN,
+  ...(process.env.LARK_BOT_OPEN_ID ? { botOpenId: process.env.LARK_BOT_OPEN_ID } : {}),
+  savedAt: new Date().toISOString()
+};
+
+writeFileSync(process.env.LARK_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+chmodSync(process.env.LARK_CONFIG_PATH, 0o600);
+NODE
 }
 
 write_config() {
@@ -289,7 +332,43 @@ EXECUTOR="$(read_with_default "Executor for local runs (codex, claude-code, echo
 validate_executor "$EXECUTOR"
 assert_executor_available "$EXECUTOR"
 
-LARK_DOMAIN="$(read_with_default "Lark domain (lark or feishu)" "${LARK_DOMAIN:-lark}")"
+SAVED_LARK_APP_ID="$(saved_lark_field appId)"
+SAVED_LARK_APP_SECRET="$(saved_lark_field appSecret)"
+SAVED_LARK_DOMAIN="$(saved_lark_field domain)"
+SAVED_LARK_BOT_OPEN_ID="$(saved_lark_field botOpenId)"
+EXPLICIT_LARK_SETUP="${OPENTAG_LARK_APP_SETUP:-}"
+LARK_CONFIG_SOURCE=""
+
+if [[ -n "${LARK_APP_ID:-}" && -n "${LARK_APP_SECRET:-}" ]]; then
+  LARK_DOMAIN="${LARK_DOMAIN:-${SAVED_LARK_DOMAIN:-lark}}"
+  log "Using LARK_APP_ID and LARK_APP_SECRET from the environment."
+  LARK_CONFIG_SOURCE="environment"
+elif [[ -n "$SAVED_LARK_APP_ID" || -n "$SAVED_LARK_APP_SECRET" ]]; then
+  if [[ -z "$SAVED_LARK_APP_ID" || -z "$SAVED_LARK_APP_SECRET" ]]; then
+    if [[ -z "$EXPLICIT_LARK_SETUP" ]]; then
+      fail "Saved Lark config at $LARK_CONFIG_PATH is incomplete. Delete it or set OPENTAG_LARK_APP_SETUP=scan or manual."
+    fi
+  elif [[ -z "$EXPLICIT_LARK_SETUP" ]]; then
+    LARK_APP_ID="$SAVED_LARK_APP_ID"
+    LARK_APP_SECRET="$SAVED_LARK_APP_SECRET"
+    LARK_DOMAIN="${LARK_DOMAIN:-${SAVED_LARK_DOMAIN:-lark}}"
+    LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-$SAVED_LARK_BOT_OPEN_ID}"
+    log "Using saved Lark app credentials from $LARK_CONFIG_PATH."
+    LARK_CONFIG_SOURCE="saved"
+  fi
+fi
+
+if [[ -z "$LARK_CONFIG_SOURCE" ]]; then
+  LARK_DOMAIN="$(read_with_default "Lark domain (lark or feishu)" "${LARK_DOMAIN:-${SAVED_LARK_DOMAIN:-lark}}")"
+  case "$LARK_DOMAIN" in
+    lark|feishu)
+      ;;
+    *)
+      fail "Lark domain must be lark or feishu."
+      ;;
+  esac
+fi
+
 case "$LARK_DOMAIN" in
   lark|feishu)
     ;;
@@ -298,10 +377,10 @@ case "$LARK_DOMAIN" in
     ;;
 esac
 
-if [[ -n "${LARK_APP_ID:-}" && -n "${LARK_APP_SECRET:-}" ]]; then
-  log "Using LARK_APP_ID and LARK_APP_SECRET from the environment."
+if [[ -n "$LARK_CONFIG_SOURCE" ]]; then
+  :
 else
-  LARK_SETUP_MODE="$(read_with_default "Lark app setup (scan or manual)" "${OPENTAG_LARK_APP_SETUP:-scan}")"
+  LARK_SETUP_MODE="$(read_with_default "Lark app setup (scan or manual)" "${EXPLICIT_LARK_SETUP:-scan}")"
   case "$LARK_SETUP_MODE" in
     scan)
       REGISTRATION_JSON="$(register_lark_personal_agent)"
@@ -324,12 +403,13 @@ else
       fail "Lark app setup must be scan or manual."
       ;;
   esac
+  LARK_CONFIG_SOURCE="setup"
 fi
 
 [[ -n "$LARK_APP_ID" ]] || fail "LARK_APP_ID is required."
 [[ -n "$LARK_APP_SECRET" ]] || fail "LARK_APP_SECRET is required."
 
-LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-}"
+LARK_BOT_OPEN_ID="${LARK_BOT_OPEN_ID:-$SAVED_LARK_BOT_OPEN_ID}"
 if [[ -n "$LARK_BOT_OPEN_ID" ]]; then
   log "Using LARK_BOT_OPEN_ID for group @mentions."
 else
@@ -343,6 +423,11 @@ else
       log "Direct Lark messages can run without LARK_BOT_OPEN_ID. Group messages require it."
       ;;
   esac
+fi
+
+if [[ "$LARK_CONFIG_SOURCE" != "environment" ]]; then
+  write_lark_config
+  log "Saved Lark app credentials to $LARK_CONFIG_PATH."
 fi
 
 PAIRING_TOKEN="${OPENTAG_PAIRING_TOKEN:-dev_pairing_token}"


### PR DESCRIPTION
## Summary
- add `scripts/dev/start-lark.sh` as the repo-local MVP wizard for starting dispatcher, local daemon, and Lark ingress together
- let Lark ingress auto-connect the first unbound chat to `OPENTAG_LARK_DEFAULT_REPO`, while preserving `/bind owner/repo` for switching chats later
- document the local Lark start path and ignore generated `.opentag/` state

## Verification
- `bash -n scripts/dev/start-lark.sh`
- `corepack pnpm exec vitest run apps/lark-events/test/app.test.ts packages/lark/test packages/dispatcher/test/lark-callback.test.ts apps/opentagd/test/config.test.ts apps/opentagd/test/doctor.test.ts`
- `corepack pnpm --filter @opentag/lark-events lint`
- `corepack pnpm --filter @opentag/opentagd lint`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `git diff --check`
- `corepack pnpm -r build`

Note: plain `pnpm build` used the globally installed pnpm 11 in this shell and failed before build with pnpm's non-TTY module purge prompt; `corepack pnpm -r build` uses the project pnpm version and passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local Lark/Feishu stack startup script with interactive “Personal Agent” QR setup.
  * Added `OPENTAG_LARK_DEFAULT_REPO` to automatically bind unbound chats before first run.
* **Documentation**
  * Expanded README examples and added local loop setup guides for Lark/Feishu.
* **Bug Fixes**
  * Improved Lark callback behavior: final callbacks render as plain text; Lark acknowledgements are suppressed and both Slack/Lark progress delivery is audit-only.
* **Tests**
  * Added coverage for auto-binding logic, callback rendering/audit behavior, and Codex cleanup of empty run branches.
* **Chores**
  * Updated `.gitignore` and added the required QR library dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->