### PR TITLE
docs: add opentag.im link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 # OpenTag
 
+**[opentag.im](https://opentag.im)**
+
 **Connect Slack, GitHub, or Lark to a local coding agent.**
 
 [![Release](https://img.shields.io/github/v/release/amplifthq/opentag?include_prereleases&label=release)](https://github.com/amplifthq/opentag/releases)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,8 @@
 
 # OpenTag
 
+**[opentag.im](https://opentag.im)**
+
 **把 Slack、GitHub 或 Lark 连接到你本地的 coding agent。**
 
 [![Release](https://img.shields.io/github/v/release/amplifthq/opentag?include_prereleases&label=release)](https://github.com/amplifthq/opentag/releases)


### PR DESCRIPTION
## Summary
- Add official website link [opentag.im](https://opentag.im) above the README tagline in English and Chinese READMEs.

## Test plan
- [x] Visual check of README rendering on GitHub

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a visible `opentag.im` link under the OpenTag heading/logo area in both the English and Chinese README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->