### PR TITLE
fix(apps): use randomUUID for runId to avoid same-millisecond primary-key collisions

### DIFF
--- a/apps/github-probot/src/app.ts
+++ b/apps/github-probot/src/app.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { createOpenTagClient, type ThreadActionInput } from "@opentag/client";
 import { parseThreadActionCommand, type OpenTagEvent } from "@opentag/core";
 import { normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment, renderAcknowledgement } from "@opentag/github";
@@ -135,9 +136,17 @@ export async function handlePullRequestReviewCommentCreated(input: {
   }
 }
 
+export function newRunId(): string {
+  // Use a unique id like every other ingress (slack/lark/github) already does.
+  // createRun only guards on eventId, not on the run's primary key, so a
+  // Date.now()-based id would collide for two distinct same-millisecond events
+  // and surface as a SQLITE_CONSTRAINT error (500 + dropped event).
+  return `run_${randomUUID()}`;
+}
+
 async function createDispatcherRun(input: { event: OpenTagEvent; log: { warn(data: unknown, message: string): void } }): Promise<{ runId?: string }> {
   const dispatcherUrl = process.env.OPENTAG_DISPATCHER_URL;
-  const runId = `run_${Date.now()}`;
+  const runId = newRunId();
   if (!dispatcherUrl) {
     input.log.warn({ runId, event: input.event }, "OPENTAG_DISPATCHER_URL is not set; run was not dispatched");
     return {};

--- a/apps/github-probot/test/app.test.ts
+++ b/apps/github-probot/test/app.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it, vi } from "vitest";
-import { handleIssueCommentCreated, handlePullRequestReviewCommentCreated } from "../src/app.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleIssueCommentCreated, handlePullRequestReviewCommentCreated, newRunId } from "../src/app.js";
+
+describe("newRunId", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("produces a unique id for distinct runs created in the same millisecond", () => {
+    // Freeze the clock: a Date.now()-based id would collide here, pass the
+    // eventId guard, then throw SQLITE_CONSTRAINT on the run primary key.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T00:00:00.000Z"));
+
+    const first = newRunId();
+    const second = newRunId();
+
+    expect(first).toMatch(/^run_/);
+    expect(second).toMatch(/^run_/);
+    expect(first).not.toBe(second);
+  });
+});
 
 describe("GitHub Probot handler", () => {
   it("creates a dispatcher run for an opentag mention", async () => {

--- a/apps/telegram-events/src/index.ts
+++ b/apps/telegram-events/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { serve } from "@hono/node-server";
 import { createOpenTagClient } from "@opentag/client";
 import { createTelegramEventsApp } from "./app.js";
@@ -89,7 +90,7 @@ serve({
       }
     },
     async createRun(event) {
-      const runId = `run_${Date.now()}`;
+      const runId = `run_${randomUUID()}`;
       await dispatcherClient.createRun({ runId, event });
       return { runId };
     },


### PR DESCRIPTION
## Problem

The `telegram-events` and `github-probot` ingresses generate their run id from the wall clock:

```ts
const runId = `run_${Date.now()}`;
```

`createRun` deduplicates on `eventId`, not on the run's primary key. So two *distinct* events that arrive within the same millisecond produce the same `runId`, sail past the `eventId` guard, and then collide on the run primary key — throwing `SQLITE_CONSTRAINT`. The caller sees a 500 and the second event is silently dropped.

This is the only place left using `Date.now()` for a run id; the slack, lark, and github ingress packages already use `randomUUID()`.

## Fix

Use a unique id like every other ingress already does:

- `apps/telegram-events/src/index.ts` and `apps/github-probot/src/app.ts` now build the id as `run_${randomUUID()}`, importing `randomUUID` from `node:crypto`.
- In `github-probot`, the generator is extracted into an exported `newRunId()` helper so the behavior can be unit-tested directly.

No behavior changes beyond the id source — the `run_` prefix and call sites are unchanged.

## Tests

- Added a focused regression test in `apps/github-probot/test/app.test.ts` that freezes the clock with fake timers and asserts two `newRunId()` calls in the same millisecond return distinct ids (the exact condition the old `Date.now()` id failed).
- `pnpm build` — green.
- `pnpm test` — green: 352 tests across 50 files pass (github-probot suite up from 7 to 8 tests with the new case).

The PR adds one test and does not modify any existing test.

Co-authored with my AI coding agent.
