### PR TITLE
Move provider vocabulary to adapter boundaries

### DIFF
--- a/apps/opentagd/test/integration.test.ts
+++ b/apps/opentagd/test/integration.test.ts
@@ -13,7 +13,18 @@ const event: OpenTagEvent = {
   actor: { provider: "github", providerUserId: "42", handle: "octocat" },
   target: { mention: "@opentag", agentId: "opentag" },
   command: { rawText: "summarize this", intent: "run", args: {} },
-  context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+  context: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+  workItem: {
+    provider: "github",
+    kind: "issue",
+    externalId: "acme/demo#1",
+    uri: "https://github.com/acme/demo/issues/1",
+    ownerContainer: {
+      provider: "github",
+      id: "acme/demo",
+      uri: "https://github.com/acme/demo"
+    }
+  },
   permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
   callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
   metadata: { owner: "acme", repo: "demo" }

--- a/docs/adapter-authoring.md
+++ b/docs/adapter-authoring.md
@@ -37,22 +37,25 @@ execution architecture. The dispatcher and runner contracts should stay shared.
 
 ## Core Schema Check
 
-Before writing code, check whether `@opentag/core` already supports the provider:
+`@opentag/core` does not whitelist product providers. Adapters may introduce
+provider ids such as `github`, `slack`, `linear`, `jira`, `teams`, or `discord`
+without changing core schema.
 
-- `SourceSchema` currently includes `github`, `slack`, `telegram`, `lark`, `cli`, and
-  `webhook`.
-- `ProviderSchema` currently includes `github`, `slack`, `telegram`, and `lark`.
-- `CallbackRouteSchema` currently includes `github`, `slack`, `telegram`, `lark`, and
-  `webhook`.
-- `ContextPointerSchema` includes GitHub, Slack, Telegram, Lark, file, URL, and text
-  pointers.
+Keep platform vocabulary at the adapter boundary:
 
-If the new app needs a new provider such as Linear, Jira, Teams, or Discord,
-extend the core enums first. Do not emit strings that fail `OpenTagEventSchema`.
+- use `source`, `actor.provider`, and `callback.provider` for the external
+  system that emitted or receives the event;
+- use context pointers shaped as `{ provider?: string, kind: string, uri: string }`;
+- use generic pointer kinds when the object is protocol-native, for example
+  `file`, `url`, or `text`;
+- use provider-scoped pointer kinds for platform objects, for example
+  `{ provider: "github", kind: "issue" }` or
+  `{ provider: "lark", kind: "message" }`;
+- populate `workItem` when the event is attached to a canonical external unit of
+  work such as an issue, pull request, task, ticket, or document.
 
-For prototypes that do not need a first-class provider yet, use an existing
-supported provider only when it is semantically true. Avoid pretending a Jira
-actor is a GitHub actor just to pass validation.
+Do not pretend a Jira actor is a GitHub actor just to reuse an existing adapter.
+The provider string is intentionally open; adapters should be honest and stable.
 
 ## Normalizer Checklist
 
@@ -77,6 +80,7 @@ Populate these fields carefully:
 | `target` | Mention text, `agentId`, and optional executor hint |
 | `command` | Use `parseOpenTagMention` for literal `@opentag`; use `commandFromRawText` after stripping platform mentions |
 | `context` | Durable pointers to the issue, thread, message, file, URL, or text |
+| `workItem` | Canonical external work item when one exists; omit for pure chat mentions that only point to a conversation |
 | `permissions` | Smallest permissions implied by the command |
 | `callback` | Provider, callback URI, and stable `threadKey` when callbacks target a thread |
 | `metadata` | Provider-specific ids needed for binding, routing, or debugging |
@@ -234,7 +238,8 @@ export function normalizeLarkMessageMention(input: LarkMessageMentionInput): Ope
     command,
     context: [
       {
-        kind: "lark.message",
+        provider: "lark",
+        kind: "message",
         uri: `lark://chat/${input.chatId}/message/${input.messageId}`,
         visibility: "organization",
         title: "Lark message"

--- a/docs/agent-work-protocol.md
+++ b/docs/agent-work-protocol.md
@@ -687,27 +687,18 @@ Represents the normalized source event:
 Points to source material without implying the whole source should be copied
 into the executor.
 
-Future kinds should include platform-specific sources without making core depend
-on platform SDKs:
+Platform-specific sources should be expressed with an open `provider` plus a
+stable adapter-owned `kind`, without making core depend on platform SDKs or
+platform enum churn:
 
-```text
-github.repo
-github.issue
-github.pull_request
-github.comment
-github.commit
-slack.channel
-slack.thread
-slack.message
-lark.chat
-lark.thread
-lark.message
-lark.doc
-lark.base
-lark.base_record
-file
-url
-text
+```ts
+{ provider: "github", kind: "repo", uri: "https://github.com/acme/demo" }
+{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1" }
+{ provider: "slack", kind: "message", uri: "slack://team/T/channel/C/message/123" }
+{ provider: "lark", kind: "message", uri: "lark://tenant/T/chat/C/message/M" }
+{ kind: "file", uri: "src/index.ts" }
+{ kind: "url", uri: "https://example.com/background" }
+{ kind: "text", uri: "original user-authored text" }
 ```
 
 Adding the kinds does not mean every adapter must implement them immediately.

--- a/docs/design.md
+++ b/docs/design.md
@@ -281,13 +281,14 @@ Responsibilities:
 ```ts
 type OpenTagEvent = {
   id: string;
-  source: "github" | "slack" | "lark" | "cli" | "webhook";
+  source: string;
   sourceEventId: string;
   receivedAt: string;
   actor: ActorIdentity;
   target: AgentTarget;
   command: OpenTagCommand;
   context: ContextPointer[];
+  workItem?: WorkItemReference;
   permissions: PermissionGrant[];
   callback: CallbackRoute;
   metadata: Record<string, unknown>;
@@ -298,7 +299,7 @@ type OpenTagEvent = {
 
 ```ts
 type ActorIdentity = {
-  provider: "github" | "slack" | "lark";
+  provider: string;
   providerUserId: string;
   handle?: string;
   displayName?: string;
@@ -331,15 +332,8 @@ type OpenTagCommand = {
 
 ```ts
 type ContextPointer = {
-  kind:
-    | "github.repo"
-    | "github.issue"
-    | "github.pull_request"
-    | "github.comment"
-    | "github.commit"
-    | "file"
-    | "url"
-    | "text";
+  provider?: string;
+  kind: string; // e.g. "issue", "pull_request", "message", "file", "url", "text"
   uri: string;
   title?: string;
   visibility: "public" | "private" | "organization";
@@ -350,14 +344,7 @@ type ContextPointer = {
 
 ```ts
 type PermissionGrant = {
-  scope:
-    | "repo:read"
-    | "repo:write"
-    | "issue:comment"
-    | "pr:create"
-    | "pr:update"
-    | "runner:local"
-    | "network:restricted";
+  scope: string;
   reason: string;
   expiresAt?: string;
 };
@@ -367,7 +354,7 @@ type PermissionGrant = {
 
 ```ts
 type CallbackRoute = {
-  provider: "github" | "slack" | "lark" | "webhook";
+  provider: string;
   uri: string;
   threadKey?: string;
 };

--- a/examples/github-to-echo/README.md
+++ b/examples/github-to-echo/README.md
@@ -73,8 +73,19 @@ curl -X POST http://localhost:3030/v1/runs \
       "target": { "mention": "@opentag", "agentId": "opentag" },
       "command": { "rawText": "fix this", "intent": "fix", "args": {} },
       "context": [
-        { "kind": "github.issue", "uri": "https://github.com/acme/demo/issues/1", "visibility": "public" }
+        { "provider": "github", "kind": "issue", "uri": "https://github.com/acme/demo/issues/1", "visibility": "public" }
       ],
+      "workItem": {
+        "provider": "github",
+        "kind": "issue",
+        "externalId": "acme/demo#1",
+        "uri": "https://github.com/acme/demo/issues/1",
+        "ownerContainer": {
+          "provider": "github",
+          "id": "acme/demo",
+          "uri": "https://github.com/acme/demo"
+        }
+      },
       "permissions": [
         { "scope": "issue:comment", "reason": "reply to source thread" }
       ],

--- a/examples/github-to-echo/run.example.json
+++ b/examples/github-to-echo/run.example.json
@@ -21,11 +21,23 @@
     },
     "context": [
       {
-        "kind": "github.issue",
+        "provider": "github",
+        "kind": "issue",
         "uri": "https://github.com/acme/demo/issues/1",
         "visibility": "public"
       }
     ],
+    "workItem": {
+      "provider": "github",
+      "kind": "issue",
+      "externalId": "acme/demo#1",
+      "uri": "https://github.com/acme/demo/issues/1",
+      "ownerContainer": {
+        "provider": "github",
+        "id": "acme/demo",
+        "uri": "https://github.com/acme/demo"
+      }
+    },
     "permissions": [
       {
         "scope": "issue:comment",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "packageManager": "pnpm@9.15.0",
   "license": "MIT",
   "scripts": {
-    "build": "pnpm -r build",
+    "build": "corepack pnpm -r build",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "lint": "pnpm -r lint",
-    "smoke:protocol": "NODE_OPTIONS='--conditions=development' pnpm --dir apps/dispatcher exec tsx ../../scripts/test/protocol-runtime-smoke.ts",
-    "smoke:slack-protocol": "NODE_OPTIONS='--conditions=development' pnpm --dir apps/dispatcher exec tsx ../../scripts/test/slack-protocol-runtime-smoke.ts"
+    "lint": "corepack pnpm -r lint",
+    "smoke:protocol": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/protocol-runtime-smoke.ts",
+    "smoke:slack-protocol": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/slack-protocol-runtime-smoke.ts"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -44,6 +44,10 @@ function contextPacketSourceRole(classification: ContextSourceClassification): "
   }
 }
 
+export function contextPointerLabel(pointer: ContextPointer): string {
+  return pointer.provider ? `${pointer.provider}.${pointer.kind}` : pointer.kind;
+}
+
 export type ContextPacketAssemblyOptions = {
   budgetTokens?: number;
   risks?: string[];
@@ -121,19 +125,11 @@ function classifyContextPointer(pointer: ContextPointer): ClassifiedContextPoint
   if (pointer.kind === "text") {
     return { pointer, classification: "primary_evidence", reason: "Original user-authored text is primary evidence." };
   }
-  if (
-    pointer.kind === "github.issue" ||
-    pointer.kind === "github.pull_request" ||
-    pointer.kind === "github.comment" ||
-    pointer.kind === "slack.thread" ||
-    pointer.kind === "slack.message" ||
-    pointer.kind === "telegram.thread" ||
-    pointer.kind === "telegram.message"
-  ) {
-    return { pointer, classification: "primary_evidence", reason: `${pointer.kind} is directly attached to the invocation.` };
+  if (["issue", "pull_request", "comment", "thread", "message"].includes(pointer.kind)) {
+    return { pointer, classification: "primary_evidence", reason: `${contextPointerLabel(pointer)} is directly attached to the invocation.` };
   }
-  if (pointer.kind === "github.repo" || pointer.kind === "file" || pointer.kind === "url") {
-    return { pointer, classification: "supporting_context", reason: `${pointer.kind} supports execution but is not itself the request.` };
+  if (["repo", "file", "url"].includes(pointer.kind)) {
+    return { pointer, classification: "supporting_context", reason: `${contextPointerLabel(pointer)} supports execution but is not itself the request.` };
   }
   return { pointer, classification: "supporting_context", reason: "Pointer is relevant context." };
 }
@@ -162,7 +158,7 @@ export function preserveContextFacts(event: OpenTagEvent, classified: Classified
       confidence: "observed"
     },
     ...classified.map((entry) => ({
-      text: `${entry.classification}: ${entry.pointer.kind}`,
+      text: `${entry.classification}: ${contextPointerLabel(entry.pointer)}`,
       sourceUri: entry.pointer.uri,
       source: entry.pointer,
       confidence: "observed" as const
@@ -257,7 +253,6 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "callback",
     requiresExplicitIntent: false,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "slack", "telegram", "lark", "webhook"],
     requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
   },
   {
@@ -266,7 +261,6 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "callback",
     requiresExplicitIntent: false,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "slack", "telegram", "lark", "webhook"],
     requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
   },
   {
@@ -275,7 +269,6 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "external_write",
     requiresExplicitIntent: true,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github"],
     requiredPermissionScopes: ["pr:create"],
     requiredExecutorConditions: ["isolated branch exists"]
   },
@@ -285,7 +278,6 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "external_write",
     requiresExplicitIntent: true,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "linear", "jira", "lark"],
     requiredPermissionScopes: ["repo:write"]
   },
   {
@@ -294,7 +286,6 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "external_write",
     requiresExplicitIntent: true,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "linear", "jira", "lark"],
     requiredPermissionScopes: ["repo:write"]
   },
   {
@@ -303,7 +294,6 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "external_write",
     requiresExplicitIntent: true,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["linear", "jira", "lark"],
     requiredPermissionScopes: ["repo:write"]
   },
   {
@@ -312,7 +302,6 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "external_write",
     requiresExplicitIntent: true,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "linear", "jira", "lark"],
     requiredPermissionScopes: ["repo:write"]
   },
   {
@@ -321,77 +310,32 @@ export const DefaultCapabilityContracts = [
     capabilityClass: "callback",
     requiresExplicitIntent: false,
     mayAutoApplyByPolicy: true,
-    adapterTargets: ["github", "slack", "telegram", "lark"],
     requiredPermissionScopes: ["issue:comment", "chat:postMessage"]
   }
 ] satisfies CapabilityContract[];
 
-function firstContextUri(event: OpenTagEvent, kind: ContextPointer["kind"]): string | undefined {
-  return event.context.find((pointer) => pointer.kind === kind)?.uri;
-}
-
-function stringMetadata(event: OpenTagEvent, key: string): string | undefined {
-  const value = event.metadata[key];
-  return typeof value === "string" ? value : undefined;
-}
-
-function numberMetadata(event: OpenTagEvent, key: string): number | undefined {
-  const value = event.metadata[key];
-  return typeof value === "number" ? value : undefined;
+function firstContextUri(event: OpenTagEvent, input: { provider?: string; kind: string }): string | undefined {
+  return event.context.find((pointer) => pointer.kind === input.kind && (!input.provider || pointer.provider === input.provider))?.uri;
 }
 
 export function workItemReferenceFromEvent(event: OpenTagEvent): WorkItemReference | undefined {
-  const owner = stringMetadata(event, "owner");
-  const repo = stringMetadata(event, "repo");
-  if (!owner || !repo) return undefined;
-
-  const issueNumber = numberMetadata(event, "issueNumber");
-  if (event.source === "github" && issueNumber !== undefined) {
-    return {
-      provider: "github",
-      kind: "issue",
-      externalId: `${owner}/${repo}#${issueNumber}`,
-      uri: firstContextUri(event, "github.issue") ?? `https://github.com/${owner}/${repo}/issues/${issueNumber}`,
-      ownerContainer: {
-        provider: "github",
-        id: `${owner}/${repo}`,
-        uri: `https://github.com/${owner}/${repo}`
-      }
-    };
-  }
-
-  const pullRequestNumber = numberMetadata(event, "pullRequestNumber");
-  if (event.source === "github" && pullRequestNumber !== undefined) {
-    return {
-      provider: "github",
-      kind: "pull_request",
-      externalId: `${owner}/${repo}#${pullRequestNumber}`,
-      uri: firstContextUri(event, "github.pull_request") ?? `https://github.com/${owner}/${repo}/pull/${pullRequestNumber}`,
-      ownerContainer: {
-        provider: "github",
-        id: `${owner}/${repo}`,
-        uri: `https://github.com/${owner}/${repo}`
-      }
-    };
-  }
-
-  return undefined;
+  return event.workItem;
 }
 
 export function primaryConversationAnchorFromEvent(event: OpenTagEvent): ConversationAnchor {
-  const structuredThreadKey =
-    event.callback.provider === "slack" || event.callback.provider === "telegram" ? event.callback.threadKey : undefined;
+  const sourcePointer =
+    firstContextUri(event, { provider: event.callback.provider, kind: "comment" }) ??
+    firstContextUri(event, { provider: event.callback.provider, kind: "message" }) ??
+    firstContextUri(event, { provider: event.callback.provider, kind: "thread" }) ??
+    firstContextUri(event, { kind: "url" });
   return {
     provider: event.callback.provider,
-    kind: event.callback.provider === "slack" || event.callback.provider === "telegram" ? "thread" : `${event.callback.provider}_thread`,
+    kind: event.callback.threadKey ? "thread" : `${event.callback.provider}_thread`,
     externalId: event.callback.threadKey ?? event.callback.uri,
-    uri:
-      firstContextUri(event, "github.comment") ??
-      firstContextUri(event, "url") ??
-      event.callback.uri,
+    uri: sourcePointer ?? event.callback.uri,
     controlPlane: true,
     canApprove: true,
-    ...(structuredThreadKey ? { threadKey: structuredThreadKey } : {})
+    ...(event.callback.threadKey ? { threadKey: event.callback.threadKey } : {})
   };
 }
 
@@ -522,7 +466,7 @@ export function preflightMutationIntent(input: {
       }
     };
   }
-  if (input.adapter && !capability.adapterTargets.includes(input.adapter)) {
+  if (input.adapter && capability.adapterTargets && !capability.adapterTargets.includes(input.adapter)) {
     return {
       capability,
       outcome: {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,18 +1,12 @@
 import { z } from "zod";
 
-export const SourceSchema = z.enum(["github", "slack", "telegram", "lark", "cli", "webhook"]);
-export const ProviderSchema = z.enum(["github", "slack", "telegram", "lark"]);
+export const ProviderSchema = z.string().min(1);
+export const SourceSchema = ProviderSchema;
+export const ContextPointerKindSchema = z.string().min(1).refine((kind) => !kind.includes("."), {
+  message: "Context pointer kind must not include a provider prefix; use the provider field instead."
+});
 export const ExecutorHintSchema = z.enum(["claude-code", "codex", "hermes", "openclaw", "custom"]);
-export const PermissionScopeSchema = z.enum([
-  "repo:read",
-  "repo:write",
-  "issue:comment",
-  "chat:postMessage",
-  "pr:create",
-  "pr:update",
-  "runner:local",
-  "network:restricted"
-]);
+export const PermissionScopeSchema = z.string().min(1);
 export const CommandArgValueSchema = z.union([z.string(), z.boolean(), z.number()]);
 export const CommandFlagValueSchema = z.union([CommandArgValueSchema, z.array(CommandArgValueSchema)]);
 
@@ -67,28 +61,8 @@ export const OpenTagCommandSchema = z.object({
 });
 
 export const ContextPointerSchema = z.object({
-  kind: z.enum([
-    "github.repo",
-    "github.issue",
-    "github.pull_request",
-    "github.comment",
-    "github.commit",
-    "slack.channel",
-    "slack.thread",
-    "slack.message",
-    "telegram.chat",
-    "telegram.thread",
-    "telegram.message",
-    "lark.chat",
-    "lark.thread",
-    "lark.message",
-    "lark.doc",
-    "lark.base",
-    "lark.base_record",
-    "file",
-    "url",
-    "text"
-  ]),
+  provider: ProviderSchema.optional(),
+  kind: ContextPointerKindSchema,
   uri: z.string().min(1),
   line: z.number().int().positive().optional(),
   startLine: z.number().int().positive().optional(),
@@ -165,7 +139,7 @@ export const CapabilityContractSchema = z.object({
   capabilityClass: CapabilityClassSchema,
   requiresExplicitIntent: z.boolean(),
   mayAutoApplyByPolicy: z.boolean(),
-  adapterTargets: z.array(z.string().min(1)),
+  adapterTargets: z.array(z.string().min(1)).optional(),
   requiredPermissionScopes: z.array(PermissionGrantSchema.shape.scope),
   requiredExecutorConditions: z.array(z.string().min(1)).optional()
 });
@@ -200,8 +174,8 @@ export const PolicyResolutionSchema = z.object({
 export const AdapterMutationMappingSchema = z.object({
   id: z.string().min(1),
   adapter: z.string().min(1),
-  domain: z.enum(["status", "priority"]),
-  strategy: z.enum(["label"]),
+  domain: z.string().min(1),
+  strategy: z.string().min(1),
   values: z.record(z.string().min(1)),
   description: z.string().min(1).optional()
 });
@@ -216,7 +190,7 @@ export const SuccessMetricNameSchema = z.enum([
 ]);
 
 export const CallbackRouteSchema = z.object({
-  provider: z.enum(["github", "slack", "telegram", "lark", "webhook"]),
+  provider: ProviderSchema,
   uri: z.string().min(1),
   threadKey: z.string().min(1).optional()
 });
@@ -238,7 +212,7 @@ export const WorkItemReferenceSchema = z.object({
 });
 
 export const ConversationAnchorSchema = z.object({
-  provider: z.enum(["github", "slack", "telegram", "lark", "webhook"]),
+  provider: ProviderSchema,
   kind: z.string().min(1),
   externalId: z.string().min(1),
   uri: z.string().min(1),
@@ -427,6 +401,7 @@ export const OpenTagEventSchema = z.object({
   target: AgentTargetSchema,
   command: OpenTagCommandSchema,
   context: z.array(ContextPointerSchema),
+  workItem: WorkItemReferenceSchema.optional(),
   permissions: z.array(PermissionGrantSchema),
   callback: CallbackRouteSchema,
   metadata: z.record(z.unknown())

--- a/packages/core/test/protocol.test.ts
+++ b/packages/core/test/protocol.test.ts
@@ -19,9 +19,20 @@ const githubEvent: OpenTagEvent = {
   target: { mention: "@opentag", agentId: "opentag" },
   command: { rawText: "fix the flaky test", intent: "fix", args: {} },
   context: [
-    { kind: "github.issue", uri: "https://github.com/acme/demo/issues/7", visibility: "public" },
-    { kind: "github.comment", uri: "https://github.com/acme/demo/issues/7#issuecomment-1", visibility: "public" }
+    { provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/7", visibility: "public" },
+    { provider: "github", kind: "comment", uri: "https://github.com/acme/demo/issues/7#issuecomment-1", visibility: "public" }
   ],
+  workItem: {
+    provider: "github",
+    kind: "issue",
+    externalId: "acme/demo#7",
+    uri: "https://github.com/acme/demo/issues/7",
+    ownerContainer: {
+      provider: "github",
+      id: "acme/demo",
+      uri: "https://github.com/acme/demo"
+    }
+  },
   permissions: [
     { scope: "issue:comment", reason: "reply to source thread" },
     { scope: "repo:write", reason: "commit on isolated branch" },
@@ -50,14 +61,15 @@ describe("protocol helpers", () => {
   });
 
   it("does not invent a canonical work item when only a Slack thread is known", () => {
+    const { workItem: _githubWorkItem, ...githubEventWithoutWorkItem } = githubEvent;
     const slackEvent: OpenTagEvent = {
-      ...githubEvent,
+      ...githubEventWithoutWorkItem,
       id: "evt_slack_1",
       source: "slack",
       sourceEventId: "Ev123",
       actor: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
       context: [
-        { kind: "url", uri: "slack://team/T123/channel/C123/message/1710000000.000100", visibility: "organization" },
+        { provider: "slack", kind: "message", uri: "slack://team/T123/channel/C123/message/1710000000.000100", visibility: "organization" },
         { kind: "text", uri: "<@U999> fix this", visibility: "organization" }
       ],
       permissions: [{ scope: "chat:postMessage", reason: "reply in Slack thread" }],
@@ -98,7 +110,7 @@ describe("protocol helpers", () => {
         ...githubEvent,
         context: [
           ...githubEvent.context,
-          { kind: "github.repo", uri: "https://github.com/acme/demo", visibility: "public" },
+          { provider: "github", kind: "repo", uri: "https://github.com/acme/demo", visibility: "public" },
           { kind: "url", uri: "https://example.com/background", visibility: "public" }
         ]
       },

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -38,7 +38,8 @@ describe("OpenTagEventSchema", () => {
       },
       context: [
         {
-          kind: "github.issue",
+          provider: "github",
+          kind: "issue",
           uri: "https://github.com/acme/demo/issues/1",
           visibility: "public"
         }
@@ -81,7 +82,8 @@ describe("OpenTagEventSchema", () => {
       },
       context: [
         {
-          kind: "telegram.message",
+          provider: "telegram",
+          kind: "message",
           uri: "telegram://bot/123/chat/456/message/789",
           visibility: "organization"
         }
@@ -102,6 +104,91 @@ describe("OpenTagEventSchema", () => {
 
     expect(parsed.source).toBe("telegram");
     expect(parsed.callback.provider).toBe("telegram");
+  });
+
+  it("accepts adapter-defined providers and context kinds without changing core", () => {
+    const parsed = OpenTagEventSchema.parse({
+      id: "evt_linear_1",
+      source: "linear",
+      sourceEventId: "comment_123",
+      receivedAt: "2026-06-25T00:00:00.000Z",
+      actor: {
+        provider: "linear",
+        providerUserId: "user_123"
+      },
+      target: {
+        mention: "@opentag",
+        agentId: "opentag"
+      },
+      command: {
+        rawText: "triage this",
+        intent: "run",
+        args: {}
+      },
+      context: [
+        {
+          provider: "linear",
+          kind: "issue",
+          uri: "linear://issue/ENG-123",
+          visibility: "organization"
+        }
+      ],
+      permissions: [
+        {
+          scope: "issue:comment",
+          reason: "reply to source thread"
+        }
+      ],
+      callback: {
+        provider: "linear",
+        uri: "linear://comment/123"
+      },
+      metadata: {}
+    });
+
+    expect(parsed.context[0]).toMatchObject({ provider: "linear", kind: "issue" });
+  });
+
+  it("rejects legacy provider-prefixed context kinds", () => {
+    expect(() =>
+      OpenTagEventSchema.parse({
+        id: "evt_legacy_kind",
+        source: "github",
+        sourceEventId: "comment_legacy_kind",
+        receivedAt: "2026-06-25T00:00:00.000Z",
+        actor: {
+          provider: "github",
+          providerUserId: "42"
+        },
+        target: {
+          mention: "@opentag",
+          agentId: "opentag"
+        },
+        command: {
+          rawText: "fix this",
+          intent: "fix",
+          args: {}
+        },
+        context: [
+          {
+            kind: "github.issue",
+            uri: "https://github.com/acme/demo/issues/1",
+            visibility: "public"
+          }
+        ],
+        permissions: [
+          {
+            scope: "issue:comment",
+            reason: "reply to source thread"
+          }
+        ],
+        callback: {
+          provider: "github",
+          uri: "https://api.github.com/repos/acme/demo/issues/1/comments"
+        },
+        metadata: {}
+      })
+    ).toThrow(/provider prefix/);
   });
 
   it("accepts the current public executor hints", () => {
@@ -195,7 +282,7 @@ describe("Agent Work Protocol schemas", () => {
   it("accepts a minimal context packet with assembly stages", () => {
     const packet = ContextPacketSchema.parse({
       summary: "Investigate the failing test on the linked issue.",
-      sourcePointers: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/123", visibility: "public" }],
+      sourcePointers: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/123", visibility: "public" }],
       intent: {
         rawText: "@opentag investigate flaky test",
         normalizedIntent: "investigate",
@@ -203,7 +290,7 @@ describe("Agent Work Protocol schemas", () => {
       },
       sources: [
         {
-          pointer: { kind: "github.issue", uri: "https://github.com/acme/demo/issues/123", visibility: "public" },
+          pointer: { provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/123", visibility: "public" },
           role: "primary",
           included: true,
           reason: "The issue is the primary source for the request."

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -150,7 +150,7 @@ function mappingsFromAdapterPlan(adapterPlan: unknown) {
 export type CallbackMessage = {
   runId: string;
   kind: "acknowledgement" | "progress" | "final";
-  provider: "github" | "slack" | "telegram" | "lark" | "webhook";
+  provider: string;
   uri: string;
   body: string;
   agentId?: string;

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -9,7 +9,18 @@ const validEvent = {
   actor: { provider: "github", providerUserId: "42", handle: "octocat" },
   target: { mention: "@opentag", agentId: "opentag" },
   command: { rawText: "fix this", intent: "fix", args: {} },
-  context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+  context: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+  workItem: {
+    provider: "github",
+    kind: "issue",
+    externalId: "acme/demo#1",
+    uri: "https://github.com/acme/demo/issues/1",
+    ownerContainer: {
+      provider: "github",
+      id: "acme/demo",
+      uri: "https://github.com/acme/demo"
+    }
+  },
   permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
   callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
   metadata: { owner: "acme", repo: "demo" }

--- a/packages/github/src/normalize.ts
+++ b/packages/github/src/normalize.ts
@@ -1,5 +1,5 @@
 import { parseOpenTagMention, type OpenTagEvent } from "@opentag/core";
-import type { ContextPointer, OpenTagCommand, PermissionGrant } from "@opentag/core";
+import type { ContextPointer, OpenTagCommand, PermissionGrant, WorkItemReference } from "@opentag/core";
 
 export type GitHubIssueCommentInput = {
   id: string;
@@ -98,6 +98,26 @@ function referenceTitle(reference: NonNullable<OpenTagCommand["parsed"]>["refere
   return reference.title ?? "Command file reference";
 }
 
+function githubWorkItem(input: {
+  owner: string;
+  repo: string;
+  kind: "issue" | "pull_request";
+  number: number;
+  uri: string;
+}): WorkItemReference {
+  return {
+    provider: "github",
+    kind: input.kind,
+    externalId: `${input.owner}/${input.repo}#${input.number}`,
+    uri: input.uri,
+    ownerContainer: {
+      provider: "github",
+      id: `${input.owner}/${input.repo}`,
+      uri: `https://github.com/${input.owner}/${input.repo}`
+    }
+  };
+}
+
 function commandMetadata(command: OpenTagCommand): Record<string, unknown> {
   if (!command.parsed) return {};
   return {
@@ -137,17 +157,26 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
     command,
     context: [
       {
-        kind: "github.issue",
+        provider: "github",
+        kind: "issue",
         uri: input.issueUrl,
         visibility: input.private ? "private" : "public"
       },
       {
-        kind: "github.comment",
+        provider: "github",
+        kind: "comment",
         uri: input.commentUrl,
         visibility: input.private ? "private" : "public"
       },
       ...contextPointersForCommand(command, input.private)
     ],
+    workItem: githubWorkItem({
+      owner: input.owner,
+      repo: input.repo,
+      kind: "issue",
+      number: input.issueNumber,
+      uri: input.issueUrl
+    }),
     permissions: permissionsForIntent(mention.intent),
     callback: {
       provider: "github",
@@ -193,17 +222,26 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
     command,
     context: [
       {
-        kind: "github.pull_request",
+        provider: "github",
+        kind: "pull_request",
         uri: input.pullRequestUrl,
         visibility: input.private ? "private" : "public"
       },
       {
-        kind: "github.comment",
+        provider: "github",
+        kind: "comment",
         uri: input.commentUrl,
         visibility: input.private ? "private" : "public"
       },
       ...contextPointersForCommand(command, input.private)
     ],
+    workItem: githubWorkItem({
+      owner: input.owner,
+      repo: input.repo,
+      kind: "pull_request",
+      number: input.pullRequestNumber,
+      uri: input.pullRequestUrl
+    }),
     permissions: permissionsForIntent(mention.intent),
     callback: {
       provider: "github",

--- a/packages/github/test/normalize.test.ts
+++ b/packages/github/test/normalize.test.ts
@@ -21,6 +21,8 @@ describe("normalizeGitHubIssueComment", () => {
 
     expect(event?.source).toBe("github");
     expect(event?.command.intent).toBe("fix");
+    expect(event?.context[0]).toMatchObject({ provider: "github", kind: "issue" });
+    expect(event?.workItem).toMatchObject({ provider: "github", kind: "issue", externalId: "acme/demo#1" });
     expect(event?.permissions.map((permission) => permission.scope)).toContain("pr:create");
     expect(event?.metadata).toMatchObject({ owner: "acme", repo: "demo", issueNumber: 1, installationId: 99 });
   });
@@ -43,7 +45,8 @@ describe("normalizeGitHubIssueComment", () => {
     });
 
     expect(event?.id).toBe("evt_github_pr_review_comment_456");
-    expect(event?.context[0]?.kind).toBe("github.pull_request");
+    expect(event?.context[0]).toMatchObject({ provider: "github", kind: "pull_request" });
+    expect(event?.workItem).toMatchObject({ provider: "github", kind: "pull_request", externalId: "acme/demo#2" });
     expect(event?.callback.threadKey).toBe("acme/demo#2");
     expect(event?.metadata).toMatchObject({ pullRequestNumber: 2, installationId: 77 });
   });

--- a/packages/lark/src/normalize.ts
+++ b/packages/lark/src/normalize.ts
@@ -146,7 +146,8 @@ export function normalizeLarkMessage(input: LarkMessageInput): OpenTagEvent | nu
     command,
     context: [
       {
-        kind: "lark.message",
+        provider: "lark",
+        kind: "message",
         uri: `lark://tenant/${input.tenantKey}/chat/${input.chatId}/message/${input.messageId}`,
         visibility: "organization",
         title: "Lark message"

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -1,4 +1,4 @@
-import type { ContextPacket, ContextPointer } from "@opentag/core";
+import { contextPointerLabel, type ContextPacket, type ContextPointer } from "@opentag/core";
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
 import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
 import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
@@ -14,7 +14,7 @@ export type ClaudeCodeExecutorOptions = {
 
 function contextLines(context: ContextPointer[]): string {
   if (!context.length) return "No additional context pointers were provided.";
-  return context.map((pointer) => `- ${pointer.kind}: ${pointer.uri}`).join("\n");
+  return context.map((pointer) => `- ${contextPointerLabel(pointer)}: ${pointer.uri}`).join("\n");
 }
 
 function buildPrompt(input: {

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -1,4 +1,4 @@
-import type { ContextPacket, ContextPointer } from "@opentag/core";
+import { contextPointerLabel, type ContextPacket, type ContextPointer } from "@opentag/core";
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
 import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
 import {
@@ -22,7 +22,7 @@ export type CodexExecutorOptions = {
 
 function contextLines(context: ContextPointer[]): string {
   if (!context.length) return "No additional context pointers were provided.";
-  return context.map((pointer) => `- ${pointer.kind}: ${pointer.uri}`).join("\n");
+  return context.map((pointer) => `- ${contextPointerLabel(pointer)}: ${pointer.uri}`).join("\n");
 }
 
 function buildPrompt(input: {

--- a/packages/runner/src/executor.ts
+++ b/packages/runner/src/executor.ts
@@ -1,4 +1,4 @@
-import type { ContextPacket, ContextPointer, OpenTagCommand, OpenTagRunResult, PermissionGrant } from "@opentag/core";
+import { contextPointerLabel, type ContextPacket, type ContextPointer, type OpenTagCommand, type OpenTagRunResult, type PermissionGrant } from "@opentag/core";
 
 export type ExecutorEvent = {
   type: "executor.started" | "executor.progress" | "executor.completed" | "executor.failed";
@@ -35,7 +35,7 @@ export function renderContextPacketForPrompt(packet?: ContextPacket): string[] {
   if (packet.sources?.length) {
     lines.push("- selected sources:");
     for (const source of packet.sources) {
-      lines.push(`  - [${source.role}] ${source.pointer.kind}: ${source.pointer.uri}`);
+      lines.push(`  - [${source.role}] ${contextPointerLabel(source.pointer)}: ${source.pointer.uri}`);
       lines.push(`    reason: ${source.reason}`);
     }
   }

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -56,10 +56,10 @@ describe("Claude Code executor", () => {
         runId: "run_1",
         workspacePath: "/tmp/demo",
         command: { rawText: "fix this", intent: "fix", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+        context: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
         contextPacket: {
           summary: "Use the linked issue and propose the narrowest fix.",
-          sourcePointers: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+          sourcePointers: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
           intent: {
             rawText: "fix this",
             normalizedIntent: "fix",
@@ -67,7 +67,7 @@ describe("Claude Code executor", () => {
           },
           sources: [
             {
-              pointer: { kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" },
+              pointer: { provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" },
               role: "primary",
               included: true,
               reason: "The issue is the main source for the request."

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -74,10 +74,10 @@ describe("Codex executor", () => {
         runId: "run_1",
         workspacePath: "/tmp/demo",
         command: { rawText: "fix this", intent: "fix", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+        context: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
         contextPacket: {
           summary: "Fix the requested issue with the narrowest possible change.",
-          sourcePointers: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+          sourcePointers: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
           facts: [{ text: "CI is failing on the linked issue." }],
           exclusions: ["Do not touch unrelated operational files."]
         },

--- a/packages/slack/src/normalize.ts
+++ b/packages/slack/src/normalize.ts
@@ -154,7 +154,8 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
     command,
     context: [
       {
-        kind: "url",
+        provider: "slack",
+        kind: "message",
         uri: `slack://team/${input.teamId}/channel/${input.channelId}/message/${input.ts}`,
         visibility: "organization",
         title: "Slack message"

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -67,7 +67,7 @@ export type OpenTagAuditEvent = {
 };
 
 export type CallbackDeliveryKind = "acknowledgement" | "progress" | "final";
-export type CallbackDeliveryProvider = "github" | "slack" | "telegram" | "lark" | "webhook";
+export type CallbackDeliveryProvider = string;
 export type CallbackDeliveryStatus = "pending" | "delivering" | "delivered" | "failed";
 
 export type CallbackDelivery = {

--- a/packages/store/test/repository.test.ts
+++ b/packages/store/test/repository.test.ts
@@ -4,6 +4,31 @@ import { describe, expect, it } from "vitest";
 import { createOpenTagRepository } from "../src/repository.js";
 import { migrateSchema } from "../src/schema.js";
 
+function githubIssueContext(issueNumber: number) {
+  return [
+    {
+      provider: "github" as const,
+      kind: "issue" as const,
+      uri: `https://github.com/acme/demo/issues/${issueNumber}`,
+      visibility: "public" as const
+    }
+  ];
+}
+
+function githubIssueWorkItem(issueNumber: number) {
+  return {
+    provider: "github" as const,
+    kind: "issue" as const,
+    externalId: `acme/demo#${issueNumber}`,
+    uri: `https://github.com/acme/demo/issues/${issueNumber}`,
+    ownerContainer: {
+      provider: "github" as const,
+      id: "acme/demo",
+      uri: "https://github.com/acme/demo"
+    }
+  };
+}
+
 describe("OpenTag repository", () => {
   it("creates and claims a run once", async () => {
     const sqlite = new Database(":memory:");
@@ -29,7 +54,8 @@ describe("OpenTag repository", () => {
         actor: { provider: "github", providerUserId: "42", handle: "octocat" },
         target: { mention: "@opentag", agentId: "opentag" },
         command: { rawText: "fix this", intent: "fix", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+        context: githubIssueContext(1),
+        workItem: githubIssueWorkItem(1),
         permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
         callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
         metadata: { owner: "acme", repo: "demo", issueNumber: 1 }
@@ -410,7 +436,8 @@ describe("OpenTag repository", () => {
         actor: { provider: "github", providerUserId: "42", handle: "octocat" },
         target: { mention: "@opentag", agentId: "opentag" },
         command: { rawText: "fix this", intent: "fix", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+        context: githubIssueContext(1),
+        workItem: githubIssueWorkItem(1),
         permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
         callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
         metadata: { owner: "acme", repo: "demo" }
@@ -593,7 +620,8 @@ describe("OpenTag repository", () => {
         actor: { provider: "github", providerUserId: "42", handle: "octocat" },
         target: { mention: "@opentag", agentId: "opentag" },
         command: { rawText: "label this bug", intent: "run", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/2", visibility: "public" }],
+        context: githubIssueContext(2),
+        workItem: githubIssueWorkItem(2),
         permissions: [
           { scope: "issue:comment", reason: "reply to source thread" },
           { scope: "repo:write", reason: "mutate issue labels after approval" }
@@ -757,7 +785,8 @@ describe("OpenTag repository", () => {
         actor: { provider: "github", providerUserId: "42", handle: "octocat" },
         target: { mention: "@opentag", agentId: "opentag" },
         command: { rawText: "label this", intent: "run", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/4", visibility: "public" }],
+        context: githubIssueContext(4),
+        workItem: githubIssueWorkItem(4),
         permissions: [
           { scope: "issue:comment", reason: "reply to source thread" },
           { scope: "repo:write", reason: "mutate labels after approval" }
@@ -860,7 +889,8 @@ describe("OpenTag repository", () => {
         actor: { provider: "github", providerUserId: "42", handle: "octocat" },
         target: { mention: "@opentag", agentId: "opentag" },
         command: { rawText: "mark blocked", intent: "run", args: {} },
-        context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/5", visibility: "public" }],
+        context: githubIssueContext(5),
+        workItem: githubIssueWorkItem(5),
         permissions: [
           { scope: "issue:comment", reason: "reply to source thread" },
           { scope: "repo:write", reason: "mutate status after approval" }
@@ -928,7 +958,8 @@ describe("OpenTag repository", () => {
       actor: { provider: "github" as const, providerUserId: "42", handle: "octocat" },
       target: { mention: "@opentag", agentId: "opentag" },
       command: { rawText: "triage this", intent: "run" as const, args: {} },
-      context: [{ kind: "github.issue" as const, uri: "https://github.com/acme/demo/issues/3", visibility: "public" as const }],
+      context: githubIssueContext(3),
+      workItem: githubIssueWorkItem(3),
       permissions: [
         { scope: "issue:comment" as const, reason: "reply to source thread" },
         { scope: "repo:write" as const, reason: "mutate issue metadata after approval" }

--- a/packages/telegram/src/normalize.ts
+++ b/packages/telegram/src/normalize.ts
@@ -188,7 +188,8 @@ export function normalizeTelegramMessage(input: TelegramMessageInput): OpenTagEv
     command,
     context: [
       {
-        kind: "telegram.message",
+        provider: "telegram",
+        kind: "message",
         uri: `telegram://bot/${input.botId}/chat/${input.chatId}/message/${input.messageId}`,
         visibility: "organization",
         title: "Telegram message"

--- a/scripts/dev/run-gh-claude-local-test.sh
+++ b/scripts/dev/run-gh-claude-local-test.sh
@@ -200,9 +200,20 @@ const body = {
       args: {}
     },
     context: [
-      { kind: "github.repo", uri: "${REPO_URL}", visibility: "public" },
-      { kind: "github.issue", uri: "${ISSUE_URL}", visibility: "public" }
+      { provider: "github", kind: "repo", uri: "${REPO_URL}", visibility: "public" },
+      { provider: "github", kind: "issue", uri: "${ISSUE_URL}", visibility: "public" }
     ],
+    workItem: {
+      provider: "github",
+      kind: "issue",
+      externalId: "${OWNER}/${REPO}#${ISSUE_NUMBER}",
+      uri: "${ISSUE_URL}",
+      ownerContainer: {
+        provider: "github",
+        id: "${OWNER}/${REPO}",
+        uri: "${REPO_URL}"
+      }
+    },
     permissions: [
       { scope: "issue:comment", reason: "reply to the source GitHub thread" },
       { scope: "runner:local", reason: "execute the run on a paired local daemon" },

--- a/scripts/dev/run-slack-claude-local-test.sh
+++ b/scripts/dev/run-slack-claude-local-test.sh
@@ -146,6 +146,7 @@ export RUN_ID THREAD_TS
 
 python3 - <<'PY'
 import json, os, urllib.request
+from datetime import datetime, timezone
 
 run_id = os.environ["RUN_ID"]
 thread_ts = os.environ["THREAD_TS"]
@@ -155,7 +156,7 @@ body = {
         "id": f"evt_{run_id}",
         "source": "slack",
         "sourceEventId": f"slack_real_{thread_ts}",
-        "receivedAt": "2026-06-24T21:55:00.000Z",
+        "receivedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "actor": {"provider": "slack", "providerUserId": "U_LOCAL", "handle": "U_LOCAL", "organizationId": os.environ["TEAM_ID"]},
         "target": {"mention": "<@opentag>", "agentId": "opentag", "executorHint": "claude-code"},
         "command": {
@@ -167,7 +168,7 @@ body = {
             "args": {},
         },
         "context": [
-            {"kind": "url", "uri": f"slack://team/{os.environ['TEAM_ID']}/channel/{os.environ['CHANNEL_ID']}/message/{thread_ts}", "visibility": "organization"},
+            {"provider": "slack", "kind": "message", "uri": f"slack://team/{os.environ['TEAM_ID']}/channel/{os.environ['CHANNEL_ID']}/message/{thread_ts}", "visibility": "organization"},
             {"kind": "text", "uri": "OpenTag Slack + Claude Code E2E test: validate real callback and metrics.", "visibility": "organization"},
         ],
         "permissions": [

--- a/scripts/test/protocol-runtime-smoke.ts
+++ b/scripts/test/protocol-runtime-smoke.ts
@@ -64,16 +64,29 @@ try {
     command: { rawText: "triage this issue", intent: "run", args: {} },
     context: [
       {
-        kind: "github.issue",
+        provider: "github",
+        kind: "issue",
         uri: "https://github.com/acme/demo/issues/9",
         visibility: "public"
       },
       {
-        kind: "github.comment",
+        provider: "github",
+        kind: "comment",
         uri: "https://github.com/acme/demo/issues/9#issuecomment-1",
         visibility: "public"
       }
     ],
+    workItem: {
+      provider: "github",
+      kind: "issue",
+      externalId: "acme/demo#9",
+      uri: "https://github.com/acme/demo/issues/9",
+      ownerContainer: {
+        provider: "github",
+        id: "acme/demo",
+        uri: "https://github.com/acme/demo"
+      }
+    },
     permissions: [
       { scope: "issue:comment", reason: "reply to source thread" },
       { scope: "repo:write", reason: "apply approved issue metadata changes" },


### PR DESCRIPTION
## Summary

- Make `@opentag/core` provider-agnostic by replacing platform enums with open provider strings and `{ provider, kind }` context pointers.
- Reject legacy provider-prefixed context kinds such as `github.issue`; adapters must now emit `{ provider: "github", kind: "issue" }` and provide `workItem` for canonical external work items.
- Move GitHub issue/PR work-item derivation into the GitHub adapter, keep Slack/Telegram/Lark message pointers adapter-owned, and preserve readable `provider.kind` labels only at prompt/rendering boundaries.
- Update tests, docs, examples, smoke scripts, callback/provider typing, and local e2e scripts to the new schema.
- Pin nested package scripts to `corepack pnpm` so project scripts consistently use the declared `pnpm@9.15.0` instead of a newer global pnpm.

## Why

OpenTag should be an AI action protocol, not a platform-specific bot schema. Core should own the action/workflow vocabulary, while adapters own GitHub, Slack, Lark, Telegram, and future app vocabulary. We do not need old schema compatibility yet, so this PR intentionally breaks stale `kind: "github.issue"` payloads instead of silently accepting the old shape.

## Verification

- `corepack pnpm typecheck`
- `corepack pnpm test`  
  32 test files, 217 tests passed
- `corepack pnpm smoke:protocol`
- `corepack pnpm smoke:slack-protocol`
- `corepack pnpm build`
- `corepack pnpm lint`
- Real GitHub E2E: `amplifthq/opentag-test` issue #17 -> OpenTag run `run_gh_claude_1782482515` -> Claude Code -> PR #18 -> GitHub final callback delivered
- Real Slack E2E: Slack thread `1782482630.358089` -> OpenTag run `run_slack_claude_real_1782482630` -> Claude Code -> Slack ack/final callbacks delivered; metrics returned `threadNoiseRatio=0.15384615384615385`

## Not Tested

- GitHub App webhook ingress through a public tunnel.
- Slack Events API public-tunnel ingress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events and examples now support a richer context format with separate provider and kind fields.
  * Added support for attaching a referenced work item to events when applicable.
  * Prompt and report output now shows clearer context labels for linked items.

* **Bug Fixes**
  * Improved handling of GitHub, Slack, Lark, and Telegram message context so items display consistently.

* **Documentation**
  * Updated adapter and protocol guidance, plus example payloads, to reflect the new event shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->