### PR TITLE
Handle worktree-side porcelain rename records

### DIFF
--- a/packages/runner/src/git.ts
+++ b/packages/runner/src/git.ts
@@ -42,8 +42,9 @@ export function parseStatusEntries(statusOutput: string): GitStatusEntry[] {
     const path = record.slice(3);
 
     // Rename/copy records carry a trailing source record we must skip past so
-    // it is not mistaken for an independent change.
-    const isRenameOrCopy = status[0] === "R" || status[0] === "C";
+    // it is not mistaken for an independent change. Git's XY status can put
+    // rename/copy in either column (index or worktree), so check both.
+    const isRenameOrCopy = status.includes("R") || status.includes("C");
     if (isRenameOrCopy) {
       index += 1;
     }

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -240,6 +240,14 @@ describe("git helpers", () => {
     expect(parseChangedFiles("C  src/copy.ts\0src/original.ts\0")).toEqual(["src/copy.ts"]);
   });
 
+  it("keeps the worktree-side rename destination and skips the source record", () => {
+    expect(parseChangedFiles(" R src/new-name.ts\0src/old-name.ts\0")).toEqual(["src/new-name.ts"]);
+  });
+
+  it("parses worktree-side copy records the same way as index-side copies", () => {
+    expect(parseChangedFiles(" C src/copy.ts\0src/original.ts\0")).toEqual(["src/copy.ts"]);
+  });
+
   it("preserves quoted and unicode paths verbatim under -z", () => {
     // With `-z` and core.quotePath=false git emits raw bytes: no surrounding
     // quotes, no escaping, and spaces inside the path are kept intact.


### PR DESCRIPTION
## Summary
- Treat Git porcelain `R`/`C` status in either XY column when parsing `status --porcelain -z` output.
- Add regression coverage for worktree-side rename and copy records (` R` / ` C`) so the source record is consumed instead of being misparsed as another changed path.

## Context
Follow-up to #49 after review noted that Git's porcelain XY status can report rename/copy in the worktree column as well as the index column.

## Verification
- `corepack pnpm exec vitest run packages/runner/test/codex.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test`
- `corepack pnpm lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Git rename/copy status entries so renamed or copied files are recognized more reliably in different status formats.
  * Fixed parsing of worktree-side rename records so the final file path is preserved correctly.

* **Tests**
  * Added coverage for an additional rename scenario to verify the parser handles this format as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->