### PR TITLE
Make Slack source-thread actions button-driven

### DIFF
--- a/apps/slack-events/test/app.test.ts
+++ b/apps/slack-events/test/app.test.ts
@@ -171,6 +171,109 @@ describe("Slack events app", () => {
     });
   });
 
+  it("submits source-thread actions from Slack Block Kit buttons", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_1" }));
+    const submitThreadAction = vi.fn(async () => ({}));
+    const interactivePayload = {
+      type: "block_actions",
+      api_app_id: "A_GEMINI",
+      team: { id: "T123" },
+      user: { id: "U456", username: "alice" },
+      channel: { id: "C123" },
+      message: {
+        ts: `${currentTimestamp}.000500`,
+        thread_ts: `${currentTimestamp}.000100`
+      },
+      container: {
+        type: "message",
+        channel_id: "C123",
+        message_ts: `${currentTimestamp}.000500`,
+        thread_ts: `${currentTimestamp}.000100`
+      },
+      trigger_id: "trigger_apply_1",
+      actions: [
+        {
+          type: "button",
+          action_id: "opentag:apply:1",
+          block_id: "opentag_actions_1",
+          value: JSON.stringify({
+            version: 1,
+            command: "apply 1",
+            proposalId: "proposal_1",
+            intentId: "intent_label_1"
+          }),
+          action_ts: `${currentTimestamp}.000600`
+        }
+      ]
+    };
+    const rawBody = new URLSearchParams({ payload: JSON.stringify(interactivePayload) }).toString();
+    const timestamp = currentTimestamp;
+    const app = createSlackEventsApp({
+      slackApps: [
+        {
+          appId: "A_GEMINI",
+          signingSecret: "secret",
+          agentId: "gemini",
+          callbackUri: "http://127.0.0.1:3102/slack-callback"
+        }
+      ],
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      createRun,
+      submitThreadAction,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": computeSlackSignature({
+          signingSecret: "secret",
+          timestamp,
+          rawBody
+        })
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    expect(createRun).not.toHaveBeenCalled();
+    expect(submitThreadAction).toHaveBeenCalledWith({
+      id: "approval_slack_block_trigger_apply_1",
+      rawText: "apply 1",
+      actor: {
+        provider: "slack",
+        providerUserId: "U456",
+        handle: "alice",
+        organizationId: "T123"
+      },
+      callback: {
+        provider: "slack",
+        uri: "http://127.0.0.1:3102/slack-callback",
+        threadKey: `T123|C123|${currentTimestamp}.000100`
+      },
+      metadata: {
+        source: "slack_button",
+        teamId: "T123",
+        channelId: "C123",
+        messageTs: `${currentTimestamp}.000500`,
+        slackAppId: "A_GEMINI",
+        actionId: "opentag:apply:1",
+        blockId: "opentag_actions_1",
+        actionTs: `${currentTimestamp}.000600`,
+        proposalId: "proposal_1",
+        intentId: "intent_label_1",
+        repoProvider: "github",
+        owner: "acme",
+        repo: "demo"
+      }
+    });
+  });
+
   it("ignores plain non-action messages before resolving channel bindings", async () => {
     const resolveChannelBinding = vi.fn(async () => ({ teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" }));
     const createRun = vi.fn(async () => ({ runId: "run_1" }));

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,6 +272,15 @@ on the dispatcher. That avoids duplicate acknowledgement comments.
 
 The legacy `apps/slack-events` process is still an Events API ingress only.
 
+Slack suggested action buttons require **Interactivity & Shortcuts** in the Slack
+app:
+
+- Socket Mode: turn Interactivity on, but do not set a Request URL. Slack sends
+  Block Kit actions over the Socket Mode WebSocket.
+- Events API: turn Interactivity on and set its Request URL to the same public
+  `/slack/events` URL used by Event Subscriptions, for example
+  `https://<your-tunnel>/slack/events`.
+
 | Variable | Required | Notes |
 | --- | --- | --- |
 | `OPENTAG_DISPATCHER_URL` | yes | Dispatcher URL |

--- a/docs/platforms/slack.en.md
+++ b/docs/platforms/slack.en.md
@@ -11,12 +11,15 @@ Both modes support the same core product flow: mention the Slack app, let OpenTa
 
 Slack-only setup proves the Slack loop. It does not by itself grant GitHub write access. If a run proposes a pull request action, `apply 1` can create a GitHub PR only when OpenTag also has a GitHub repository target and GitHub token configured.
 
+Suggested action buttons use Slack Block Kit interactivity. Enable **Interactivity & Shortcuts** in the Slack app so buttons such as **Apply 1** can submit the same source-thread action as a typed `apply 1` reply.
+
 ## Official Links
 
 - [Slack app settings](https://api.slack.com/apps)
 - [Slack app quickstart](https://docs.slack.dev/quickstart/)
 - [Using Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode/)
 - [Verifying requests from Slack](https://docs.slack.dev/authentication/verifying-requests-from-slack/)
+- [Slack interactivity](https://api.slack.com/interactivity)
 - [Slack OAuth scopes](https://api.slack.com/scopes)
 
 ## Recommended: Local Socket Mode
@@ -41,7 +44,7 @@ Choose this mode when you want `opentag start` on your computer to receive Slack
 If Slack offers **Create from manifest**, that is the fastest path. Use a manifest with:
 
 - Socket Mode enabled.
-- Bot scopes: `app_mentions:read`, `chat:write`, `channels:history`.
+- Bot scopes: `app_mentions:read`, `chat:write`, `reactions:write`, `channels:history`.
 - Bot event subscriptions: `app_mention`, `message.channels`.
 
 You still need to install the app and create the App-Level Token in the steps below.
@@ -67,6 +70,7 @@ Slack App-Level Token
 2. Under **Bot Token Scopes**, add:
    - `app_mentions:read`
    - `chat:write`
+   - `reactions:write`
    - `channels:history`
 3. Install or reinstall the app to your workspace.
 4. Copy **Bot User OAuth Token**. It starts with `xoxb-`.
@@ -89,6 +93,15 @@ Slack Bot User OAuth Token
 Do not enter a Request URL for Socket Mode. Slack delivers the event through the WebSocket connection opened by `opentag start`.
 
 `message.channels` lets OpenTag receive thread replies such as `apply 1` in public channels. For private channels, also add the `groups:history` bot scope and subscribe to `message.groups`.
+
+### Enable Interactivity For Buttons
+
+1. In the same Slack app, go to **Interactivity & Shortcuts**.
+2. Turn **Interactivity** on.
+3. Do not enter a Request URL for Socket Mode. Slack sends Block Kit button actions over the same Socket Mode WebSocket connection.
+4. Save changes.
+
+This is what makes Slack buttons such as **Apply 1**, **Approve**, and **Reject** work. If Interactivity is off, OpenTag can still receive typed thread replies like `apply 1`, but clicking a button will fail in Slack before it reaches OpenTag.
 
 ## Advanced: Public Events API
 
@@ -131,6 +144,7 @@ Do not use `http://localhost:3040/slack/events` as the Slack Request URL. Slack 
 3. Go to **OAuth & Permissions** and add the same bot scopes:
    - `app_mentions:read`
    - `chat:write`
+   - `reactions:write`
    - `channels:history`
 4. Install or reinstall the app.
 5. Go to **Event Subscriptions**.
@@ -146,9 +160,23 @@ https://<your-tunnel-host>/slack/events
    - `message.channels`
 9. Save changes.
 
+### Configure Interactivity For Buttons
+
+1. In the same Slack app, go to **Interactivity & Shortcuts**.
+2. Turn **Interactivity** on.
+3. Paste the same public Request URL:
+
+```text
+https://<your-tunnel-host>/slack/events
+```
+
+4. Save changes.
+
 Do not enable Socket Mode for this Events API setup.
 
 `message.channels` lets OpenTag receive thread replies such as `apply 1` in public channels. For private channels, also add the `groups:history` bot scope and subscribe to `message.groups`.
+
+Use the same `/slack/events` URL for **Event Subscriptions** and **Interactivity & Shortcuts**. OpenTag verifies the Slack signature for both request types, then routes button clicks into the same `/v1/thread-actions` flow used by typed replies.
 
 If Slack says the Request URL did not respond with the challenge value, check these three things:
 
@@ -203,5 +231,13 @@ Then mention the app in the bound channel:
 ```
 
 OpenTag should acknowledge the request and later reply in the same Slack thread.
+By default, the acknowledgement is a lightweight `eyes` reaction on your source message instead of a new thread reply.
+
+When OpenTag posts suggested actions, click **Apply 1** in Slack or type `apply 1` in the thread. Both paths apply the same source-thread action.
 
 If the reply includes a pull request action, but your config only contains Slack credentials, OpenTag will continue with a follow-up run instead of creating the GitHub PR directly. Configure GitHub as a repository target before expecting Slack `apply 1` replies to create PRs.
+
+If suggested action buttons are visible but clicking them shows an error in Slack, re-check **Interactivity & Shortcuts**:
+
+- Socket Mode: Interactivity is on, and no Request URL is required.
+- Events API: Interactivity is on, and the Request URL is `https://<your-tunnel-host>/slack/events`.

--- a/docs/platforms/slack.zh-CN.md
+++ b/docs/platforms/slack.zh-CN.md
@@ -11,12 +11,15 @@ OpenTag 支持两种 Slack 连接方式：
 
 Slack-only setup 证明的是 Slack 这条链路。它不会自动获得 GitHub 写权限。如果某次 run 产出了 pull request action，只有在 OpenTag 同时配置了 GitHub repository target 和 GitHub token 时，Slack thread 里的 `apply 1` 才能直接创建 GitHub PR。
 
+Suggested action 按钮依赖 Slack Block Kit interactivity。需要在 Slack app 里开启 **Interactivity & Shortcuts**，这样 **Apply 1** 这类按钮才会提交和手动回复 `apply 1` 相同的 source-thread action。
+
 ## 官方入口
 
 - [Slack App 管理页](https://api.slack.com/apps)
 - [Slack App Quickstart](https://docs.slack.dev/quickstart/)
 - [Using Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode/)
 - [Verifying requests from Slack](https://docs.slack.dev/authentication/verifying-requests-from-slack/)
+- [Slack interactivity](https://api.slack.com/interactivity)
 - [Slack OAuth scopes](https://api.slack.com/scopes)
 
 ## 推荐：本地 Socket Mode
@@ -41,7 +44,7 @@ Slack-only setup 证明的是 Slack 这条链路。它不会自动获得 GitHub 
 如果 Slack 提供 **Create from manifest**，这条路更快。Manifest 里一次性配置：
 
 - 开启 Socket Mode。
-- Bot scopes: `app_mentions:read`, `chat:write`, `channels:history`。
+- Bot scopes: `app_mentions:read`, `chat:write`, `reactions:write`, `channels:history`。
 - Bot event subscriptions: `app_mention`, `message.channels`。
 
 后面仍然需要安装 app，并创建 App-Level Token。
@@ -67,6 +70,7 @@ Slack App-Level Token
 2. 在 **Bot Token Scopes** 里添加：
    - `app_mentions:read`
    - `chat:write`
+   - `reactions:write`
    - `channels:history`
 3. 安装或重新安装 app 到 workspace。
 4. 复制 **Bot User OAuth Token**。它一般以 `xoxb-` 开头。
@@ -89,6 +93,15 @@ Slack Bot User OAuth Token
 Socket Mode 不需要填写 Request URL。`opentag start` 会主动连到 Slack WebSocket，Slack 会通过这条连接把事件推回来。
 
 `message.channels` 用来接收 public channel 里的 thread reply，比如用户回复 `apply 1`。如果你要在 private channel 里测试，还要添加 `groups:history` bot scope，并订阅 `message.groups`。
+
+### 开启按钮交互
+
+1. 在同一个 Slack app 里进入 **Interactivity & Shortcuts**。
+2. 打开 **Interactivity**。
+3. Socket Mode 不需要填写 Request URL。Slack 会通过同一条 Socket Mode WebSocket 连接发送 Block Kit button action。
+4. 保存设置。
+
+这一步会让 Slack 里的 **Apply 1**、**Approve**、**Reject** 按钮真正可用。如果没有开启 Interactivity，OpenTag 仍然可以接收用户手打的 `apply 1` thread reply，但点击按钮会在 Slack 侧失败，事件不会到达 OpenTag。
 
 ## 高级：公网 Events API
 
@@ -131,6 +144,7 @@ https://<你的 tunnel 域名>/slack/events
 3. 进入 **OAuth & Permissions**，添加同样的 bot scopes：
    - `app_mentions:read`
    - `chat:write`
+   - `reactions:write`
    - `channels:history`
 4. 安装或重新安装 app。
 5. 进入 **Event Subscriptions**。
@@ -146,9 +160,23 @@ https://<你的 tunnel 域名>/slack/events
    - `message.channels`
 9. 保存设置。
 
+### 配置按钮交互
+
+1. 在同一个 Slack app 里进入 **Interactivity & Shortcuts**。
+2. 打开 **Interactivity**。
+3. 填入同一个公网 Request URL：
+
+```text
+https://<你的 tunnel 域名>/slack/events
+```
+
+4. 保存设置。
+
 这条 Events API 路线不要开启 Socket Mode，否则你会调错接入方式。
 
 `message.channels` 用来接收 public channel 里的 thread reply，比如用户回复 `apply 1`。如果你要在 private channel 里测试，还要添加 `groups:history` bot scope，并订阅 `message.groups`。
+
+**Event Subscriptions** 和 **Interactivity & Shortcuts** 都使用同一个 `/slack/events` URL。OpenTag 会对两类请求都做 Slack 签名校验，然后把按钮点击转成和手动回复相同的 `/v1/thread-actions` 流程。
 
 如果 Slack 提示 Request URL 没有返回 challenge value，优先检查这三件事：
 
@@ -203,5 +231,13 @@ opentag start
 ```
 
 OpenTag 应该会先确认收到请求，执行完成后再回到同一个 Slack thread 里回复。
+默认确认方式是在你的源消息上加一个轻量的 `eyes` reaction，而不是额外发一条 thread reply。
+
+当 OpenTag 发出 suggested actions 时，可以在 Slack 里点击 **Apply 1**，也可以在线程里手动回复 `apply 1`。两种方式都会应用同一个 source-thread action。
 
 如果回复里出现 pull request action，但你的配置里只有 Slack 凭据，OpenTag 会创建一个 follow-up run，而不是直接创建 GitHub PR。想让 Slack 里的 `apply 1` 直接创建 PR，需要先配置 GitHub repository target。
+
+如果 suggested action 按钮能看到，但点击后 Slack 提示失败，优先检查 **Interactivity & Shortcuts**：
+
+- Socket Mode：Interactivity 已开启，不需要 Request URL。
+- Events API：Interactivity 已开启，Request URL 是 `https://<你的 tunnel 域名>/slack/events`。

--- a/docs/real-integration-smoke-test.md
+++ b/docs/real-integration-smoke-test.md
@@ -416,7 +416,7 @@ Expected result:
 - dispatcher creates a run
 - daemon claims and executes the run
 - the Slack thread receives:
-  - acknowledgement
+  - reaction receipt (`eyes`)
   - final result
 
 Routine progress should be visible in dispatcher audit events, not as Slack replies.

--- a/docs/real-integration-smoke-test.md
+++ b/docs/real-integration-smoke-test.md
@@ -314,12 +314,12 @@ Slack thread -> dispatcher -> opentagd -> local Claude Code -> pushed run branch
 Expected Slack thread shape:
 
 - original user/bot seed message
-- OpenTag acknowledgement
+- OpenTag `eyes` reaction receipt on the source message
 - OpenTag final result
 - optional `apply 1` reply when validating the action loop
 - optional apply result callback containing the PR URL or child-run fallback context
 
-Routine progress stays audit-only by default, so it should not produce additional Slack thread replies.
+Routine acknowledgement and progress stay out of Slack thread replies by default, so they should not produce additional Slack messages.
 
 ### Slack Events API App Setup
 
@@ -327,6 +327,7 @@ Required bot scopes:
 
 - `app_mentions:read`
 - `chat:write`
+- `reactions:write`
 
 Required bot event:
 
@@ -457,7 +458,7 @@ Important fields:
 - `childRunCount`
 - `applyOutcomeCounts`
 
-For Slack, `humanCallbackCount` should normally be `2` for a completed run: acknowledgement plus final. A low `threadNoiseRatio` means OpenTag is recording detail in audit without flooding the human thread.
+For Slack, `humanCallbackCount` should normally be `1` for a completed run: the final callback. The source receipt is a reaction, and routine progress stays audit-only. A low `threadNoiseRatio` means OpenTag is recording detail in audit without flooding the human thread.
 
 ## Dogfood Trace: Thread-Native Action Loop
 

--- a/examples/github-to-echo/README.md
+++ b/examples/github-to-echo/README.md
@@ -172,5 +172,6 @@ Example config fragment:
 }
 ```
 
-3. Point Slack Events API to `/slack/events` on `apps/slack-events`.
-4. Send an `app_mention` in the bound channel. OpenTag will acknowledge, stream progress, and post the final summary back to that Slack thread.
+3. Point Slack **Event Subscriptions** to `/slack/events` on `apps/slack-events`.
+4. Enable Slack **Interactivity & Shortcuts** and point its Request URL to the same `/slack/events` endpoint. This lets Block Kit buttons such as **Apply 1** submit the same source-thread action as typing `apply 1`.
+5. Send an `app_mention` in the bound channel. OpenTag will add a lightweight reaction receipt, keep routine progress audit-only, and post the final summary back to that Slack thread.

--- a/packages/cli/src/setup/guides.ts
+++ b/packages/cli/src/setup/guides.ts
@@ -24,7 +24,7 @@ function setupNeeds(platform: PlatformId, language: CliLanguage): string[] {
       case "lark":
         return ["推荐直接扫码创建 Personal Agent", "手动配置时需要 Lark App ID 和 App Secret"];
       case "slack":
-        return ["推荐本地使用 Socket Mode", "Socket Mode 需要 Slack App-Level Token 和 Bot User OAuth Token", "Events API 需要 Slack Signing Secret 和公网 Request URL", "Slack bot scopes 需要 app_mentions:read、chat:write、channels:history", "订阅 bot events: app_mention、message.channels", "Slack Team ID", "Slack Channel ID", "测试前需要把 Slack app 邀请进目标 channel"];
+        return ["推荐本地使用 Socket Mode", "Socket Mode 需要 Slack App-Level Token 和 Bot User OAuth Token", "Events API 需要 Slack Signing Secret 和公网 Request URL", "开启 Interactivity & Shortcuts 以支持 Apply 1 按钮", "Slack bot scopes 需要 app_mentions:read、chat:write、reactions:write、channels:history", "订阅 bot events: app_mention、message.channels", "Slack Team ID", "Slack Channel ID", "测试前需要把 Slack app 邀请进目标 channel"];
       case "github":
         return ["GitHub 仓库 owner/repo", "GitHub token（用于回写评论；你回复 apply 1 后也用于创建 PR）", "OpenTag 会自动生成 webhook secret", "本地 webhook 端口，默认 3050", "需要一个公网 tunnel 转发 GitHub webhook"];
       case "telegram":
@@ -36,7 +36,7 @@ function setupNeeds(platform: PlatformId, language: CliLanguage): string[] {
     case "lark":
       return ["QR scan is the recommended path", "manual setup needs a Lark App ID and App Secret"];
     case "slack":
-      return ["Socket Mode is recommended for local OpenTag", "Socket Mode needs a Slack App-Level Token and Bot User OAuth Token", "Events API needs a Slack Signing Secret and public Request URL", "Slack bot scopes need app_mentions:read, chat:write, channels:history", "Subscribe to bot events: app_mention, message.channels", "Slack Team ID", "Slack Channel ID", "Invite the Slack app to the target channel before testing"];
+      return ["Socket Mode is recommended for local OpenTag", "Socket Mode needs a Slack App-Level Token and Bot User OAuth Token", "Events API needs a Slack Signing Secret and public Request URL", "Enable Interactivity & Shortcuts for Apply 1 buttons", "Slack bot scopes need app_mentions:read, chat:write, reactions:write, channels:history", "Subscribe to bot events: app_mention, message.channels", "Slack Team ID", "Slack Channel ID", "Invite the Slack app to the target channel before testing"];
     case "github":
       return ["GitHub repository owner/repo", "GitHub token for comments and PR creation after you reply `apply 1`", "OpenTag generates the webhook secret", "Local webhook port, default 3050", "A public tunnel is required for GitHub webhook delivery"];
     case "telegram":
@@ -153,19 +153,20 @@ export function formatSlackCredentialHelp(language: CliLanguage, mode: SlackSetu
         ? [
             `- Socket Mode 官方文档: ${OFFICIAL_SETUP_LINKS.slackSocketModeDocs}`,
             "- Slack App-Level Token: Basic Information -> App-Level Tokens -> Generate Token and Scopes，scope 选 connections:write",
-            "- Socket Mode 不需要 Request URL"
+            "- Interactivity & Shortcuts: 打开 Interactivity；Socket Mode 不需要 Request URL"
           ]
         : [
             `- Signing Secret 官方文档: ${OFFICIAL_SETUP_LINKS.slackSigningSecretDocs}`,
             "- Slack Signing Secret: Basic Information -> App Credentials",
-            "- Request URL: 填你的公网 tunnel，例如 https://<your-tunnel>/slack/events"
+            "- Event Subscriptions Request URL: 填你的公网 tunnel，例如 https://<your-tunnel>/slack/events",
+            "- Interactivity & Shortcuts Request URL: 填同一个 https://<your-tunnel>/slack/events"
           ];
     return [
       "Slack 这些值在哪里拿:",
       `- Slack App 管理页: ${OFFICIAL_SETUP_LINKS.slackApps}`,
       ...modeSpecific,
       "- Slack Bot User OAuth Token: OAuth & Permissions -> Bot User OAuth Token",
-      "- Bot Token Scopes: app_mentions:read, chat:write, channels:history",
+      "- Bot Token Scopes: app_mentions:read, chat:write, reactions:write, channels:history",
       "- Bot Events: app_mention, message.channels",
       "- Team ID / Channel ID: 用浏览器打开 Slack channel，从地址里复制 T... 和 C...",
       "- 测试前在目标 channel 里运行 /invite @你的 App 名称，把 app 邀请进 channel"
@@ -177,19 +178,20 @@ export function formatSlackCredentialHelp(language: CliLanguage, mode: SlackSetu
       ? [
           `- Socket Mode docs: ${OFFICIAL_SETUP_LINKS.slackSocketModeDocs}`,
           "- Slack App-Level Token: Basic Information -> App-Level Tokens -> Generate Token and Scopes, then add connections:write",
-          "- Socket Mode does not need a Request URL"
+          "- Interactivity & Shortcuts: turn Interactivity on; Socket Mode does not need a Request URL"
         ]
       : [
           `- Signing Secret docs: ${OFFICIAL_SETUP_LINKS.slackSigningSecretDocs}`,
           "- Slack Signing Secret: Basic Information -> App Credentials",
-          "- Request URL: use your public tunnel, for example https://<your-tunnel>/slack/events"
+          "- Event Subscriptions Request URL: use your public tunnel, for example https://<your-tunnel>/slack/events",
+          "- Interactivity & Shortcuts Request URL: use the same https://<your-tunnel>/slack/events"
         ];
   return [
     "Where to find these Slack values:",
     `- Slack app settings: ${OFFICIAL_SETUP_LINKS.slackApps}`,
     ...modeSpecific,
     "- Slack Bot User OAuth Token: OAuth & Permissions -> Bot User OAuth Token",
-    "- Bot Token Scopes: app_mentions:read, chat:write, channels:history",
+    "- Bot Token Scopes: app_mentions:read, chat:write, reactions:write, channels:history",
     "- Bot Events: app_mention, message.channels",
     "- Team ID / Channel ID: open the Slack channel in a browser and copy the T... and C... values from the URL",
     "- Before testing, run /invite @your app name in the target channel so Slack sends mentions to the app"

--- a/packages/core/src/mention.ts
+++ b/packages/core/src/mention.ts
@@ -34,6 +34,7 @@ const PERMISSION_SCOPES = new Set<PermissionGrant["scope"]>([
   "repo:write",
   "issue:comment",
   "chat:postMessage",
+  "reactions:write",
   "pr:create",
   "pr:update",
   "runner:local",

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -11,7 +11,7 @@ import type { CallbackMessage, CallbackSink, SourceReceipt, SourceReceiptSink } 
 
 export type FetchLike = typeof fetch;
 
-const DEFAULT_SLACK_SOURCE_RECEIPT_TIMEOUT_MS = 2_000;
+const DEFAULT_SLACK_SOURCE_RECEIPT_TIMEOUT_MS = 5_000;
 
 function slackUpdateUriFrom(postMessageUri: string): string {
   return postMessageUri.replace(/\/chat\.postMessage$/, "/chat.update");

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -24,9 +24,9 @@ function githubCommentUriFrom(input: { commentsUri: string; responseBody: { id?:
 }
 
 function slackBotTokenFor(input: {
-  botToken?: string;
-  botTokensByAgentId?: Record<string, string>;
-  agentId?: string;
+  botToken?: string | undefined;
+  botTokensByAgentId?: Record<string, string> | undefined;
+  agentId?: string | undefined;
 }): string | undefined {
   if (
     input.agentId &&
@@ -112,9 +112,9 @@ export function createSlackCallbackSink(input: {
     async deliver(message: CallbackMessage): Promise<void> {
       if (message.provider !== "slack") return;
       const botToken = slackBotTokenFor({
-        ...(input.botToken ? { botToken: input.botToken } : {}),
-        ...(input.botTokensByAgentId ? { botTokensByAgentId: input.botTokensByAgentId } : {}),
-        ...(message.agentId ? { agentId: message.agentId } : {})
+        botToken: input.botToken,
+        botTokensByAgentId: input.botTokensByAgentId,
+        agentId: message.agentId
       });
       if (!botToken) return;
 
@@ -179,9 +179,9 @@ export function createSlackSourceReceiptSink(input: {
       if (!target) return { delivered: false };
 
       const botToken = slackBotTokenFor({
-        ...(input.botToken ? { botToken: input.botToken } : {}),
-        ...(input.botTokensByAgentId ? { botTokensByAgentId: input.botTokensByAgentId } : {}),
-        ...(receipt.agentId ? { agentId: receipt.agentId } : {})
+        botToken: input.botToken,
+        botTokensByAgentId: input.botTokensByAgentId,
+        agentId: receipt.agentId
       });
       if (!botToken) return { delivered: false };
 
@@ -203,9 +203,9 @@ export function createSlackSourceReceiptSink(input: {
       if (!response.ok) {
         throw new Error(`deliver Slack source receipt failed: ${response.status} ${await response.text()}`);
       }
-      const body = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
-      if (body.ok === false && body.error !== "already_reacted") {
-        throw new Error(`deliver Slack source receipt failed: ${body.error ?? "unknown_error"}`);
+      const body = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string } | null;
+      if (body?.ok === false && body.error !== "already_reacted") {
+        throw new Error(`deliver Slack source receipt failed: ${body?.error ?? "unknown_error"}`);
       }
       return { delivered: true };
     }
@@ -258,9 +258,9 @@ export function createTelegramCallbackSink(input: {
     async deliver(message: CallbackMessage): Promise<void> {
       if (message.provider !== "telegram") return;
       const botToken = slackBotTokenFor({
-        ...(input.botToken ? { botToken: input.botToken } : {}),
-        ...(input.botTokensByAgentId ? { botTokensByAgentId: input.botTokensByAgentId } : {}),
-        ...(message.agentId ? { agentId: message.agentId } : {})
+        botToken: input.botToken,
+        botTokensByAgentId: input.botTokensByAgentId,
+        agentId: message.agentId
       });
       if (!botToken) return;
 

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -1,7 +1,13 @@
 import { createLarkReplyClient, type LarkReplyClient, parseLarkThreadKey, replyLarkMessage } from "@opentag/lark";
-import { createSlackPostMessagePayload, createSlackUpdateMessagePayload, parseSlackThreadKey } from "@opentag/slack";
+import {
+  createSlackPostMessagePayload,
+  createSlackReactionPayload,
+  createSlackUpdateMessagePayload,
+  parseSlackThreadKey,
+  slackSourceReceiptReactionName
+} from "@opentag/slack";
 import { createTelegramSendMessageDraftPayload, createTelegramSendMessagePayload, parseTelegramThreadKey } from "@opentag/telegram";
-import type { CallbackMessage, CallbackSink } from "./server.js";
+import type { CallbackMessage, CallbackSink, SourceReceipt, SourceReceiptSink } from "./server.js";
 
 export type FetchLike = typeof fetch;
 
@@ -31,6 +37,18 @@ function slackBotTokenFor(input: {
     return input.botTokensByAgentId[input.agentId];
   }
   return input.botToken;
+}
+
+function metadataString(metadata: Record<string, unknown>, key: string): string | undefined {
+  const value = metadata[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function slackSourceMessageTarget(receipt: SourceReceipt): { channelId: string; messageTs: string } | null {
+  if (receipt.provider !== "slack") return null;
+  const channelId = metadataString(receipt.event.metadata, "channelId");
+  const messageTs = metadataString(receipt.event.metadata, "messageTs");
+  return channelId && messageTs ? { channelId, messageTs } : null;
 }
 
 export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: FetchLike }): CallbackSink {
@@ -142,6 +160,54 @@ export function createSlackCallbackSink(input: {
           }
         }
       }
+    }
+  };
+}
+
+export function createSlackSourceReceiptSink(input: {
+  botToken?: string;
+  botTokensByAgentId?: Record<string, string>;
+  fetchImpl?: FetchLike;
+  reactionsAddUri?: string;
+}): SourceReceiptSink {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const reactionsAddUri = input.reactionsAddUri ?? "https://slack.com/api/reactions.add";
+
+  return {
+    async deliver(receipt: SourceReceipt) {
+      const target = slackSourceMessageTarget(receipt);
+      if (!target) return { delivered: false };
+
+      const botToken = slackBotTokenFor({
+        ...(input.botToken ? { botToken: input.botToken } : {}),
+        ...(input.botTokensByAgentId ? { botTokensByAgentId: input.botTokensByAgentId } : {}),
+        ...(receipt.agentId ? { agentId: receipt.agentId } : {})
+      });
+      if (!botToken) return { delivered: false };
+
+      const response = await fetchImpl(reactionsAddUri, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${botToken}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(
+          createSlackReactionPayload({
+            channelId: target.channelId,
+            messageTs: target.messageTs,
+            name: slackSourceReceiptReactionName(receipt.state)
+          })
+        )
+      });
+
+      if (!response.ok) {
+        throw new Error(`deliver Slack source receipt failed: ${response.status} ${await response.text()}`);
+      }
+      const body = (await response.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (body.ok === false && body.error !== "already_reacted") {
+        throw new Error(`deliver Slack source receipt failed: ${body.error ?? "unknown_error"}`);
+      }
+      return { delivered: true };
     }
   };
 }

--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -11,6 +11,8 @@ import type { CallbackMessage, CallbackSink, SourceReceipt, SourceReceiptSink } 
 
 export type FetchLike = typeof fetch;
 
+const DEFAULT_SLACK_SOURCE_RECEIPT_TIMEOUT_MS = 2_000;
+
 function slackUpdateUriFrom(postMessageUri: string): string {
   return postMessageUri.replace(/\/chat\.postMessage$/, "/chat.update");
 }
@@ -49,6 +51,28 @@ function slackSourceMessageTarget(receipt: SourceReceipt): { channelId: string; 
   const channelId = metadataString(receipt.event.metadata, "channelId");
   const messageTs = metadataString(receipt.event.metadata, "messageTs");
   return channelId && messageTs ? { channelId, messageTs } : null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+async function fetchWithTimeout(input: {
+  fetchImpl: FetchLike;
+  uri: string;
+  init: RequestInit;
+  timeoutMs: number;
+}): Promise<Response | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), input.timeoutMs);
+  try {
+    return await input.fetchImpl(input.uri, { ...input.init, signal: controller.signal });
+  } catch (error) {
+    if (isAbortError(error)) return null;
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export function createGitHubCallbackSink(input: { token?: string; fetchImpl?: FetchLike }): CallbackSink {
@@ -169,9 +193,11 @@ export function createSlackSourceReceiptSink(input: {
   botTokensByAgentId?: Record<string, string>;
   fetchImpl?: FetchLike;
   reactionsAddUri?: string;
+  timeoutMs?: number;
 }): SourceReceiptSink {
   const fetchImpl = input.fetchImpl ?? fetch;
   const reactionsAddUri = input.reactionsAddUri ?? "https://slack.com/api/reactions.add";
+  const timeoutMs = input.timeoutMs ?? DEFAULT_SLACK_SOURCE_RECEIPT_TIMEOUT_MS;
 
   return {
     async deliver(receipt: SourceReceipt) {
@@ -185,20 +211,26 @@ export function createSlackSourceReceiptSink(input: {
       });
       if (!botToken) return { delivered: false };
 
-      const response = await fetchImpl(reactionsAddUri, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${botToken}`,
-          "content-type": "application/json"
-        },
-        body: JSON.stringify(
-          createSlackReactionPayload({
-            channelId: target.channelId,
-            messageTs: target.messageTs,
-            name: slackSourceReceiptReactionName(receipt.state)
-          })
-        )
+      const response = await fetchWithTimeout({
+        fetchImpl,
+        uri: reactionsAddUri,
+        timeoutMs,
+        init: {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${botToken}`,
+            "content-type": "application/json"
+          },
+          body: JSON.stringify(
+            createSlackReactionPayload({
+              channelId: target.channelId,
+              messageTs: target.messageTs,
+              name: slackSourceReceiptReactionName(receipt.state)
+            })
+          )
+        }
       });
+      if (!response) return { delivered: false };
 
       if (!response.ok) {
         throw new Error(`deliver Slack source receipt failed: ${response.status} ${await response.text()}`);

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -23,7 +23,7 @@ export type CallbackPresentation = {
 export function createDefaultCallbackPresentation(): CallbackPresentation {
   return {
     shouldDeliverAcknowledgement(provider) {
-      return provider !== "lark";
+      return provider !== "lark" && provider !== "slack";
     },
 
     shouldDeliverProgress(provider) {

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -13,6 +13,7 @@ import {
   type MutationIntent,
   type OpenTagEvent,
   type OpenTagRun,
+  type PermissionGrant,
   type SuggestedChangesSnapshot,
   type SuggestedActionCandidate,
   type ThreadActionCommand,
@@ -184,6 +185,7 @@ function childEventFromParent(input: {
   receivedAt: string;
   extraContext?: OpenTagEvent["context"];
   metadata?: Record<string, unknown>;
+  permissions?: PermissionGrant[];
 }): OpenTagEvent {
   return {
     ...input.parentEvent,
@@ -202,7 +204,8 @@ function childEventFromParent(input: {
     metadata: {
       ...input.parentEvent.metadata,
       ...(input.metadata ?? {})
-    }
+    },
+    permissions: input.permissions ?? input.parentEvent.permissions
   };
 }
 
@@ -599,6 +602,32 @@ function selectedActionSummary(candidates: ResolvedThreadAction["selectedCandida
   return candidates.map((candidate) => `${candidate.index}. ${candidate.intent.summary}`).join("; ");
 }
 
+function addPermissionGrant(permissions: PermissionGrant[], grant: PermissionGrant): PermissionGrant[] {
+  if (permissions.some((permission) => permission.scope === grant.scope)) return permissions;
+  return [...permissions, grant];
+}
+
+function childRunPermissionsForThreadAction(input: { resolved: ResolvedThreadAction; command: ThreadActionCommand }): PermissionGrant[] {
+  let permissions = [...input.resolved.proposal.event.permissions];
+  if (input.command.verb === "apply" || input.command.verb === "continue") {
+    permissions = addPermissionGrant(permissions, {
+      scope: "repo:read",
+      reason: "inspect the repository while continuing an approved source-thread action"
+    });
+    permissions = addPermissionGrant(permissions, {
+      scope: "repo:write",
+      reason: "apply an approved source-thread mutation on a run branch"
+    });
+  }
+  if (input.resolved.selectedCandidates.some((candidate) => candidate.intent.action === "create_pull_request")) {
+    permissions = addPermissionGrant(permissions, {
+      scope: "pr:create",
+      reason: "create the pull request approved in the source thread"
+    });
+  }
+  return permissions;
+}
+
 function childRunContextLines(input: {
   resolved: ResolvedThreadAction;
   approvalDecisionId?: string;
@@ -621,10 +650,17 @@ function renderChildRunCreatedBody(input: {
   lead: string;
   resolved: ResolvedThreadAction;
   childRun: OpenTagRun;
+  provider?: string;
   approvalDecisionId?: string;
   sourceApplyPlanId?: string;
   fallbackReason?: string;
 }): string {
+  if (input.provider === "slack") {
+    return [
+      "Approved. OpenTag will continue from this proposal in a follow-up run.",
+      ...(input.fallbackReason ? [`Reason: ${input.fallbackReason}`] : [])
+    ].join("\n");
+  }
   return [
     input.lead,
     "",
@@ -635,6 +671,56 @@ function renderChildRunCreatedBody(input: {
     "",
     "The model will continue from this approved proposal instead of starting from a fresh mention."
   ].join("\n");
+}
+
+function renderAppliedThreadActionBody(input: {
+  provider: string;
+  selectionText: string;
+  proposalId: string;
+  selectedIntentIds: string[];
+  outcomes: ApplyIntentOutcome[];
+}): string {
+  const selectedOutcomes = input.outcomes.filter((outcome) => input.selectedIntentIds.includes(outcome.intentId));
+  if (input.provider === "slack") {
+    const lines = [`Applied ${input.selectionText}.`];
+    for (const outcome of selectedOutcomes) {
+      if (outcome.externalUri) {
+        lines.push(`Result: ${outcome.externalUri}`);
+      } else if (outcome.message) {
+        lines.push(`Result: ${outcome.outcome}. ${outcome.message}`);
+      } else {
+        lines.push(`Result: ${outcome.outcome}.`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  return [
+    `Applied ${input.selectionText} from \`${input.proposalId}\`.`,
+    "",
+    "Result:",
+    ...selectedOutcomes.map((outcome) => `- \`${outcome.intentId}\`: ${outcome.outcome}${outcome.externalUri ? ` (${outcome.externalUri})` : ""}`)
+  ].join("\n");
+}
+
+function renderThreadActionRecordedBody(input: {
+  provider: string;
+  verb: "approve" | "reject";
+  selectionText: string;
+  proposalId: string;
+  applyIndex?: number;
+}): string {
+  const pastTense = input.verb === "approve" ? "Approved" : "Rejected";
+  if (input.provider === "slack") {
+    if (input.verb === "approve") {
+      return `${pastTense} ${input.selectionText}.\nNext: use Apply ${input.applyIndex ?? 1} when you want OpenTag to perform it.`;
+    }
+    return `${pastTense} ${input.selectionText}.`;
+  }
+  if (input.verb === "approve") {
+    return `${pastTense} ${input.selectionText} from \`${input.proposalId}\`.\n\nReply with \`apply ${input.applyIndex ?? 1}\` to apply it, or \`continue ${input.applyIndex ?? 1}\` to continue with a follow-up run.`;
+  }
+  return `${pastTense} ${input.selectionText} from \`${input.proposalId}\`.`;
 }
 
 function actionContextPointer(input: {
@@ -719,7 +805,8 @@ async function createChildRunForThreadAction(input: {
         ...(input.approvalDecisionId ? { approvalDecisionId: input.approvalDecisionId } : {}),
         ...(input.sourceApplyPlanId ? { sourceApplyPlanId: input.sourceApplyPlanId } : {}),
         ...(input.fallbackReason ? { fallbackReason: input.fallbackReason } : {})
-      }
+      },
+      permissions: childRunPermissionsForThreadAction({ resolved: input.resolved, command: input.command })
     }),
     parentRunId: input.resolved.proposal.runId,
     triggeredByAction: action,
@@ -743,6 +830,24 @@ export type CallbackMessage = {
 
 export type CallbackSink = {
   deliver(message: CallbackMessage): Promise<void>;
+};
+
+export type SourceReceiptState = "received";
+
+export type SourceReceiptDelivery = {
+  delivered: boolean;
+};
+
+export type SourceReceipt = {
+  runId: string;
+  provider: string;
+  state: SourceReceiptState;
+  event: OpenTagEvent;
+  agentId?: string;
+};
+
+export type SourceReceiptSink = {
+  deliver(receipt: SourceReceipt): Promise<SourceReceiptDelivery>;
 };
 
 export type CallbackRetryOptions = {
@@ -833,6 +938,12 @@ async function executeGitHubApplyPlan(input: {
 const noopCallbackSink: CallbackSink = {
   async deliver() {
     return;
+  }
+};
+
+const noopSourceReceiptSink: SourceReceiptSink = {
+  async deliver() {
+    return { delivered: false };
   }
 };
 
@@ -933,6 +1044,41 @@ async function deliverAndAudit(input: {
   });
 }
 
+async function deliverSourceReceiptBestEffort(input: {
+  repo: ReturnType<typeof createOpenTagRepository>;
+  sink: SourceReceiptSink;
+  receipt: SourceReceipt;
+}): Promise<void> {
+  try {
+    const result = await input.sink.deliver(input.receipt);
+    if (!result.delivered) return;
+    await input.repo.appendRunEvent({
+      runId: input.receipt.runId,
+      type: "source_receipt.delivered",
+      payload: {
+        provider: input.receipt.provider,
+        state: input.receipt.state
+      },
+      visibility: "audit",
+      importance: "low",
+      message: `Source ${input.receipt.state} receipt delivered.`
+    });
+  } catch (error) {
+    await input.repo.appendRunEvent({
+      runId: input.receipt.runId,
+      type: "source_receipt.failed",
+      payload: {
+        provider: input.receipt.provider,
+        state: input.receipt.state,
+        error: error instanceof Error ? error.message : String(error)
+      },
+      visibility: "audit",
+      importance: "low",
+      message: `Source ${input.receipt.state} receipt failed.`
+    });
+  }
+}
+
 function isAuthorized(request: Request, pairingToken: string | undefined): boolean {
   if (!pairingToken) return true;
   return request.headers.get("authorization") === `Bearer ${pairingToken}`;
@@ -941,6 +1087,7 @@ function isAuthorized(request: Request, pairingToken: string | undefined): boole
 export function createDispatcherApp(input: {
   databasePath: string;
   callbackSink?: CallbackSink;
+  sourceReceiptSink?: SourceReceiptSink;
   pairingToken?: string;
   presentation?: CallbackPresentation;
   githubApply?: GitHubApplyOptions;
@@ -952,6 +1099,7 @@ export function createDispatcherApp(input: {
   const repo = createOpenTagRepository(drizzle(sqlite));
   const app = new Hono();
   const callbackSink = input.callbackSink ?? noopCallbackSink;
+  const sourceReceiptSink = input.sourceReceiptSink ?? noopSourceReceiptSink;
   const presentation = input.presentation ?? createDefaultCallbackPresentation();
   const callbackRetry = input.callbackRetry ?? {};
   const admission = createAdmissionRuntime({
@@ -1148,6 +1296,17 @@ export function createDispatcherApp(input: {
       );
     }
     const { run } = createdRun;
+    await deliverSourceReceiptBestEffort({
+      repo,
+      sink: sourceReceiptSink,
+      receipt: {
+        runId: run.id,
+        provider: parsed.event.callback.provider,
+        state: "received",
+        event: parsed.event,
+        ...(parsed.event.target.agentId ? { agentId: parsed.event.target.agentId } : {})
+      }
+    });
     if (presentation.shouldDeliverAcknowledgement(parsed.event.callback.provider)) {
       await deliverAndAudit({
         repo,
@@ -1253,6 +1412,7 @@ export function createDispatcherApp(input: {
               lead: "This action was already planned, so OpenTag will not execute the external write again.",
               resolved: resolved.resolved,
               childRun,
+              provider: parsed.callback.provider,
               approvalDecisionId: existingPlan.approvalDecisionId,
               sourceApplyPlanId: existingPlan.id,
               fallbackReason
@@ -1309,7 +1469,12 @@ export function createDispatcherApp(input: {
       if (existingDecision) {
         return c.json({ outcome: "already_rejected", decision }, 200);
       }
-      const body = `Rejected ${selectionText} from \`${resolved.resolved.proposal.snapshot.proposalId}\`.`;
+      const body = renderThreadActionRecordedBody({
+        provider: parsed.callback.provider,
+        verb: "reject",
+        selectionText,
+        proposalId: resolved.resolved.proposal.snapshot.proposalId
+      });
       await deliverAndAudit({
         repo,
         sink: callbackSink,
@@ -1330,7 +1495,13 @@ export function createDispatcherApp(input: {
       if (existingDecision) {
         return c.json({ outcome: "already_approved", decision }, 200);
       }
-      const body = `Approved ${selectionText} from \`${resolved.resolved.proposal.snapshot.proposalId}\`.\n\nReply with \`apply ${resolved.resolved.selectedCandidates[0]?.index ?? 1}\` to apply it, or \`continue ${resolved.resolved.selectedCandidates[0]?.index ?? 1}\` to continue with a follow-up run.`;
+      const body = renderThreadActionRecordedBody({
+        provider: parsed.callback.provider,
+        verb: "approve",
+        selectionText,
+        proposalId: resolved.resolved.proposal.snapshot.proposalId,
+        applyIndex: resolved.resolved.selectedCandidates[0]?.index ?? 1
+      });
       await deliverAndAudit({
         repo,
         sink: callbackSink,
@@ -1359,6 +1530,7 @@ export function createDispatcherApp(input: {
         lead: `Continuing from ${selectionText} in \`${resolved.resolved.proposal.snapshot.proposalId}\`.`,
         resolved: resolved.resolved,
         childRun,
+        provider: parsed.callback.provider,
         approvalDecisionId: decision.id
       });
       await deliverAndAudit({
@@ -1419,6 +1591,7 @@ export function createDispatcherApp(input: {
             lead: "This action was already planned, so OpenTag will not execute the external write again.",
             resolved: resolved.resolved,
             childRun,
+            provider: parsed.callback.provider,
             approvalDecisionId: decision.id,
             sourceApplyPlanId: planResult.plan.id,
             fallbackReason
@@ -1438,14 +1611,13 @@ export function createDispatcherApp(input: {
     });
     if (execution.executed) {
       const outcomes = execution.plan.outcomes ?? [];
-      const body = [
-        `Applied ${selectionText} from \`${resolved.resolved.proposal.snapshot.proposalId}\`.`,
-        "",
-        "Result:",
-        ...outcomes
-          .filter((outcome) => resolved.resolved.selectedIntentIds.includes(outcome.intentId))
-          .map((outcome) => `- \`${outcome.intentId}\`: ${outcome.outcome}${outcome.externalUri ? ` (${outcome.externalUri})` : ""}`)
-      ].join("\n");
+      const body = renderAppliedThreadActionBody({
+        provider: parsed.callback.provider,
+        selectionText,
+        proposalId: resolved.resolved.proposal.snapshot.proposalId,
+        selectedIntentIds: resolved.resolved.selectedIntentIds,
+        outcomes
+      });
       await deliverAndAudit({
         repo,
         sink: callbackSink,
@@ -1480,6 +1652,7 @@ export function createDispatcherApp(input: {
       lead: `Action ${selectionText} was approved, but OpenTag cannot directly apply it yet.`,
       resolved: resolved.resolved,
       childRun,
+      provider: parsed.callback.provider,
       approvalDecisionId: decision.id,
       sourceApplyPlanId: execution.plan.id,
       fallbackReason: execution.fallbackReason ?? "The adapter could not execute the selected intent."

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -1048,10 +1048,10 @@ async function deliverSourceReceiptBestEffort(input: {
   repo: ReturnType<typeof createOpenTagRepository>;
   sink: SourceReceiptSink;
   receipt: SourceReceipt;
-}): Promise<void> {
+}): Promise<SourceReceiptDelivery> {
   try {
     const result = await input.sink.deliver(input.receipt);
-    if (!result.delivered) return;
+    if (!result.delivered) return result;
     await input.repo.appendRunEvent({
       runId: input.receipt.runId,
       type: "source_receipt.delivered",
@@ -1063,6 +1063,7 @@ async function deliverSourceReceiptBestEffort(input: {
       importance: "low",
       message: `Source ${input.receipt.state} receipt delivered.`
     });
+    return result;
   } catch (error) {
     await input.repo.appendRunEvent({
       runId: input.receipt.runId,
@@ -1076,6 +1077,7 @@ async function deliverSourceReceiptBestEffort(input: {
       importance: "low",
       message: `Source ${input.receipt.state} receipt failed.`
     });
+    return { delivered: false };
   }
 }
 
@@ -1296,7 +1298,7 @@ export function createDispatcherApp(input: {
       );
     }
     const { run } = createdRun;
-    await deliverSourceReceiptBestEffort({
+    const sourceReceiptDelivery = await deliverSourceReceiptBestEffort({
       repo,
       sink: sourceReceiptSink,
       receipt: {
@@ -1307,7 +1309,10 @@ export function createDispatcherApp(input: {
         ...(parsed.event.target.agentId ? { agentId: parsed.event.target.agentId } : {})
       }
     });
-    if (presentation.shouldDeliverAcknowledgement(parsed.event.callback.provider)) {
+    const shouldDeliverAcknowledgement =
+      presentation.shouldDeliverAcknowledgement(parsed.event.callback.provider) ||
+      (parsed.event.callback.provider === "slack" && !sourceReceiptDelivery.delivered);
+    if (shouldDeliverAcknowledgement) {
       await deliverAndAudit({
         repo,
         sink: callbackSink,

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -608,7 +608,7 @@ function addPermissionGrant(permissions: PermissionGrant[], grant: PermissionGra
 }
 
 function childRunPermissionsForThreadAction(input: { resolved: ResolvedThreadAction; command: ThreadActionCommand }): PermissionGrant[] {
-  let permissions = [...input.resolved.proposal.event.permissions];
+  let permissions = [...(input.resolved.proposal.event.permissions ?? [])];
   if (input.command.verb === "apply" || input.command.verb === "continue") {
     permissions = addPermissionGrant(permissions, {
       scope: "repo:read",

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -595,6 +595,56 @@ describe("createGitHubCallbackSink", () => {
     ).resolves.toEqual({ delivered: true });
   });
 
+  it("bounds Slack source receipt reaction delivery with a timeout", async () => {
+    let aborted = false;
+    const sink = createSlackSourceReceiptSink({
+      botToken: "xoxb-test",
+      timeoutMs: 1,
+      fetchImpl: (async (_url, init) => {
+        const signal = init?.signal;
+        if (!signal) throw new Error("expected abort signal");
+        return await new Promise<Response>((_resolve, reject) => {
+          const abort = () => {
+            aborted = true;
+            const error = new Error("aborted");
+            error.name = "AbortError";
+            reject(error);
+          };
+          if (signal.aborted) {
+            abort();
+            return;
+          }
+          signal.addEventListener("abort", abort, { once: true });
+        });
+      }) as typeof fetch
+    });
+
+    await expect(
+      sink.deliver({
+        runId: "run_1",
+        provider: "slack",
+        state: "received",
+        event: {
+          id: "evt_1",
+          source: "slack",
+          sourceEventId: "Ev123",
+          receivedAt: "2026-06-24T00:00:00.000Z",
+          actor: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
+          target: { mention: "@opentag", agentId: "opentag" },
+          command: { rawText: "fix this", intent: "fix", args: {} },
+          context: [{ provider: "slack", kind: "message", uri: "slack://team/T123/channel/C123/message/1710000000.000100" }],
+          callback: {
+            provider: "slack",
+            uri: "https://slack.com/api/chat.postMessage",
+            threadKey: "T123|C123|1710000000.000100"
+          },
+          metadata: { teamId: "T123", channelId: "C123", messageTs: "1710000000.000100" }
+        }
+      })
+    ).resolves.toEqual({ delivered: false });
+    expect(aborted).toBe(true);
+  });
+
   it("fans out across composed sinks", async () => {
     const messages: string[] = [];
     const sink = createCompositeCallbackSink([

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { createCompositeCallbackSink, createGitHubCallbackSink, createSlackCallbackSink, createTelegramCallbackSink } from "../src/callbacks.js";
+import {
+  createCompositeCallbackSink,
+  createGitHubCallbackSink,
+  createSlackCallbackSink,
+  createSlackSourceReceiptSink,
+  createTelegramCallbackSink
+} from "../src/callbacks.js";
 
 describe("createGitHubCallbackSink", () => {
   it("posts GitHub callback messages to the callback URI", async () => {
@@ -495,6 +501,64 @@ describe("createGitHubCallbackSink", () => {
               }
             }
           ]
+        }
+      }
+    ]);
+  });
+
+  it("adds Slack source receipt reactions to the source message", async () => {
+    const requests: { url: string; authorization: string | null; body: unknown }[] = [];
+    const sink = createSlackSourceReceiptSink({
+      botTokensByAgentId: {
+        opentag: "xoxb-opentag"
+      },
+      fetchImpl: (async (url, init) => {
+        requests.push({
+          url: String(url),
+          authorization: new Headers(init?.headers).get("authorization"),
+          body: JSON.parse(String(init?.body))
+        });
+        return Response.json({ ok: true });
+      }) as typeof fetch
+    });
+
+    await expect(
+      sink.deliver({
+        runId: "run_1",
+        provider: "slack",
+        state: "received",
+        agentId: "opentag",
+        event: {
+          id: "evt_1",
+          source: "slack",
+          sourceEventId: "Ev123",
+          receivedAt: "2026-06-24T00:00:00.000Z",
+          actor: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
+          target: { mention: "@opentag", agentId: "opentag" },
+          command: { rawText: "fix this", intent: "fix", args: {} },
+          context: [{ provider: "slack", kind: "message", uri: "slack://team/T123/channel/C123/message/1710000000.000100" }],
+          permissions: [
+            { scope: "chat:postMessage", reason: "reply to source thread" },
+            { scope: "reactions:write", reason: "mark the source Slack message as received" }
+          ],
+          callback: {
+            provider: "slack",
+            uri: "https://slack.com/api/chat.postMessage",
+            threadKey: "T123|C123|1710000000.000100"
+          },
+          metadata: { teamId: "T123", channelId: "C123", messageTs: "1710000000.000100" }
+        }
+      })
+    ).resolves.toEqual({ delivered: true });
+
+    expect(requests).toEqual([
+      {
+        url: "https://slack.com/api/reactions.add",
+        authorization: "Bearer xoxb-opentag",
+        body: {
+          channel: "C123",
+          timestamp: "1710000000.000100",
+          name: "eyes"
         }
       }
     ]);

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -564,6 +564,37 @@ describe("createGitHubCallbackSink", () => {
     ]);
   });
 
+  it("does not crash when Slack source receipt responses have a null JSON body", async () => {
+    const sink = createSlackSourceReceiptSink({
+      botToken: "xoxb-test",
+      fetchImpl: (async () => Response.json(null)) as typeof fetch
+    });
+
+    await expect(
+      sink.deliver({
+        runId: "run_1",
+        provider: "slack",
+        state: "received",
+        event: {
+          id: "evt_1",
+          source: "slack",
+          sourceEventId: "Ev123",
+          receivedAt: "2026-06-24T00:00:00.000Z",
+          actor: { provider: "slack", providerUserId: "U123", handle: "U123", organizationId: "T123" },
+          target: { mention: "@opentag", agentId: "opentag" },
+          command: { rawText: "fix this", intent: "fix", args: {} },
+          context: [{ provider: "slack", kind: "message", uri: "slack://team/T123/channel/C123/message/1710000000.000100" }],
+          callback: {
+            provider: "slack",
+            uri: "https://slack.com/api/chat.postMessage",
+            threadKey: "T123|C123|1710000000.000100"
+          },
+          metadata: { teamId: "T123", channelId: "C123", messageTs: "1710000000.000100" }
+        }
+      })
+    ).resolves.toEqual({ delivered: true });
+  });
+
   it("fans out across composed sinks", async () => {
     const messages: string[] = [];
     const sink = createCompositeCallbackSink([

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -188,10 +188,11 @@ describe("default callback presentation", () => {
     };
 
     const github = presentation.final({ provider: "github", result }).body;
-    expect(github).toContain("Title: OpenTag run run_1");
-    expect(github).toContain("Branch: `opentag/run_1` -> `main`");
-    expect(github).toContain("Changed files: `src/demo.ts`");
-    expect(github).toContain("`pnpm test`: passed");
+    expect(github).toContain("- Title: OpenTag run run_1");
+    expect(github).toContain("- Branch: `opentag/run_1` -> `main`");
+    expect(github).toContain("- Changed files: `src/demo.ts`");
+    expect(github).toContain("- Verification:\n  - `pnpm test`: passed");
+    expect(github).not.toContain("   Title:");
 
     const slack = presentation.final({ provider: "slack", result });
     expect(slack.body).toContain("Branch: `opentag/run_1` -> `main`");

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 import { createDefaultCallbackPresentation } from "../src/presentation.js";
 
 describe("default callback presentation", () => {
-  it("keeps Lark acknowledgements silent while preserving other provider acknowledgements", () => {
+  it("keeps chat acknowledgements quiet where thread noise matters", () => {
     const presentation = createDefaultCallbackPresentation();
 
     expect(presentation.shouldDeliverAcknowledgement("lark")).toBe(false);
-    expect(presentation.shouldDeliverAcknowledgement("slack")).toBe(true);
+    expect(presentation.shouldDeliverAcknowledgement("slack")).toBe(false);
     expect(presentation.shouldDeliverAcknowledgement("telegram")).toBe(true);
     expect(presentation.shouldDeliverAcknowledgement("github")).toBe(true);
   });
@@ -29,27 +29,26 @@ describe("default callback presentation", () => {
     };
 
     expect(presentation.acknowledgement({ provider: "github", runId: "run_1" })).toBe("OpenTag picked this up. Run: `run_1`");
-    expect(presentation.acknowledgement({ provider: "slack", runId: "run_1" })).toBe("I picked this up: `run_1`");
+    expect(presentation.acknowledgement({ provider: "slack", runId: "run_1" })).toBe("Working on it.");
     expect(presentation.acknowledgement({ provider: "telegram", runId: "run_1" })).toBe("I picked this up: run_1");
     expect(presentation.final({ provider: "github", result })).toEqual({
       body: "OpenTag finished with **success**.\n\ndone\n\nVerification:\n- `echo`: passed"
     });
     expect(presentation.final({ provider: "slack", result })).toEqual({
-      body: "Finished with *success*.\n\ndone\n\n*Verification*\n- `echo`: passed",
+      body: "*Finished: success.*\ndone\nVerified: `echo` passed",
       blocks: [
         {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: "*Finished with success.*\ndone"
+            text: "*Finished: success.*\ndone"
           }
         },
-        { type: "divider" },
         {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: "*Verification*\n- `echo`: passed"
+            text: "Verified: `echo` passed"
           }
         }
       ]
@@ -90,20 +89,20 @@ describe("default callback presentation", () => {
     };
 
     expect(presentation.final({ provider: "github", result }).body).toContain("Next action: Approve intent_label_1");
-    expect(presentation.final({ provider: "slack", result }).body).toContain("*Next action*: Approve intent_label_1");
+    expect(presentation.final({ provider: "slack", result }).body).toContain("Next: Approve intent_label_1");
     expect(presentation.final({ provider: "slack", result }).blocks).toEqual([
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Finished with needs_human.*\nPrepared a suggested change snapshot."
+          text: "*Finished: needs_human.*\nPrepared a suggested change snapshot."
         }
       },
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Next action*: Approve intent_label_1 to add the bug label."
+          text: "Next: Approve intent_label_1 to add the bug label."
         }
       }
     ]);
@@ -136,20 +135,25 @@ describe("default callback presentation", () => {
 
     const github = presentation.final({ provider: "github", result }).body;
     expect(github).toContain("Suggested actions:");
-    expect(github).toContain("1. **Add the bug label.**");
+    expect(github).toContain("Source-thread approval:");
+    expect(github).toContain("#### Action 1: Add the bug label.");
+    expect(github).toContain("System-of-record action: `add_label` (`labels`)");
     expect(github).toContain("Proposal: `proposal_1`");
     expect(github).toContain("Intent ID: `intent_label_1`");
-    expect(github).toContain("`apply 1`");
+    expect(github).toContain("| Apply now | `apply 1` |");
 
     const slack = presentation.final({ provider: "slack", result });
     expect(slack.body).toContain("*Suggested actions*");
     expect(slack.body).toContain("1. *Add the bug label.*");
-    expect(slack.body).toContain("`continue 1`");
+    expect(slack.body).not.toContain("Proposal:");
+    expect(slack.body).not.toContain("Intent ID:");
     expect(slack.blocks?.at(-1)).toMatchObject({
-      type: "section",
-      text: {
-        type: "mrkdwn"
-      }
+      type: "actions",
+      elements: [
+        { type: "button", text: { type: "plain_text", text: "Apply 1" }, action_id: "opentag:apply:1", style: "primary" },
+        { type: "button", text: { type: "plain_text", text: "Approve" }, action_id: "opentag:approve:1" },
+        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" }
+      ]
     });
   });
 
@@ -190,11 +194,11 @@ describe("default callback presentation", () => {
     expect(github).toContain("`pnpm test`: passed");
 
     const slack = presentation.final({ provider: "slack", result });
-    expect(slack.body).toContain("Title: OpenTag run run_1");
     expect(slack.body).toContain("Branch: `opentag/run_1` -> `main`");
     expect(slack.body).toContain("Changed files: `src/demo.ts`");
-    expect(slack.body).toContain("`pnpm test`: passed");
-    expect(JSON.stringify(slack.blocks)).toContain("Title: OpenTag run run_1");
-    expect(JSON.stringify(slack.blocks)).toContain("`pnpm test`: passed");
+    expect(slack.body).not.toContain("Title: OpenTag run run_1");
+    expect(slack.body).not.toContain("`pnpm test`: passed");
+    expect(JSON.stringify(slack.blocks)).toContain("Branch: `opentag/run_1` -> `main`");
+    expect(JSON.stringify(slack.blocks)).not.toContain("Title: OpenTag run run_1");
   });
 });

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -606,6 +606,11 @@ describe("dispatcher API", () => {
         async deliver(message) {
           delivered.push({ kind: message.kind, body: message.body, ...(message.blocks?.length ? { blocks: message.blocks } : {}) });
         }
+      },
+      sourceReceiptSink: {
+        async deliver() {
+          return { delivered: true };
+        }
       }
     });
 
@@ -694,6 +699,7 @@ describe("dispatcher API", () => {
       "admission.decided",
       "run.created",
       "context_packet.generated",
+      "source_receipt.delivered",
       "run.claimed",
       "run.progress",
       "run.completed",
@@ -778,6 +784,42 @@ describe("dispatcher API", () => {
         state: "received"
       }
     });
+  });
+
+  it("falls back to a Slack text acknowledgement when the source receipt is not delivered", async () => {
+    const callbacks: Array<{ kind: string; body: string }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          callbacks.push({ kind: message.kind, body: message.body });
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", jsonRequest({
+      provider: "github",
+      owner: "acme",
+      repo: "demo",
+      runnerId: "runner_1",
+      workspacePath: "/Users/test/demo",
+      defaultExecutor: "echo"
+    }));
+
+    const event = slackRepoEvent({ id: "evt_slack_receipt_fallback", sourceEventId: "EvSlackReceiptFallback", threadKey: "T123|C123|1710000000.000100" });
+    const createResponse = await app.request("/v1/runs", jsonRequest({ runId: "run_slack_receipt_fallback", event }));
+    expect(createResponse.status).toBe(201);
+    expect(callbacks).toEqual([{ kind: "acknowledgement", body: "Working on it." }]);
+
+    const eventsResponse = await app.request("/v1/runs/run_slack_receipt_fallback/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toEqual([
+      "admission.decided",
+      "run.created",
+      "context_packet.generated",
+      "callback.acknowledgement.queued",
+      "callback.acknowledgement.delivered"
+    ]);
   });
 
   it("renders Lark final callbacks as plain text while keeping acknowledgement and progress audit-only", async () => {
@@ -1815,6 +1857,11 @@ describe("dispatcher API", () => {
             kind: message.kind,
             ...(message.agentId ? { agentId: message.agentId } : {})
           });
+        }
+      },
+      sourceReceiptSink: {
+        async deliver() {
+          return { delivered: true };
         }
       }
     });

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -93,6 +93,7 @@ function slackRepoEvent(input: { id: string; sourceEventId: string; threadKey: s
     context: [{ provider: "slack", kind: "message", uri: "slack://team/T123/channel/C123/message/1710000000.000100", visibility: "organization" }],
     permissions: [
       { scope: "chat:postMessage", reason: "reply to source thread" },
+      { scope: "reactions:write", reason: "mark the source Slack message as received" },
       { scope: "runner:local", reason: "execute on local daemon" },
       { scope: "repo:write", reason: "modify the mapped repository" },
       { scope: "pr:create", reason: "create an approved pull request" }
@@ -663,24 +664,22 @@ describe("dispatcher API", () => {
     expect(completeResponse.status).toBe(200);
 
     expect(delivered).toEqual([
-      { kind: "acknowledgement", body: "I picked this up: `run_slack_1`" },
       {
         kind: "final",
-        body: "Finished with *success*.\n\nEchoed OpenTag command: introduce yourself\n\n*Verification*\n- `echo`: passed",
+        body: "*Finished: success.*\nEchoed OpenTag command: introduce yourself\nVerified: `echo` passed",
         blocks: [
           {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: "*Finished with success.*\nEchoed OpenTag command: introduce yourself"
+              text: "*Finished: success.*\nEchoed OpenTag command: introduce yourself"
             }
           },
-          { type: "divider" },
           {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: "*Verification*\n- `echo`: passed"
+              text: "Verified: `echo` passed"
             }
           }
         ]
@@ -695,8 +694,6 @@ describe("dispatcher API", () => {
       "admission.decided",
       "run.created",
       "context_packet.generated",
-      "callback.acknowledgement.queued",
-      "callback.acknowledgement.delivered",
       "run.claimed",
       "run.progress",
       "run.completed",
@@ -707,6 +704,79 @@ describe("dispatcher API", () => {
       visibility: "audit",
       importance: "normal",
       message: "Echo executor started"
+    });
+  });
+
+  it("delivers Slack source receipts without posting text acknowledgements", async () => {
+    const callbacks: { kind: string }[] = [];
+    const receipts: Array<{ runId: string; provider: string; state: string; agentId?: string; channelId: unknown; messageTs: unknown }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          callbacks.push({ kind: message.kind });
+        }
+      },
+      sourceReceiptSink: {
+        async deliver(receipt) {
+          receipts.push({
+            runId: receipt.runId,
+            provider: receipt.provider,
+            state: receipt.state,
+            ...(receipt.agentId ? { agentId: receipt.agentId } : {}),
+            channelId: receipt.event.metadata["channelId"],
+            messageTs: receipt.event.metadata["messageTs"]
+          });
+          return { delivered: true };
+        }
+      }
+    });
+
+    await app.request("/v1/repo-bindings", jsonRequest({
+      provider: "github",
+      owner: "acme",
+      repo: "demo",
+      runnerId: "runner_1",
+      workspacePath: "/Users/test/demo",
+      defaultExecutor: "echo"
+    }));
+
+    const event = slackRepoEvent({ id: "evt_slack_receipt", sourceEventId: "EvSlackReceipt", threadKey: "T123|C123|1710000000.000100" });
+    const createResponse = await app.request("/v1/runs", jsonRequest({ runId: "run_slack_receipt", event }));
+    expect(createResponse.status).toBe(201);
+
+    const replayResponse = await app.request("/v1/runs", jsonRequest({ runId: "run_slack_receipt_replay", event }));
+    expect(replayResponse.status).toBe(200);
+
+    expect(callbacks).toEqual([]);
+    expect(receipts).toEqual([
+      {
+        runId: "run_slack_receipt",
+        provider: "slack",
+        state: "received",
+        agentId: "opentag",
+        channelId: "C123",
+        messageTs: "1710000000.000100"
+      }
+    ]);
+
+    const eventsResponse = await app.request("/v1/runs/run_slack_receipt/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).toEqual([
+      "admission.decided",
+      "run.created",
+      "context_packet.generated",
+      "source_receipt.delivered",
+      "admission.decided",
+      "run.create_idempotent_replay"
+    ]);
+    expect(events.find((event: { type: string }) => event.type === "source_receipt.delivered")).toMatchObject({
+      visibility: "audit",
+      importance: "low",
+      payload: {
+        provider: "slack",
+        state: "received"
+      }
     });
   });
 
@@ -1790,7 +1860,6 @@ describe("dispatcher API", () => {
     expect(completeResponse.status).toBe(200);
 
     expect(delivered).toEqual([
-      { kind: "acknowledgement", agentId: "deepseek" },
       { kind: "final", agentId: "deepseek" }
     ]);
   });
@@ -2527,7 +2596,10 @@ describe("dispatcher API", () => {
         }
       }
     ]);
-    expect(delivered.some((message) => message.kind === "final" && message.body.includes("https://github.com/acme/demo/pull/43"))).toBe(true);
+    const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("https://github.com/acme/demo/pull/43"));
+    expect(finalMessage?.body).toContain("Applied 1. Create PR for branch opentag/run_slack_create_pr.");
+    expect(finalMessage?.body).not.toContain("proposal_slack_create_pr");
+    expect(finalMessage?.body).not.toContain("intent_slack_create_pr");
   });
 
   it("falls back to a child run when a PR review request lacks reviewer params", async () => {
@@ -2735,6 +2807,9 @@ describe("dispatcher API", () => {
       previousRunSummary: "Prepared suggested actions."
     });
     expect(stored.event.metadata.fallbackReason).toContain("No selected intent has a direct adapter execution path.");
+    expect(stored.event.permissions.map((permission: { scope: string }) => permission.scope)).toEqual(
+      expect.arrayContaining(["repo:read", "repo:write"])
+    );
     expect(stored.run.contextPacket.facts.map((fact: { text: string }) => fact.text)).toEqual(
       expect.arrayContaining([
         "Action loop thread action: apply",

--- a/packages/github/src/render.ts
+++ b/packages/github/src/render.ts
@@ -25,7 +25,10 @@ function renderVerificationParams(params: Record<string, unknown> | undefined): 
       if (!item || typeof item !== "object" || Array.isArray(item)) return undefined;
       const command = (item as Record<string, unknown>)["command"];
       const outcome = (item as Record<string, unknown>)["outcome"];
-      return typeof command === "string" && typeof outcome === "string" ? `  - \`${command}\`: ${outcome}` : undefined;
+      const summary = (item as Record<string, unknown>)["summary"];
+      if (typeof outcome !== "string") return undefined;
+      const prefix = typeof command === "string" && command.length > 0 ? `\`${command}\`: ${outcome}` : outcome;
+      return typeof summary === "string" && summary.length > 0 ? `  - ${prefix} - ${summary}` : `  - ${prefix}`;
     })
     .filter((line): line is string => Boolean(line));
 }

--- a/packages/github/src/render.ts
+++ b/packages/github/src/render.ts
@@ -25,7 +25,7 @@ function renderVerificationParams(params: Record<string, unknown> | undefined): 
       if (!item || typeof item !== "object" || Array.isArray(item)) return undefined;
       const command = (item as Record<string, unknown>)["command"];
       const outcome = (item as Record<string, unknown>)["outcome"];
-      return typeof command === "string" && typeof outcome === "string" ? `   - \`${command}\`: ${outcome}` : undefined;
+      return typeof command === "string" && typeof outcome === "string" ? `  - \`${command}\`: ${outcome}` : undefined;
     })
     .filter((line): line is string => Boolean(line));
 }
@@ -39,17 +39,17 @@ function renderSuggestedActionDetails(params: Record<string, unknown> | undefine
   const changedFiles = stringArrayParam(params, "changedFiles");
   const risks = stringArrayParam(params, "risks");
   const verification = renderVerificationParams(params);
-  if (title) lines.push(`   Title: ${title}`);
-  if (head || base) lines.push(`   Branch: \`${head ?? "unknown"}\` -> \`${base ?? "main"}\``);
-  if (changedFiles.length > 0) lines.push(`   Changed files: ${changedFiles.map((file) => `\`${file}\``).join(", ")}`);
+  if (title) lines.push(`- Title: ${title}`);
+  if (head || base) lines.push(`- Branch: \`${head ?? "unknown"}\` -> \`${base ?? "main"}\``);
+  if (changedFiles.length > 0) lines.push(`- Changed files: ${changedFiles.map((file) => `\`${file}\``).join(", ")}`);
   if (risks.length > 0) {
-    lines.push("   Risks:");
+    lines.push("- Risks:");
     for (const risk of risks) {
-      lines.push(`   - ${risk}`);
+      lines.push(`  - ${risk}`);
     }
   }
   if (verification.length > 0) {
-    lines.push("   Verification:");
+    lines.push("- Verification:");
     lines.push(...verification);
   }
   return lines;

--- a/packages/github/src/render.ts
+++ b/packages/github/src/render.ts
@@ -59,32 +59,41 @@ function renderSuggestedActions(result: OpenTagRunResult): string[] {
   const candidates = suggestedActionCandidatesFromResult(result);
   if (candidates.length === 0) return [];
 
-  const lines = ["Suggested actions:"];
+  const lines = [
+    "### Suggested actions:",
+    "",
+    "Source-thread approval: choose one command in this GitHub thread to apply a protocolized mutation or PR action to the system of record."
+  ];
   for (const candidate of candidates) {
     lines.push(
       "",
-      `${candidate.index}. **${candidate.intent.summary}**`,
-      `   Intent: \`${candidate.intent.action}\` (\`${candidate.intent.domain}\`)`,
-      `   Proposal: \`${candidate.proposalId}\``,
-      `   Intent ID: \`${candidate.intent.intentId}\``
+      `#### Action ${candidate.index}: ${candidate.intent.summary}`,
+      "",
+      `- System-of-record action: \`${candidate.intent.action}\` (\`${candidate.intent.domain}\`)`,
+      `- Proposal: \`${candidate.proposalId}\``,
+      `- Intent ID: \`${candidate.intent.intentId}\``
     );
     lines.push(...renderSuggestedActionDetails(candidate.intent.params, candidate.intent.action));
     if (candidate.proposalPreconditions?.length) {
-      lines.push("   Preconditions:");
+      lines.push("- Preconditions:");
       for (const precondition of candidate.proposalPreconditions) {
-        lines.push(`   - ${precondition}`);
+        lines.push(`  - ${precondition}`);
       }
     }
+    lines.push(
+      "",
+      "**Approve in this thread**",
+      "",
+      `| Decision | Comment command | Effect |`,
+      `| --- | --- | --- |`,
+      `| Apply now | \`apply ${candidate.index}\` | Applies this action to the system of record. |`,
+      `| Approve only | \`approve ${candidate.index}\` | Records approval without applying yet. |`,
+      `| Continue | \`continue ${candidate.index}\` | Starts a follow-up run from this proposal. |`,
+      `| Reject | \`reject ${candidate.index}\` | Rejects this action. |`
+    );
   }
 
-  lines.push(
-    "",
-    "Reply with:",
-    "- `approve 1` to record approval without applying yet",
-    "- `apply 1` or `apply all` to apply supported actions",
-    "- `continue 1` to continue with a follow-up run",
-    "- `reject 1` to reject an action"
-  );
+  lines.push("", "Bulk shortcut: comment `apply all` to apply every supported approved action in this thread.");
   return lines;
 }
 

--- a/packages/github/test/render.test.ts
+++ b/packages/github/test/render.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { renderFinalResult } from "../src/render.js";
+
+describe("GitHub result rendering", () => {
+  it("renders suggested-action verification rows without requiring a command", () => {
+    const body = renderFinalResult({
+      conclusion: "success",
+      summary: "Prepared a branch.",
+      suggestedChanges: [
+        {
+          proposalId: "proposal_1",
+          createdAt: "2026-06-29T00:00:00.000Z",
+          sourceRunId: "run_1",
+          summary: "Create a pull request.",
+          intents: [
+            {
+              intentId: "intent_create_pr",
+              domain: "pull_request",
+              action: "create_pull_request",
+              summary: "Create a pull request for branch opentag/run_1.",
+              params: {
+                title: "OpenTag run run_1",
+                head: "opentag/run_1",
+                base: "main",
+                changedFiles: ["README.md"],
+                verification: [
+                  { command: "pnpm test", outcome: "passed" },
+                  { outcome: "passed", summary: "Structured report parsed successfully." }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(body).toContain("- Verification:\n  - `pnpm test`: passed\n  - passed - Structured report parsed successfully.");
+  });
+});

--- a/packages/local-runtime/src/dispatcher.ts
+++ b/packages/local-runtime/src/dispatcher.ts
@@ -5,6 +5,7 @@ import {
   createGitHubCallbackSink,
   createLarkCallbackSink,
   createSlackCallbackSink,
+  createSlackSourceReceiptSink,
   createTelegramCallbackSink
 } from "@opentag/dispatcher";
 
@@ -107,6 +108,10 @@ export function startDispatcher(input: LocalDispatcherRuntimeInput): LocalDispat
       databasePath: input.databasePath,
       ...(input.pairingToken ? { pairingToken: input.pairingToken } : {}),
       ...(input.githubToken ? { githubApply: { token: input.githubToken } } : {}),
+      sourceReceiptSink: createSlackSourceReceiptSink({
+        ...(input.slackBotToken ? { botToken: input.slackBotToken } : {}),
+        ...(input.slackBotTokensByAgentId ? { botTokensByAgentId: input.slackBotTokensByAgentId } : {})
+      }),
       callbackSink: createCompositeCallbackSink([
         createGitHubCallbackSink({
           ...(input.githubToken ? { token: input.githubToken } : {})

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -1,5 +1,6 @@
 import { contextPointerLabel, type ContextPacket, type ContextPointer } from "@opentag/core";
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
+import { executorReportPromptLines } from "./executor-report.js";
 import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
 import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
 import { createExecutorRunResult } from "./result.js";
@@ -40,7 +41,7 @@ function buildPrompt(input: {
     "Do not run, request, or recommend git add, git commit, git push, or gh pr create.",
     "Do not ask the user to approve local source-control commands; summarize file changes and verification only.",
     "OpenTag will publish the run branch and expose pull-request creation as a suggested action.",
-    "End with a concise summary of what changed, what was verified, and the recommended next action."
+    ...executorReportPromptLines()
   ].join("\n");
 }
 

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -36,6 +36,10 @@ function buildPrompt(input: {
     contextLines(input.context),
     "",
     "Work autonomously but keep the change narrow. Run relevant verification if you modify files.",
+    "OpenTag owns the source-control handoff after you finish.",
+    "Do not run, request, or recommend git add, git commit, git push, or gh pr create.",
+    "Do not ask the user to approve local source-control commands; summarize file changes and verification only.",
+    "OpenTag will publish the run branch and expose pull-request creation as a suggested action.",
     "End with a concise summary of what changed, what was verified, and the recommended next action."
   ].join("\n");
 }

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -1,6 +1,6 @@
 import { contextPointerLabel, type ContextPacket, type ContextPointer } from "@opentag/core";
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
-import { executorReportPromptLines } from "./executor-report.js";
+import { executorPolicyPromptLines } from "./executor-report.js";
 import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
 import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
 import { createExecutorRunResult } from "./result.js";
@@ -36,12 +36,7 @@ function buildPrompt(input: {
     "Context pointers:",
     contextLines(input.context),
     "",
-    "Work autonomously but keep the change narrow. Run relevant verification if you modify files.",
-    "OpenTag owns the source-control handoff after you finish.",
-    "Do not run, request, or recommend git add, git commit, git push, or gh pr create.",
-    "Do not ask the user to approve local source-control commands; summarize file changes and verification only.",
-    "OpenTag will publish the run branch and expose pull-request creation as a suggested action.",
-    ...executorReportPromptLines()
+    ...executorPolicyPromptLines()
   ].join("\n");
 }
 

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -1,6 +1,6 @@
 import { contextPointerLabel, type ContextPacket, type ContextPointer } from "@opentag/core";
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
-import { executorReportPromptLines } from "./executor-report.js";
+import { executorPolicyPromptLines } from "./executor-report.js";
 import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
 import {
   branchNameForRun,
@@ -45,12 +45,7 @@ function buildPrompt(input: {
     "Context pointers:",
     contextLines(input.context),
     "",
-    "Work autonomously but keep the change narrow. Run relevant verification if you modify files.",
-    "OpenTag owns the source-control handoff after you finish.",
-    "Do not run, request, or recommend git add, git commit, git push, or gh pr create.",
-    "Do not ask the user to approve local source-control commands; summarize file changes and verification only.",
-    "OpenTag will publish the run branch and expose pull-request creation as a suggested action.",
-    ...executorReportPromptLines()
+    ...executorPolicyPromptLines()
   ].join("\n");
 }
 

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -44,7 +44,12 @@ function buildPrompt(input: {
     "Context pointers:",
     contextLines(input.context),
     "",
-    "Work autonomously but keep the change narrow. Run relevant verification if you modify files. End with a concise summary."
+    "Work autonomously but keep the change narrow. Run relevant verification if you modify files.",
+    "OpenTag owns the source-control handoff after you finish.",
+    "Do not run, request, or recommend git add, git commit, git push, or gh pr create.",
+    "Do not ask the user to approve local source-control commands; summarize file changes and verification only.",
+    "OpenTag will publish the run branch and expose pull-request creation as a suggested action.",
+    "End with a concise summary."
   ].join("\n");
 }
 

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -1,5 +1,6 @@
 import { contextPointerLabel, type ContextPacket, type ContextPointer } from "@opentag/core";
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
+import { executorReportPromptLines } from "./executor-report.js";
 import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
 import {
   branchNameForRun,
@@ -49,7 +50,7 @@ function buildPrompt(input: {
     "Do not run, request, or recommend git add, git commit, git push, or gh pr create.",
     "Do not ask the user to approve local source-control commands; summarize file changes and verification only.",
     "OpenTag will publish the run branch and expose pull-request creation as a suggested action.",
-    "End with a concise summary."
+    ...executorReportPromptLines()
   ].join("\n");
 }
 

--- a/packages/runner/src/executor-report.ts
+++ b/packages/runner/src/executor-report.ts
@@ -1,0 +1,174 @@
+export const EXECUTOR_REPORT_START = "OPENTAG_EXECUTOR_REPORT_START";
+export const EXECUTOR_REPORT_END = "OPENTAG_EXECUTOR_REPORT_END";
+
+const REPORT_OUTCOMES = new Set(["passed", "failed", "not_run"]);
+const MAX_REPORT_ITEMS = 8;
+const MAX_REPORT_TEXT_LENGTH = 600;
+
+export type ExecutorReport = {
+  changes: Array<{
+    file?: string;
+    summary: string;
+  }>;
+  verification?: Array<{
+    command?: string;
+    outcome: "passed" | "failed" | "not_run";
+    summary?: string;
+  }>;
+  risks?: string[];
+  notes?: string[];
+};
+
+export function executorReportPromptLines(): string[] {
+  return [
+    "End with this exact machine-readable OpenTag executor report block. Put it last.",
+    "Replace every example value with the actual result. Use changes: [] if no files changed.",
+    "Use verification: [] if no checks ran. Use verification outcome exactly one of: passed, failed, not_run.",
+    EXECUTOR_REPORT_START,
+    JSON.stringify(
+      {
+        changes: [{ file: "README.md", summary: "Added one sentence describing the completed change." }],
+        verification: [{ command: "corepack pnpm test", outcome: "passed", summary: "Tests passed." }],
+        risks: []
+      },
+      null,
+      2
+    ),
+    EXECUTOR_REPORT_END
+  ];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function cleanReportText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const text = value.replace(/\s+/g, " ").trim();
+  return text.length > 0 ? text.slice(0, MAX_REPORT_TEXT_LENGTH) : undefined;
+}
+
+function cleanStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value.map(cleanReportText).filter((item): item is string => Boolean(item));
+  return items.length > 0 ? items.slice(0, MAX_REPORT_ITEMS) : undefined;
+}
+
+function normalizeReport(value: unknown): ExecutorReport | undefined {
+  const record = asRecord(value);
+  if (!record || !Array.isArray(record["changes"])) return undefined;
+
+  const changes = record["changes"]
+    .map((item) => {
+      const change = asRecord(item);
+      if (!change) return undefined;
+      const summary = cleanReportText(change["summary"]);
+      if (!summary) return undefined;
+      const file = cleanReportText(change["file"]);
+      return file ? { file, summary } : { summary };
+    })
+    .filter((item): item is ExecutorReport["changes"][number] => Boolean(item))
+    .slice(0, MAX_REPORT_ITEMS);
+
+  if ((record["changes"] as unknown[]).length > 0 && changes.length === 0) return undefined;
+
+  const verificationRaw = record["verification"];
+  const verification = Array.isArray(verificationRaw)
+    ? verificationRaw
+        .map((item) => {
+          const check = asRecord(item);
+          if (!check || typeof check["outcome"] !== "string" || !REPORT_OUTCOMES.has(check["outcome"])) return undefined;
+          const command = cleanReportText(check["command"]);
+          const summary = cleanReportText(check["summary"]);
+          return {
+            ...(command ? { command } : {}),
+            outcome: check["outcome"] as "passed" | "failed" | "not_run",
+            ...(summary ? { summary } : {})
+          };
+        })
+        .filter((item): item is NonNullable<ExecutorReport["verification"]>[number] => Boolean(item))
+        .slice(0, MAX_REPORT_ITEMS)
+    : undefined;
+
+  if (Array.isArray(verificationRaw) && verificationRaw.length > 0 && (!verification || verification.length === 0)) {
+    return undefined;
+  }
+
+  const risks = cleanStringArray(record["risks"]);
+  const notes = cleanStringArray(record["notes"]);
+
+  return {
+    changes,
+    ...(verification && verification.length > 0 ? { verification } : {}),
+    ...(risks ? { risks } : {}),
+    ...(notes ? { notes } : {})
+  };
+}
+
+function markerCandidate(output: string): string | undefined {
+  const startIndex = output.lastIndexOf(EXECUTOR_REPORT_START);
+  if (startIndex < 0) return undefined;
+  const afterStart = output.slice(startIndex + EXECUTOR_REPORT_START.length);
+  const endIndex = afterStart.indexOf(EXECUTOR_REPORT_END);
+  return (endIndex >= 0 ? afterStart.slice(0, endIndex) : afterStart).trim();
+}
+
+function parseCandidate(candidate: string): ExecutorReport | undefined {
+  try {
+    return normalizeReport(JSON.parse(candidate));
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseExecutorReport(output: string): ExecutorReport | undefined {
+  const marker = markerCandidate(output);
+  if (marker) {
+    const parsed = parseCandidate(marker);
+    if (parsed) return parsed;
+  }
+
+  return parseCandidate(output.trim());
+}
+
+function deterministicSummary(input: { executorName: string; changedFiles: string[] }): string {
+  if (input.changedFiles.length === 0) {
+    return `${input.executorName} completed without file changes.`;
+  }
+
+  return `${input.executorName} changed ${input.changedFiles.length} file(s). Changed files: ${input.changedFiles.join(", ")}.`;
+}
+
+export function renderExecutorReportSummary(input: {
+  executorName: string;
+  changedFiles: string[];
+  report: ExecutorReport;
+}): string {
+  const lines: string[] = [];
+
+  if (input.report.changes.length > 0) {
+    lines.push("What changed:");
+    for (const change of input.report.changes) {
+      lines.push(`- ${change.file ? `\`${change.file}\`: ` : ""}${change.summary}`);
+    }
+  }
+
+  if (input.report.verification?.length) {
+    if (lines.length > 0) lines.push("");
+    lines.push("Verified:");
+    for (const check of input.report.verification) {
+      const prefix = check.command ? `\`${check.command}\`: ${check.outcome}` : check.outcome;
+      lines.push(`- ${check.summary ? `${prefix} - ${check.summary}` : prefix}`);
+    }
+  }
+
+  if (input.report.risks?.length) {
+    if (lines.length > 0) lines.push("");
+    lines.push("Risks:");
+    for (const risk of input.report.risks) {
+      lines.push(`- ${risk}`);
+    }
+  }
+
+  return lines.length > 0 ? lines.join("\n") : deterministicSummary(input);
+}

--- a/packages/runner/src/executor-report.ts
+++ b/packages/runner/src/executor-report.ts
@@ -38,6 +38,17 @@ export function executorReportPromptLines(): string[] {
   ];
 }
 
+export function executorPolicyPromptLines(): string[] {
+  return [
+    "Work autonomously but keep the change narrow. Run relevant verification if you modify files.",
+    "OpenTag owns the source-control handoff after you finish.",
+    "Do not run, request, or recommend git add, git commit, git push, or gh pr create.",
+    "Do not ask the user to approve local source-control commands; summarize file changes and verification only.",
+    "OpenTag will publish the run branch and expose pull-request creation as a suggested action.",
+    ...executorReportPromptLines()
+  ];
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
 }

--- a/packages/runner/src/result.ts
+++ b/packages/runner/src/result.ts
@@ -1,5 +1,65 @@
 import type { OpenTagRunResult } from "@opentag/core";
 
+const MAX_EXECUTOR_SUMMARY_LENGTH = 4000;
+
+const GIT_HANDOFF_PATTERNS = [
+  /\bgit\s+(?:add|commit|push|status|checkout)\b/i,
+  /\bgh\s+pr\s+create\b/i,
+  /\binteractive user approval\b/i,
+  /\bpermission system\b/i,
+  /\brequires?\s+approval\b.*\b(?:git|commit|push|pull request|pr)\b/i,
+  /\b(?:cannot|can't|need|needs|please|approve|approval|required)\b.*\b(?:git|commit|push|pull request|pr)\b/i,
+  /\b(?:commit|push|create (?:a )?(?:pull request|pr)|open (?:a )?pull request)\b.*\b(?:approve|approval|manual|finish|next|requires?|required)\b/i
+];
+
+const HANDOFF_HEADING_PATTERN =
+  /^(?:#{1,6}\s*)?(?:\*\*)?\s*(?:blocker|recommended next action|next action|remaining work|manual steps|to finish)\b/i;
+
+function looksLikeGitHandoff(line: string): boolean {
+  return GIT_HANDOFF_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+function stripGitHandoffTail(line: string): string {
+  if (!looksLikeGitHandoff(line)) return line;
+  return line
+    .replace(/\s*(?:Blocker|Recommended next action|Next action|Remaining work|Manual steps|To finish)\s*:.*$/i, "")
+    .trimEnd();
+}
+
+function cleanOrFallbackExecutorSummary(input: {
+  executorName: string;
+  output: string;
+  changedFiles: string[];
+}): string {
+  const rawSummary = input.output.slice(-MAX_EXECUTOR_SUMMARY_LENGTH).replace(/\r\n/g, "\n");
+  const filteredLines: string[] = [];
+
+  for (const rawLine of rawSummary.split("\n")) {
+    const trimmed = rawLine.trim();
+    if (HANDOFF_HEADING_PATTERN.test(trimmed)) continue;
+
+    const withoutHandoffTail = stripGitHandoffTail(rawLine);
+    if (looksLikeGitHandoff(withoutHandoffTail)) continue;
+    if (withoutHandoffTail.trim().length === 0 && trimmed.length > 0) continue;
+
+    filteredLines.push(withoutHandoffTail);
+  }
+
+  const summary = filteredLines
+    .join("\n")
+    .replace(/```[^\n]*\n\s*```/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  if (summary.length > 0) return summary;
+
+  if (input.changedFiles.length === 0) {
+    return `${input.executorName} completed without file changes.`;
+  }
+
+  return `${input.executorName} changed ${input.changedFiles.length} file(s). Changed files: ${input.changedFiles.join(", ")}.`;
+}
+
 export function createExecutorRunResult(input: {
   executorName: string;
   runId: string;
@@ -10,7 +70,7 @@ export function createExecutorRunResult(input: {
   extraArtifacts?: NonNullable<OpenTagRunResult["artifacts"]>;
 }): OpenTagRunResult {
   const proposalId = `proposal_${input.runId}`;
-  const summary = input.output.slice(-4000);
+  const summary = cleanOrFallbackExecutorSummary(input);
   const suggestedChanges =
     input.changedFiles.length > 0
       ? [

--- a/packages/runner/src/result.ts
+++ b/packages/runner/src/result.ts
@@ -1,4 +1,5 @@
 import type { OpenTagRunResult } from "@opentag/core";
+import { parseExecutorReport, renderExecutorReportSummary } from "./executor-report.js";
 
 const MAX_EXECUTOR_SUMMARY_LENGTH = 4000;
 
@@ -70,7 +71,8 @@ export function createExecutorRunResult(input: {
   extraArtifacts?: NonNullable<OpenTagRunResult["artifacts"]>;
 }): OpenTagRunResult {
   const proposalId = `proposal_${input.runId}`;
-  const summary = cleanOrFallbackExecutorSummary(input);
+  const report = parseExecutorReport(input.output);
+  const summary = report ? renderExecutorReportSummary({ ...input, report }) : cleanOrFallbackExecutorSummary(input);
   const suggestedChanges =
     input.changedFiles.length > 0
       ? [

--- a/packages/runner/src/result.ts
+++ b/packages/runner/src/result.ts
@@ -3,18 +3,17 @@ import { parseExecutorReport, renderExecutorReportSummary } from "./executor-rep
 
 const MAX_EXECUTOR_SUMMARY_LENGTH = 4000;
 
+const DIRECT_SOURCE_CONTROL_COMMAND_PATTERN = /^\s*(?:[-*]\s*)?(?:`{1,3})?\s*(?:git\s+(?:add|commit|push|checkout)|gh\s+pr\s+create)\b/i;
+
 const GIT_HANDOFF_PATTERNS = [
-  /\bgit\s+(?:add|commit|push|status|checkout)\b/i,
-  /\bgh\s+pr\s+create\b/i,
-  /\binteractive user approval\b/i,
-  /\bpermission system\b/i,
-  /\brequires?\s+approval\b.*\b(?:git|commit|push|pull request|pr)\b/i,
-  /\b(?:cannot|can't|need|needs|please|approve|approval|required)\b.*\b(?:git|commit|push|pull request|pr)\b/i,
-  /\b(?:commit|push|create (?:a )?(?:pull request|pr)|open (?:a )?pull request)\b.*\b(?:approve|approval|manual|finish|next|requires?|required)\b/i
+  DIRECT_SOURCE_CONTROL_COMMAND_PATTERN,
+  /\b(?:interactive user approval|permission system)\b.*\b(?:git|source-control|commit|push|pull request|pr)\b/i,
+  /\b(?:git|source-control|commit|push|pull request|pr)\b.*\b(?:interactive user approval|permission system)\b/i,
+  /(?=.*\b(?:git\s+(?:add|commit|push|checkout)|gh\s+pr\s+create|commit|push|pull request|pr)\b)(?=.*\b(?:approval|approve|manual|need|needs|cannot|can't|please|requires?|required|finish|next action|remaining work|blocked|blocker|permission)\b)/i
 ];
 
 const HANDOFF_HEADING_PATTERN =
-  /^(?:#{1,6}\s*)?(?:\*\*)?\s*(?:blocker|recommended next action|next action|remaining work|manual steps|to finish)\b/i;
+  /^(?:#{1,6}\s*)?(?:\*\*)?\s*(?:blocker|recommended next action|next action|remaining work|manual steps|to finish)\b.*\b(?:git|source-control|commit|push|pull request|pr)\b/i;
 
 function looksLikeGitHandoff(line: string): boolean {
   return GIT_HANDOFF_PATTERNS.some((pattern) => pattern.test(line));
@@ -48,6 +47,7 @@ function cleanOrFallbackExecutorSummary(input: {
 
   const summary = filteredLines
     .join("\n")
+    .replace(/(?:^|\n)\s*(?:To finish|Manual steps):\s*\n```[^\n]*\n\s*```/gi, "\n")
     .replace(/```[^\n]*\n\s*```/g, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -103,6 +103,9 @@ describe("Claude Code executor", () => {
     expect(claudePrintCall?.input).toContain("OpenTag owns the source-control handoff after you finish.");
     expect(claudePrintCall?.input).toContain("Do not run, request, or recommend git add, git commit, git push, or gh pr create.");
     expect(claudePrintCall?.input).toContain("OpenTag will publish the run branch and expose pull-request creation as a suggested action.");
+    expect(claudePrintCall?.input).toContain("OPENTAG_EXECUTOR_REPORT_START");
+    expect(claudePrintCall?.input).toContain('"outcome": "passed"');
+    expect(claudePrintCall?.input).toContain("OPENTAG_EXECUTOR_REPORT_END");
     expect(events).toEqual(["executor.started", "executor.progress", "executor.progress", "executor.completed"]);
     expect(result.changedFiles).toEqual(["src/demo.ts", "test/demo.test.ts"]);
     expect(result.summary).toContain("Implemented the requested Claude Code change.");

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -100,6 +100,9 @@ describe("Claude Code executor", () => {
     expect(claudePrintCall?.input).toContain("[primary] github.issue: https://github.com/acme/demo/issues/1");
     expect(claudePrintCall?.input).toContain("Do not modify unrelated callback code.");
     expect(claudePrintCall?.input).toContain("fix this");
+    expect(claudePrintCall?.input).toContain("OpenTag owns the source-control handoff after you finish.");
+    expect(claudePrintCall?.input).toContain("Do not run, request, or recommend git add, git commit, git push, or gh pr create.");
+    expect(claudePrintCall?.input).toContain("OpenTag will publish the run branch and expose pull-request creation as a suggested action.");
     expect(events).toEqual(["executor.started", "executor.progress", "executor.progress", "executor.completed"]);
     expect(result.changedFiles).toEqual(["src/demo.ts", "test/demo.test.ts"]);
     expect(result.summary).toContain("Implemented the requested Claude Code change.");

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -116,6 +116,9 @@ describe("Codex executor", () => {
     expect(codexExecCall?.input).toContain("OpenTag owns the source-control handoff after you finish.");
     expect(codexExecCall?.input).toContain("Do not run, request, or recommend git add, git commit, git push, or gh pr create.");
     expect(codexExecCall?.input).toContain("OpenTag will publish the run branch and expose pull-request creation as a suggested action.");
+    expect(codexExecCall?.input).toContain("OPENTAG_EXECUTOR_REPORT_START");
+    expect(codexExecCall?.input).toContain('"outcome": "passed"');
+    expect(codexExecCall?.input).toContain("OPENTAG_EXECUTOR_REPORT_END");
     expect(codexExecCall?.cwd).toBe(worktreePath);
     expect(codexExecCall?.env?.OPENAI_API_KEY).toBeUndefined();
     expect(events).toEqual(["executor.started", "executor.progress", "executor.progress", "executor.progress", "executor.completed"]);

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -113,6 +113,9 @@ describe("Codex executor", () => {
     expect(codexExecCall?.input).toContain("Fix the requested issue with the narrowest possible change.");
     expect(codexExecCall?.input).toContain("Do not touch unrelated operational files.");
     expect(codexExecCall?.input).toContain("fix this");
+    expect(codexExecCall?.input).toContain("OpenTag owns the source-control handoff after you finish.");
+    expect(codexExecCall?.input).toContain("Do not run, request, or recommend git add, git commit, git push, or gh pr create.");
+    expect(codexExecCall?.input).toContain("OpenTag will publish the run branch and expose pull-request creation as a suggested action.");
     expect(codexExecCall?.cwd).toBe(worktreePath);
     expect(codexExecCall?.env?.OPENAI_API_KEY).toBeUndefined();
     expect(events).toEqual(["executor.started", "executor.progress", "executor.progress", "executor.progress", "executor.completed"]);

--- a/packages/runner/test/result.test.ts
+++ b/packages/runner/test/result.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { createExecutorRunResult } from "../src/result.js";
+
+describe("createExecutorRunResult", () => {
+  it("removes executor source-control handoff instructions from user-visible summaries", () => {
+    const result = createExecutorRunResult({
+      executorName: "Claude Code",
+      runId: "run_1",
+      branchName: "opentag/run_1",
+      output: [
+        "What changed: Added the requested README sentence.",
+        "",
+        "Verified: The edit applied cleanly.",
+        "",
+        "Recommended next action: Commit the change and push to the branch.",
+        "",
+        "Blocker: I cannot run `git add README.md` or `git commit` because those commands require interactive user approval.",
+        "",
+        "To finish:",
+        "```bash",
+        "git add README.md && git commit -m \"Update README\" && gh pr create",
+        "```"
+      ].join("\n"),
+      changedFiles: ["README.md"]
+    });
+
+    expect(result.summary).toContain("What changed: Added the requested README sentence.");
+    expect(result.summary).toContain("Verified: The edit applied cleanly.");
+    expect(result.summary).not.toMatch(/git\s+add/i);
+    expect(result.summary).not.toMatch(/git\s+commit/i);
+    expect(result.summary).not.toMatch(/git\s+push/i);
+    expect(result.summary).not.toMatch(/gh\s+pr\s+create/i);
+    expect(result.summary).not.toMatch(/interactive user approval/i);
+    expect(result.summary).not.toContain("```");
+
+    const pullRequestBody = result.suggestedChanges?.[0]?.intents[0]?.params?.["body"];
+    expect(pullRequestBody).toContain("What changed: Added the requested README sentence.");
+    expect(pullRequestBody).toContain("Verified: The edit applied cleanly.");
+    expect(pullRequestBody).not.toMatch(/git\s+add/i);
+    expect(pullRequestBody).not.toMatch(/git\s+commit/i);
+    expect(pullRequestBody).not.toMatch(/gh\s+pr\s+create/i);
+    expect(result.nextAction).toMatchObject({
+      summary: "Review the proposed pull request action and reply `apply 1` if the branch should become a PR."
+    });
+  });
+
+  it("falls back to an OpenTag-owned summary when the executor output is only handoff noise", () => {
+    const result = createExecutorRunResult({
+      executorName: "Claude Code",
+      runId: "run_1",
+      branchName: "opentag/run_1",
+      output: "Please approve `git add README.md && git commit && gh pr create` to finish.",
+      changedFiles: ["README.md", "docs/setup.md"]
+    });
+
+    expect(result.summary).toBe("Claude Code changed 2 file(s). Changed files: README.md, docs/setup.md.");
+    expect(result.summary).not.toMatch(/git\s+add/i);
+    expect(result.suggestedChanges?.[0]?.intents[0]?.params?.["body"]).not.toMatch(/git\s+add/i);
+  });
+});

--- a/packages/runner/test/result.test.ts
+++ b/packages/runner/test/result.test.ts
@@ -97,4 +97,26 @@ describe("createExecutorRunResult", () => {
     expect(result.summary).not.toMatch(/git\s+add/i);
     expect(result.suggestedChanges?.[0]?.intents[0]?.params?.["body"]).not.toMatch(/git\s+add/i);
   });
+
+  it("preserves generic blocker and permission-system status lines in fallback summaries", () => {
+    const result = createExecutorRunResult({
+      executorName: "Claude Code",
+      runId: "run_1",
+      branchName: "opentag/run_1",
+      output: [
+        "What changed:",
+        "- Updated permission-system documentation.",
+        "",
+        "Blocker: External API credentials are missing.",
+        "",
+        "Verified: Not run because credentials are missing."
+      ].join("\n"),
+      changedFiles: ["docs/security.md"]
+    });
+
+    expect(result.summary).toContain("What changed:");
+    expect(result.summary).toContain("Updated permission-system documentation.");
+    expect(result.summary).toContain("Blocker: External API credentials are missing.");
+    expect(result.summary).toContain("Verified: Not run because credentials are missing.");
+  });
 });

--- a/packages/runner/test/result.test.ts
+++ b/packages/runner/test/result.test.ts
@@ -1,7 +1,47 @@
 import { describe, expect, it } from "vitest";
+import { EXECUTOR_REPORT_END, EXECUTOR_REPORT_START } from "../src/executor-report.js";
 import { createExecutorRunResult } from "../src/result.js";
 
 describe("createExecutorRunResult", () => {
+  it("renders user-visible summaries from the structured executor report when present", () => {
+    const result = createExecutorRunResult({
+      executorName: "Claude Code",
+      runId: "run_1",
+      branchName: "opentag/run_1",
+      output: [
+        "Raw executor note: please approve `git commit` and `gh pr create` to finish.",
+        EXECUTOR_REPORT_START,
+        JSON.stringify({
+          changes: [{ file: "README.md", summary: "Added one sentence about clean Slack approval summaries." }],
+          verification: [{ outcome: "passed", summary: "The edit applied cleanly." }],
+          risks: ["No known risks beyond reviewing the generated diff."]
+        }),
+        EXECUTOR_REPORT_END
+      ].join("\n"),
+      changedFiles: ["README.md"]
+    });
+
+    expect(result.summary).toBe(
+      [
+        "What changed:",
+        "- `README.md`: Added one sentence about clean Slack approval summaries.",
+        "",
+        "Verified:",
+        "- passed - The edit applied cleanly.",
+        "",
+        "Risks:",
+        "- No known risks beyond reviewing the generated diff."
+      ].join("\n")
+    );
+    expect(result.summary).not.toMatch(/git\s+commit/i);
+    expect(result.summary).not.toMatch(/gh\s+pr\s+create/i);
+
+    const pullRequestBody = result.suggestedChanges?.[0]?.intents[0]?.params?.["body"];
+    expect(pullRequestBody).toContain("- `README.md`: Added one sentence about clean Slack approval summaries.");
+    expect(pullRequestBody).not.toMatch(/git\s+commit/i);
+    expect(pullRequestBody).not.toMatch(/gh\s+pr\s+create/i);
+  });
+
   it("removes executor source-control handoff instructions from user-visible summaries", () => {
     const result = createExecutorRunResult({
       executorName: "Claude Code",

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -1,5 +1,6 @@
 import { parseThreadActionCommand, type OpenTagEvent } from "@opentag/core";
 import { encodeSlackThreadKey, normalizeSlackAppMention, stripSlackAppMention, type SlackChannelBinding } from "./normalize.js";
+import { parseSlackSuggestedActionButtonValue } from "./render.js";
 
 export type SlackThreadActionInput = {
   id: string;
@@ -39,6 +40,28 @@ export type SlackEventEnvelope = {
   authorizations?: Array<{ user_id?: string }>;
 };
 
+export type SlackInteractiveBlockAction = {
+  type?: string;
+  action_id?: string;
+  block_id?: string;
+  value?: string;
+  action_ts?: string;
+};
+
+export type SlackInteractivePayload = {
+  type: "block_actions";
+  api_app_id?: string;
+  team?: { id?: string; domain?: string };
+  user?: { id?: string; username?: string; name?: string };
+  channel?: { id?: string; name?: string };
+  message?: { ts?: string; thread_ts?: string };
+  container?: { type?: string; channel_id?: string; message_ts?: string; thread_ts?: string };
+  trigger_id?: string;
+  actions?: SlackInteractiveBlockAction[];
+};
+
+export type SlackIngressPayload = SlackEventEnvelope | SlackInteractivePayload;
+
 export type SlackAppRuntimeConfig = {
   agentId: string;
   appId?: string;
@@ -75,8 +98,84 @@ function text(body: string, status: SlackEventProcessorStatus = 200): SlackEvent
 }
 
 export function createSlackEventProcessor(input: SlackEventProcessorInput) {
+  async function processBlockActions(payload: SlackInteractivePayload, slackApp: SlackAppRuntimeConfig): Promise<SlackEventProcessorResult> {
+    const action = payload.actions?.find((candidate) => {
+      if (candidate.action_id?.startsWith("opentag:")) return true;
+      return typeof candidate.value === "string" && parseSlackSuggestedActionButtonValue(candidate.value) !== null;
+    });
+    if (!action) {
+      return json({ ok: true });
+    }
+
+    const parsedValue = typeof action.value === "string" ? parseSlackSuggestedActionButtonValue(action.value) : null;
+    const rawText =
+      parsedValue?.command ??
+      (typeof action.value === "string" && parseThreadActionCommand(action.value) ? action.value.trim() : undefined);
+    if (!rawText || !parseThreadActionCommand(rawText)) {
+      return json({ error: "invalid_interactive_action" }, 400);
+    }
+    if (!input.submitThreadAction) {
+      return json({ ok: true });
+    }
+
+    const teamId = payload.team?.id;
+    const userId = payload.user?.id;
+    const channelId = payload.channel?.id ?? payload.container?.channel_id;
+    const messageTs = payload.message?.ts ?? payload.container?.message_ts;
+    const threadTs = payload.message?.thread_ts ?? payload.container?.thread_ts ?? messageTs;
+    if (!teamId || !userId || !channelId || !messageTs || !threadTs) {
+      return json({ error: "invalid_interactive_payload" }, 400);
+    }
+
+    const binding = await input.resolveChannelBinding({
+      teamId,
+      channelId
+    });
+    if (!binding) {
+      return json({ ok: true, ignored: "unbound_channel" });
+    }
+
+    await input.submitThreadAction({
+      id: `approval_slack_block_${payload.trigger_id ?? `${action.action_id ?? "action"}_${action.action_ts ?? messageTs}`}`,
+      rawText,
+      actor: {
+        provider: "slack",
+        providerUserId: userId,
+        handle: payload.user?.username ?? payload.user?.name ?? userId,
+        organizationId: teamId
+      },
+      callback: {
+        provider: "slack",
+        uri: slackApp.callbackUri ?? "https://slack.com/api/chat.postMessage",
+        threadKey: encodeSlackThreadKey({
+          teamId,
+          channelId,
+          threadTs
+        })
+      },
+      metadata: {
+        source: "slack_button",
+        teamId,
+        channelId,
+        messageTs,
+        ...(payload.api_app_id ? { slackAppId: payload.api_app_id } : {}),
+        ...(action.action_id ? { actionId: action.action_id } : {}),
+        ...(action.block_id ? { blockId: action.block_id } : {}),
+        ...(action.action_ts ? { actionTs: action.action_ts } : {}),
+        ...(parsedValue ? { proposalId: parsedValue.proposalId, intentId: parsedValue.intentId } : {}),
+        repoProvider: binding.repoProvider ?? "github",
+        owner: binding.owner,
+        repo: binding.repo
+      }
+    });
+    return json({ ok: true });
+  }
+
   return {
-    async process(payload: SlackEventEnvelope, slackApp: SlackAppRuntimeConfig): Promise<SlackEventProcessorResult> {
+    async process(payload: SlackIngressPayload, slackApp: SlackAppRuntimeConfig): Promise<SlackEventProcessorResult> {
+      if (payload.type === "block_actions") {
+        return processBlockActions(payload, slackApp);
+      }
       if (payload.type === "url_verification") {
         return text(payload.challenge ?? "");
       }

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -2,7 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { createSlackDispatcherEventProcessorInput } from "./dispatcher-events.js";
-import { createSlackEventProcessor, type SlackAppRuntimeConfig, type SlackEventEnvelope, type SlackEventProcessorInput } from "./events.js";
+import { createSlackEventProcessor, type SlackAppRuntimeConfig, type SlackEventProcessorInput, type SlackIngressPayload } from "./events.js";
 
 export type SlackEventsAppInput = {
   slackApps: Array<
@@ -65,9 +65,14 @@ export function createSlackEventsApp(input: SlackEventsAppInput) {
   const app = new Hono();
   const processor = createSlackEventProcessor(input);
 
-  function parseSlackPayload(rawBody: string): SlackEventEnvelope | null {
+  function parseSlackPayload(rawBody: string, contentType?: string): SlackIngressPayload | null {
     try {
-      return JSON.parse(rawBody) as SlackEventEnvelope;
+      if (contentType?.includes("application/x-www-form-urlencoded") || rawBody.startsWith("payload=")) {
+        const interactivePayload = new URLSearchParams(rawBody).get("payload");
+        if (!interactivePayload) return null;
+        return JSON.parse(interactivePayload) as SlackIngressPayload;
+      }
+      return JSON.parse(rawBody) as SlackIngressPayload;
     } catch {
       return null;
     }
@@ -106,7 +111,7 @@ export function createSlackEventsApp(input: SlackEventsAppInput) {
       return c.json({ error: "stale_signature_timestamp" }, 401);
     }
     const rawBody = await c.req.text();
-    const payload = parseSlackPayload(rawBody);
+    const payload = parseSlackPayload(rawBody, c.req.header("content-type"));
     if (!payload) {
       return c.json({ error: "invalid_json" }, 400);
     }

--- a/packages/slack/src/normalize.ts
+++ b/packages/slack/src/normalize.ts
@@ -70,11 +70,21 @@ export function parseSlackThreadKey(threadKey: string): { teamId: string; channe
   return { teamId, channelId, threadTs };
 }
 
-function permissionsForIntent(intent: OpenTagCommand["intent"]): PermissionGrant[] {
+function commandLooksWriteCapable(command: OpenTagCommand): boolean {
+  return /\b(add|append|apply|change|commit|create|delete|edit|fix|modify|open\s+a?\s*pr|pull\s+request|remove|update|write)\b/i.test(
+    command.rawText
+  );
+}
+
+function permissionsForCommand(command: OpenTagCommand): PermissionGrant[] {
   const permissions: PermissionGrant[] = [
     {
       scope: "chat:postMessage",
       reason: "reply in the originating Slack thread"
+    },
+    {
+      scope: "reactions:write",
+      reason: "mark the originating Slack message as received without posting a thread reply"
     },
     {
       scope: "runner:local",
@@ -82,7 +92,7 @@ function permissionsForIntent(intent: OpenTagCommand["intent"]): PermissionGrant
     }
   ];
 
-  if (intent === "fix" || intent === "run") {
+  if (command.intent === "fix" || command.intent === "run" || (command.intent === "unknown" && commandLooksWriteCapable(command))) {
     permissions.push(
       {
         scope: "repo:read",
@@ -187,7 +197,7 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
       },
       ...contextPointersForCommand(command)
     ],
-    permissions: permissionsForIntent(command.intent),
+    permissions: permissionsForCommand(command),
     callback: {
       provider: "slack",
       uri: input.callbackUri ?? "https://slack.com/api/chat.postMessage",

--- a/packages/slack/src/normalize.ts
+++ b/packages/slack/src/normalize.ts
@@ -70,10 +70,12 @@ export function parseSlackThreadKey(threadKey: string): { teamId: string; channe
   return { teamId, channelId, threadTs };
 }
 
-function commandLooksWriteCapable(command: OpenTagCommand): boolean {
-  return /\b(add|append|apply|change|commit|create|delete|edit|fix|modify|open\s+a?\s*pr|pull\s+request|remove|update|write)\b/i.test(
-    command.rawText
-  );
+const UNKNOWN_WRITE_VERB_PATTERN = /\b(add|append|apply|change|commit|create|delete|edit|fix|modify|open\s+a?\s*pr|pull\s+request|remove|update|write)\b/i;
+const REPO_WRITE_TARGET_PATTERN =
+  /\b(repo|repository|code|file|files|branch|commit|diff|patch|readme|pr|pull\s+request|package\.json|pnpm|npm|test|build)\b|(?:^|\s)[./\w-]+\.(?:cjs|css|go|html|js|json|jsx|lock|md|mjs|py|rb|rs|sh|toml|ts|tsx|txt|yaml|yml)\b/i;
+
+function commandLooksRepoWriteCapable(command: OpenTagCommand): boolean {
+  return UNKNOWN_WRITE_VERB_PATTERN.test(command.rawText) && REPO_WRITE_TARGET_PATTERN.test(command.rawText);
 }
 
 function permissionsForCommand(command: OpenTagCommand): PermissionGrant[] {
@@ -92,7 +94,7 @@ function permissionsForCommand(command: OpenTagCommand): PermissionGrant[] {
     }
   ];
 
-  if (command.intent === "fix" || command.intent === "run" || (command.intent === "unknown" && commandLooksWriteCapable(command))) {
+  if (command.intent === "fix" || command.intent === "run" || (command.intent === "unknown" && commandLooksRepoWriteCapable(command))) {
     permissions.push(
       {
         scope: "repo:read",

--- a/packages/slack/src/normalize.ts
+++ b/packages/slack/src/normalize.ts
@@ -72,7 +72,7 @@ export function parseSlackThreadKey(threadKey: string): { teamId: string; channe
 
 const UNKNOWN_WRITE_VERB_PATTERN = /\b(add|append|apply|change|commit|create|delete|edit|fix|modify|open\s+a?\s*pr|pull\s+request|remove|update|write)\b/i;
 const REPO_WRITE_TARGET_PATTERN =
-  /\b(repo|repository|code|file|files|branch|commit|diff|patch|readme|pr|pull\s+request|package\.json|pnpm|npm|test|build)\b|(?:^|\s)[./\w-]+\.(?:cjs|css|go|html|js|json|jsx|lock|md|mjs|py|rb|rs|sh|toml|ts|tsx|txt|yaml|yml)\b/i;
+  /\b(repo|repository|code|file|files|branch|commit|diff|patch|readme|pr|pull\s+request|package\.json|pnpm|npm|test|build)\b|(?:^|\s)[./\w-]+\.(?:cjs|css|gitignore|go|html|js|json|jsx|lock|md|mjs|py|rb|rs|sh|toml|ts|tsx|txt|yaml|yml)\b|(?:^|[\s`'"(])(?:[./\w-]+\/)?(?:Dockerfile|Makefile|Procfile|Rakefile|Gemfile|Brewfile|Justfile|Taskfile|\.dockerignore|\.env(?:\.[\w-]+)?|\.gitignore|\.npmrc)(?=$|[\s`'",.):])/i;
 
 function commandLooksRepoWriteCapable(command: OpenTagCommand): boolean {
   return UNKNOWN_WRITE_VERB_PATTERN.test(command.rawText) && REPO_WRITE_TARGET_PATTERN.test(command.rawText);

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -1,4 +1,4 @@
-import { suggestedActionCandidatesFromResult, type OpenTagRunResult } from "@opentag/core";
+import { suggestedActionCandidatesFromResult, type OpenTagRunResult, type SuggestedActionCandidate } from "@opentag/core";
 
 export type SlackTextBlock = {
   type: "section";
@@ -12,7 +12,32 @@ export type SlackDividerBlock = {
   type: "divider";
 };
 
-export type SlackBlock = SlackTextBlock | SlackDividerBlock;
+export type SlackButtonElement = {
+  type: "button";
+  text: {
+    type: "plain_text";
+    text: string;
+    emoji?: boolean;
+  };
+  action_id: string;
+  value: string;
+  style?: "primary" | "danger";
+};
+
+export type SlackActionsBlock = {
+  type: "actions";
+  block_id?: string;
+  elements: SlackButtonElement[];
+};
+
+export type SlackBlock = SlackTextBlock | SlackDividerBlock | SlackActionsBlock;
+
+export type SlackSuggestedActionButtonValue = {
+  version: 1;
+  command: string;
+  proposalId: string;
+  intentId: string;
+};
 
 export type SlackMessagePayload = {
   channel: string;
@@ -21,6 +46,43 @@ export type SlackMessagePayload = {
   ts?: string;
   blocks?: SlackBlock[];
 };
+
+export type SlackReactionPayload = {
+  channel: string;
+  timestamp: string;
+  name: string;
+};
+
+export type SlackSourceReceiptState = "received";
+
+export function buildSlackSuggestedActionButtonValue(input: SlackSuggestedActionButtonValue): string {
+  return JSON.stringify(input);
+}
+
+export function parseSlackSuggestedActionButtonValue(value: string): SlackSuggestedActionButtonValue | null {
+  try {
+    const parsed = JSON.parse(value) as Partial<SlackSuggestedActionButtonValue>;
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.command !== "string" ||
+      parsed.command.trim().length === 0 ||
+      typeof parsed.proposalId !== "string" ||
+      parsed.proposalId.length === 0 ||
+      typeof parsed.intentId !== "string" ||
+      parsed.intentId.length === 0
+    ) {
+      return null;
+    }
+    return {
+      version: 1,
+      command: parsed.command.trim(),
+      proposalId: parsed.proposalId,
+      intentId: parsed.intentId
+    };
+  } catch {
+    return null;
+  }
+}
 
 function escapeSlackText(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -40,7 +102,21 @@ export function markdownToSlackMrkdwn(text: string): string {
 }
 
 export function renderSlackAcknowledgement(runId: string): string {
-  return `I picked this up: \`${runId}\``;
+  void runId;
+  return "Working on it.";
+}
+
+export function slackSourceReceiptReactionName(state: SlackSourceReceiptState): string {
+  if (state === "received") return "eyes";
+  return "eyes";
+}
+
+export function createSlackReactionPayload(input: { channelId: string; messageTs: string; name: string }): SlackReactionPayload {
+  return {
+    channel: input.channelId,
+    timestamp: input.messageTs,
+    name: input.name
+  };
 }
 
 function nextActionSummary(result: OpenTagRunResult): string | undefined {
@@ -98,52 +174,112 @@ function renderSuggestedActionDetails(params: Record<string, unknown> | undefine
   return lines;
 }
 
+function truncateSlackText(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function firstMarkdownSection(text: string, heading: string): string | undefined {
+  const pattern = new RegExp(`\\*\\*${heading}:\\*\\*\\s*([\\s\\S]*?)(?=\\n\\s*\\n\\*\\*[^*]+:\\*\\*|\\n\\s*\\n[A-Z][^\\n]{0,60}:|$)`, "i");
+  const match = text.match(pattern);
+  return match?.[1]?.trim();
+}
+
+function compactSlackSummary(summary: string): string {
+  const whatChanged = firstMarkdownSection(summary, "What changed");
+  const firstParagraph = summary
+    .split(/\n\s*\n/)
+    .map((part) => part.trim())
+    .find(Boolean);
+  const selected = whatChanged ?? firstParagraph ?? summary;
+  return truncateSlackText(selected.replace(/^\*\*[^*]+:\*\*\s*/i, ""), 360);
+}
+
+function compactNextAction(nextAction: string): string {
+  return truncateSlackText(nextAction, 180);
+}
+
+function renderSuggestedActionCandidateLines(candidate: SuggestedActionCandidate): string[] {
+  const lines = [`${candidate.index}. *${markdownToSlackMrkdwn(candidate.intent.summary)}*`];
+  const details = renderSuggestedActionDetails(candidate.intent.params, candidate.intent.action)
+    .filter((line) => line.trim().startsWith("Branch:") || line.trim().startsWith("Changed files:"))
+    .map((line) => line.replace(/^\s+/, ""));
+  lines.push(...details);
+  if (candidate.proposalPreconditions?.length) {
+    lines.push(`Preconditions: ${candidate.proposalPreconditions.length} check(s) in the audit log.`);
+  }
+  return lines;
+}
+
 function renderSuggestedActionsMarkdown(result: OpenTagRunResult): string[] {
   const candidates = suggestedActionCandidatesFromResult(result);
   if (candidates.length === 0) return [];
 
   const lines = ["*Suggested actions*"];
   for (const candidate of candidates) {
-    lines.push(
-      "",
-      `${candidate.index}. *${markdownToSlackMrkdwn(candidate.intent.summary)}*`,
-      `   Intent: \`${candidate.intent.action}\` (\`${candidate.intent.domain}\`)`,
-      `   Proposal: \`${candidate.proposalId}\``,
-      `   Intent ID: \`${candidate.intent.intentId}\``
-    );
-    lines.push(...renderSuggestedActionDetails(candidate.intent.params, candidate.intent.action));
-    if (candidate.proposalPreconditions?.length) {
-      lines.push("   Preconditions:");
-      for (const precondition of candidate.proposalPreconditions) {
-        lines.push(`   - ${markdownToSlackMrkdwn(precondition)}`);
-      }
-    }
+    lines.push("", ...renderSuggestedActionCandidateLines(candidate));
   }
 
-  lines.push(
-    "",
-    "Reply with:",
-    "- `approve 1` to record approval",
-    "- `apply 1` or `apply all` to apply supported actions",
-    "- `continue 1` to continue with a follow-up run",
-    "- `reject 1` to reject an action"
-  );
+  lines.push("", "Use the buttons below, or reply `apply 1`, `approve 1`, or `reject 1`.");
   return lines;
 }
 
+function createSuggestedActionButtons(candidate: SuggestedActionCandidate): SlackButtonElement[] {
+  return [
+    {
+      type: "button",
+      text: { type: "plain_text", text: `Apply ${candidate.index}`, emoji: true },
+      action_id: `opentag:apply:${candidate.index}`,
+      value: buildSlackSuggestedActionButtonValue({
+        version: 1,
+        command: `apply ${candidate.index}`,
+        proposalId: candidate.proposalId,
+        intentId: candidate.intent.intentId
+      }),
+      style: "primary"
+    },
+    {
+      type: "button",
+      text: { type: "plain_text", text: "Approve", emoji: true },
+      action_id: `opentag:approve:${candidate.index}`,
+      value: buildSlackSuggestedActionButtonValue({
+        version: 1,
+        command: `approve ${candidate.index}`,
+        proposalId: candidate.proposalId,
+        intentId: candidate.intent.intentId
+      })
+    },
+    {
+      type: "button",
+      text: { type: "plain_text", text: "Reject", emoji: true },
+      action_id: `opentag:reject:${candidate.index}`,
+      value: buildSlackSuggestedActionButtonValue({
+        version: 1,
+        command: `reject ${candidate.index}`,
+        proposalId: candidate.proposalId,
+        intentId: candidate.intent.intentId
+      }),
+      style: "danger"
+    }
+  ];
+}
+
 export function renderSlackFinalResult(result: OpenTagRunResult): string {
-  const lines = [`Finished with *${result.conclusion}*.`, "", markdownToSlackMrkdwn(result.summary)];
+  const lines = [`*Finished: ${result.conclusion}.*`, markdownToSlackMrkdwn(compactSlackSummary(result.summary))];
 
   if (result.verification?.length) {
-    lines.push("", "*Verification*");
-    for (const check of result.verification) {
-      lines.push(`- \`${check.command}\`: ${check.outcome}`);
-    }
+    lines.push(
+      `Verified: ${result.verification
+        .slice(0, 3)
+        .map((check) => `\`${check.command}\` ${check.outcome}`)
+        .join(", ")}`
+    );
   }
 
   const nextAction = nextActionSummary(result);
-  if (nextAction) {
-    lines.push("", `*Next action*: ${markdownToSlackMrkdwn(nextAction)}`);
+  if (nextAction && !result.suggestedChanges?.length) {
+    lines.push(`Next: ${markdownToSlackMrkdwn(compactNextAction(nextAction))}`);
   }
 
   const suggestedActions = renderSuggestedActionsMarkdown(result);
@@ -160,43 +296,61 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlo
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Finished with ${result.conclusion}.*\n${markdownToSlackMrkdwn(result.summary)}`
+        text: `*Finished: ${result.conclusion}.*\n${markdownToSlackMrkdwn(compactSlackSummary(result.summary))}`
       }
     }
   ];
 
   if (result.verification?.length) {
-    blocks.push({ type: "divider" });
     blocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: markdownToSlackMrkdwn(["*Verification*", ...result.verification.map((check) => `- \`${check.command}\`: ${check.outcome}`)].join("\n"))
+        text: `Verified: ${markdownToSlackMrkdwn(
+          result.verification
+            .slice(0, 3)
+            .map((check) => `\`${check.command}\` ${check.outcome}`)
+            .join(", ")
+        )}`
       }
     });
   }
 
   const nextAction = nextActionSummary(result);
-  if (nextAction) {
+  const suggestedActionCandidates = suggestedActionCandidatesFromResult(result);
+  if (nextAction && suggestedActionCandidates.length === 0) {
     blocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Next action*: ${markdownToSlackMrkdwn(nextAction)}`
+        text: `Next: ${markdownToSlackMrkdwn(compactNextAction(nextAction))}`
       }
     });
   }
 
-  const suggestedActions = renderSuggestedActionsMarkdown(result);
-  if (suggestedActions.length > 0) {
+  if (suggestedActionCandidates.length > 0) {
     blocks.push({ type: "divider" });
     blocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: suggestedActions.join("\n")
+        text: "*Suggested actions*\nChoose an action in this thread. Details stay in the OpenTag audit log."
       }
     });
+    for (const candidate of suggestedActionCandidates) {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: renderSuggestedActionCandidateLines(candidate).join("\n")
+        }
+      });
+      blocks.push({
+        type: "actions",
+        block_id: `opentag_actions_${candidate.index}`,
+        elements: createSuggestedActionButtons(candidate)
+      });
+    }
   }
 
   return blocks;

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -55,6 +55,8 @@ export type SlackReactionPayload = {
 
 export type SlackSourceReceiptState = "received";
 
+const MAX_SLACK_SUGGESTED_ACTION_CANDIDATES = 20;
+
 export function buildSlackSuggestedActionButtonValue(input: SlackSuggestedActionButtonValue): string {
   return JSON.stringify(input);
 }
@@ -217,10 +219,15 @@ function renderSuggestedActionsMarkdown(result: OpenTagRunResult): string[] {
   if (candidates.length === 0) return [];
 
   const lines = ["*Suggested actions*"];
-  for (const candidate of candidates) {
+  const visibleCandidates = candidates.slice(0, MAX_SLACK_SUGGESTED_ACTION_CANDIDATES);
+  for (const candidate of visibleCandidates) {
     lines.push("", ...renderSuggestedActionCandidateLines(candidate));
   }
 
+  const remainingCount = candidates.length - visibleCandidates.length;
+  if (remainingCount > 0) {
+    lines.push("", `Showing first ${visibleCandidates.length} of ${candidates.length} actions. Reply with an action number for the rest.`);
+  }
   lines.push("", "Use the buttons below, or reply `apply 1`, `approve 1`, or `reject 1`.");
   return lines;
 }
@@ -272,7 +279,7 @@ export function renderSlackFinalResult(result: OpenTagRunResult): string {
     lines.push(
       `Verified: ${result.verification
         .slice(0, 3)
-        .map((check) => `\`${check.command}\` ${check.outcome}`)
+        .map((check) => `\`${markdownToSlackMrkdwn(check.command)}\` ${markdownToSlackMrkdwn(check.outcome)}`)
         .join(", ")}`
     );
   }
@@ -337,7 +344,8 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlo
         text: "*Suggested actions*\nChoose an action in this thread. Details stay in the OpenTag audit log."
       }
     });
-    for (const candidate of suggestedActionCandidates) {
+    const visibleCandidates = suggestedActionCandidates.slice(0, MAX_SLACK_SUGGESTED_ACTION_CANDIDATES);
+    for (const candidate of visibleCandidates) {
       blocks.push({
         type: "section",
         text: {
@@ -349,6 +357,16 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlo
         type: "actions",
         block_id: `opentag_actions_${candidate.index}`,
         elements: createSuggestedActionButtons(candidate)
+      });
+    }
+    const remainingCount = suggestedActionCandidates.length - visibleCandidates.length;
+    if (remainingCount > 0) {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `Showing first ${visibleCandidates.length} of ${suggestedActionCandidates.length} actions. Reply with an action number for the rest.`
+        }
       });
     }
   }

--- a/packages/slack/src/socket-mode.ts
+++ b/packages/slack/src/socket-mode.ts
@@ -1,6 +1,6 @@
 import WebSocket, { type RawData } from "ws";
 import { createSlackDispatcherEventProcessorInput, type SlackDispatcherEventConfig } from "./dispatcher-events.js";
-import { createSlackEventProcessor, type SlackAppRuntimeConfig, type SlackEventEnvelope, type SlackEventProcessorInput } from "./events.js";
+import { createSlackEventProcessor, type SlackAppRuntimeConfig, type SlackEventProcessorInput, type SlackIngressPayload } from "./events.js";
 
 const SLACK_CONNECTIONS_OPEN_URL = "https://slack.com/api/apps.connections.open";
 const DEFAULT_RECONNECT_DELAY_MS = 1_000;
@@ -37,7 +37,7 @@ function isTerminalSlackAuthError(error: unknown): boolean {
 export type SlackSocketModeEnvelope = {
   type?: string;
   envelope_id?: string;
-  payload?: SlackEventEnvelope;
+  payload?: SlackIngressPayload;
   accepts_response_payload?: boolean;
 };
 
@@ -120,10 +120,13 @@ async function handleSocketMessage(input: {
 
   input.socket.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
 
-  if (envelope.type !== "events_api" || !envelope.payload) {
+  if (!envelope.payload) {
     return;
   }
   if (input.slackApp.appId && envelope.payload.api_app_id && envelope.payload.api_app_id !== input.slackApp.appId) {
+    return;
+  }
+  if (envelope.type !== "events_api" && envelope.payload.type !== "block_actions") {
     return;
   }
 

--- a/packages/slack/test/normalize.test.ts
+++ b/packages/slack/test/normalize.test.ts
@@ -150,4 +150,26 @@ describe("Slack normalization", () => {
       expect.arrayContaining(["chat:postMessage", "reactions:write", "runner:local", "repo:read", "repo:write", "pr:create"])
     );
   });
+
+  it("keeps non-repo unknown write-like requests read-only", () => {
+    const event = normalizeSlackAppMention({
+      teamId: "T123",
+      channelId: "C123",
+      userId: "U456",
+      text: "<@U_APP> Add a Linear ticket for this customer",
+      ts: "1710000000.000100",
+      eventId: "Ev791",
+      eventTime: 1710000000,
+      botUserId: "U_APP",
+      binding: {
+        teamId: "T123",
+        channelId: "C123",
+        owner: "acme",
+        repo: "demo"
+      }
+    });
+
+    expect(event?.command.intent).toBe("unknown");
+    expect(event?.permissions.map((permission) => permission.scope)).toEqual(["chat:postMessage", "reactions:write", "runner:local"]);
+  });
 });

--- a/packages/slack/test/normalize.test.ts
+++ b/packages/slack/test/normalize.test.ts
@@ -83,6 +83,7 @@ describe("Slack normalization", () => {
     expect(event?.metadata).toMatchObject({ repoProvider: "gitlab" });
     expect(event?.metadata).toMatchObject({ slackAppId: "A123", slackBotUserId: "U_APP" });
     expect(event?.permissions.map((permission) => permission.scope)).toContain("chat:postMessage");
+    expect(event?.permissions.map((permission) => permission.scope)).toContain("reactions:write");
     expect(event?.callback.uri).toBe("http://127.0.0.1:3102/github-comment");
   });
 
@@ -117,12 +118,36 @@ describe("Slack normalization", () => {
     expect(event?.target).toMatchObject({ agentId: "gemini", executorHint: "codex" });
     expect(event?.command.parsed?.requestedScopes).toEqual(["repo:write"]);
     expect(event?.permissions.map((permission) => permission.scope)).toEqual(
-      expect.arrayContaining(["chat:postMessage", "runner:local", "repo:read", "repo:write", "pr:create"])
+      expect.arrayContaining(["chat:postMessage", "reactions:write", "runner:local", "repo:read", "repo:write", "pr:create"])
     );
     expect(event?.context).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ kind: "file", uri: "src/auth.ts", line: 12 })
       ])
+    );
+  });
+
+  it("grants repo write permissions for write-like natural language tasks", () => {
+    const event = normalizeSlackAppMention({
+      teamId: "T123",
+      channelId: "C123",
+      userId: "U456",
+      text: "<@U_APP> Add one short sentence to README.md",
+      ts: "1710000000.000100",
+      eventId: "Ev790",
+      eventTime: 1710000000,
+      botUserId: "U_APP",
+      binding: {
+        teamId: "T123",
+        channelId: "C123",
+        owner: "acme",
+        repo: "demo"
+      }
+    });
+
+    expect(event?.command.intent).toBe("unknown");
+    expect(event?.permissions.map((permission) => permission.scope)).toEqual(
+      expect.arrayContaining(["chat:postMessage", "reactions:write", "runner:local", "repo:read", "repo:write", "pr:create"])
     );
   });
 });

--- a/packages/slack/test/normalize.test.ts
+++ b/packages/slack/test/normalize.test.ts
@@ -151,6 +151,30 @@ describe("Slack normalization", () => {
     );
   });
 
+  it("grants repo write permissions for extensionless repository file targets", () => {
+    const event = normalizeSlackAppMention({
+      teamId: "T123",
+      channelId: "C123",
+      userId: "U456",
+      text: "<@U_APP> Add a healthcheck to Dockerfile",
+      ts: "1710000000.000100",
+      eventId: "Ev792",
+      eventTime: 1710000000,
+      botUserId: "U_APP",
+      binding: {
+        teamId: "T123",
+        channelId: "C123",
+        owner: "acme",
+        repo: "demo"
+      }
+    });
+
+    expect(event?.command.intent).toBe("unknown");
+    expect(event?.permissions.map((permission) => permission.scope)).toEqual(
+      expect.arrayContaining(["chat:postMessage", "reactions:write", "runner:local", "repo:read", "repo:write", "pr:create"])
+    );
+  });
+
   it("keeps non-repo unknown write-like requests read-only", () => {
     const event = normalizeSlackAppMention({
       teamId: "T123",

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
+  parseSlackSuggestedActionButtonValue,
   createSlackFinalResultBlocks,
   createSlackPostMessagePayload,
+  createSlackReactionPayload,
   createSlackUpdateMessagePayload,
   markdownToSlackMrkdwn,
   renderSlackAcknowledgement,
-  renderSlackFinalResult
+  renderSlackFinalResult,
+  slackSourceReceiptReactionName
 } from "../src/render.js";
 
 describe("Slack callback rendering", () => {
   it("renders Slack-friendly acknowledgement messages", () => {
-    expect(renderSlackAcknowledgement("run_1")).toBe("I picked this up: `run_1`");
+    expect(renderSlackAcknowledgement("run_1")).toBe("Working on it.");
   });
 
   it("uses Slack mrkdwn for final results", () => {
@@ -22,7 +25,7 @@ describe("Slack callback rendering", () => {
     });
 
     expect(text).toBe(
-      "Finished with *success*.\n\nEchoed *OpenTag* command: <https://example.com/cmd|introduce yourself>\n\n*Verification*\n- `echo`: passed\n\n*Next action*: Open <https://example.com/thread|thread> &amp; follow up"
+      "*Finished: success.*\nEchoed *OpenTag* command: <https://example.com/cmd|introduce yourself>\nVerified: `echo` passed\nNext: Open <https://example.com/thread|thread> &amp; follow up"
     );
     expect(text).not.toContain("**success**");
   });
@@ -47,6 +50,15 @@ describe("Slack callback rendering", () => {
     });
   });
 
+  it("builds lightweight source receipt reaction payloads", () => {
+    expect(slackSourceReceiptReactionName("received")).toBe("eyes");
+    expect(createSlackReactionPayload({ channelId: "C123", messageTs: "171.001", name: "eyes" })).toEqual({
+      channel: "C123",
+      timestamp: "171.001",
+      name: "eyes"
+    });
+  });
+
   it("builds Block Kit sections for final results", () => {
     const blocks = createSlackFinalResultBlocks({
       conclusion: "success",
@@ -59,17 +71,63 @@ describe("Slack callback rendering", () => {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Finished with success.*\nSee <https://example.com/pr|PR>"
+          text: "*Finished: success.*\nSee <https://example.com/pr|PR>"
         }
       },
-      { type: "divider" },
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Verification*\n- `echo '&lt;tag&gt;'`: passed"
+          text: "Verified: `echo '&lt;tag&gt;'` passed"
         }
       }
     ]);
+  });
+
+  it("adds Block Kit buttons for suggested source-thread actions", () => {
+    const blocks = createSlackFinalResultBlocks({
+      conclusion: "needs_human",
+      summary: "Prepared a proposal.",
+      suggestedChanges: [
+        {
+          proposalId: "proposal_1",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Move issue forward.",
+          intents: [
+            {
+              intentId: "intent_label_1",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+
+    const rendered = JSON.stringify(blocks);
+    expect(rendered).toContain("1. *Add the bug label.*");
+    expect(rendered).not.toContain("Proposal:");
+    expect(rendered).not.toContain("Intent ID:");
+
+    const actionsBlock = blocks.find((block) => block.type === "actions");
+    expect(actionsBlock).toMatchObject({
+      type: "actions",
+      block_id: "opentag_actions_1",
+      elements: [
+        { type: "button", text: { type: "plain_text", text: "Apply 1" }, action_id: "opentag:apply:1", style: "primary" },
+        { type: "button", text: { type: "plain_text", text: "Approve" }, action_id: "opentag:approve:1" },
+        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" }
+      ]
+    });
+
+    if (actionsBlock?.type !== "actions") throw new Error("expected actions block");
+    expect(parseSlackSuggestedActionButtonValue(actionsBlock.elements[0]?.value ?? "")).toEqual({
+      version: 1,
+      command: "apply 1",
+      proposalId: "proposal_1",
+      intentId: "intent_label_1"
+    });
   });
 });

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -20,12 +20,12 @@ describe("Slack callback rendering", () => {
     const text = renderSlackFinalResult({
       conclusion: "success",
       summary: "Echoed **OpenTag** command: [introduce yourself](https://example.com/cmd)",
-      verification: [{ command: "echo", outcome: "passed" }],
+      verification: [{ command: "echo '<tag>' & check", outcome: "passed" }],
       nextAction: "Open [thread](https://example.com/thread) & follow up"
     });
 
     expect(text).toBe(
-      "*Finished: success.*\nEchoed *OpenTag* command: <https://example.com/cmd|introduce yourself>\nVerified: `echo` passed\nNext: Open <https://example.com/thread|thread> &amp; follow up"
+      "*Finished: success.*\nEchoed *OpenTag* command: <https://example.com/cmd|introduce yourself>\nVerified: `echo '&lt;tag&gt;' &amp; check` passed\nNext: Open <https://example.com/thread|thread> &amp; follow up"
     );
     expect(text).not.toContain("**success**");
   });
@@ -123,11 +123,52 @@ describe("Slack callback rendering", () => {
     });
 
     if (actionsBlock?.type !== "actions") throw new Error("expected actions block");
-    expect(parseSlackSuggestedActionButtonValue(actionsBlock.elements[0]?.value ?? "")).toEqual({
-      version: 1,
-      command: "apply 1",
-      proposalId: "proposal_1",
-      intentId: "intent_label_1"
+    expect(actionsBlock.elements.map((element) => parseSlackSuggestedActionButtonValue(element.value))).toEqual([
+      {
+        version: 1,
+        command: "apply 1",
+        proposalId: "proposal_1",
+        intentId: "intent_label_1"
+      },
+      {
+        version: 1,
+        command: "approve 1",
+        proposalId: "proposal_1",
+        intentId: "intent_label_1"
+      },
+      {
+        version: 1,
+        command: "reject 1",
+        proposalId: "proposal_1",
+        intentId: "intent_label_1"
+      }
+    ]);
+  });
+
+  it("caps suggested action blocks to stay under Slack's Block Kit limit", () => {
+    const blocks = createSlackFinalResultBlocks({
+      conclusion: "needs_human",
+      summary: "Prepared many proposals.",
+      suggestedChanges: Array.from({ length: 30 }, (_item, index) => ({
+        proposalId: `proposal_${index + 1}`,
+        createdAt: "2026-06-24T00:00:00.000Z",
+        summary: `Move item ${index + 1}.`,
+        intents: [
+          {
+            intentId: `intent_${index + 1}`,
+            domain: "labels",
+            action: "add_label",
+            summary: `Add label ${index + 1}.`,
+            params: { label: `label-${index + 1}` }
+          }
+        ]
+      }))
     });
+
+    const rendered = JSON.stringify(blocks);
+    expect(blocks.length).toBeLessThanOrEqual(50);
+    expect(rendered).toContain("Apply 20");
+    expect(rendered).not.toContain("Apply 21");
+    expect(rendered).toContain("Showing first 20 of 30 actions");
   });
 });

--- a/packages/slack/test/socket-mode.test.ts
+++ b/packages/slack/test/socket-mode.test.ts
@@ -110,6 +110,117 @@ describe("Slack Socket Mode", () => {
     expect(socket.closeCalled).toBe(true);
   });
 
+  it("processes Block Kit button actions through Socket Mode", async () => {
+    const socket = new FakeWebSocket();
+    let socketCreated = false;
+    const createRun = vi.fn(async () => ({ runId: "run_1" }));
+    const submitThreadAction = vi.fn(async () => ({}));
+    const fetchImpl = vi.fn(async () => Response.json({ ok: true, url: "wss://slack.example/socket" })) as unknown as typeof fetch;
+    const handle = startSlackSocketModeApp(
+      {
+        appToken: "xapp-token",
+        slackApp: {
+          agentId: "opentag",
+          appId: "A123",
+          callbackUri: "https://slack.com/api/chat.postMessage"
+        },
+        async resolveChannelBinding() {
+          return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+        },
+        createRun,
+        submitThreadAction,
+        now: () => "2024-06-24T00:00:00.000Z"
+      },
+      {
+        fetchImpl,
+        reconnectDelayMs: 1,
+        createWebSocket(url) {
+          expect(url).toBe("wss://slack.example/socket");
+          socketCreated = true;
+          return socket as unknown as WebSocket;
+        },
+        log() {},
+        logError() {}
+      }
+    );
+
+    await eventually(() => expect(fetchImpl).toHaveBeenCalledOnce());
+    await eventually(() => expect(socketCreated).toBe(true));
+    await Promise.resolve();
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "interactive",
+          envelope_id: "envelope_button_1",
+          payload: {
+            type: "block_actions",
+            api_app_id: "A123",
+            team: { id: "T123" },
+            user: { id: "U456", username: "alice" },
+            channel: { id: "C123" },
+            message: {
+              ts: "1719187200.000500",
+              thread_ts: "1719187200.000100"
+            },
+            trigger_id: "trigger_apply_1",
+            actions: [
+              {
+                type: "button",
+                action_id: "opentag:apply:1",
+                block_id: "opentag_actions_1",
+                value: JSON.stringify({
+                  version: 1,
+                  command: "apply 1",
+                  proposalId: "proposal_1",
+                  intentId: "intent_label_1"
+                }),
+                action_ts: "1719187200.000600"
+              }
+            ]
+          }
+        })
+      )
+    );
+
+    await eventually(() => expect(submitThreadAction).toHaveBeenCalledOnce());
+    expect(createRun).not.toHaveBeenCalled();
+    expect(socket.sent).toEqual([JSON.stringify({ envelope_id: "envelope_button_1" })]);
+    expect(submitThreadAction).toHaveBeenCalledWith({
+      id: "approval_slack_block_trigger_apply_1",
+      rawText: "apply 1",
+      actor: {
+        provider: "slack",
+        providerUserId: "U456",
+        handle: "alice",
+        organizationId: "T123"
+      },
+      callback: {
+        provider: "slack",
+        uri: "https://slack.com/api/chat.postMessage",
+        threadKey: "T123|C123|1719187200.000100"
+      },
+      metadata: {
+        source: "slack_button",
+        teamId: "T123",
+        channelId: "C123",
+        messageTs: "1719187200.000500",
+        slackAppId: "A123",
+        actionId: "opentag:apply:1",
+        blockId: "opentag_actions_1",
+        actionTs: "1719187200.000600",
+        proposalId: "proposal_1",
+        intentId: "intent_label_1",
+        repoProvider: "github",
+        owner: "acme",
+        repo: "demo"
+      }
+    });
+
+    await handle.close();
+    expect(socket.closeCalled).toBe(true);
+  });
+
   it("retries after a transient apps.connections.open failure instead of rejecting the start promise", async () => {
     const socket = new FakeWebSocket();
     let socketCreated = false;


### PR DESCRIPTION
## Summary
- add Slack Block Kit buttons for suggested source-thread actions and route button clicks through the same `/v1/thread-actions` path as typed replies
- replace noisy Slack pickup acknowledgements with a lightweight source-message reaction receipt
- make Slack final callbacks shorter and render GitHub suggested actions as clearer system-of-record approvals
- carry approved action permissions into child runs and document the Slack Interactivity/reactions setup

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm build`
- `corepack pnpm lint` after build completed
- `git diff --check`

## Notes
- This PR contains the remaining tracked Slack/GitHub interaction changes from the local worktree.
- It intentionally excludes the manual dogfood script, which was handled separately in #55.
- I did not rerun the full live Slack/GitHub E2E from this clean branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack Block Kit **Apply/Approve/Reject** buttons now flow into the same thread actions as typed replies.
  * Slack “source receipts” are delivered as lightweight message reactions (e.g., **eyes**).
  * Executor results now support structured executor reports (rendering **What changed**, **Verified**, and **Risks** when available).
* **Bug Fixes**
  * Updated Slack callback/ack behavior to avoid extra acknowledgements and align with receipt-delivery semantics.
  * Improved permission grants for write-like commands (incl. added **reactions:write**).
* **Documentation**
  * Expanded Slack setup/testing steps (Interactivity & Shortcuts + **reactions:write**) across guides and examples.
* **Tests**
  * Added/updated coverage for interactive button handling, reaction receipts, and updated Slack/executor rendering outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->