### PR TITLE
Stop double-committing Codex runs when preparing a PR branch

### DIFF
--- a/apps/opentagd/test/daemon.test.ts
+++ b/apps/opentagd/test/daemon.test.ts
@@ -323,6 +323,70 @@ describe("opentagd", () => {
     expect(calls).toEqual(["claim", "running:run_1:echo", "complete:run_1:failure:Echo failed: executor exploded"]);
   });
 
+  it("does not recommit codex changes from the claimed run row when preparing a PR branch", async () => {
+    const checkoutPath = "/tmp/demo";
+    const commands: string[] = [];
+    let completed: OpenTagRunResult | undefined;
+
+    const didWork = await runOneDaemonIteration({
+      runnerId: "runner_1",
+      repositories: [{ provider: "github", owner: "acme", repo: "demo", checkoutPath, defaultExecutor: "codex" }],
+      executors: {
+        codex: {
+          ...createEchoExecutor(),
+          id: "codex",
+          displayName: "Codex",
+          async run() {
+            return { conclusion: "success", summary: "Changed README.md.", changedFiles: ["README.md"] };
+          }
+        }
+      },
+      pullRequestOptions: {
+        preparePullRequestBranch: true,
+        commandRunner: {
+          async run(command, args, options) {
+            commands.push(`${options?.cwd ?? ""}: ${command} ${args.join(" ")}`);
+            if (command === "git" && args[0] === "commit" && options?.cwd === checkoutPath) {
+              return { exitCode: 1, stdout: "", stderr: "nothing to commit" };
+            }
+            return { exitCode: 0, stdout: "", stderr: "" };
+          }
+        }
+      },
+      client: {
+        async claim() {
+          return {
+            run,
+            event: {
+              ...event,
+              permissions: [
+                ...event.permissions,
+                { scope: "repo:write", reason: "write branch" },
+                { scope: "pr:create", reason: "create the pull request action" }
+              ]
+            }
+          };
+        },
+        async markRunning() {
+          return;
+        },
+        async heartbeat() {
+          return;
+        },
+        async progress() {
+          return;
+        },
+        async complete(_runId, result) {
+          completed = result;
+        }
+      }
+    });
+
+    expect(didWork).toBe(true);
+    expect(commands).toEqual(["/tmp/demo: git push -u origin opentag/run_1"]);
+    expect(completed).toMatchObject({ conclusion: "success", changedFiles: ["README.md"] });
+  });
+
   it("completes with needs_human when preparing the PR action branch fails", async () => {
     const commands: string[] = [];
     let completed: OpenTagRunResult | undefined;

--- a/apps/opentagd/test/pr.test.ts
+++ b/apps/opentagd/test/pr.test.ts
@@ -68,6 +68,7 @@ describe("maybeCreatePullRequest", () => {
     const requests: string[] = [];
     const updated = await maybeCreatePullRequest({
       run,
+      executor: "echo",
       event,
       binding: {
         provider: "github",
@@ -111,6 +112,7 @@ describe("maybeCreatePullRequest", () => {
     await expect(
       maybeCreatePullRequest({
         run,
+        executor: "echo",
         event,
         binding: { provider: "github", owner: "acme", repo: "demo", checkoutPath: "/tmp/demo" },
         result,
@@ -124,6 +126,7 @@ describe("maybeCreatePullRequest", () => {
     await expect(
       maybeCreatePullRequest({
         run,
+        executor: "echo",
         event,
         binding: { provider: "github", owner: "acme", repo: "demo", checkoutPath: "/tmp/demo" },
         result,
@@ -146,6 +149,7 @@ describe("maybeCreatePullRequest", () => {
     const requests: string[] = [];
     const updated = await maybeCreatePullRequest({
       run,
+      executor: "echo",
       event,
       binding: {
         provider: "github",
@@ -181,6 +185,7 @@ describe("maybeCreatePullRequest", () => {
     const commands: string[] = [];
     const updated = await maybeCreatePullRequest({
       run,
+      executor: "echo",
       event,
       binding: {
         provider: "github",
@@ -211,6 +216,7 @@ describe("maybeCreatePullRequest", () => {
     const requests: string[] = [];
     const updated = await maybeCreatePullRequest({
       run,
+      executor: "echo",
       event: slackEvent,
       binding: {
         provider: "github",
@@ -246,7 +252,8 @@ describe("maybeCreatePullRequest", () => {
   it("does not recommit files for Codex-generated branches before opening the pull request", async () => {
     const commands: string[] = [];
     await maybeCreatePullRequest({
-      run: { ...run, executor: "codex" },
+      run,
+      executor: "codex",
       event,
       binding: {
         provider: "github",
@@ -281,6 +288,7 @@ describe("maybeCreatePullRequest", () => {
     };
     const updated = await maybeCreatePullRequest({
       run,
+      executor: "echo",
       event: mismatchEvent,
       binding: {
         provider: "github",

--- a/packages/cli/test/platform-contract.test.ts
+++ b/packages/cli/test/platform-contract.test.ts
@@ -218,11 +218,7 @@ describe("CLI platform contract smoke", () => {
       }
     });
 
-    expect(gitCommands).toEqual([
-      "git add -- README.md",
-      "git commit -m OpenTag run run_github_contract",
-      "git push -u origin opentag/run_github_contract"
-    ]);
+    expect(gitCommands).toEqual(["git push -u origin opentag/run_github_contract"]);
     expect(delivered.some((message) => message.kind === "final" && message.body.includes("Create a pull request"))).toBe(true);
 
     const applyBody = JSON.stringify({

--- a/packages/local-runtime/src/daemon.ts
+++ b/packages/local-runtime/src/daemon.ts
@@ -199,6 +199,7 @@ export async function runOneDaemonIteration(input: {
   try {
     result = await maybeCreatePullRequest({
       run: claimed.run,
+      executor: executorId,
       event: claimed.event,
       binding,
       result: executorResult,

--- a/packages/local-runtime/src/pr.ts
+++ b/packages/local-runtime/src/pr.ts
@@ -29,7 +29,7 @@ function repositoryTargetMatchesBinding(input: { event: OpenTagEvent; binding: R
 
 export async function maybeCreatePullRequest(input: {
   run: OpenTagRun;
-  executor: string;
+  executor?: string;
   event: OpenTagEvent;
   binding: RepositoryBindingConfig;
   result: OpenTagRunResult;
@@ -46,7 +46,11 @@ export async function maybeCreatePullRequest(input: {
 
   const branchName = branchNameForRun(input.run.id);
   const runner = input.options.commandRunner ?? nodeCommandRunner;
-  if (input.executor !== "codex") {
+  // Codex commits inside its own worktree, so the daemon must not re-add/commit its
+  // files. Prefer the explicitly-resolved executor; fall back to the run row for
+  // backward compatibility when an external caller omits it.
+  const resolvedExecutor = input.executor ?? input.run.executor;
+  if (resolvedExecutor !== "codex") {
     await commitChangedFiles({
       runner,
       workspacePath: input.binding.checkoutPath,

--- a/packages/local-runtime/src/pr.ts
+++ b/packages/local-runtime/src/pr.ts
@@ -29,6 +29,7 @@ function repositoryTargetMatchesBinding(input: { event: OpenTagEvent; binding: R
 
 export async function maybeCreatePullRequest(input: {
   run: OpenTagRun;
+  executor: string;
   event: OpenTagEvent;
   binding: RepositoryBindingConfig;
   result: OpenTagRunResult;
@@ -45,7 +46,7 @@ export async function maybeCreatePullRequest(input: {
 
   const branchName = branchNameForRun(input.run.id);
   const runner = input.options.commandRunner ?? nodeCommandRunner;
-  if (input.run.executor !== "codex") {
+  if (input.executor !== "codex") {
     await commitChangedFiles({
       runner,
       workspacePath: input.binding.checkoutPath,


### PR DESCRIPTION
## Problem
Codex runs were being downgraded success → needs_human when opening a PR. The daemon claims an `assigned` run and threads that pre-`markRunning` snapshot into `maybeCreatePullRequest`, but `runs.executor` is only populated at the `markRunning` transition (`store/repository.ts`). So `input.run.executor` is genuinely `undefined` at PR time. The old gate `run.executor !== "codex"` evaluated true, the daemon ran `commitChangedFiles`, and `git commit` found nothing to commit (codex already self-committed in its own worktree) → `assertCommandSucceeded` threw → caught at `daemon.ts` → `needs_human`.

## Fix
Gate the daemon-side add/commit on the already-resolved `executorId` (`daemon.ts`, = `binding.defaultExecutor ?? event.target.executorHint ?? "echo"`) — the same value that routes codex into its self-committing worktree and that `markRunning` records — instead of the stale, often-undefined `run.executor`. Thread `executorId` into `maybeCreatePullRequest` and gate on `input.executor !== "codex"`. `echo` and `claude-code` are unaffected: they don't self-commit, so they still add+commit.

## Why the `platform-contract.test.ts` assertion changed
That test's expected `gitCommands` change from `[git add, git commit, git push]` to `[git push]`. This is **not** loosening coverage to make the change pass — the old assertion was encoding the bug. The test builds config via `createSetupConfig({ executor: "codex" })` and registers `{ codex: changingExecutor }`, so the daemon resolves `executorId = "codex"` and must skip the daemon-side add/commit (codex commits inside its own worktree). The previous three-command expectation was only green because the bug forced a commit anyway; the new single-command expectation reflects the corrected behavior.

## Tests
- New end-to-end regression in `daemon.test.ts` drives `runOneDaemonIteration` with `defaultExecutor: "codex"`, a codex run returning `changedFiles: ["README.md"]`, and a git-commit stub returning exitCode 1 ("nothing to commit") — reproducing the exact production downgrade a unit test couldn't catch.
- `pr.test.ts` was de-masked: it previously hand-faked `{ ...run, executor: "codex" }` (only green because prod read `run.executor`); it now passes `executor: "codex"` as the real top-level field.
- Reverting the gate to its buggy form fails three tests (`daemon.test.ts`, `platform-contract.test.ts`, `pr.test.ts`) — the coverage is non-vacuous.
- `pnpm typecheck`, `pnpm test` (full suite), and `pnpm build` all pass locally.

---
*Co-developed with my AI coding agent; I verified the fix and ran the full suite + build locally.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pull request branch preparation from re-applying or duplicating “codex” changes when they are already reflected in the repository.
  * Streamlined the GitHub PR “apply” flow to push the prepared branch without performing unnecessary add/commit steps.
* **Tests**
  * Updated daemon and pull request tests to match the revised pull request preparation/creation behavior and command expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->