### PR TITLE
fix(runner): guard executor stdin against EPIPE so an early-exiting child cannot crash the daemon

### DIFF
--- a/packages/runner/src/command.ts
+++ b/packages/runner/src/command.ts
@@ -34,6 +34,14 @@ export const nodeCommandRunner: CommandRunner = {
         });
       });
 
+      // A large prompt (larger than the OS pipe buffer, ~64KB) written to a
+      // child that exits or closes its stdin before the full write drains emits
+      // an EPIPE on the stdin stream. Without a listener that error is uncaught
+      // and crashes the long-lived local-runtime polling daemon. Swallow it: the
+      // child's exit/close is already handled above and is the authoritative
+      // signal here.
+      child.stdin.on("error", () => {});
+
       if (options.input) {
         child.stdin.write(options.input);
       }

--- a/packages/runner/test/command.test.ts
+++ b/packages/runner/test/command.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { nodeCommandRunner } from "../src/command.js";
+
+describe("nodeCommandRunner stdin EPIPE guard", () => {
+  it("resolves without an uncaught EPIPE when a large prompt is written to a child that closes stdin early", async () => {
+    // The child reads nothing and exits immediately, closing its stdin while a
+    // prompt larger than the OS pipe buffer (~64KB) is still draining. That
+    // combination — large input AND an early-exiting child — is what triggers
+    // the EPIPE on the writer side. A short prompt would fit in the buffer and
+    // never surface the error.
+    const largeInput = "x".repeat(1024 * 1024); // 1 MiB, well over the pipe buffer
+
+    let unhandled: unknown;
+    const onUnhandled = (err: unknown) => {
+      unhandled = err;
+    };
+    process.on("uncaughtException", onUnhandled);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const result = await nodeCommandRunner.run(
+        process.execPath,
+        ["-e", "process.exit(0)"],
+        { input: largeInput }
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      // Give the event loop a tick so any deferred EPIPE would surface.
+      await new Promise((r) => setTimeout(r, 25));
+      expect(unhandled).toBeUndefined();
+    } finally {
+      process.off("uncaughtException", onUnhandled);
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`nodeCommandRunner.run` in `packages/runner/src/command.ts` writes the executor input to `child.stdin` without an `error` listener on that stream.

When the input prompt is larger than the OS pipe buffer (~64KB) **and** the child process exits or closes its stdin before the write fully drains, Node emits an `EPIPE` error on the `child.stdin` stream. With no listener attached, that stream error is uncaught and propagates as an unhandled exception — which crashes the long-lived `local-runtime` polling daemon mid-poll.

Note the precise trigger: it takes **both** a large prompt (exceeding the pipe buffer) **and** an early-exiting/early-closing child. A short prompt fits entirely in the kernel buffer and never surfaces the error, and a child that drains the input cleanly is also fine.

## Fix

Attach a no-op `error` listener to `child.stdin` before writing:

```ts
child.stdin.on("error", () => {});
```

The child's `close`/`error` events on the process itself are already handled and are the authoritative completion signal, so the stdin write error can be safely swallowed. This converts a daemon-killing uncaught exception into a benign no-op while leaving the resolved/rejected result of the run unchanged.

## Tests

Adds a focused regression test in `packages/runner/test/command.test.ts` that writes a 1 MiB prompt to a child which exits immediately (`process.exit(0)`), then asserts the run resolves and no uncaught `EPIPE` surfaces on the process.

- Verified the test **fails** (uncaught `EPIPE`) when the fix is reverted, and **passes** with it.
- `pnpm build`: green.
- `pnpm test`: green — 352 tests passed across 51 files (was 351; this PR adds 1).

Co-authored with my AI coding agent.
