### PR TITLE
fix(config): accept custom executor ids in repository bindings

### DIFF
--- a/packages/cli/src/catalogs/executors.ts
+++ b/packages/cli/src/catalogs/executors.ts
@@ -45,11 +45,8 @@ function pathExistsOnPath(command: string, env: NodeJS.ProcessEnv = process.env)
   return paths.some((directory) => candidates.some((candidate) => existsSync(join(directory, candidate))));
 }
 
-export function parseExecutorId(value: string): ExecutorId {
-  if (value === "echo" || value === "codex" || value === "claude-code") {
-    return value;
-  }
-  throw new Error("Executor must be echo, codex, or claude-code.");
+export function isExecutorId(value: string): value is ExecutorId {
+  return value === "echo" || value === "codex" || value === "claude-code";
 }
 
 export function detectExecutors(env: NodeJS.ProcessEnv = process.env): ExecutorDetection[] {
@@ -87,7 +84,7 @@ export function defaultExecutorId(input: {
   return "echo";
 }
 
-export function executorLabel(id: ExecutorId): string {
+export function executorLabel(id: string): string {
   return EXECUTOR_CATALOG.find((executor) => executor.id === id)?.label ?? id;
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -8,7 +8,11 @@ import type { ExecutorId } from "./catalogs/executors.js";
 import type { CliLanguage } from "./catalogs/languages.js";
 import type { PlatformId } from "./catalogs/platforms.js";
 
-const ExecutorSchema = z.enum(["echo", "codex", "claude-code"]);
+// Executor ids (repository bindings and the last-used preference) accept any
+// non-empty string so custom executors registered by a standalone runner
+// validate; echo, codex, and claude-code remain the documented built-ins.
+// Mirrors the daemon config and the open runtime dispatch.
+const ExecutorIdSchema = z.string().min(1);
 const KeepWorktreeSchema = z.enum(["always", "on_failure", "never"]);
 const PositiveIntegerSchema = z.number().int().positive();
 const CliLanguageSchema = z.enum(["en", "zh-CN"]);
@@ -24,7 +28,7 @@ const RepositoryBindingSchema = z
     owner: z.string().min(1),
     repo: z.string().min(1),
     checkoutPath: z.string().min(1),
-    defaultExecutor: ExecutorSchema,
+    defaultExecutor: ExecutorIdSchema,
     baseBranch: z.string().min(1),
     pushRemote: z.string().min(1),
     worktreeRoot: z.string().min(1),
@@ -136,7 +140,7 @@ const PreferencesSchema = z
     lastSetup: z
       .object({
         platforms: z.array(PlatformSchema).optional(),
-        executor: ExecutorSchema.optional(),
+        executor: ExecutorIdSchema.optional(),
         projectPath: z.string().min(1).optional(),
         larkSetupMethod: LarkSetupMethodSchema.optional(),
         larkDomain: z.enum(["lark", "feishu"]).optional(),

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -4,15 +4,14 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { formatConfigError as formatDaemonConfigError, parseDaemonConfig, type OpenTagDaemonConfig } from "@opentag/local-runtime";
 import { z } from "zod";
-import type { ExecutorId } from "./catalogs/executors.js";
 import type { CliLanguage } from "./catalogs/languages.js";
 import type { PlatformId } from "./catalogs/platforms.js";
 
 // Executor ids (repository bindings and the last-used preference) accept any
-// non-empty string so custom executors registered by a standalone runner
+// trimmed non-empty string so custom executors registered by a standalone runner
 // validate; echo, codex, and claude-code remain the documented built-ins.
 // Mirrors the daemon config and the open runtime dispatch.
-const ExecutorIdSchema = z.string().min(1);
+const ExecutorIdSchema = z.string().trim().min(1);
 const KeepWorktreeSchema = z.enum(["always", "on_failure", "never"]);
 const PositiveIntegerSchema = z.number().int().positive();
 const CliLanguageSchema = z.enum(["en", "zh-CN"]);
@@ -189,7 +188,7 @@ export type OpenTagCliPreferences = NonNullable<OpenTagCliConfig["preferences"]>
 export type OpenTagCliLastSetup = NonNullable<OpenTagCliPreferences["lastSetup"]>;
 export type OpenTagCliLanguage = CliLanguage;
 export type OpenTagCliPlatform = PlatformId;
-export type OpenTagCliExecutor = ExecutorId;
+export type OpenTagCliExecutor = string;
 
 export type PathEnvironment = Partial<
   Record<"OPENTAG_CONFIG_PATH" | "OPENTAG_CONFIG_HOME" | "OPENTAG_STATE_DIR" | "XDG_CONFIG_HOME" | "XDG_STATE_HOME", string>

--- a/packages/cli/src/setup/flow.ts
+++ b/packages/cli/src/setup/flow.ts
@@ -7,8 +7,7 @@ import {
   detectExecutors,
   EXECUTOR_CATALOG,
   executorLabel,
-  parseExecutorId,
-  type ExecutorId
+  isExecutorId
 } from "../catalogs/executors.js";
 import { LANGUAGE_OPTIONS, parseCliLanguage, type CliLanguage } from "../catalogs/languages.js";
 import { formatPlatformStatus, PLATFORM_CATALOG, parsePlatformId, platformById, type PlatformId } from "../catalogs/platforms.js";
@@ -292,12 +291,18 @@ async function collectExecutor(
   prompts: PromptAdapter,
   language: CliLanguage,
   env: NodeJS.ProcessEnv | undefined
-): Promise<ExecutorId> {
+): Promise<string> {
   if (options.executor) {
-    return parseExecutorId(options.executor);
+    return options.executor;
   }
   const detections = detectExecutors(env);
   const previous = defaults.executor;
+  if (previous !== undefined && !isExecutorId(previous)) {
+    // Preserve a configured custom executor: the built-in picker can't
+    // represent it, so silently replacing it with a built-in would discard
+    // the user's choice on an unrelated wizard re-run.
+    return previous;
+  }
   const initialValue = defaultExecutorId({
     ...(previous ? { previous } : {}),
     detections

--- a/packages/cli/src/setup/flow.ts
+++ b/packages/cli/src/setup/flow.ts
@@ -300,13 +300,16 @@ async function collectExecutor(
     return executor;
   }
   const detections = detectExecutors(env);
-  const previous = defaults.executor;
-  const previousBuiltIn = previous !== undefined && isExecutorId(previous) ? previous : undefined;
+  const normalizedPrevious = defaults.executor?.trim();
+  if (normalizedPrevious !== undefined && normalizedPrevious.length === 0) {
+    throw new Error("Executor id must not be empty.");
+  }
+  const previousBuiltIn = normalizedPrevious !== undefined && isExecutorId(normalizedPrevious) ? normalizedPrevious : undefined;
   // A configured custom executor can't be represented by the built-in picker,
   // so surface it as a pre-selected option: the user keeps it by default but
   // can still switch to a built-in, instead of it being silently overwritten
   // (or the prompt being skipped) on an unrelated wizard re-run.
-  const customPrevious = previous !== undefined && previousBuiltIn === undefined ? previous : undefined;
+  const customPrevious = normalizedPrevious !== undefined && previousBuiltIn === undefined ? normalizedPrevious : undefined;
   const initialValue =
     customPrevious ??
     defaultExecutorId({
@@ -323,7 +326,7 @@ async function collectExecutor(
         language,
         executor,
         available: detection?.available ?? false,
-        current: executor.id === previous,
+        current: executor.id === normalizedPrevious,
         selectedByDefault: executor.id === initialValue
       })
     };

--- a/packages/cli/src/setup/flow.ts
+++ b/packages/cli/src/setup/flow.ts
@@ -14,7 +14,7 @@ import { formatPlatformStatus, PLATFORM_CATALOG, parsePlatformId, platformById, 
 import { formatSavedLarkCredentialsHint } from "../platforms/lark/display.js";
 import { readLegacyLarkCredentials, type SavedLarkCredentials } from "../platforms/lark/saved-config.js";
 import { DEFAULT_GITHUB_WEBHOOK_PORT, DEFAULT_SLACK_EVENTS_PORT, parseLocalPort } from "../platforms/ports.js";
-import type { PromptAdapter } from "../ui/prompts.js";
+import type { PromptAdapter, PromptOption } from "../ui/prompts.js";
 import { bindingMethodHint, bindingMethodLabel, larkSetupHint, larkSetupLabel, slackModeHint, slackModeLabel, t } from "../ui/messages.js";
 import { loadSetupDefaults } from "./defaults.js";
 import { formatGitHubTokenHelp, formatLarkManualCredentialHelp, formatPlatformSetupGuide, formatSlackCredentialHelp } from "./guides.js";
@@ -292,39 +292,49 @@ async function collectExecutor(
   language: CliLanguage,
   env: NodeJS.ProcessEnv | undefined
 ): Promise<string> {
-  if (options.executor) {
-    return options.executor;
+  if (options.executor !== undefined) {
+    const executor = options.executor.trim();
+    if (executor.length === 0) {
+      throw new Error("Executor id must not be empty.");
+    }
+    return executor;
   }
   const detections = detectExecutors(env);
   const previous = defaults.executor;
-  if (previous !== undefined && !isExecutorId(previous)) {
-    // Preserve a configured custom executor: the built-in picker can't
-    // represent it, so silently replacing it with a built-in would discard
-    // the user's choice on an unrelated wizard re-run.
-    return previous;
-  }
-  const initialValue = defaultExecutorId({
-    ...(previous ? { previous } : {}),
-    detections
+  const previousBuiltIn = previous !== undefined && isExecutorId(previous) ? previous : undefined;
+  // A configured custom executor can't be represented by the built-in picker,
+  // so surface it as a pre-selected option: the user keeps it by default but
+  // can still switch to a built-in, instead of it being silently overwritten
+  // (or the prompt being skipped) on an unrelated wizard re-run.
+  const customPrevious = previous !== undefined && previousBuiltIn === undefined ? previous : undefined;
+  const initialValue =
+    customPrevious ??
+    defaultExecutorId({
+      ...(previousBuiltIn ? { previous: previousBuiltIn } : {}),
+      detections
+    });
+
+  const builtInOptions: Array<PromptOption<string>> = EXECUTOR_CATALOG.map((executor) => {
+    const detection = detections.find((entry) => entry.id === executor.id);
+    return {
+      value: executor.id,
+      label: executor.label,
+      hint: formatExecutorHint({
+        language,
+        executor,
+        available: detection?.available ?? false,
+        current: executor.id === previous,
+        selectedByDefault: executor.id === initialValue
+      })
+    };
   });
 
   return prompts.select({
     message: t(language, "executor"),
     initialValue,
-    options: EXECUTOR_CATALOG.map((executor) => {
-      const detection = detections.find((entry) => entry.id === executor.id);
-      return {
-        value: executor.id,
-        label: executor.label,
-        hint: formatExecutorHint({
-          language,
-          executor,
-          available: detection?.available ?? false,
-          current: executor.id === previous,
-          selectedByDefault: executor.id === initialValue
-        })
-      };
-    })
+    options: customPrevious
+      ? [{ value: customPrevious, label: customPrevious, hint: t(language, "executorCustomHint") }, ...builtInOptions]
+      : builtInOptions
   });
 }
 

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -1,6 +1,5 @@
 import type { LarkDomain } from "@opentag/lark";
 import type { CliLanguage } from "../catalogs/languages.js";
-import type { ExecutorId } from "../catalogs/executors.js";
 import type { PlatformId } from "../catalogs/platforms.js";
 import type { SavedLarkCredentials } from "../platforms/lark/saved-config.js";
 
@@ -45,7 +44,7 @@ export type OpenTagSetupInput = {
   language: CliLanguage;
   platform: PlatformId;
   projectPath: string;
-  executor: ExecutorId;
+  executor: string;
   stateDirectory?: string;
   lark?: LarkSetupInput;
   slack?: SlackSetupInput;
@@ -56,7 +55,7 @@ export type SetupDefaults = Partial<{
   language: CliLanguage;
   platform: PlatformId;
   projectPath: string;
-  executor: ExecutorId;
+  executor: string;
   larkSetupMethod: LarkSetupMethod;
   larkDomain: LarkDomain;
   slackMode: SlackSetupMode;

--- a/packages/cli/src/ui/messages.ts
+++ b/packages/cli/src/ui/messages.ts
@@ -6,6 +6,7 @@ type MessageKey =
   | "language"
   | "platform"
   | "executor"
+  | "executorCustomHint"
   | "projectPath"
   | "larkSetup"
   | "larkDomain"
@@ -36,6 +37,7 @@ const MESSAGES: Record<CliLanguage, Record<MessageKey, string>> = {
     language: "Language / 语言",
     platform: "Where should OpenTag listen?",
     executor: "Which coding agent should OpenTag use?",
+    executorCustomHint: "Currently configured custom executor",
     projectPath: "Which project should OpenTag use?",
     larkSetup: "How should OpenTag connect to Lark / Feishu?",
     larkDomain: "Which Lark domain should OpenTag use?",
@@ -65,6 +67,7 @@ const MESSAGES: Record<CliLanguage, Record<MessageKey, string>> = {
     language: "Language / 语言",
     platform: "OpenTag 要监听哪个平台？",
     executor: "OpenTag 要使用哪个 coding agent？",
+    executorCustomHint: "当前配置的自定义执行器",
     projectPath: "OpenTag 要使用哪个项目？",
     larkSetup: "OpenTag 要如何连接 Lark / 飞书？",
     larkDomain: "OpenTag 要使用哪个 Lark 域名？",

--- a/packages/cli/test/setup-defaults.test.ts
+++ b/packages/cli/test/setup-defaults.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseCliConfig } from "../src/config.js";
+import { setupDefaultsFromConfig } from "../src/setup/defaults.js";
+
+function cliConfig(defaultExecutor: string) {
+  return parseCliConfig({
+    schemaVersion: 1,
+    state: {
+      directory: "/tmp/opentag-state",
+      databasePath: "/tmp/opentag-state/db.sqlite",
+      worktreeRoot: "/tmp/opentag-state/worktrees"
+    },
+    daemon: {
+      runnerId: "runner_local",
+      dispatcherUrl: "http://localhost:3030",
+      pairingToken: "pairing_token",
+      pollIntervalMs: 5000,
+      heartbeatIntervalMs: 15000,
+      repositories: [
+        {
+          provider: "github",
+          owner: "acme",
+          repo: "widgets",
+          checkoutPath: "/tmp/acme-widgets",
+          defaultExecutor,
+          baseBranch: "main",
+          pushRemote: "origin",
+          worktreeRoot: "/tmp/acme-widgets-worktrees",
+          keepWorktree: "on_failure"
+        }
+      ]
+    },
+    platforms: {}
+  });
+}
+
+describe("setupDefaultsFromConfig executor", () => {
+  it("preserves a custom executor so re-running setup does not silently overwrite it", () => {
+    // Regression: a custom executor must survive into the wizard defaults.
+    // Dropping it here caused re-running setup to overwrite it with a built-in.
+    expect(setupDefaultsFromConfig(cliConfig("custom-runner")).executor).toBe("custom-runner");
+  });
+
+  it("preserves a built-in executor", () => {
+    expect(setupDefaultsFromConfig(cliConfig("codex")).executor).toBe("codex");
+  });
+});

--- a/packages/cli/test/setup-defaults.test.ts
+++ b/packages/cli/test/setup-defaults.test.ts
@@ -44,4 +44,12 @@ describe("setupDefaultsFromConfig executor", () => {
   it("preserves a built-in executor", () => {
     expect(setupDefaultsFromConfig(cliConfig("codex")).executor).toBe("codex");
   });
+
+  it("normalizes a stored built-in executor before setup reuses it", () => {
+    expect(setupDefaultsFromConfig(cliConfig(" codex ")).executor).toBe("codex");
+  });
+
+  it("rejects whitespace-only stored executor ids", () => {
+    expect(() => cliConfig("   ")).toThrow();
+  });
 });

--- a/packages/cli/test/setup.test.ts
+++ b/packages/cli/test/setup.test.ts
@@ -78,6 +78,48 @@ describe("OpenTag CLI setup", () => {
     });
   });
 
+  it("normalizes a saved built-in executor before reusing setup defaults", async () => {
+    const configPath = join(tempDir(), "config.json");
+    const projectPath = tempDir();
+
+    await runSetupCommand(
+      {
+        config: configPath,
+        project: projectPath,
+        platform: "lark",
+        larkSetup: "manual",
+        larkDomain: "lark",
+        larkAppId: "cli_manual",
+        larkAppSecret: "secret_manual",
+        force: true,
+        yes: true
+      },
+      {
+        prompts: testPrompts(),
+        defaults: { executor: " codex " }
+      }
+    );
+
+    expect(readCliConfig(configPath).daemon.repositories[0].defaultExecutor).toBe("codex");
+  });
+
+  it("rejects whitespace-only saved executor defaults", async () => {
+    await expect(
+      runSetupCommand(
+        {
+          config: join(tempDir(), "config.json"),
+          platform: "lark",
+          force: true,
+          yes: true
+        },
+        {
+          prompts: testPrompts(),
+          defaults: { executor: "   " }
+        }
+      )
+    ).rejects.toThrow("Executor id must not be empty.");
+  });
+
   it("supports explicit manual Lark credentials", async () => {
     const configPath = join(tempDir(), "config.json");
 

--- a/packages/local-runtime/src/config.ts
+++ b/packages/local-runtime/src/config.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 
-const ExecutorSchema = z.enum(["echo", "codex", "claude-code"]);
+// Accept any non-empty executor id. The built-ins are echo, codex, and
+// claude-code, but custom executors registered by a standalone runner are
+// equally valid — config validation must not be stricter than the runtime
+// dispatch (which resolves executors by id) or the dispatcher wire contract
+// (executor: z.string().min(1)).
+const ExecutorSchema = z.string().min(1);
 const KeepWorktreeSchema = z.enum(["always", "on_failure", "never"]);
 const PositiveIntegerSchema = z.number().int().positive();
 

--- a/packages/local-runtime/src/config.ts
+++ b/packages/local-runtime/src/config.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 
-// Accept any non-empty executor id. The built-ins are echo, codex, and
+// Accept any trimmed non-empty executor id. The built-ins are echo, codex, and
 // claude-code, but custom executors registered by a standalone runner are
 // equally valid — config validation must not be stricter than the runtime
 // dispatch (which resolves executors by id) or the dispatcher wire contract
 // (executor: z.string().min(1)).
-const ExecutorSchema = z.string().min(1);
+const ExecutorSchema = z.string().trim().min(1);
 const KeepWorktreeSchema = z.enum(["always", "on_failure", "never"]);
 const PositiveIntegerSchema = z.number().int().positive();
 

--- a/packages/local-runtime/test/config.test.ts
+++ b/packages/local-runtime/test/config.test.ts
@@ -24,6 +24,13 @@ describe("parseDaemonConfig defaultExecutor", () => {
     expect(config.repositories[0].defaultExecutor).toBe("custom-runner");
   });
 
+  it("trims executor ids before storing them", () => {
+    const config = parseDaemonConfig({
+      repositories: [{ ...baseRepository, defaultExecutor: " custom-runner " }]
+    });
+    expect(config.repositories[0].defaultExecutor).toBe("custom-runner");
+  });
+
   it("defaults defaultExecutor to echo when omitted", () => {
     const config = parseDaemonConfig({ repositories: [{ ...baseRepository }] });
     expect(config.repositories[0].defaultExecutor).toBe("echo");
@@ -33,6 +40,14 @@ describe("parseDaemonConfig defaultExecutor", () => {
     expect(() =>
       parseDaemonConfig({
         repositories: [{ ...baseRepository, defaultExecutor: "" }]
+      })
+    ).toThrow();
+  });
+
+  it("rejects a whitespace-only executor id", () => {
+    expect(() =>
+      parseDaemonConfig({
+        repositories: [{ ...baseRepository, defaultExecutor: "   " }]
       })
     ).toThrow();
   });

--- a/packages/local-runtime/test/config.test.ts
+++ b/packages/local-runtime/test/config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseDaemonConfig } from "../src/config.js";
+
+const baseRepository = {
+  owner: "acme",
+  repo: "widgets",
+  checkoutPath: "/tmp/acme-widgets"
+};
+
+describe("parseDaemonConfig defaultExecutor", () => {
+  it("accepts the built-in executors", () => {
+    for (const executor of ["echo", "codex", "claude-code"]) {
+      const config = parseDaemonConfig({
+        repositories: [{ ...baseRepository, defaultExecutor: executor }]
+      });
+      expect(config.repositories[0].defaultExecutor).toBe(executor);
+    }
+  });
+
+  it("accepts a custom executor id so standalone runners can register their own", () => {
+    const config = parseDaemonConfig({
+      repositories: [{ ...baseRepository, defaultExecutor: "custom-runner" }]
+    });
+    expect(config.repositories[0].defaultExecutor).toBe("custom-runner");
+  });
+
+  it("defaults defaultExecutor to echo when omitted", () => {
+    const config = parseDaemonConfig({ repositories: [{ ...baseRepository }] });
+    expect(config.repositories[0].defaultExecutor).toBe("echo");
+  });
+
+  it("rejects an empty executor id", () => {
+    expect(() =>
+      parseDaemonConfig({
+        repositories: [{ ...baseRepository, defaultExecutor: "" }]
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

OpenTag's runtime resolves executors by id (the `local-runtime` daemon dispatch), and the dispatcher's wire contract already accepts `executor: z.string().min(1)`. But config validation is stricter: both `@opentag/local-runtime` and `@opentag/cli` validate a repository binding's `defaultExecutor` against `z.enum(["echo", "codex", "claude-code"])`.

So a custom executor the runtime fully supports (per `examples/custom-runner`) can't be registered through config — `parseDaemonConfig` / `parseCliConfig` reject it before the open runtime dispatch ever sees it.

## Fix

- Repository bindings accept any non-empty executor id (`z.string().min(1)`) in both the daemon and CLI config schemas. `echo`, `codex`, and `claude-code` remain the documented built-ins.
- Custom executors are also made first-class in the setup wizard: `SetupDefaults` / `OpenTagSetupInput` carry the executor as a string, and the wizard now **preserves** a configured custom executor instead of dropping it — which would otherwise silently overwrite it with an auto-detected built-in on an unrelated re-run. Adds an `isExecutorId` guard and removes the now-unused `parseExecutorId` helper.

## Tests

- `packages/local-runtime/test/config.test.ts` — built-in, custom, default, and empty-id cases.
- `packages/cli/test/setup-defaults.test.ts` — a custom executor survives `setupDefaultsFromConfig` (regression for the wizard-overwrite case).

Full suite green.

---

Co-authored with my AI coding agent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom (non-empty) executor IDs in both CLI and local runtime configuration.
  * Enhanced the setup flow to retain a previously selected custom executor and surface it with a dedicated UI hint.

* **Bug Fixes**
  * Prevented configured executor values (custom or built-in) from being overwritten on subsequent runs.
  * Continued to reject empty-string executor values while preserving built-in executor behavior.

* **Tests**
  * Added coverage for executor defaulting and preservation in setup defaults and daemon config parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->