### PR TITLE
Add stable Project Target refs for local Lark runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The smoke tests start an in-process dispatcher with a temporary SQLite database 
 - **Control where execution happens** - keep coding work local with `opentagd`, or use hosted/custom runners that implement the same claim and callback contracts.
 - **Use any approved executor** - built-in adapters cover `echo`, `claude-code`, and `codex`; custom runners can implement the same contract.
 - **Return outcomes, not noise** - human threads get useful acknowledgements and final results while detailed progress stays in audit events and metrics.
-- **Govern external writes** - repository bindings, permission scopes, context packets, and audit trails make agent authority explicit.
+- **Govern external writes** - Project Target bindings, permission scopes, context packets, and audit trails make agent authority explicit.
 
 ## How It Works
 
@@ -78,7 +78,7 @@ flowchart LR
 
 ## Why Teams Can Trust the Loop
 
-- **Bounded claims** - runners claim only repositories or channels explicitly bound to them.
+- **Bounded claims** - runners claim only Project Targets or channels explicitly bound to them.
 - **Local-first execution** - repo access, build tools, credentials, and private context can stay in the user's own checkout.
 - **Branch isolation** - coding executors work on an `opentag/<runId>` branch or worktree instead of writing directly to the target branch.
 - **Dirty-worktree protection** - Codex and Claude Code executors refuse to run against unsafe local checkout state.
@@ -91,8 +91,8 @@ flowchart LR
 | Area | Status | Notes |
 | --- | --- | --- |
 | GitHub | Works today | Issue comments, PR review comments, callbacks, and pull request creation from local daemon runs when configured |
-| Slack | Works today | App mentions, channel-to-repo bindings, thread callbacks, and audit-only routine progress |
-| Local daemon | Works today | Polling, heartbeats, lease-based claiming, repository bindings, and dirty-worktree protection |
+| Slack | Works today | App mentions, channel-to-Project Target bindings, thread callbacks, and audit-only routine progress |
+| Local daemon | Works today | Polling, heartbeats, lease-based claiming, Project Target bindings, and dirty-worktree protection |
 | Executors | Works today | `echo`, Claude Code (`claude --print`), Codex (`codex exec`), and custom executor contracts |
 | Protocol runtime | Works today | Work Threads, Context Packets, Audit Trails, run admission, quiet callbacks, and metrics |
 | Telegram and Lark | Experimental adapters | Normalizers, ingress apps, and callback helpers are present; treat them as adapter-expansion surfaces rather than the main v0 golden path |

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -62,6 +62,31 @@ const BIND_USAGE =
 const UNBOUND_HINT =
   "This chat isn't connected to a Project Target yet. @-mention me with `/bind <owner>/<repo>` to connect it — e.g. /bind amplifthq/opentag.";
 
+type DefaultRepoBinding = NonNullable<LarkMessageHandlerConfig["defaultRepoBinding"]>;
+
+function bindingFromDefault(input: { tenantKey: string; chatId: string; binding: DefaultRepoBinding }): LarkChannelBinding {
+  return {
+    tenantKey: input.tenantKey,
+    chatId: input.chatId,
+    repoProvider: input.binding.repoProvider,
+    owner: input.binding.owner,
+    repo: input.binding.repo
+  };
+}
+
+function shouldMigrateLegacyLocalBinding(input: {
+  existing: LarkChannelBinding;
+  defaultBinding: DefaultRepoBinding;
+}): boolean {
+  return (
+    input.defaultBinding.repoProvider === "local" &&
+    input.defaultBinding.owner.startsWith("path_") &&
+    input.existing.repoProvider === "local" &&
+    input.existing.owner === "local" &&
+    input.existing.repo === input.defaultBinding.repo
+  );
+}
+
 function extractText(content: string | undefined): string {
   if (!content) return "";
   try {
@@ -147,6 +172,18 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
     }
 
     let binding = await config.resolveChannelBinding({ tenantKey, chatId });
+    if (binding && config.defaultRepoBinding && config.bindChannel) {
+      if (shouldMigrateLegacyLocalBinding({ existing: binding, defaultBinding: config.defaultRepoBinding })) {
+        await config.bindChannel({
+          tenantKey,
+          chatId,
+          repoProvider: config.defaultRepoBinding.repoProvider,
+          owner: config.defaultRepoBinding.owner,
+          repo: config.defaultRepoBinding.repo
+        });
+        binding = bindingFromDefault({ tenantKey, chatId, binding: config.defaultRepoBinding });
+      }
+    }
     if (!binding) {
       if (config.defaultRepoBinding && config.bindChannel) {
         await config.bindChannel({
@@ -156,13 +193,7 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
           owner: config.defaultRepoBinding.owner,
           repo: config.defaultRepoBinding.repo
         });
-        binding = {
-          tenantKey,
-          chatId,
-          repoProvider: config.defaultRepoBinding.repoProvider,
-          owner: config.defaultRepoBinding.owner,
-          repo: config.defaultRepoBinding.repo
-        };
+        binding = bindingFromDefault({ tenantKey, chatId, binding: config.defaultRepoBinding });
       } else {
         await config.reply?.({ messageId, text: UNBOUND_HINT });
         return { status: "ignored_unbound_chat", tenantKey, chatId };

--- a/apps/lark-events/src/app.ts
+++ b/apps/lark-events/src/app.ts
@@ -1,4 +1,4 @@
-import type { OpenTagEvent } from "@opentag/core";
+import { parseProjectTargetRef, type OpenTagEvent } from "@opentag/core";
 import { type LarkChannelBinding, normalizeLarkMessage, stripLarkMention } from "@opentag/lark";
 
 export type LarkMention = { key?: string; id?: { open_id?: string }; name?: string };
@@ -57,9 +57,10 @@ export type LarkMessageHandlerOutcome = {
   chatId?: string;
 };
 
-const BIND_USAGE = "Usage: /bind <owner>/<repo> — e.g. /bind amplifthq/opentag (or /bind github:amplifthq/opentag).";
+const BIND_USAGE =
+  "Usage: /bind <owner>/<repo> — e.g. /bind amplifthq/opentag (or /bind github:amplifthq/opentag).";
 const UNBOUND_HINT =
-  "👋 This chat isn't connected to a repo yet. @-mention me with `/bind <owner>/<repo>` to connect it — e.g. /bind amplifthq/opentag.";
+  "This chat isn't connected to a Project Target yet. @-mention me with `/bind <owner>/<repo>` to connect it — e.g. /bind amplifthq/opentag.";
 
 function extractText(content: string | undefined): string {
   if (!content) return "";
@@ -80,9 +81,14 @@ function parseBindCommand(
   command: string
 ): { ok: true; repoProvider: string; owner: string; repo: string } | { ok: false } | null {
   if (!/^\/bind(\s|$)/.test(command)) return null;
-  const match = command.match(/^\/bind\s+(?:([\w-]+):)?([\w.-]+)\/([\w.-]+)\s*$/);
+  const match = command.match(/^\/bind\s+(\S+)\s*$/);
   if (!match) return { ok: false };
-  return { ok: true, repoProvider: match[1] ?? "github", owner: match[2] as string, repo: match[3] as string };
+  try {
+    const ref = parseProjectTargetRef(match[1] as string);
+    return { ok: true, repoProvider: ref.provider, owner: ref.owner, repo: ref.repo };
+  } catch {
+    return { ok: false };
+  }
 }
 
 // Handle one inbound Lark message: group messages must @-mention the bot, then handle /bind, resolve binding, normalize, create a run.
@@ -115,7 +121,7 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
 
     const command = stripLarkMention(extractText(message.content));
 
-    // Self-service binding: connect this chat to a repo without leaving Lark.
+    // Self-service binding: connect this chat to a Project Target without leaving Lark.
     const bindRequest = parseBindCommand(command);
     if (bindRequest && config.bindChannel) {
       if (!bindRequest.ok) {
@@ -131,7 +137,7 @@ export function createLarkMessageHandler(config: LarkMessageHandlerConfig) {
       });
       await config.reply?.({
         messageId,
-        text: `✅ Connected this chat to ${bindRequest.repoProvider}:${bindRequest.owner}/${bindRequest.repo}. @-mention me with a task to start a run.`
+        text: `Connected this chat to Project Target ${bindRequest.repoProvider}:${bindRequest.owner}/${bindRequest.repo}. @-mention me with a task to start a run.`
       });
       return { status: "bound", tenantKey, chatId };
     }

--- a/apps/lark-events/src/index.ts
+++ b/apps/lark-events/src/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as lark from "@larksuiteoapi/node-sdk";
 import { createOpenTagClient } from "@opentag/client";
+import { parseProjectTargetRef } from "@opentag/core";
 import { createLarkReplyClient, replyLarkMessage } from "@opentag/lark";
 import { createLarkMessageHandler, type LarkInboundMessageEvent, type LarkMessageHandlerOutcome } from "./app.js";
 
@@ -24,15 +25,16 @@ const replyClient = createLarkReplyClient({ appId, appSecret, domain: larkDomain
 
 function defaultRepoBindingFromEnv(value: string | undefined) {
   if (!value) return undefined;
-  const match = value.match(/^(?:([\w-]+):)?([\w.-]+)\/([\w.-]+)$/);
-  if (!match) {
+  try {
+    const ref = parseProjectTargetRef(value);
+    return {
+      repoProvider: ref.provider,
+      owner: ref.owner,
+      repo: ref.repo
+    };
+  } catch {
     throw new Error("OPENTAG_LARK_DEFAULT_REPO must be formatted as owner/repo or provider:owner/repo");
   }
-  return {
-    repoProvider: match[1] ?? "github",
-    owner: match[2] as string,
-    repo: match[3] as string
-  };
 }
 
 const defaultRepoBinding = defaultRepoBindingFromEnv(process.env.OPENTAG_LARK_DEFAULT_REPO);
@@ -86,7 +88,7 @@ function logIgnored(outcome: LarkMessageHandlerOutcome): void {
   if (outcome.status === "created" || outcome.status === "bound") return;
   if (outcome.status === "ignored_unbound_chat") {
     console.log(
-      `[lark] ignored unbound chat — bind it: provider=lark accountId(tenant_key)=${outcome.tenantKey} conversationId(chat_id)=${outcome.chatId} (reply '/bind owner/repo' in the chat, or POST /v1/channel-bindings)`
+      `[lark] ignored unbound chat — bind it: provider=lark accountId(tenant_key)=${outcome.tenantKey} conversationId(chat_id)=${outcome.chatId} (reply '/bind owner/repo' with a Project Target ref, or POST /v1/channel-bindings)`
     );
     return;
   }

--- a/apps/lark-events/test/app.test.ts
+++ b/apps/lark-events/test/app.test.ts
@@ -157,6 +157,32 @@ describe("createLarkMessageHandler", () => {
     expect(event?.metadata).toMatchObject({ repoProvider: "github", owner: "amplifthq", repo: "opentag" });
   });
 
+  it("migrates an existing legacy local binding to the default local Project Target before creating a run", async () => {
+    const { handler, bindChannel, createRun } = makeHandler({
+      binding: {
+        tenantKey: "tk_123",
+        chatId: "oc_chat",
+        repoProvider: "local",
+        owner: "local",
+        repo: "opentag"
+      },
+      defaultRepoBinding: { repoProvider: "local", owner: "path_abc123", repo: "opentag" }
+    });
+
+    const outcome = await handler(messageEvent({ text: "@_user_1 investigate this setup" }));
+
+    expect(outcome.status).toBe("created");
+    expect(bindChannel).toHaveBeenCalledWith({
+      tenantKey: "tk_123",
+      chatId: "oc_chat",
+      repoProvider: "local",
+      owner: "path_abc123",
+      repo: "opentag"
+    });
+    const event = createRun.mock.calls[0]?.[0];
+    expect(event?.metadata).toMatchObject({ repoProvider: "local", owner: "path_abc123", repo: "opentag" });
+  });
+
   it("does not auto-bind an empty @mention", async () => {
     const { handler, bindChannel, reply, createRun } = makeHandler({
       binding: null,

--- a/apps/opentagd/src/daemon.ts
+++ b/apps/opentagd/src/daemon.ts
@@ -1,4 +1,4 @@
-import type { OpenTagEvent, OpenTagRun, OpenTagRunResult } from "@opentag/core";
+import { projectTargetRefFromEvent, type OpenTagEvent, type OpenTagRun, type OpenTagRunResult } from "@opentag/core";
 import {
   assessRunnerSecurity,
   formatSecurityAssessment,
@@ -23,15 +23,15 @@ export type DaemonClient = {
 };
 
 export function resolveRepositoryBinding(event: OpenTagEvent, repositories: RepositoryBindingConfig[]): RepositoryBindingConfig | null {
-  const owner = event.metadata["owner"];
-  const repo = event.metadata["repo"];
-  const repoProvider =
-    typeof event.metadata["repoProvider"] === "string" ? (event.metadata["repoProvider"] as string) : "github";
-  if (typeof owner !== "string" || typeof repo !== "string") return null;
+  const projectTargetRef = projectTargetRefFromEvent(event);
+  if (!projectTargetRef) return null;
 
   return (
     repositories.find(
-      (candidate) => candidate.provider === repoProvider && candidate.owner === owner && candidate.repo === repo
+      (candidate) =>
+        candidate.provider === projectTargetRef.provider &&
+        candidate.owner === projectTargetRef.owner &&
+        candidate.repo === projectTargetRef.repo
     ) ?? null
   );
 }

--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -48,6 +48,32 @@ function executorsFromConfig(config: ReturnType<typeof loadConfigFromEnv>) {
   };
 }
 
+async function bindConfiguredProjectTargets(): Promise<void> {
+  const config = loadConfigOrExit();
+  const client = createDispatcherAdminClient({
+    dispatcherUrl: config.dispatcherUrl,
+    runnerId: config.runnerId,
+    ...(config.pairingToken ? { pairingToken: config.pairingToken } : {})
+  });
+  for (const repository of config.repositories) {
+    await client.bindRepository({
+      provider: repository.provider,
+      owner: repository.owner,
+      repo: repository.repo,
+      checkoutPath: repository.checkoutPath,
+      defaultExecutor: repository.defaultExecutor,
+      baseBranch: repository.baseBranch,
+      pushRemote: repository.pushRemote,
+      ...(repository.worktreeRoot ? { worktreeRoot: repository.worktreeRoot } : {}),
+      ...(repository.keepWorktree ? { keepWorktree: repository.keepWorktree } : {})
+    });
+    console.log(`Bound Project Target ${repository.provider}:${repository.owner}/${repository.repo} to ${repository.checkoutPath}`);
+  }
+  if (config.repositories.length === 0) {
+    console.log("No Project Targets configured. Set OPENTAG_CONFIG_PATH or OPENTAG_REPO_OWNER/OPENTAG_REPO_NAME/OPENTAG_WORKSPACE_PATH.");
+  }
+}
+
 program
   .name("opentagd")
   .description("OpenTag local daemon");
@@ -118,33 +144,14 @@ program
   });
 
 program
-  .command("bind-repos")
+  .command("bind-project-targets")
   .description("Sync configured Project Target bindings to the dispatcher")
-  .action(async () => {
-    const config = loadConfigOrExit();
-    const client = createDispatcherAdminClient({
-      dispatcherUrl: config.dispatcherUrl,
-      runnerId: config.runnerId,
-      ...(config.pairingToken ? { pairingToken: config.pairingToken } : {})
-    });
-    for (const repository of config.repositories) {
-      await client.bindRepository({
-        provider: repository.provider,
-        owner: repository.owner,
-        repo: repository.repo,
-        checkoutPath: repository.checkoutPath,
-        defaultExecutor: repository.defaultExecutor,
-        baseBranch: repository.baseBranch,
-        pushRemote: repository.pushRemote,
-        ...(repository.worktreeRoot ? { worktreeRoot: repository.worktreeRoot } : {}),
-        ...(repository.keepWorktree ? { keepWorktree: repository.keepWorktree } : {})
-      });
-      console.log(`Bound Project Target ${repository.provider}:${repository.owner}/${repository.repo} to ${repository.checkoutPath}`);
-    }
-    if (config.repositories.length === 0) {
-      console.log("No Project Targets configured. Set OPENTAG_CONFIG_PATH or OPENTAG_REPO_OWNER/OPENTAG_REPO_NAME/OPENTAG_WORKSPACE_PATH.");
-    }
-  });
+  .action(bindConfiguredProjectTargets);
+
+program
+  .command("bind-repos", { hidden: true })
+  .description("Compatibility alias for bind-project-targets")
+  .action(bindConfiguredProjectTargets);
 
 program
   .command("bind-slack-channels")

--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -61,11 +61,7 @@ async function bindConfiguredProjectTargets(): Promise<void> {
       owner: repository.owner,
       repo: repository.repo,
       checkoutPath: repository.checkoutPath,
-      defaultExecutor: repository.defaultExecutor,
-      baseBranch: repository.baseBranch,
-      pushRemote: repository.pushRemote,
-      ...(repository.worktreeRoot ? { worktreeRoot: repository.worktreeRoot } : {}),
-      ...(repository.keepWorktree ? { keepWorktree: repository.keepWorktree } : {})
+      defaultExecutor: repository.defaultExecutor
     });
     console.log(`Bound Project Target ${repository.provider}:${repository.owner}/${repository.repo} to ${repository.checkoutPath}`);
   }

--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -119,7 +119,7 @@ program
 
 program
   .command("bind-repos")
-  .description("Sync configured repository bindings to the dispatcher")
+  .description("Sync configured Project Target bindings to the dispatcher")
   .action(async () => {
     const config = loadConfigOrExit();
     const client = createDispatcherAdminClient({
@@ -139,10 +139,10 @@ program
         ...(repository.worktreeRoot ? { worktreeRoot: repository.worktreeRoot } : {}),
         ...(repository.keepWorktree ? { keepWorktree: repository.keepWorktree } : {})
       });
-      console.log(`Bound ${repository.provider}:${repository.owner}/${repository.repo} to ${repository.checkoutPath}`);
+      console.log(`Bound Project Target ${repository.provider}:${repository.owner}/${repository.repo} to ${repository.checkoutPath}`);
     }
     if (config.repositories.length === 0) {
-      console.log("No repositories configured. Set OPENTAG_CONFIG_PATH or OPENTAG_REPO_OWNER/OPENTAG_REPO_NAME/OPENTAG_WORKSPACE_PATH.");
+      console.log("No Project Targets configured. Set OPENTAG_CONFIG_PATH or OPENTAG_REPO_OWNER/OPENTAG_REPO_NAME/OPENTAG_WORKSPACE_PATH.");
     }
   });
 

--- a/docs/adapter-authoring.md
+++ b/docs/adapter-authoring.md
@@ -142,7 +142,8 @@ Callback sinks should:
 ## Binding Model
 
 Do not create a second execution model for chat surfaces. Chat adapters should
-resolve to the same repository and runner bindings used by GitHub-shaped runs.
+resolve to the same Project Target and runner bindings used by GitHub-shaped
+runs.
 
 Current Slack behavior is the model:
 
@@ -155,18 +156,18 @@ Current Slack behavior is the model:
 }
 ```
 
-That binding lets a Slack thread create a run against `acme/demo`, then the
-daemon claims it only if its repository binding allows that repo.
+That binding lets a Slack thread create a run against the `acme/demo` Project
+Target, then the daemon claims it only if its Project Target binding allows it.
 
 For a new app, define the smallest binding that maps the app container to the
 work context owner. Examples:
 
 | App surface | Likely binding |
 | --- | --- |
-| Lark chat | `chatId -> owner/repo` |
-| Linear project | `teamId/projectId -> owner/repo` |
-| Jira project | `siteId/projectKey -> owner/repo` |
-| Microsoft Teams channel | `tenantId/teamId/channelId -> owner/repo` |
+| Lark chat | `chatId -> Project Target ref` |
+| Linear project | `teamId/projectId -> Project Target ref` |
+| Jira project | `siteId/projectKey -> Project Target ref` |
+| Microsoft Teams channel | `tenantId/teamId/channelId -> Project Target ref` |
 
 ## Package Layout
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,7 +141,7 @@ Use daemon security settings to keep executor runs constrained:
 | `runnerId` | `runner_local` | Stable identity used by the dispatcher lease and binding tables |
 | `dispatcherUrl` | `http://localhost:3030` | Dispatcher base URL |
 | `pairingToken` | none | Shared Bearer token for dispatcher `/v1/*` calls |
-| `repositories` | `[]` | Legacy physical Project Target bindings this daemon is allowed to claim |
+| `repositories` | `[]` | Current compatibility array for Project Target bindings this daemon is allowed to claim |
 | `channelBindings` | none | Generic channel bindings such as Telegram `botId/chatId -> Project Target` |
 | `slackChannels` | none | Slack compatibility bindings that map `teamId/channelId` into the generic channel binding table |
 | `larkChannels` | none | Lark bindings that map `tenantKey/chatId` into the generic channel binding table |
@@ -157,7 +157,7 @@ Project Target binding fields:
 | Field | Default | Notes |
 | --- | --- | --- |
 | `provider` | `github` | Project Target provider. GitHub-backed targets use `github`; local-only targets use `local` |
-| `owner` | required | Repository owner for GitHub targets, or the stable local path identity for local-only targets |
+| `owner` | required | Repository owner for GitHub targets, or the stable canonical-path identity for local-only targets |
 | `repo` | required | Repository name or readable local Project Target name |
 | `checkoutPath` | required | Absolute local path attached to this Project Target |
 | `defaultExecutor` | `echo` | `echo`, `codex`, or `claude-code` |
@@ -173,22 +173,22 @@ for repeatable setups.
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `OPENTAG_CONFIG_PATH` | none | Path to daemon JSON config. Takes precedence over repo env fallback |
+| `OPENTAG_CONFIG_PATH` | none | Path to daemon JSON config. Takes precedence over Project Target env fallback |
 | `OPENTAG_RUNNER_ID` | `runner_local` | Runner identity |
 | `OPENTAG_DISPATCHER_URL` | `http://localhost:3030` | Dispatcher URL |
-| `OPENTAG_REPO_OWNER` | none | Required for env-derived repository binding |
-| `OPENTAG_REPO_NAME` | none | Required for env-derived repository binding |
-| `OPENTAG_WORKSPACE_PATH` | none | Required for env-derived repository binding |
+| `OPENTAG_REPO_OWNER` | none | Required for env-derived Project Target binding |
+| `OPENTAG_REPO_NAME` | none | Required for env-derived Project Target binding |
+| `OPENTAG_WORKSPACE_PATH` | none | Required for env-derived Project Target binding |
 | `OPENTAG_DEFAULT_EXECUTOR` | `echo` | `echo`, `codex`, or `claude-code` |
 | `OPENTAG_BASE_BRANCH` | `main` | PR target branch |
 | `OPENTAG_PUSH_REMOTE` | `origin` | Git remote for run branches |
 | `OPENTAG_WORKTREE_ROOT` | none | Optional worktree root |
 | `OPENTAG_KEEP_WORKTREE` | `on_failure` | `always`, `on_failure`, or `never` |
-| `OPENTAG_SLACK_TEAM_ID` | none | Creates one env-derived Slack channel binding when paired with repo env |
-| `OPENTAG_SLACK_CHANNEL_ID` | none | Creates one env-derived Slack channel binding when paired with repo env |
-| `OPENTAG_SLACK_REPO_PROVIDER` | `github` | Repo provider used for the env-derived Slack channel binding |
-| `OPENTAG_LARK_TENANT_KEY` | none | Creates one env-derived Lark channel binding when paired with repo env |
-| `OPENTAG_LARK_CHAT_ID` | none | Creates one env-derived Lark channel binding when paired with repo env |
+| `OPENTAG_SLACK_TEAM_ID` | none | Creates one env-derived Slack channel binding when paired with Project Target env |
+| `OPENTAG_SLACK_CHANNEL_ID` | none | Creates one env-derived Slack channel binding when paired with Project Target env |
+| `OPENTAG_SLACK_REPO_PROVIDER` | `github` | Project Target provider used for the env-derived Slack channel binding |
+| `OPENTAG_LARK_TENANT_KEY` | none | Creates one env-derived Lark channel binding when paired with Project Target env |
+| `OPENTAG_LARK_CHAT_ID` | none | Creates one env-derived Lark channel binding when paired with Project Target env |
 | `OPENTAG_CLAUDE_COMMAND` | `claude` in executor default | Claude Code CLI command |
 | `OPENTAG_CLAUDE_MODEL` | none | Optional Claude model |
 | `OPENTAG_CLAUDE_PERMISSION_MODE` | none | `acceptEdits`, `auto`, `bypassPermissions`, `default`, or `plan` |
@@ -280,8 +280,8 @@ Slack threads.
 tunnel) and creates OpenTag runs from `im.message.receive_v1` events.
 
 For the shortest local setup, run `scripts/dev/start-lark.sh` and choose the QR
-scan path. It creates a Personal Agent app, connects the chat to a local project
-target, saves the Personal Agent credentials to `.opentag/lark/lark.local.json`,
+scan path. It creates a Personal Agent app, connects the chat to a Project
+Target, saves the Personal Agent credentials to `.opentag/lark/lark.local.json`,
 and exports these values for the local dispatcher and Lark ingress. Rerunning
 the script reuses that saved app unless `OPENTAG_LARK_APP_SETUP=scan` or
 `OPENTAG_LARK_APP_SETUP=manual` is set explicitly. Use the environment variables
@@ -302,12 +302,13 @@ Set `LARK_APP_ID` / `LARK_APP_SECRET` / `LARK_DOMAIN` on the dispatcher too, so
 the Lark callback sink can post replies. Bind a chat to a Project Target with
 `opentagd bind-lark-channels` (using `larkChannels`) or `POST /v1/channel-bindings`.
 
-Each chat is bound independently (one `tenantKey/chatId` to one project target),
-so one bot can serve several chats that each target a different local project.
+Each chat is bound independently (one `tenantKey/chatId` to one Project Target),
+so one bot can serve several chats that each target a different local Project
+Target.
 Manual and hosted setups can still bind a chat from inside Lark with
 `/bind <owner>/<repo>` or `/bind <provider>:<owner>/<repo>`. Treat that as an
 advanced route; the local start script auto-connects the first chat to the
-selected local project. The target must already be registered on a runner
+selected Project Target. The target must already be registered on a runner
 (`opentagd bind-repos`).
 
 ## Telegram Ingress Environment

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,7 +309,7 @@ Manual and hosted setups can still bind a chat from inside Lark with
 `/bind <owner>/<repo>` or `/bind <provider>:<owner>/<repo>`. Treat that as an
 advanced route; the local start script auto-connects the first chat to the
 selected Project Target. The target must already be registered on a runner
-(`opentagd bind-repos`).
+(`opentagd bind-project-targets`; `bind-repos` remains available as a compatibility alias).
 
 ## Telegram Ingress Environment
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,20 +14,20 @@ OpenTag has five runtime surfaces today:
 | Surface | Process | Owns |
 | --- | --- | --- |
 | Dispatcher | `apps/dispatcher` | Run storage, leases, callbacks, pairing token checks |
-| Local daemon | `apps/opentagd` | Runner identity, repository bindings, workspace paths, executor settings |
+| Local daemon | `apps/opentagd` | Runner identity, Project Target bindings, local checkout paths, executor settings |
 | GitHub ingress | `apps/github-probot` | GitHub App webhooks and GitHub event normalization |
 | Slack ingress | `apps/slack-events` | Slack Events API verification and Slack event normalization |
 | Telegram ingress | `apps/telegram-events` | Telegram webhook ingestion and Telegram event normalization |
 
 Keep these boundaries separate. Ingress apps should know how to receive platform
 events and create runs. The dispatcher should coordinate runs and callbacks. The
-daemon should decide whether it can claim and execute work for a bound checkout.
+daemon should decide whether it can claim and execute work for a bound Project Target.
 
 ## Local Daemon Config
 
 `opentagd` prefers a JSON config file. Point to it with `OPENTAG_CONFIG_PATH`.
 When `OPENTAG_CONFIG_PATH` is set, the daemon reads that file and does not build
-repository bindings from the environment fallback variables.
+Project Target bindings from the environment fallback variables.
 
 Minimal local config:
 
@@ -53,7 +53,7 @@ Minimal local config:
 }
 ```
 
-Add Slack channel bindings when a chat surface should route work to a repository:
+Add Slack channel bindings when a chat surface should route work to a Project Target:
 
 ```json
 {
@@ -70,7 +70,7 @@ Add Slack channel bindings when a chat surface should route work to a repository
 ```
 
 Add generic channel bindings when a non-Slack chat surface should route work to
-a repository:
+a Project Target:
 
 ```json
 {
@@ -141,8 +141,8 @@ Use daemon security settings to keep executor runs constrained:
 | `runnerId` | `runner_local` | Stable identity used by the dispatcher lease and binding tables |
 | `dispatcherUrl` | `http://localhost:3030` | Dispatcher base URL |
 | `pairingToken` | none | Shared Bearer token for dispatcher `/v1/*` calls |
-| `repositories` | `[]` | Repository bindings this daemon is allowed to claim |
-| `channelBindings` | none | Generic channel bindings such as Telegram `botId/chatId -> repo` |
+| `repositories` | `[]` | Legacy physical Project Target bindings this daemon is allowed to claim |
+| `channelBindings` | none | Generic channel bindings such as Telegram `botId/chatId -> Project Target` |
 | `slackChannels` | none | Slack compatibility bindings that map `teamId/channelId` into the generic channel binding table |
 | `larkChannels` | none | Lark bindings that map `tenantKey/chatId` into the generic channel binding table |
 | `claudeCode` | none | Claude Code executor settings |
@@ -152,14 +152,14 @@ Use daemon security settings to keep executor runs constrained:
 | `pollIntervalMs` | `5000` | Poll interval for `serve` |
 | `heartbeatIntervalMs` | `15000` | Heartbeat interval for claimed runs |
 
-Repository binding fields:
+Project Target binding fields:
 
 | Field | Default | Notes |
 | --- | --- | --- |
-| `provider` | `github` | Repo provider for the binding |
-| `owner` | required | Repository owner or organization |
-| `repo` | required | Repository name |
-| `checkoutPath` | required | Absolute path to the local checkout |
+| `provider` | `github` | Project Target provider. GitHub-backed targets use `github`; local-only targets use `local` |
+| `owner` | required | Repository owner for GitHub targets, or the stable local path identity for local-only targets |
+| `repo` | required | Repository name or readable local Project Target name |
+| `checkoutPath` | required | Absolute local path attached to this Project Target |
 | `defaultExecutor` | `echo` | `echo`, `codex`, or `claude-code` |
 | `baseBranch` | `main` | PR target branch |
 | `pushRemote` | `origin` | Remote used for PR branches |
@@ -296,10 +296,10 @@ below for manual or hosted setups.
 | `OPENTAG_DISPATCHER_TOKEN` | when dispatcher is paired | Bearer token for dispatcher `/v1/*` |
 | `LARK_BOT_OPEN_ID` | for group chats | Bot open id; group messages must @-mention it. Direct p2p chats do not need it |
 | `OPENTAG_LARK_AGENT_ID` | no | Agent id for the ingress. Defaults to `opentag` |
-| `OPENTAG_LARK_DEFAULT_REPO` | no | Optional internal project target formatted as `owner/repo` or `provider:owner/repo`; unbound chats auto-connect to it before creating the first run |
+| `OPENTAG_LARK_DEFAULT_REPO` | no | Optional Project Target ref formatted as `owner/repo` or `provider:owner/repo`; unbound chats auto-connect to it before creating the first run |
 
 Set `LARK_APP_ID` / `LARK_APP_SECRET` / `LARK_DOMAIN` on the dispatcher too, so
-the Lark callback sink can post replies. Bind a chat to a repo with
+the Lark callback sink can post replies. Bind a chat to a Project Target with
 `opentagd bind-lark-channels` (using `larkChannels`) or `POST /v1/channel-bindings`.
 
 Each chat is bound independently (one `tenantKey/chatId` to one project target),

--- a/docs/lark-local-start.md
+++ b/docs/lark-local-start.md
@@ -31,7 +31,7 @@ From the OpenTag repository:
 
 The script prompts for:
 
-- Project Target path, which is the local project this agent should work on
+- Project Target path, which is the local codebase this agent should work on
 - executor: `codex`, `claude-code`, or `echo`
 - Lark domain: `lark` or `feishu`, only when no saved app exists
 - Lark app setup: `scan` or `manual`, only when no saved app exists
@@ -66,10 +66,15 @@ new QR code. To create a new Personal Agent app intentionally, set
 
 ## Project Target
 
-The Lark MVP path is Project Target first. A Project Target is the local project
-this agent works on. The script asks for the local path for this Project Target
+The Lark MVP path is Project Target first. A Project Target is the local
+codebase this agent works on. The script asks for the local path for this Project Target
 and connects the first Lark chat to it. The first-run path does not require a
 GitHub repo.
+
+For local-only Project Targets, OpenTag derives the internal `local:path_...`
+identity from the canonical local path used during setup. That keeps symlinked
+and real paths pointed at the same checkout on the same computer aligned without
+asking users to understand the internal ref.
 
 ## First Message
 

--- a/docs/lark-local-start.md
+++ b/docs/lark-local-start.md
@@ -31,7 +31,7 @@ From the OpenTag repository:
 
 The script prompts for:
 
-- local project path
+- Project Target path, which is the local project this agent should work on
 - executor: `codex`, `claude-code`, or `echo`
 - Lark domain: `lark` or `feishu`, only when no saved app exists
 - Lark app setup: `scan` or `manual`, only when no saved app exists
@@ -66,10 +66,10 @@ new QR code. To create a new Personal Agent app intentionally, set
 
 ## Project Target
 
-The Lark MVP path is local-project first. The script asks for the folder where
-the agent should run and connects the first Lark chat to that local project.
-OpenTag still creates an internal project target so the dispatcher and local
-daemon can route the run, but the first-run path does not require a GitHub repo.
+The Lark MVP path is Project Target first. A Project Target is the local project
+this agent works on. The script asks for the local path for this Project Target
+and connects the first Lark chat to it. The first-run path does not require a
+GitHub repo.
 
 ## First Message
 
@@ -86,14 +86,14 @@ In a group chat, send:
 ```
 
 The first chat that messages the bot is automatically connected to the selected
-project path. This keeps the first-run path short.
+Project Target. This keeps the first-run path short.
 
 ## Advanced GitHub Target
 
 GitHub repository settings are optional for the Lark local loop. Use them later
 when you want GitHub-specific behavior such as repository policy, branch push, or
 pull request creation. Set `OPENTAG_REPO_OWNER` and `OPENTAG_REPO_NAME` before
-starting the script to use a GitHub-style project target.
+starting the script to attach a GitHub repository identity to the Project Target.
 
 ## Expected Result
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./json-schema.js";
 export * from "./mention.js";
+export * from "./project-target.js";
 export * from "./protocol.js";
 export * from "./schema.js";

--- a/packages/core/src/project-target.ts
+++ b/packages/core/src/project-target.ts
@@ -5,7 +5,7 @@ export type ProjectTargetRef = {
 };
 
 export type EventMetadataWithProjectTarget = {
-  metadata: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 };
 
 const PROJECT_TARGET_REF_PATTERN = /^(?:([\w-]+):)?([\w.-]+)\/([\w.-]+)$/;
@@ -60,13 +60,26 @@ export function parseProjectTargetRef(value: string): ProjectTargetRef {
   };
 }
 
-export function projectTargetRefFromEvent(input: EventMetadataWithProjectTarget): ProjectTargetRef | null {
-  const owner = input.metadata["owner"];
-  const repo = input.metadata["repo"];
-  if (typeof owner !== "string" || typeof repo !== "string") return null;
+function nonBlankMetadataString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function projectTargetRefFromEvent(input: EventMetadataWithProjectTarget | null | undefined): ProjectTargetRef | null {
+  const metadata = input?.metadata;
+  if (!metadata) return null;
+
+  const owner = nonBlankMetadataString(metadata["owner"]);
+  const repo = nonBlankMetadataString(metadata["repo"]);
+  if (!owner || !repo) return null;
+
+  const rawProvider = metadata["repoProvider"];
+  const provider = rawProvider === undefined ? "github" : nonBlankMetadataString(rawProvider);
+  if (!provider) return null;
 
   return {
-    provider: typeof input.metadata["repoProvider"] === "string" ? input.metadata["repoProvider"] : "github",
+    provider,
     owner,
     repo
   };

--- a/packages/core/src/project-target.ts
+++ b/packages/core/src/project-target.ts
@@ -1,0 +1,82 @@
+export type ProjectTargetRef = {
+  provider: string;
+  owner: string;
+  repo: string;
+};
+
+export type EventMetadataWithProjectTarget = {
+  metadata: Record<string, unknown>;
+};
+
+const PROJECT_TARGET_REF_PATTERN = /^(?:([\w-]+):)?([\w.-]+)\/([\w.-]+)$/;
+
+function normalizeLocalPath(path: string): string {
+  const normalized = path.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+function safeProjectSegment(value: string, fallback: string): string {
+  const safe = value
+    .trim()
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return safe || fallback;
+}
+
+function basename(path: string): string {
+  const segments = normalizeLocalPath(path).split("/").filter(Boolean);
+  return segments.at(-1) ?? "project";
+}
+
+function stableHash(value: string): string {
+  let first = 0xdeadbeef ^ value.length;
+  let second = 0x41c6ce57 ^ value.length;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    first = Math.imul(first ^ code, 2654435761);
+    second = Math.imul(second ^ code, 1597334677);
+  }
+
+  first = Math.imul(first ^ (first >>> 16), 2246822507) ^ Math.imul(second ^ (second >>> 13), 3266489909);
+  second = Math.imul(second ^ (second >>> 16), 2246822507) ^ Math.imul(first ^ (first >>> 13), 3266489909);
+
+  return `${(second >>> 0).toString(36)}${(first >>> 0).toString(36)}`.slice(0, 12);
+}
+
+export function formatProjectTargetRef(ref: ProjectTargetRef): string {
+  return `${ref.provider}:${ref.owner}/${ref.repo}`;
+}
+
+export function parseProjectTargetRef(value: string): ProjectTargetRef {
+  const match = value.match(PROJECT_TARGET_REF_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid Project Target ref: ${value}`);
+  }
+  return {
+    provider: match[1] ?? "github",
+    owner: match[2] as string,
+    repo: match[3] as string
+  };
+}
+
+export function projectTargetRefFromEvent(input: EventMetadataWithProjectTarget): ProjectTargetRef | null {
+  const owner = input.metadata["owner"];
+  const repo = input.metadata["repo"];
+  if (typeof owner !== "string" || typeof repo !== "string") return null;
+
+  return {
+    provider: typeof input.metadata["repoProvider"] === "string" ? input.metadata["repoProvider"] : "github",
+    owner,
+    repo
+  };
+}
+
+export function projectTargetRefFromLocalPath(path: string): ProjectTargetRef {
+  const normalizedPath = normalizeLocalPath(path);
+  return {
+    provider: "local",
+    owner: `path_${stableHash(normalizedPath)}`,
+    repo: safeProjectSegment(basename(path), "project")
+  };
+}

--- a/packages/core/test/project-target.test.ts
+++ b/packages/core/test/project-target.test.ts
@@ -1,7 +1,8 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   formatProjectTargetRef,
@@ -37,6 +38,19 @@ describe("ProjectTargetRef", () => {
   it("returns null when event metadata does not name a project target", () => {
     expect(projectTargetRefFromEvent({ metadata: { owner: "acme" } })).toBeNull();
     expect(projectTargetRefFromEvent({ metadata: { repo: "demo" } })).toBeNull();
+    expect(projectTargetRefFromEvent(undefined)).toBeNull();
+    expect(projectTargetRefFromEvent({})).toBeNull();
+  });
+
+  it("normalizes event metadata and rejects blank project target segments", () => {
+    expect(projectTargetRefFromEvent({ metadata: { repoProvider: " gitlab ", owner: " acme ", repo: " demo " } })).toEqual({
+      provider: "gitlab",
+      owner: "acme",
+      repo: "demo"
+    });
+    expect(projectTargetRefFromEvent({ metadata: { owner: " ", repo: "demo" } })).toBeNull();
+    expect(projectTargetRefFromEvent({ metadata: { owner: "acme", repo: "" } })).toBeNull();
+    expect(projectTargetRefFromEvent({ metadata: { repoProvider: " ", owner: "acme", repo: "demo" } })).toBeNull();
   });
 
   it("uses the full normalized local path for local project identity", () => {
@@ -61,8 +75,9 @@ describe("ProjectTargetRef", () => {
     const symlinkPath = `${workspace}-link`;
     try {
       symlinkSync(workspace, symlinkPath);
-      const appDir = join(process.cwd(), "apps/lark-events");
-      const script = "../../scripts/dev/print-local-project-target-ref.ts";
+      const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+      const appDir = join(repoRoot, "apps/lark-events");
+      const script = join(repoRoot, "scripts/dev/print-local-project-target-ref.ts");
       const tsx = join(appDir, "node_modules/.bin/tsx");
       const env = { ...process.env, NODE_OPTIONS: "--conditions=development" };
 
@@ -73,7 +88,7 @@ describe("ProjectTargetRef", () => {
       expect(fromRealPath).toBe(fromCore);
       expect(fromSymlinkPath).toBe(fromCore);
     } finally {
-      rmSync(symlinkPath, { force: true });
+      if (existsSync(symlinkPath)) unlinkSync(symlinkPath);
       rmSync(workspace, { force: true, recursive: true });
     }
   });

--- a/packages/core/test/project-target.test.ts
+++ b/packages/core/test/project-target.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatProjectTargetRef,
+  parseProjectTargetRef,
+  projectTargetRefFromEvent,
+  projectTargetRefFromLocalPath
+} from "../src/project-target.js";
+
+describe("ProjectTargetRef", () => {
+  it("formats and parses the existing provider:owner/repo shape", () => {
+    const ref = { provider: "github", owner: "acme", repo: "demo" };
+
+    expect(formatProjectTargetRef(ref)).toBe("github:acme/demo");
+    expect(parseProjectTargetRef("github:acme/demo")).toEqual(ref);
+  });
+
+  it("parses owner/repo as a GitHub Project Target ref for compatibility", () => {
+    expect(parseProjectTargetRef("acme/demo")).toEqual({
+      provider: "github",
+      owner: "acme",
+      repo: "demo"
+    });
+  });
+
+  it("defaults event metadata without repoProvider to github", () => {
+    expect(projectTargetRefFromEvent({ metadata: { owner: "acme", repo: "demo" } })).toEqual({
+      provider: "github",
+      owner: "acme",
+      repo: "demo"
+    });
+  });
+
+  it("returns null when event metadata does not name a project target", () => {
+    expect(projectTargetRefFromEvent({ metadata: { owner: "acme" } })).toBeNull();
+    expect(projectTargetRefFromEvent({ metadata: { repo: "demo" } })).toBeNull();
+  });
+
+  it("uses the full normalized local path for local project identity", () => {
+    const first = projectTargetRefFromLocalPath("/Users/alice/work/app");
+    const second = projectTargetRefFromLocalPath("/Users/alice/scratch/app");
+
+    expect(first.provider).toBe("local");
+    expect(first.repo).toBe("app");
+    expect(second.repo).toBe("app");
+    expect(first.owner).not.toBe(second.owner);
+    expect(formatProjectTargetRef(first)).not.toBe(formatProjectTargetRef(second));
+  });
+
+  it("keeps local project target refs stable for trailing slash variants", () => {
+    expect(projectTargetRefFromLocalPath("/Users/alice/work/app")).toEqual(
+      projectTargetRefFromLocalPath("/Users/alice/work/app/")
+    );
+  });
+});

--- a/packages/core/test/project-target.test.ts
+++ b/packages/core/test/project-target.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   formatProjectTargetRef,
@@ -50,5 +54,27 @@ describe("ProjectTargetRef", () => {
     expect(projectTargetRefFromLocalPath("/Users/alice/work/app")).toEqual(
       projectTargetRefFromLocalPath("/Users/alice/work/app/")
     );
+  });
+
+  it("keeps the local Project Target script helper consistent with the core helper", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "opentag-project-target-"));
+    const symlinkPath = `${workspace}-link`;
+    try {
+      symlinkSync(workspace, symlinkPath);
+      const appDir = join(process.cwd(), "apps/lark-events");
+      const script = "../../scripts/dev/print-local-project-target-ref.ts";
+      const tsx = join(appDir, "node_modules/.bin/tsx");
+      const env = { ...process.env, NODE_OPTIONS: "--conditions=development" };
+
+      const fromRealPath = execFileSync(tsx, [script, workspace], { cwd: appDir, env, encoding: "utf8" });
+      const fromSymlinkPath = execFileSync(tsx, [script, symlinkPath], { cwd: appDir, env, encoding: "utf8" });
+      const fromCore = formatProjectTargetRef(projectTargetRefFromLocalPath(realpathSync.native(workspace)));
+
+      expect(fromRealPath).toBe(fromCore);
+      expect(fromSymlinkPath).toBe(fromCore);
+    } finally {
+      rmSync(symlinkPath, { force: true });
+      rmSync(workspace, { force: true, recursive: true });
+    }
   });
 });

--- a/packages/dispatcher/README.md
+++ b/packages/dispatcher/README.md
@@ -43,7 +43,7 @@ export const dispatcher = createDispatcherApp({
 
 ## API Shape
 
-The app exposes `/healthz` and `/v1/*` dispatcher endpoints for runners, repository bindings, generic channel bindings, Slack compatibility bindings, runs, progress, heartbeats, completion, and audit event lookup.
+The app exposes `/healthz` and `/v1/*` dispatcher endpoints for runners, Project Target bindings, generic channel bindings, Slack compatibility bindings, runs, progress, heartbeats, completion, and audit event lookup.
 
 When `pairingToken` is set, every `/v1/*` endpoint requires:
 

--- a/packages/dispatcher/src/admission.ts
+++ b/packages/dispatcher/src/admission.ts
@@ -1,5 +1,6 @@
 import {
   conversationKeyFromEvent,
+  projectTargetRefFromEvent,
   RunAdmissionDecisionSchema,
   type OpenTagEvent,
   type OpenTagRun,
@@ -51,17 +52,6 @@ export type AdmitRunResult =
       outcome: "needs_human_decision";
       decision: RunAdmissionDecision;
     };
-
-function repoKeyFromEvent(event: OpenTagEvent): { provider: string; owner: string; repo: string } | null {
-  const owner = event.metadata["owner"];
-  const repo = event.metadata["repo"];
-  if (typeof owner !== "string" || typeof repo !== "string") return null;
-  return {
-    provider: typeof event.metadata["repoProvider"] === "string" ? (event.metadata["repoProvider"] as string) : "github",
-    owner,
-    repo
-  };
-}
 
 function isWriteCapable(event: OpenTagEvent): boolean {
   return event.permissions.some((permission) => ["repo:write", "pr:create", "pr:update"].includes(permission.scope));
@@ -117,7 +107,7 @@ export function createAdmissionRuntime(input: {
         };
       }
 
-      const repoKey = repoKeyFromEvent(request.event);
+      const repoKey = projectTargetRefFromEvent(request.event);
       if (!repoKey) {
         return {
           outcome: "needs_human_decision",

--- a/packages/dispatcher/test/admission.test.ts
+++ b/packages/dispatcher/test/admission.test.ts
@@ -1,3 +1,4 @@
+import { projectTargetRefFromLocalPath } from "@opentag/core";
 import { describe, expect, it, vi } from "vitest";
 import { createAdmissionRuntime } from "../src/admission.js";
 
@@ -104,5 +105,41 @@ describe("Admission Runtime", () => {
       decision: { action: "queue_follow_up" }
     });
     expect(appendRunEvent).not.toHaveBeenCalled();
+  });
+
+  it("admits local Project Target events through the shared project target ref", async () => {
+    const localProject = projectTargetRefFromLocalPath("/Users/test/work/app");
+    const getRepoBinding = vi.fn(async () => ({
+      ...localProject,
+      runnerId: "runner_1",
+      workspacePath: "/Users/test/work/app"
+    }));
+    const admission = createAdmissionRuntime({
+      repo: {
+        getRunByEventId: async () => null,
+        getRepoBinding,
+        findActiveRunForConversation: async () => null,
+        createFollowUpRequest: async () => {
+          throw new Error("should not queue follow-up");
+        },
+        appendRunEvent: async () => undefined
+      } as never
+    });
+
+    const result = await admission.admitRun({
+      requestId: "req_local",
+      event: {
+        ...event,
+        id: "evt_local",
+        source: "lark",
+        sourceEventId: "message_local",
+        actor: { provider: "lark", providerUserId: "ou_user" },
+        callback: { provider: "lark", uri: "lark://im/v1/messages", threadKey: "tk|oc|om" },
+        metadata: { repoProvider: localProject.provider, owner: localProject.owner, repo: localProject.repo }
+      }
+    });
+
+    expect(result).toMatchObject({ outcome: "start", binding: { runnerId: "runner_1" } });
+    expect(getRepoBinding).toHaveBeenCalledWith(localProject);
   });
 });

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -12,6 +12,7 @@ import {
   PolicyRuleSchema,
   ProposalLineageSchema,
   preflightMutationIntent,
+  projectTargetRefFromEvent,
   protocolRunFieldsFromEvent,
   RunAdmissionDecisionSchema,
   RunEventImportanceSchema,
@@ -295,17 +296,6 @@ function channelBindingFromRow(row: typeof channelBindings.$inferSelect): Channe
     owner: row.owner,
     repo: row.repo,
     ...(metadata ? { metadata } : {})
-  };
-}
-
-function repoKeyFromEvent(event: OpenTagEvent): { provider: string; owner: string; repo: string } | null {
-  const owner = event.metadata["owner"];
-  const repo = event.metadata["repo"];
-  if (typeof owner !== "string" || typeof repo !== "string") return null;
-  return {
-    provider: typeof event.metadata["repoProvider"] === "string" ? (event.metadata["repoProvider"] as string) : "github",
-    owner,
-    repo
   };
 }
 
@@ -804,7 +794,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const triggeredByAction = input.triggeredByAction ? ActionHintSchema.parse(input.triggeredByAction) : undefined;
       const createdAt = nowIso();
       const protocolFields = protocolRunFieldsFromEvent(event, createdAt);
-      const repoKey = repoKeyFromEvent(event);
+      const repoKey = projectTargetRefFromEvent(event);
       const insertResult = await db
         .insert(runs)
         .values({
@@ -962,7 +952,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const queuedRows = await db.select().from(runs).where(eq(runs.status, "queued")).orderBy(asc(runs.createdAt));
       const row = queuedRows.find((candidate) => {
         const event = OpenTagEventSchema.parse(JSON.parse(candidate.eventJson));
-        const repoKey = repoKeyFromEvent(event);
+        const repoKey = projectTargetRefFromEvent(event);
         if (!repoKey) return false;
         const binding = db
           .select()
@@ -1359,7 +1349,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const runRow = await db.select().from(runs).where(eq(runs.id, storedProposal.runId)).limit(1).get();
       if (!runRow) return null;
       const event = OpenTagEventSchema.parse(JSON.parse(runRow.eventJson));
-      const repoKey = repoKeyFromEvent(event);
+      const repoKey = projectTargetRefFromEvent(event);
       const storedPolicyRuleRows = repoKey
         ? await db
             .select()

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -1,3 +1,4 @@
+import { projectTargetRefFromLocalPath } from "@opentag/core";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
@@ -91,6 +92,76 @@ describe("OpenTag repository", () => {
       workspacePath: "/Users/test/demo",
       defaultExecutor: "echo",
       allowedActors: ["octocat"]
+    });
+  });
+
+  it("keeps same-name local Project Targets distinct by local path identity", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    migrateSchema(sqlite);
+    const repo = createOpenTagRepository(db);
+    const firstProject = projectTargetRefFromLocalPath("/Users/test/work/app");
+    const secondProject = projectTargetRefFromLocalPath("/Users/test/archive/app");
+
+    await repo.registerRunner({ runnerId: "runner_1", name: "Runner One" });
+    await repo.registerRunner({ runnerId: "runner_2", name: "Runner Two" });
+    await repo.createRepoBinding({
+      ...firstProject,
+      runnerId: "runner_1",
+      workspacePath: "/Users/test/work/app",
+      defaultExecutor: "echo"
+    });
+    await repo.createRepoBinding({
+      ...secondProject,
+      runnerId: "runner_2",
+      workspacePath: "/Users/test/archive/app",
+      defaultExecutor: "echo"
+    });
+
+    await repo.createRun({
+      id: "run_first_local",
+      event: {
+        id: "evt_first_local",
+        source: "lark",
+        sourceEventId: "message_first_local",
+        receivedAt: "2026-06-26T00:00:00.000Z",
+        actor: { provider: "lark", providerUserId: "ou_user" },
+        target: { mention: "@app", agentId: "opentag" },
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: [],
+        permissions: [{ scope: "runner:local", reason: "execute locally" }],
+        callback: { provider: "lark", uri: "lark://im/v1/messages", threadKey: "tk|oc|om_1" },
+        metadata: { repoProvider: firstProject.provider, owner: firstProject.owner, repo: firstProject.repo }
+      }
+    });
+    await repo.createRun({
+      id: "run_second_local",
+      event: {
+        id: "evt_second_local",
+        source: "lark",
+        sourceEventId: "message_second_local",
+        receivedAt: "2026-06-26T00:00:00.000Z",
+        actor: { provider: "lark", providerUserId: "ou_user" },
+        target: { mention: "@app", agentId: "opentag" },
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: [],
+        permissions: [{ scope: "runner:local", reason: "execute locally" }],
+        callback: { provider: "lark", uri: "lark://im/v1/messages", threadKey: "tk|oc|om_2" },
+        metadata: { repoProvider: secondProject.provider, owner: secondProject.owner, repo: secondProject.repo }
+      }
+    });
+
+    await expect(repo.claimNextRun({ runnerId: "runner_1", leaseSeconds: 60 })).resolves.toMatchObject({
+      run: { id: "run_first_local" }
+    });
+    await expect(repo.claimNextRun({ runnerId: "runner_2", leaseSeconds: 60 })).resolves.toMatchObject({
+      run: { id: "run_second_local" }
+    });
+    await expect(repo.getRepoBinding(firstProject)).resolves.toMatchObject({
+      workspacePath: "/Users/test/work/app"
+    });
+    await expect(repo.getRepoBinding(secondProject)).resolves.toMatchObject({
+      workspacePath: "/Users/test/archive/app"
     });
   });
 

--- a/scripts/dev/print-local-project-target-ref.ts
+++ b/scripts/dev/print-local-project-target-ref.ts
@@ -1,0 +1,10 @@
+import { realpathSync } from "node:fs";
+import { formatProjectTargetRef, projectTargetRefFromLocalPath } from "../../packages/core/src/index.ts";
+
+const localPath = process.argv[2];
+if (!localPath) {
+  throw new Error("Usage: print-local-project-target-ref <local-path>");
+}
+
+const canonicalPath = realpathSync.native(localPath);
+process.stdout.write(formatProjectTargetRef(projectTargetRefFromLocalPath(canonicalPath)));

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -101,6 +101,29 @@ process.stdout.write(safeName);
 ' "$checkout_path"
 }
 
+local_project_owner() {
+  local checkout_path="$1"
+  node -e '
+function normalizeLocalPath(value) {
+  const normalized = value.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized || "/";
+}
+function stableHash(value) {
+  let first = 0xdeadbeef ^ value.length;
+  let second = 0x41c6ce57 ^ value.length;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    first = Math.imul(first ^ code, 2654435761);
+    second = Math.imul(second ^ code, 1597334677);
+  }
+  first = Math.imul(first ^ (first >>> 16), 2246822507) ^ Math.imul(second ^ (second >>> 13), 3266489909);
+  second = Math.imul(second ^ (second >>> 16), 2246822507) ^ Math.imul(first ^ (first >>> 13), 3266489909);
+  process.stdout.write(`path_${`${(second >>> 0).toString(36)}${(first >>> 0).toString(36)}`.slice(0, 12)}`);
+}
+stableHash(normalizeLocalPath(process.argv[1]));
+' "$checkout_path"
+}
+
 port_is_in_use() {
   local port="$1"
   if command -v lsof >/dev/null 2>&1; then
@@ -353,11 +376,11 @@ if ! workspace_dependencies_installed; then
 fi
 
 DEFAULT_CHECKOUT="$(git -C "$ROOT_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$ROOT_DIR")"
-CHECKOUT_INPUT="${OPENTAG_WORKSPACE_PATH:-$(read_with_default "Local project path for this agent" "$DEFAULT_CHECKOUT")}"
+CHECKOUT_INPUT="${OPENTAG_WORKSPACE_PATH:-$(read_with_default "Local path for this Project Target" "$DEFAULT_CHECKOUT")}"
 CHECKOUT_PATH="$(absolute_path "$CHECKOUT_INPUT")"
 
-[[ -d "$CHECKOUT_PATH" ]] || fail "Project path does not exist: $CHECKOUT_PATH"
-git -C "$CHECKOUT_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "Project path must be a git checkout: $CHECKOUT_PATH"
+[[ -d "$CHECKOUT_PATH" ]] || fail "Project Target path does not exist: $CHECKOUT_PATH"
+git -C "$CHECKOUT_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "Project Target path must be a git checkout: $CHECKOUT_PATH"
 
 if [[ -n "${OPENTAG_REPO_OWNER:-}" && -n "${OPENTAG_REPO_NAME:-}" ]]; then
   REPO_PROVIDER="${OPENTAG_REPO_PROVIDER:-github}"
@@ -366,7 +389,7 @@ if [[ -n "${OPENTAG_REPO_OWNER:-}" && -n "${OPENTAG_REPO_NAME:-}" ]]; then
   log "Advanced repository target enabled for PR-capable workflows."
 else
   REPO_PROVIDER="local"
-  REPO_OWNER="local"
+  REPO_OWNER="$(local_project_owner "$CHECKOUT_PATH")"
   REPO_NAME="$(local_project_name "$CHECKOUT_PATH")"
 fi
 
@@ -492,8 +515,8 @@ write_config
 
 log
 log "Starting OpenTag for Lark"
-log "- Project: $REPO_NAME"
-log "- Path: $CHECKOUT_PATH"
+log "- Project Target: $REPO_NAME"
+log "- Project Target path: $CHECKOUT_PATH"
 log "- Executor: $EXECUTOR"
 log "- Dispatcher: $DISPATCHER_URL"
 log "- Config: $CONFIG_PATH"

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -91,37 +91,17 @@ absolute_path() {
   node -e 'const path = require("node:path"); console.log(path.resolve(process.argv[1]));' "$raw"
 }
 
-local_project_name() {
-  local checkout_path="$1"
-  node -e '
-const path = require("node:path");
-const rawName = path.basename(process.argv[1]).trim() || "project";
-const safeName = rawName.replace(/[^\w.-]+/g, "-").replace(/^-+|-+$/g, "") || "project";
-process.stdout.write(safeName);
-' "$checkout_path"
+canonical_path() {
+  node -e 'const fs = require("node:fs"); console.log(fs.realpathSync.native(process.argv[1]));' "$1"
 }
 
-local_project_owner() {
+local_project_ref() {
   local checkout_path="$1"
-  node -e '
-function normalizeLocalPath(value) {
-  const normalized = value.trim().replace(/\\/g, "/").replace(/\/+$/, "");
-  return normalized || "/";
-}
-function stableHash(value) {
-  let first = 0xdeadbeef ^ value.length;
-  let second = 0x41c6ce57 ^ value.length;
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index);
-    first = Math.imul(first ^ code, 2654435761);
-    second = Math.imul(second ^ code, 1597334677);
-  }
-  first = Math.imul(first ^ (first >>> 16), 2246822507) ^ Math.imul(second ^ (second >>> 13), 3266489909);
-  second = Math.imul(second ^ (second >>> 16), 2246822507) ^ Math.imul(first ^ (first >>> 13), 3266489909);
-  process.stdout.write(`path_${`${(second >>> 0).toString(36)}${(first >>> 0).toString(36)}`.slice(0, 12)}`);
-}
-stableHash(normalizeLocalPath(process.argv[1]));
-' "$checkout_path"
+  (
+    cd "$ROOT_DIR/apps/lark-events"
+    NODE_OPTIONS='--conditions=development' node_modules/.bin/tsx \
+      ../../scripts/dev/print-local-project-target-ref.ts "$checkout_path"
+  )
 }
 
 port_is_in_use() {
@@ -381,6 +361,7 @@ CHECKOUT_PATH="$(absolute_path "$CHECKOUT_INPUT")"
 
 [[ -d "$CHECKOUT_PATH" ]] || fail "Project Target path does not exist: $CHECKOUT_PATH"
 git -C "$CHECKOUT_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "Project Target path must be a git checkout: $CHECKOUT_PATH"
+CHECKOUT_PATH="$(canonical_path "$CHECKOUT_PATH")"
 
 if [[ -n "${OPENTAG_REPO_OWNER:-}" && -n "${OPENTAG_REPO_NAME:-}" ]]; then
   REPO_PROVIDER="${OPENTAG_REPO_PROVIDER:-github}"
@@ -388,9 +369,11 @@ if [[ -n "${OPENTAG_REPO_OWNER:-}" && -n "${OPENTAG_REPO_NAME:-}" ]]; then
   REPO_NAME="$OPENTAG_REPO_NAME"
   log "Advanced repository target enabled for PR-capable workflows."
 else
-  REPO_PROVIDER="local"
-  REPO_OWNER="$(local_project_owner "$CHECKOUT_PATH")"
-  REPO_NAME="$(local_project_name "$CHECKOUT_PATH")"
+  PROJECT_TARGET_REF="$(local_project_ref "$CHECKOUT_PATH")"
+  REPO_PROVIDER="${PROJECT_TARGET_REF%%:*}"
+  PROJECT_TARGET_PATH="${PROJECT_TARGET_REF#*:}"
+  REPO_OWNER="${PROJECT_TARGET_PATH%%/*}"
+  REPO_NAME="${PROJECT_TARGET_PATH#*/}"
 fi
 
 BASE_BRANCH="${OPENTAG_BASE_BRANCH:-$(git -C "$CHECKOUT_PATH" branch --show-current 2>/dev/null || true)}"
@@ -585,7 +568,7 @@ else
   log "Group chat needs LARK_BOT_OPEN_ID. Direct chat is ready now."
   log
 fi
-log "This script auto-connects the first Lark chat that messages the bot to this local project."
+log "This script auto-connects the first Lark chat that messages the bot to this Project Target."
 log
 log "Expected AHA moment:"
 log "1. This terminal shows the local daemon running the executor."

--- a/scripts/dev/start-lark.sh
+++ b/scripts/dev/start-lark.sh
@@ -523,7 +523,7 @@ wait_for_dispatcher "$DISPATCHER_URL"
 
 log "Registering local runner and binding the selected project..."
 run_opentagd register-runner
-run_opentagd bind-repos
+run_opentagd bind-project-targets
 
 log "Starting local daemon..."
 (


### PR DESCRIPTION
## Summary
- Add shared Project Target ref helpers and route dispatcher/store/opentagd through them.
- Generate local-only Project Target refs from the canonical setup path, using a shared script helper instead of duplicating the hash in shell.
- Lazily migrate existing Lark local bindings from local/local/<repo> to the new local/path_<hash>/<repo> default before creating a run.
- Update Lark/local docs to describe the current repositories[] compatibility shape without implying a DB migration.

## Verification
- git diff --check
- bash -n scripts/dev/start-lark.sh
- corepack pnpm exec vitest run packages/core/test/project-target.test.ts apps/lark-events/test/app.test.ts packages/dispatcher/test/admission.test.ts packages/store/test/repository.test.ts
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm -r build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Project Target ref utilities (format/parse/from events and local paths) and a dev CLI to generate/display them consistently.
  * Introduced `bind-project-targets` sync flow and updated startup/binding to support Project Target-based connectivity.

* **Bug Fixes**
  * Improved parsing and binding for inbound `/bind` requests, including a migration path for legacy local bindings.
  * Updated dispatcher/store/admission to resolve and match runs using Project Target context.

* **Documentation**
  * Refreshed governance and configuration docs to consistently use Project Target terminology and updated examples.

* **Tests**
  * Added coverage for legacy local binding migration and local Project Target admission/repo handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->