### PR TITLE
Prepare OpenTag CLI npm release

### DIFF
--- a/docs/npm-release.md
+++ b/docs/npm-release.md
@@ -1,0 +1,84 @@
+# Publishing OpenTag to npm
+
+OpenTag npm packages are published manually from a local checkout until a release pipeline exists.
+
+## What gets published
+
+Publish all public packages together with the same version. The CLI depends on local runtime and adapter packages, so publishing only `@opentag/cli` is not enough.
+
+Current release version:
+
+```text
+0.2.0
+```
+
+Package publish order:
+
+1. `@opentag/core`
+2. `@opentag/client`
+3. `@opentag/telegram`
+4. `@opentag/runner`
+5. `@opentag/store`
+6. `@opentag/github`
+7. `@opentag/lark`
+8. `@opentag/slack`
+9. `@opentag/dispatcher`
+10. `@opentag/local-runtime`
+11. `@opentag/cli`
+
+## Preflight
+
+Use the repository package manager through Corepack:
+
+```bash
+corepack pnpm install --frozen-lockfile
+corepack pnpm release:check
+```
+
+`release:check` builds the workspace, packs every publishable package, installs those tarballs into a clean npm project, and verifies that the installed `opentag` command runs.
+
+## Publish
+
+Log in to npm first:
+
+```bash
+npm whoami
+```
+
+Then publish each package from the repo root:
+
+```bash
+corepack pnpm --dir packages/core publish --access public
+corepack pnpm --dir packages/client publish --access public
+corepack pnpm --dir packages/telegram publish --access public
+corepack pnpm --dir packages/runner publish --access public
+corepack pnpm --dir packages/store publish --access public
+corepack pnpm --dir packages/github publish --access public
+corepack pnpm --dir packages/lark publish --access public
+corepack pnpm --dir packages/slack publish --access public
+corepack pnpm --dir packages/dispatcher publish --access public
+corepack pnpm --dir packages/local-runtime publish --access public
+corepack pnpm --dir packages/cli publish --access public
+```
+
+## User install check
+
+After publishing, verify the global CLI path:
+
+```bash
+npm install -g @opentag/cli
+opentag --help
+opentag setup
+```
+
+The `@opentag/cli` package exposes this binary:
+
+```json
+{
+  "bin": {
+    "opentag": "./dist/index.js"
+  }
+}
+```
+
+That means a normal npm install creates an `opentag` command for the user.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run",
     "typecheck": "tsc -b",
     "lint": "corepack pnpm -r lint",
+    "release:check": "node scripts/release/check-cli-package.mjs",
     "opentag-dev": "node scripts/dev/install-opentag-dev.mjs",
     "smoke:protocol": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/protocol-runtime-smoke.ts",
     "smoke:slack-protocol": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/slack-protocol-runtime-smoke.ts"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,77 @@
+# @opentag/cli
+
+OpenTag CLI for setting up and running a local OpenTag stack.
+
+## Install
+
+```bash
+npm install -g @opentag/cli
+```
+
+Then run:
+
+```bash
+opentag setup
+opentag start
+```
+
+`opentag setup` walks through the local configuration:
+
+- Choose a language.
+- Choose a platform: Lark / Feishu, Slack, or GitHub.
+- Choose a coding agent: Codex, Claude Code, or Echo for local testing.
+- Configure platform credentials.
+- Bind the selected project.
+- Optionally start OpenTag immediately.
+
+## Commands
+
+```bash
+opentag setup
+opentag start
+opentag status
+opentag doctor
+opentag config path
+opentag config show
+opentag platforms
+opentag executors
+```
+
+## Local Config
+
+OpenTag stores local configuration at:
+
+```text
+~/.config/opentag/config.json
+```
+
+The config contains local secrets, so the CLI writes it with private file permissions.
+
+## Platform Guides
+
+The setup wizard links to the matching guide for each platform:
+
+- Lark / Feishu: `docs/platforms/lark.en.md`
+- Slack: `docs/platforms/slack.en.md`
+- GitHub: `docs/platforms/github.en.md`
+
+## Requirements
+
+- Node.js 20 or newer.
+- A local coding agent if you choose Codex or Claude Code.
+- Platform credentials for the platform you connect.
+
+## Local Development
+
+Inside the OpenTag monorepo, install the development command:
+
+```bash
+corepack pnpm opentag-dev
+```
+
+Then run:
+
+```bash
+opentag-dev setup
+opentag-dev start
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenTag command line interface.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "opentag": "./dist/index.js"
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,7 +8,9 @@
   "references": [
     { "path": "../client" },
     { "path": "../core" },
+    { "path": "../github" },
     { "path": "../lark" },
-    { "path": "../local-runtime" }
+    { "path": "../local-runtime" },
+    { "path": "../slack" }
   ]
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "HTTP client SDK for creating, claiming, and updating OpenTag dispatcher runs.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Core OpenTag protocol schemas, types, JSON Schema, and mention parsing.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/dispatcher/package.json
+++ b/packages/dispatcher/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/dispatcher",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Embeddable OpenTag dispatcher Hono app and callback sinks.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/github",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "GitHub event normalization and callback rendering for OpenTag.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/lark/README.md
+++ b/packages/lark/README.md
@@ -1,0 +1,39 @@
+# @opentag/lark
+
+Lark / Feishu adapter helpers for OpenTag.
+
+Use this package to receive Lark Personal Agent messages, normalize them into OpenTag events, register a Personal Agent by QR scan, and send local replies through the OpenTag dispatcher.
+
+## Install
+
+```bash
+pnpm add @opentag/lark
+```
+
+## Exports
+
+- `createLarkMessageHandler`: handles `im.message.receive_v1` events.
+- `startLarkIngress`: starts a Lark long-connection ingress.
+- `registerLarkPersonalAgent`: creates a Personal Agent registration flow.
+- `normalizeLarkMessage`: converts Lark messages into `OpenTagEvent` objects.
+- `renderLarkFinalResult`: renders OpenTag run results for Lark.
+
+## Example
+
+```ts
+import { startLarkIngress } from "@opentag/lark";
+
+const ingress = startLarkIngress({
+  appId: process.env.LARK_APP_ID!,
+  appSecret: process.env.LARK_APP_SECRET!,
+  domain: "lark",
+  dispatcherUrl: "http://localhost:3030",
+  agentId: "opentag"
+});
+
+await ingress.startPromise;
+```
+
+## Stability
+
+The event normalization and ingress config shapes are public adapter contracts. Add optional fields instead of changing existing required fields.

--- a/packages/lark/package.json
+++ b/packages/lark/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/lark",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Lark/Feishu message normalization and callback helpers for OpenTag.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/local-runtime/README.md
+++ b/packages/local-runtime/README.md
@@ -1,0 +1,38 @@
+# @opentag/local-runtime
+
+Local OpenTag runtime helpers used by `@opentag/cli`.
+
+Use this package when embedding the same local dispatcher, daemon, diagnostics, and GitHub PR helpers that the CLI uses.
+
+## Install
+
+```bash
+pnpm add @opentag/local-runtime
+```
+
+## Exports
+
+- `startDispatcher`: starts the local dispatcher with callback sinks.
+- `serveDaemon`: starts the local daemon loop.
+- `createDaemonRuntimeInput`: derives daemon runtime input from config.
+- `runDoctor`: checks dispatcher, bindings, checkouts, and executors.
+- `parseDaemonConfig`: parses daemon config with compatibility aliases.
+- `maybeCreatePullRequest`: creates GitHub pull requests from prepared run branches.
+
+Subpath exports are also available:
+
+```ts
+import { startDispatcher } from "@opentag/local-runtime/dispatcher";
+import { serveDaemon } from "@opentag/local-runtime/daemon";
+import { runDoctor } from "@opentag/local-runtime/doctor";
+```
+
+## Requirements
+
+- Node.js 20 or newer.
+- A writable SQLite database path for the dispatcher.
+- A local checkout for any Project Target you bind.
+
+## Stability
+
+This package is the local runtime boundary for the CLI. Keep app wrappers thin and put reusable local runtime behavior here.

--- a/packages/local-runtime/package.json
+++ b/packages/local-runtime/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/local-runtime",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Local OpenTag dispatcher, daemon, and diagnostics runtime helpers.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/runner",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Executor contracts and built-in runner adapters for OpenTag.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/slack",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Slack app mention normalization and callback helpers for OpenTag.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/store",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SQLite and Drizzle persistence primitives for OpenTag runs and leases.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@opentag/telegram",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Telegram message normalization and callback helpers for OpenTag.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/scripts/dev/install-opentag-dev.mjs
+++ b/scripts/dev/install-opentag-dev.mjs
@@ -75,7 +75,7 @@ function createShim() {
 }
 
 console.log("Building @opentag/cli...");
-run("corepack", ["pnpm", "--filter", "@opentag/cli", "build"]);
+run("corepack", ["pnpm", "--filter", "@opentag/cli...", "build"]);
 
 createShim();
 

--- a/scripts/release/check-cli-package.mjs
+++ b/scripts/release/check-cli-package.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const packageDirs = [
+  "core",
+  "client",
+  "telegram",
+  "runner",
+  "store",
+  "github",
+  "lark",
+  "slack",
+  "dispatcher",
+  "local-runtime",
+  "cli"
+];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    stdio: options.stdio ?? "inherit",
+    shell: process.platform === "win32",
+    env: {
+      ...process.env,
+      npm_config_audit: "false",
+      npm_config_fund: "false"
+    }
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+  return result;
+}
+
+function packPackage(packageDir, packDir) {
+  const before = new Set(readdirSync(packDir));
+  run("corepack", ["pnpm", "--dir", path.join("packages", packageDir), "pack", "--pack-destination", packDir]);
+  const created = readdirSync(packDir).filter((file) => file.endsWith(".tgz") && !before.has(file));
+  if (created.length !== 1) {
+    throw new Error(`Expected one tarball for packages/${packageDir}, found ${created.length}.`);
+  }
+  return path.join(packDir, created[0]);
+}
+
+function commandPath(cwd, command) {
+  return path.join(cwd, "node_modules", ".bin", process.platform === "win32" ? `${command}.cmd` : command);
+}
+
+const tempRoot = mkdtempSync(path.join(tmpdir(), "opentag-release-check-"));
+const packDir = path.join(tempRoot, "packs");
+const installDir = path.join(tempRoot, "install");
+
+try {
+  console.log("Building workspace packages...");
+  run("corepack", ["pnpm", "build"]);
+
+  console.log("Packing publishable packages...");
+  mkdirSync(packDir, { recursive: true });
+  const tarballs = packageDirs.map((packageDir) => packPackage(packageDir, packDir));
+
+  console.log("Installing packed packages into a clean npm project...");
+  mkdirSync(installDir, { recursive: true });
+  writeFileSync(path.join(installDir, "package.json"), "{\"private\":true,\"type\":\"module\"}\n");
+  run("npm", ["install", "--no-audit", "--no-fund", ...tarballs], { cwd: installDir });
+
+  console.log("Checking the installed opentag command...");
+  run(commandPath(installDir, "opentag"), ["--help"], { cwd: installDir });
+
+  console.log("");
+  console.log("OpenTag CLI package check passed.");
+  console.log(`Packed tarballs: ${packDir}`);
+} finally {
+  if (process.env.OPENTAG_KEEP_RELEASE_CHECK !== "1") {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "customConditions": ["development"],
     "strict": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary
- prepare all public OpenTag packages for a coordinated npm release at 0.2.0
- keep the @opentag/cli npm binary as `opentag` and add a release check that packs packages, installs them into a clean npm project, and runs `opentag --help`
- add package READMEs plus a local manual npm publishing guide
- make `opentag-dev` build the CLI dependency chain before installing the local shim

## Verification
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`
- `corepack pnpm release:check`

No npm publish was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `release:check` script to validate the CLI can be packaged and run after publishing.
* **Documentation**
  * Added/expanded documentation for the CLI, local runtime, and the Lark adapter, including setup guidance and example usage.
* **Chores**
  * Bumped OpenTag packages to version `0.2.0`.
  * Updated packages to require **Node.js 20+**.
* **Bug Fixes**
  * Broadened the dev install/build workspace selection to include additional CLI-related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->