### PR TITLE
[codex] Add Codex config doctor check and Slack tunnel docs

### DIFF
--- a/docs/platforms/slack.en.md
+++ b/docs/platforms/slack.en.md
@@ -102,17 +102,27 @@ Choose this mode when OpenTag has a stable public endpoint, or when you intentio
 - A Slack Bot User OAuth Token.
 - The target Slack channel where people will mention the app.
 
-For local testing, expose OpenTag with a tunnel:
+For local testing, expose OpenTag with a tunnel. Cloudflare Tunnel works well for quick manual tests:
+
+```bash
+cloudflared tunnel --url http://localhost:3040
+```
+
+ngrok works too:
 
 ```bash
 ngrok http 3040
 ```
+
+Keep the tunnel process running while you verify the Slack app. The free Cloudflare `trycloudflare.com` URL changes when you restart `cloudflared`, so update Slack's Request URL after each restart.
 
 Your Slack Request URL should look like:
 
 ```text
 https://<your-tunnel-host>/slack/events
 ```
+
+Do not use `http://localhost:3040/slack/events` as the Slack Request URL. Slack validates the URL from Slack's servers, so it must be a public HTTPS URL that forwards to your local OpenTag Slack ingress.
 
 ### Configure Events API
 
@@ -139,6 +149,12 @@ https://<your-tunnel-host>/slack/events
 Do not enable Socket Mode for this Events API setup.
 
 `message.channels` lets OpenTag receive thread replies such as `apply 1` in public channels. For private channels, also add the `groups:history` bot scope and subscribe to `message.groups`.
+
+If Slack says the Request URL did not respond with the challenge value, check these three things:
+
+1. `opentag start` or the Slack Events ingress is running locally on port `3040`.
+2. Your tunnel forwards to `http://localhost:3040`, not the dispatcher port.
+3. The Request URL in Slack ends with `/slack/events` and uses the current tunnel hostname.
 
 ## Find Team and Channel IDs
 

--- a/docs/platforms/slack.zh-CN.md
+++ b/docs/platforms/slack.zh-CN.md
@@ -102,17 +102,27 @@ Socket Mode 不需要填写 Request URL。`opentag start` 会主动连到 Slack 
 - Slack Bot User OAuth Token。
 - 一个用于测试的 Slack channel。
 
-本地测试时，可以先用 tunnel 暴露 OpenTag：
+本地测试时，可以先用 tunnel 暴露 OpenTag。Cloudflare Tunnel 很适合快速手动测试：
+
+```bash
+cloudflared tunnel --url http://localhost:3040
+```
+
+也可以用 ngrok：
 
 ```bash
 ngrok http 3040
 ```
+
+验证 Slack app 时，保持 tunnel 进程运行。免费的 Cloudflare `trycloudflare.com` 地址会在重启 `cloudflared` 后变化，所以每次重启 tunnel 后都要更新 Slack 里的 Request URL。
 
 Slack 的 Request URL 应该长这样：
 
 ```text
 https://<你的 tunnel 域名>/slack/events
 ```
+
+不要把 `http://localhost:3040/slack/events` 填进 Slack Request URL。Slack 会从 Slack 自己的服务器访问并验证这个 URL，所以它必须是一个会转发到本机 OpenTag Slack ingress 的公网 HTTPS URL。
 
 ### 配置 Events API
 
@@ -139,6 +149,12 @@ https://<你的 tunnel 域名>/slack/events
 这条 Events API 路线不要开启 Socket Mode，否则你会调错接入方式。
 
 `message.channels` 用来接收 public channel 里的 thread reply，比如用户回复 `apply 1`。如果你要在 private channel 里测试，还要添加 `groups:history` bot scope，并订阅 `message.groups`。
+
+如果 Slack 提示 Request URL 没有返回 challenge value，优先检查这三件事：
+
+1. `opentag start` 或 Slack Events ingress 正在本机 `3040` 端口运行。
+2. tunnel 转发的是 `http://localhost:3040`，不是 dispatcher 端口。
+3. Slack 里的 Request URL 以 `/slack/events` 结尾，并且使用的是当前 tunnel hostname。
 
 ## 找到 Team ID 和 Channel ID
 

--- a/docs/real-integration-smoke-test.md
+++ b/docs/real-integration-smoke-test.md
@@ -352,14 +352,22 @@ If Socket Mode is still enabled, Slack may give confusing signals in the dashboa
 Expose the Slack Events ingress port:
 
 ```bash
+cloudflared tunnel --url http://localhost:3040
+```
+
+ngrok works too:
+
+```bash
 ngrok http 3040
 ```
 
 Use the resulting public URL in Slack Event Subscriptions:
 
 ```text
-https://<ngrok-host>/slack/events
+https://<tunnel-host>/slack/events
 ```
+
+Do not use `http://localhost:3040/slack/events` in Slack. Slack validates the Request URL from Slack's servers, so the URL must be public HTTPS and must forward to the local Slack ingress port `3040`.
 
 ### Local Processes
 

--- a/packages/local-runtime/src/doctor.ts
+++ b/packages/local-runtime/src/doctor.ts
@@ -18,7 +18,9 @@ function check(status: DoctorCheckStatus, name: string, message: string): Doctor
   return { name, status, message };
 }
 
-const CODEX_SERVICE_TIERS = new Set(["fast", "flex"]);
+// Codex accepts built-in tiers (e.g. flex, fast), legacy request values (e.g. priority),
+// and catalog-provided tier IDs. OpenTag should not maintain a closed allowlist here.
+const CODEX_DEPRECATED_SERVICE_TIERS = new Set(["default"]);
 
 function defaultCodexConfigPath(): string {
   return join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "config.toml");
@@ -51,12 +53,12 @@ function checkCodexConfig(configPath = defaultCodexConfigPath()): DoctorCheck {
     return check("ok", "Codex config", `No service_tier override configured in ${configPath}`);
   }
 
-  const invalidTier = serviceTiers.find((tier) => !CODEX_SERVICE_TIERS.has(tier));
-  if (invalidTier) {
+  const deprecatedTier = serviceTiers.find((tier) => CODEX_DEPRECATED_SERVICE_TIERS.has(tier));
+  if (deprecatedTier) {
     return check(
       "fail",
       "Codex config",
-      `Unsupported service_tier '${invalidTier}' in ${configPath}. Use 'fast' or 'flex'.`
+      `Deprecated service_tier '${deprecatedTier}' in ${configPath}. Remove it or set a current Codex tier such as 'flex' or 'fast'.`
     );
   }
 

--- a/packages/local-runtime/src/doctor.ts
+++ b/packages/local-runtime/src/doctor.ts
@@ -1,4 +1,6 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { nodeCommandRunner, type CommandRunner, type ExecutorAdapter } from "@opentag/runner";
 import { createOpenTagClient } from "@opentag/client";
 import { normalizeChannelBindings } from "./config.js";
@@ -14,6 +16,51 @@ export type DoctorCheck = {
 
 function check(status: DoctorCheckStatus, name: string, message: string): DoctorCheck {
   return { name, status, message };
+}
+
+const CODEX_SERVICE_TIERS = new Set(["fast", "flex"]);
+
+function defaultCodexConfigPath(): string {
+  return join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "config.toml");
+}
+
+function parseCodexServiceTiers(configText: string): string[] {
+  return [...configText.matchAll(/^\s*service_tier\s*=\s*["']([^"']+)["']\s*$/gm)]
+    .map((match) => match[1])
+    .filter((value): value is string => Boolean(value));
+}
+
+function shouldCheckCodexConfig(config: OpenTagDaemonConfig): boolean {
+  return config.repositories.some((repository) => repository.defaultExecutor === "codex");
+}
+
+function checkCodexConfig(configPath = defaultCodexConfigPath()): DoctorCheck {
+  if (!existsSync(configPath)) {
+    return check("ok", "Codex config", `No Codex config file found at ${configPath}; CLI defaults will be used`);
+  }
+
+  let configText: string;
+  try {
+    configText = readFileSync(configPath, "utf8");
+  } catch (error) {
+    return check("fail", "Codex config", error instanceof Error ? error.message : String(error));
+  }
+
+  const serviceTiers = parseCodexServiceTiers(configText);
+  if (!serviceTiers.length) {
+    return check("ok", "Codex config", `No service_tier override configured in ${configPath}`);
+  }
+
+  const invalidTier = serviceTiers.find((tier) => !CODEX_SERVICE_TIERS.has(tier));
+  if (invalidTier) {
+    return check(
+      "fail",
+      "Codex config",
+      `Unsupported service_tier '${invalidTier}' in ${configPath}. Use 'fast' or 'flex'.`
+    );
+  }
+
+  return check("ok", "Codex config", `service_tier=${serviceTiers.join(", ")}`);
 }
 
 async function checkGitCheckout(input: {
@@ -84,6 +131,7 @@ export async function runDoctor(input: {
   executors: Record<string, ExecutorAdapter>;
   fetchImpl?: typeof fetch;
   commandRunner?: CommandRunner;
+  codexConfigPath?: string;
 }): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
   const commandRunner = input.commandRunner ?? nodeCommandRunner;
@@ -110,6 +158,10 @@ export async function runDoctor(input: {
 
   if (!input.config.repositories.length) {
     checks.push(check("fail", "repository config", "No repositories are configured."));
+  }
+
+  if (shouldCheckCodexConfig(input.config)) {
+    checks.push(checkCodexConfig(input.codexConfigPath));
   }
 
   for (const repository of input.config.repositories) {

--- a/packages/local-runtime/src/doctor.ts
+++ b/packages/local-runtime/src/doctor.ts
@@ -25,8 +25,8 @@ function defaultCodexConfigPath(): string {
 }
 
 function parseCodexServiceTiers(configText: string): string[] {
-  return [...configText.matchAll(/^\s*service_tier\s*=\s*["']([^"']+)["']\s*$/gm)]
-    .map((match) => match[1])
+  return [...configText.matchAll(/^\s*service_tier\s*=\s*(?:"([^"]+)"|'([^']+)')(?:\s*#.*)?\s*$/gm)]
+    .map((match) => match[1] ?? match[2])
     .filter((value): value is string => Boolean(value));
 }
 

--- a/packages/local-runtime/test/doctor.test.ts
+++ b/packages/local-runtime/test/doctor.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { CommandRunner, ExecutorAdapter } from "@opentag/runner";
+import { doctorHasFailures, formatDoctorChecks, runDoctor } from "../src/doctor.js";
+
+const commandRunner: CommandRunner = {
+  async run(command, args) {
+    if (command === "git" && args.join(" ") === "rev-parse --is-inside-work-tree") {
+      return { exitCode: 0, stdout: "true\n", stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+  }
+};
+
+const codexExecutor: ExecutorAdapter = {
+  id: "codex",
+  displayName: "Codex Executor",
+  async canRun() {
+    return { ready: true };
+  },
+  async run() {
+    throw new Error("not used in doctor tests");
+  },
+  async cancel() {}
+};
+
+async function runCodexDoctor(codexConfig: string) {
+  const root = mkdtempSync(join(tmpdir(), "opentag-local-runtime-doctor-"));
+  const checkoutPath = join(root, "demo");
+  const codexConfigPath = join(root, "codex-config.toml");
+  mkdirSync(checkoutPath, { recursive: true });
+  writeFileSync(join(checkoutPath, ".git"), "gitdir: /tmp/fake-git\n");
+  writeFileSync(codexConfigPath, codexConfig);
+
+  try {
+    return await runDoctor({
+      config: {
+        runnerId: "runner_local",
+        dispatcherUrl: "http://dispatcher.test",
+        repositories: [
+          {
+            provider: "github",
+            owner: "acme",
+            repo: "demo",
+            checkoutPath,
+            defaultExecutor: "codex",
+            baseBranch: "main",
+            pushRemote: "origin",
+            keepWorktree: "on_failure"
+          }
+        ],
+        githubToken: "ghs_test",
+        pollIntervalMs: 5000,
+        heartbeatIntervalMs: 15000
+      },
+      executors: { codex: codexExecutor },
+      commandRunner,
+      codexConfigPath,
+      fetchImpl: async (url) => {
+        const stringUrl = String(url);
+        if (stringUrl.endsWith("/healthz")) {
+          return Response.json({ ok: true });
+        }
+        if (stringUrl.endsWith("/v1/runners/runner_local")) {
+          return Response.json({
+            runner: { runnerId: "runner_local", name: "Local Runner", createdAt: "2026-06-24T00:00:00.000Z" }
+          });
+        }
+        if (stringUrl.endsWith("/v1/repo-bindings/github/acme/demo")) {
+          return Response.json({
+            binding: {
+              provider: "github",
+              owner: "acme",
+              repo: "demo",
+              runnerId: "runner_local",
+              workspacePath: checkoutPath,
+              defaultExecutor: "codex"
+            }
+          });
+        }
+        return new Response("not found", { status: 404 });
+      }
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("local-runtime doctor", () => {
+  it("passes when the Codex service tier is supported", async () => {
+    const checks = await runCodexDoctor('service_tier = "fast"\n');
+
+    expect(doctorHasFailures(checks)).toBe(false);
+    expect(formatDoctorChecks(checks)).toContain("OK   Codex config: service_tier=fast");
+  });
+
+  it("fails when the Codex service tier is unsupported", async () => {
+    const checks = await runCodexDoctor('service_tier = "default"\n');
+
+    expect(doctorHasFailures(checks)).toBe(true);
+    expect(formatDoctorChecks(checks)).toContain("FAIL Codex config: Unsupported service_tier 'default'");
+  });
+});

--- a/packages/local-runtime/test/doctor.test.ts
+++ b/packages/local-runtime/test/doctor.test.ts
@@ -96,10 +96,24 @@ describe("local-runtime doctor", () => {
     expect(formatDoctorChecks(checks)).toContain("OK   Codex config: service_tier=fast");
   });
 
-  it("fails when the Codex service tier is unsupported", async () => {
+  it("fails when the Codex service tier is a known deprecated value", async () => {
     const checks = await runCodexDoctor("service_tier = 'default' # old setting\n");
 
     expect(doctorHasFailures(checks)).toBe(true);
-    expect(formatDoctorChecks(checks)).toContain("FAIL Codex config: Unsupported service_tier 'default'");
+    expect(formatDoctorChecks(checks)).toContain("FAIL Codex config: Deprecated service_tier 'default'");
+  });
+
+  it("passes when the Codex service tier is priority", async () => {
+    const checks = await runCodexDoctor('service_tier = "priority"\n');
+
+    expect(doctorHasFailures(checks)).toBe(false);
+    expect(formatDoctorChecks(checks)).toContain("OK   Codex config: service_tier=priority");
+  });
+
+  it("passes when the Codex service tier is a catalog-provided id", async () => {
+    const checks = await runCodexDoctor('service_tier = "acme-enterprise-tier"\n');
+
+    expect(doctorHasFailures(checks)).toBe(false);
+    expect(formatDoctorChecks(checks)).toContain("OK   Codex config: service_tier=acme-enterprise-tier");
   });
 });

--- a/packages/local-runtime/test/doctor.test.ts
+++ b/packages/local-runtime/test/doctor.test.ts
@@ -90,14 +90,14 @@ async function runCodexDoctor(codexConfig: string) {
 
 describe("local-runtime doctor", () => {
   it("passes when the Codex service tier is supported", async () => {
-    const checks = await runCodexDoctor('service_tier = "fast"\n');
+    const checks = await runCodexDoctor('service_tier = "fast" # use the low-latency tier\n');
 
     expect(doctorHasFailures(checks)).toBe(false);
     expect(formatDoctorChecks(checks)).toContain("OK   Codex config: service_tier=fast");
   });
 
   it("fails when the Codex service tier is unsupported", async () => {
-    const checks = await runCodexDoctor('service_tier = "default"\n');
+    const checks = await runCodexDoctor("service_tier = 'default' # old setting\n");
 
     expect(doctorHasFailures(checks)).toBe(true);
     expect(formatDoctorChecks(checks)).toContain("FAIL Codex config: Unsupported service_tier 'default'");


### PR DESCRIPTION
## Summary
- add a Codex config doctor check that flags unsupported `service_tier` values before executor runs
- document Cloudflare Tunnel/ngrok Slack Events API Request URL setup and localhost pitfalls
- add local-runtime doctor coverage for supported and unsupported Codex service tiers

## Validation
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @opentag/local-runtime... build`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @opentag/local-runtime lint`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run packages/local-runtime/test/doctor.test.ts apps/opentagd/test/doctor.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run packages/cli/test/docs-contract.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the local runtime “doctor” to validate Codex configuration by checking `service_tier` values and reporting deprecated tiers; supports an optional custom Codex config path.
* **Bug Fixes**
  * Improved Slack Events API setup guidance to require a public HTTPS Request URL (not localhost) and added troubleshooting for failed challenge verification.
* **Documentation**
  * Updated Slack Public Events API and smoke test docs with Cloudflare Tunnel (and ngrok) examples and clarified forwarding expectations.
* **Tests**
  * Added/expanded Vitest coverage for Codex health check pass/fail scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->