### PR TITLE
docs: guide Codex setup through askhuman choices

### DIFF
--- a/packages/cli/test/docs-contract.test.ts
+++ b/packages/cli/test/docs-contract.test.ts
@@ -7,6 +7,32 @@ function repoFile(path: string): string {
 }
 
 describe("platform setup docs contract", () => {
+  it("keeps the OpenTag skill aligned with Codex askhuman setup guidance", () => {
+    const skill = repoFile("skills/opentag/SKILL.md");
+
+    expect(skill).toContain("request_user_input");
+    expect(skill).toContain("askhuman");
+    expect(skill).toContain("Plan mode");
+    expect(skill).toContain("Default mode");
+    expect(skill).toContain("route setup choice collection through Codex Plan mode");
+    expect(skill).toContain("use a Codex runtime-provided Plan-mode transition if one is actually available");
+    expect(skill).toContain("report that askhuman cannot render from Default mode");
+    expect(skill).toContain("Do not claim a handoff happened");
+    expect(skill).toContain("do not ask the user to switch modes");
+    expect(skill).toContain("do not continue setup from Default mode");
+    expect(skill).toContain("do not ask the same choices in plain text");
+    expect(skill).toContain("Platform: Slack, GitHub, or Lark / Feishu");
+    expect(skill).toContain("Coding agent: Codex, Claude Code, or Echo");
+    expect(skill).toContain("Never request secrets through askhuman");
+    expect(skill).toContain("--platform");
+    expect(skill).toContain("--executor");
+    expect(skill).toContain("--project");
+    expect(skill).not.toContain("agent-owned flow control");
+    expect(skill).not.toContain("trigger the Codex Plan-mode transition or handoff first");
+    expect(skill).not.toContain("ask for the same choices in plain text instead");
+    expect(skill).not.toContain("text fallback");
+  });
+
   it("keeps Slack setup docs aligned with the official Socket Mode and Events API requirements", () => {
     const english = repoFile("docs/platforms/slack.en.md");
     const chinese = repoFile("docs/platforms/slack.zh-CN.md");

--- a/skills/opentag/SKILL.md
+++ b/skills/opentag/SKILL.md
@@ -46,11 +46,27 @@ For platform credential steps, use the repository docs as the source of truth:
 
 - Keep setup user-led. Never invent tokens, app IDs, Slack team/channel IDs, GitHub owner/repo names, or local project paths.
 - Prefer Slack, then GitHub, then Lark / Feishu when listing platforms.
-- Ask the user which platform and coding agent they want if it is not already clear.
+- Ask the user which platform and coding agent they want if it is not already clear outside Codex.
+- In Codex, route setup choice collection through Codex Plan mode before calling `request_user_input` / askhuman. Collect non-secret choices before running `opentag setup`, then pass them as CLI flags so the terminal wizard does not silently choose defaults.
+- Askhuman is only available in Codex Plan mode, not Codex Default mode. If setup choices are needed while Codex is in Default mode, use a Codex runtime-provided Plan-mode transition if one is actually available. If no such transition exists in the current host, stop and report that askhuman cannot render from Default mode in this run. Do not claim a handoff happened, do not ask the user to perform the switch, do not continue setup from Default mode, do not ask the same choices in plain text, and do not guess defaults.
+- Never request secrets through askhuman. Tokens, app secrets, channel IDs, repository names, and project paths still need explicit user confirmation before they are entered.
 - Use Codex when `codex` is available, Claude Code when `claude` is available, and Echo only for dev/test verification.
 - Treat `opentag start` as a foreground process. Tell the user to keep it running and stop it with Ctrl-C.
 - Do not expose secrets in responses. Use `opentag config show` for redacted config.
 - When credentials are needed, point the user to the matching platform guide and walk them through the official setup.
+
+## Codex Plan Mode Askhuman Setup Choices
+
+When helping a Codex user install or configure OpenTag, enter Codex Plan mode before the CLI reaches platform setup prompts. In Plan mode, render `request_user_input` / askhuman choices for:
+
+- Platform: Slack, GitHub, or Lark / Feishu.
+- Coding agent: Codex, Claude Code, or Echo, using local detection from `opentag executors` when available.
+- Local project: the current working directory as the recommended option, plus a free-form path option inside askhuman for another path.
+- Platform mode choices that are not secrets, such as Slack Socket Mode vs Events API, Lark / Feishu domain, Lark scan vs manual setup, and default project binding vs bind later.
+
+If the run is still in Codex Default mode at this point, first look for an actual runtime Plan-mode transition. If none exists, stop and report that the current Codex host cannot render askhuman from Default mode. Do not claim a Plan-mode handoff is complete, do not ask the user to switch modes, do not run `opentag setup`, do not ask the choices in plain text, and do not continue with CLI defaults.
+
+After the user chooses, run `opentag setup` with the matching flags, for example `--platform`, `--executor`, `--project`, `--slack-mode`, `--lark-domain`, `--lark-setup`, and `--binding`. Stop before entering any credential, token, app ID, app secret, channel ID, repository, or unconfirmed project path.
 
 ## Setup Workflow
 


### PR DESCRIPTION
## Summary

Fixes #59.

This updates the OpenTag skill so Codex users are guided through non-secret setup choices with `request_user_input` / askhuman before `opentag setup` reaches the terminal platform prompts. It also documents the important runtime distinction: askhuman is available in Codex Plan mode, not Default mode, so agents should clearly fall back to plain-text choices instead of silently accepting CLI defaults.

## Validation

- `corepack pnpm test packages/cli/test/docs-contract.test.ts`
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @opentag/cli lint`
- `corepack pnpm release:check`
- `git diff --check`

## Notes

The CLI remains unchanged because Codex askhuman is a host-agent interaction, not a terminal prompt feature. The skill now tells Codex to collect platform, executor, project, and non-secret mode choices first, then pass those selections to `opentag setup` as flags while still stopping before credentials or secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup guidance for Codex-based workflows, including which choices can be collected up front, when to use setup flags, and reminders to avoid requesting secrets through interactive prompts.
  * Added a dedicated section outlining the available setup-choice categories and example command options.

* **Tests**
  * Added a contract test to keep the setup guidance document aligned with expected platform and CLI instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->