### PR TITLE
fix(runner): parse git status --porcelain with -z for renames and quoted paths

### DIFF
--- a/packages/runner/src/git.ts
+++ b/packages/runner/src/git.ts
@@ -15,16 +15,44 @@ export function branchNameForRun(runId: string): string {
   return `opentag/${safeRunId}`;
 }
 
+// Git status command used by the helpers below. We use the NUL-delimited
+// porcelain form (`-z`) so that renamed/copied entries and paths containing
+// spaces, quotes, newlines, or unicode survive parsing intact. `-z` also
+// disables the quoting/escaping that the default newline form applies, and
+// `core.quotePath=false` keeps unicode bytes verbatim rather than \NNN escapes.
+export const STATUS_PORCELAIN_Z_ARGS = ["-c", "core.quotePath=false", "status", "--porcelain", "-z"];
+
+// Parses `git status --porcelain -z` output (NUL-delimited records).
+//
+// In the `-z` format each record is terminated by a NUL byte. For ordinary
+// entries a record is `XY <path>`. For rename ("R") and copy ("C") entries the
+// destination is emitted in the `XY <dest>` record and the source path follows
+// as a SEPARATE NUL-terminated record. We consume that following record as the
+// source and keep the destination as the changed path, so consumers never see
+// the literal `original -> renamed` arrow form that breaks `git add --`.
 export function parseStatusEntries(statusOutput: string): GitStatusEntry[] {
-  return statusOutput
-    .split("\n")
-    .map((line) => line.replace(/\r$/, ""))
-    .filter(Boolean)
-    .map((line) => ({
-      status: line.slice(0, 2),
-      path: line.slice(3).trim()
-    }))
-    .filter((entry) => entry.path.length > 0);
+  const records = statusOutput.split("\0");
+  const entries: GitStatusEntry[] = [];
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) continue;
+
+    const status = record.slice(0, 2);
+    const path = record.slice(3);
+
+    // Rename/copy records carry a trailing source record we must skip past so
+    // it is not mistaken for an independent change.
+    const isRenameOrCopy = status[0] === "R" || status[0] === "C";
+    if (isRenameOrCopy) {
+      index += 1;
+    }
+
+    if (path.length === 0) continue;
+    entries.push({ status, path });
+  }
+
+  return entries;
 }
 
 export function isInternalArtifactPath(path: string): boolean {
@@ -92,13 +120,13 @@ export async function deleteRunBranch(input: { runner: CommandRunner; workspaceP
 }
 
 export async function changedFiles(input: { runner: CommandRunner; workspacePath: string }): Promise<string[]> {
-  const result = await input.runner.run("git", ["status", "--porcelain"], { cwd: input.workspacePath });
+  const result = await input.runner.run("git", STATUS_PORCELAIN_Z_ARGS, { cwd: input.workspacePath });
   await assertCommandSucceeded(result, "read changed files");
   return parseChangedFiles(result.stdout);
 }
 
 export async function cleanupInternalArtifacts(input: { runner: CommandRunner; workspacePath: string }): Promise<string[]> {
-  const statusResult = await input.runner.run("git", ["status", "--porcelain"], { cwd: input.workspacePath });
+  const statusResult = await input.runner.run("git", STATUS_PORCELAIN_Z_ARGS, { cwd: input.workspacePath });
   await assertCommandSucceeded(statusResult, "scan internal artifacts");
   const untrackedRoots = Array.from(
     new Set(

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -11,17 +11,15 @@ describe("Claude Code executor", () => {
         if (command === "claude" && args.includes("--version")) {
           return { exitCode: 0, stdout: "1.0.0", stderr: "" };
         }
+        // The canRun dirty-check uses plain `status --porcelain`; the git
+        // helpers (cleanup + changedFiles) use the NUL-delimited `-z` form.
         if (command === "git" && args.join(" ") === "status --porcelain") {
-          return calls.length < 4
-            ? { exitCode: 0, stdout: "", stderr: "" }
-            : {
-                exitCode: 0,
-                stdout:
-                  calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .claude")
-                    ? " M src/demo.ts\n?? test/demo.test.ts\n"
-                    : "?? .claude/\n M src/demo.ts\n?? test/demo.test.ts\n",
-                stderr: ""
-              };
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
+          return calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .claude")
+            ? { exitCode: 0, stdout: " M src/demo.ts\0?? test/demo.test.ts\0", stderr: "" }
+            : { exitCode: 0, stdout: "?? .claude/\0 M src/demo.ts\0?? test/demo.test.ts\0", stderr: "" };
         }
         if (command === "git" && args[0] === "checkout") {
           return { exitCode: 0, stdout: "", stderr: "" };

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -23,15 +23,15 @@ describe("Codex executor", () => {
         if (command === "git" && args.join(" ") === "rev-parse --verify main^{commit}") {
           return { exitCode: 0, stdout: "abc123\n", stderr: "" };
         }
-        if (command === "git" && args.join(" ") === "status --porcelain") {
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
           return calls.length < 4
             ? { exitCode: 0, stdout: "", stderr: "" }
             : {
                 exitCode: 0,
                 stdout:
                   calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .omx")
-                    ? " M src/demo.ts\n?? test/demo.test.ts\n"
-                    : "?? .omx/\n M src/demo.ts\n?? test/demo.test.ts\n",
+                    ? " M src/demo.ts\0?? test/demo.test.ts\0"
+                    : "?? .omx/\0 M src/demo.ts\0?? test/demo.test.ts\0",
                 stderr: ""
               };
         }
@@ -158,7 +158,7 @@ describe("Codex executor", () => {
         if (command === "git" && args.join(" ") === "rev-parse --verify main^{commit}") {
           return { exitCode: 0, stdout: "abc123\n", stderr: "" };
         }
-        if (command === "git" && args.join(" ") === "status --porcelain") {
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
           return { exitCode: 0, stdout: "", stderr: "" };
         }
         if (command === "git" && args[0] === "worktree" && args[1] === "add") {
@@ -227,7 +227,31 @@ describe("Codex executor", () => {
 
 describe("git helpers", () => {
   it("parses porcelain changed files and filters internal artifacts", () => {
-    expect(parseChangedFiles("?? .omx/\n M src/demo.ts\n?? test/demo.test.ts\n")).toEqual(["src/demo.ts", "test/demo.test.ts"]);
+    expect(parseChangedFiles("?? .omx/\0 M src/demo.ts\0?? test/demo.test.ts\0")).toEqual(["src/demo.ts", "test/demo.test.ts"]);
+  });
+
+  it("keeps the rename destination and skips the source record", () => {
+    // `R  dest\0src\0` — porcelain -z emits the destination in the record and
+    // the source as a separate following NUL-terminated record.
+    expect(parseChangedFiles("R  src/new-name.ts\0src/old-name.ts\0")).toEqual(["src/new-name.ts"]);
+  });
+
+  it("parses copy records the same way as renames", () => {
+    expect(parseChangedFiles("C  src/copy.ts\0src/original.ts\0")).toEqual(["src/copy.ts"]);
+  });
+
+  it("preserves quoted and unicode paths verbatim under -z", () => {
+    // With `-z` and core.quotePath=false git emits raw bytes: no surrounding
+    // quotes, no escaping, and spaces inside the path are kept intact.
+    expect(parseChangedFiles(' M src/a file with spaces.ts\0?? "weird".ts\0 M café/résumé.ts\0')).toEqual([
+      "src/a file with spaces.ts",
+      '"weird".ts',
+      "café/résumé.ts"
+    ]);
+  });
+
+  it("handles a rename of a unicode path followed by an ordinary change", () => {
+    expect(parseChangedFiles("R  docs/náme.md\0docs/óld.md\0 M src/demo.ts\0")).toEqual(["docs/náme.md", "src/demo.ts"]);
   });
 
   it("sanitizes branch names", () => {
@@ -239,8 +263,8 @@ describe("git helpers", () => {
     const runner: CommandRunner = {
       async run(command, args) {
         calls.push(`${command} ${args.join(" ")}`);
-        if (command === "git" && args.join(" ") === "status --porcelain") {
-          return { exitCode: 0, stdout: " M src/demo.ts\n?? test/demo.test.ts\n", stderr: "" };
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
+          return { exitCode: 0, stdout: " M src/demo.ts\0?? test/demo.test.ts\0", stderr: "" };
         }
         return { exitCode: 0, stdout: "", stderr: "" };
       }
@@ -253,7 +277,7 @@ describe("git helpers", () => {
     });
 
     expect(calls).toEqual([
-      "git status --porcelain",
+      "git -c core.quotePath=false status --porcelain -z",
       "git add -- src/demo.ts test/demo.test.ts",
       "git commit -m OpenTag run run_1"
     ]);


### PR DESCRIPTION
## Problem

When a run renames a file, the commit step fails and the whole run errors out.

`packages/runner/src/git.ts` reads changed files by splitting `git status --porcelain` output on newlines. For a renamed (or copied) file, porcelain emits the entry as `R  original -> renamed` (a single line containing both paths joined by ` -> `). The parser took everything after the status code as the path, so the changed-file list contained the literal string `original -> renamed`. That string is then passed to `git add -- <paths>`, which fails:

```
fatal: pathspec 'original -> renamed' did not match any files
```

`git add` exits 128, `assertCommandSucceeded` throws, and the run errors at commit time — on the core dispatch path (`commitRunChanges` / `changedFiles` / `cleanupInternalArtifacts`).

As a secondary issue, the newline-split parser also mishandles paths containing spaces, quotes, newlines, or unicode, because the default porcelain format quotes/escapes such paths and `.trim()` could clip meaningful characters.

## Fix

Switch the git-status helpers to the NUL-delimited porcelain form and parse accordingly:

- Run `git -c core.quotePath=false status --porcelain -z`. The `-z` flag NUL-terminates each record and disables the quoting/escaping the newline format applies; `core.quotePath=false` keeps unicode bytes verbatim instead of `\NNN` escapes.
- Split the output on NUL bytes instead of newlines, and stop trimming the path (raw bytes are emitted verbatim under `-z`).
- Handle rename/copy records correctly: in `-z` format, a record whose status starts with `R` or `C` carries the **destination** path, and the **source** path follows as a **separate** NUL-terminated record. The parser consumes (and discards) that following source record and keeps the destination as the changed path — so consumers never see the `original -> renamed` arrow form.

This is applied to the three status invocations that feed `git add`: `changedFiles`, `cleanupInternalArtifacts`, and (transitively) `commitRunChanges`. The Claude Code executor's pre-flight "is the workspace dirty?" check is left on plain `status --porcelain` — it only tests for emptiness and never parses paths, so it is unaffected.

## Tests

I changed the shape of the git-status command, so the test mocks had to change with it — these are not unchanged:

- Updated the three `git status --porcelain` mocks in `packages/runner/test/codex.test.ts` to the new `-c core.quotePath=false status --porcelain -z` form and converted their fixture output from newline- to NUL-delimited, including the `commitRunChanges` call-sequence assertion.
- Updated the corresponding mocks in `packages/runner/test/claude-code.test.ts` (the executor shares the same git helpers), splitting the dirty-check call from the `-z` helper calls.
- Added parser tests covering: a rename record + its source record yielding only the destination, a copy record, a rename followed by an ordinary change, and quoted/space/unicode paths preserved verbatim under `-z`.

`pnpm build` and the full `pnpm test` suite both pass (50 test files, 355 tests).

Co-authored with my AI coding agent.
