### PR TITLE
Harden OpenTag setup skill guidance

### DIFF
--- a/packages/cli/test/docs-contract.test.ts
+++ b/packages/cli/test/docs-contract.test.ts
@@ -30,13 +30,20 @@ describe("platform setup docs contract", () => {
     expect(skill).toContain("EAI_AGAIN");
     expect(skill).toContain("ETIMEDOUT");
     expect(skill).toContain("ECONNRESET");
+    expect(skill).toContain("TLS certificate errors");
     expect(skill).toContain("npm config get registry");
     expect(skill).toContain("npm config get proxy");
     expect(skill).toContain("npm config get https-proxy");
     expect(skill).toContain("registry.npmjs.org");
     expect(skill).toContain("npm view @opentag/cli version --fetch-timeout=15000");
+    expect(skill).toContain("proxy-scoped registry retry");
+    expect(skill).toContain('HTTPS_PROXY="<proxy-url>" HTTP_PROXY="<proxy-url>" curl -I');
+    expect(skill).toContain("Only after registry reachability is confirmed");
+    expect(skill).toContain("npx --yes @opentag/cli --help");
     expect(skill).toContain("do not permanently change `npm config` without explicit user confirmation");
     expect(skill).toContain("Only use a proxy URL the user provides or that is already active in the environment");
+    expect(skill).toContain("npm cache metadata exists");
+    expect(skill).toContain("`npx --offline` or `npm pack --offline`");
     expect(skill).toContain("do not claim the CLI is available offline");
     expect(skill).toContain("Platform: Slack, GitHub, or Lark / Feishu");
     expect(skill).toContain("Coding agent: Codex, Claude Code, or Echo");
@@ -52,6 +59,9 @@ describe("platform setup docs contract", () => {
     expect(skill).toContain("--lark-domain");
     expect(skill).toContain("--lark-setup");
     expect(skill).toContain("--binding");
+    expect(skill).toContain(
+      "Stop before entering any credential, token, app ID, app secret, signing secret, channel ID, repository name, or unconfirmed project path."
+    );
     expect(skill).not.toContain("agent-owned flow control");
     expect(skill).not.toContain("trigger the Codex Plan-mode transition or handoff first");
     expect(skill).not.toContain("ask for the same choices in plain text instead");

--- a/packages/cli/test/docs-contract.test.ts
+++ b/packages/cli/test/docs-contract.test.ts
@@ -7,6 +7,56 @@ function repoFile(path: string): string {
 }
 
 describe("platform setup docs contract", () => {
+  it("keeps the OpenTag skill aligned with Codex askhuman setup guidance", () => {
+    const skill = repoFile("skills/opentag/SKILL.md");
+
+    expect(skill).toContain("request_user_input");
+    expect(skill).toContain("askhuman");
+    expect(skill).toContain("Codex Plan mode");
+    expect(skill).toContain("Codex Default mode cannot render askhuman choice cards");
+    expect(skill).toContain("runtime-provided Plan-mode transition");
+    expect(skill).toContain("askhuman cannot render from Default mode");
+    expect(skill).toContain("Do not claim a Plan-mode handoff happened");
+    expect(skill).toContain("do not ask the user to switch modes");
+    expect(skill).toContain("do not ask the same choices in plain text");
+    expect(skill).toContain("do not present a plain-text fallback");
+    expect(skill).toContain("do not continue with CLI defaults");
+    expect(skill).toContain("Never request secrets through askhuman");
+    expect(skill).toContain("Do not ask setup users to run `codex exec` directly");
+    expect(skill).toContain("check `codex exec --help` first");
+    expect(skill).toContain("only use flags that the installed Codex version advertises");
+    expect(skill).toContain("Npm Registry And Network Failures");
+    expect(skill).toContain("ENOTFOUND");
+    expect(skill).toContain("EAI_AGAIN");
+    expect(skill).toContain("ETIMEDOUT");
+    expect(skill).toContain("ECONNRESET");
+    expect(skill).toContain("npm config get registry");
+    expect(skill).toContain("npm config get proxy");
+    expect(skill).toContain("npm config get https-proxy");
+    expect(skill).toContain("registry.npmjs.org");
+    expect(skill).toContain("npm view @opentag/cli version --fetch-timeout=15000");
+    expect(skill).toContain("do not permanently change `npm config` without explicit user confirmation");
+    expect(skill).toContain("Only use a proxy URL the user provides or that is already active in the environment");
+    expect(skill).toContain("do not claim the CLI is available offline");
+    expect(skill).toContain("Platform: Slack, GitHub, or Lark / Feishu");
+    expect(skill).toContain("Coding agent: Codex, Claude Code, or Echo");
+    expect(skill).toContain("Local project: the current working directory");
+    expect(skill).toContain("Slack Socket Mode vs Events API");
+    expect(skill).toContain("Lark / Feishu domain");
+    expect(skill).toContain("Lark scan vs manual setup");
+    expect(skill).toContain("default project binding vs bind later");
+    expect(skill).toContain("--platform");
+    expect(skill).toContain("--executor");
+    expect(skill).toContain("--project");
+    expect(skill).toContain("--slack-mode");
+    expect(skill).toContain("--lark-domain");
+    expect(skill).toContain("--lark-setup");
+    expect(skill).toContain("--binding");
+    expect(skill).not.toContain("agent-owned flow control");
+    expect(skill).not.toContain("trigger the Codex Plan-mode transition or handoff first");
+    expect(skill).not.toContain("ask for the same choices in plain text instead");
+  });
+
   it("keeps Slack setup docs aligned with the official Socket Mode and Events API requirements", () => {
     const english = repoFile("docs/platforms/slack.en.md");
     const chinese = repoFile("docs/platforms/slack.zh-CN.md");

--- a/skills/opentag/SKILL.md
+++ b/skills/opentag/SKILL.md
@@ -46,11 +46,53 @@ For platform credential steps, use the repository docs as the source of truth:
 
 - Keep setup user-led. Never invent tokens, app IDs, Slack team/channel IDs, GitHub owner/repo names, or local project paths.
 - Prefer Slack, then GitHub, then Lark / Feishu when listing platforms.
-- Ask the user which platform and coding agent they want if it is not already clear.
+- Ask the user which platform and coding agent they want if it is not already clear outside Codex.
+- In Codex Plan mode, use `request_user_input` / askhuman to collect non-secret setup choices before running `opentag setup`, then pass those choices as CLI flags so the terminal wizard does not silently choose defaults.
+- Codex Default mode cannot render askhuman choice cards. If setup choices are needed and the current host does not expose a runtime transition into Plan mode, stop and explain that askhuman cannot render from Default mode in this run. Do not claim a Plan-mode handoff happened, do not ask the user to switch modes, do not ask the same choices in plain text, do not continue with CLI defaults, and do not run `opentag setup` until the choices are explicitly collected.
+- Never request secrets through askhuman. Tokens, app secrets, signing secrets, app IDs, channel IDs, repository names, and any non-recommended project path still need explicit user confirmation before they are entered into the CLI or config.
 - Use Codex when `codex` is available, Claude Code when `claude` is available, and Echo only for dev/test verification.
+- Do not ask setup users to run `codex exec` directly. OpenTag invokes Codex internally; when debugging the Codex CLI, check `codex exec --help` first and only use flags that the installed Codex version advertises.
 - Treat `opentag start` as a foreground process. Tell the user to keep it running and stop it with Ctrl-C.
 - Do not expose secrets in responses. Use `opentag config show` for redacted config.
 - When credentials are needed, point the user to the matching platform guide and walk them through the official setup.
+
+## Npm Registry And Network Failures
+
+If `npm install -g @opentag/cli` or `npx @opentag/cli ...` fails before the OpenTag CLI starts, keep the exact npm error and diagnose the package delivery path before giving up. Treat errors such as `ENOTFOUND`, `EAI_AGAIN`, `ETIMEDOUT`, `ECONNRESET`, `fetch failed`, proxy connection failures, and TLS certificate errors as network or npm-environment issues, not as OpenTag setup failures.
+
+Use safe, non-secret checks first:
+
+```bash
+node --version
+npm config get registry
+npm config get proxy
+npm config get https-proxy
+env | grep -i proxy
+node -e "require('dns').lookup('registry.npmjs.org', (e, a, f) => console.log(e ? e.code + ' ' + e.message : a + ' ' + f))"
+curl -I --max-time 15 https://registry.npmjs.org/@opentag%2fcli
+npm view @opentag/cli version --fetch-timeout=15000
+```
+
+If DNS or registry access is flaky, say that the published CLI could not be reached yet and retry once after checking connectivity. If the user has a VPN or proxy, compare direct access with a one-command proxy-scoped retry, but do not permanently change `npm config` without explicit user confirmation:
+
+```bash
+HTTPS_PROXY="<proxy-url>" HTTP_PROXY="<proxy-url>" npx --yes @opentag/cli --help
+```
+
+Only use a proxy URL the user provides or that is already active in the environment. Do not invent proxy hosts, tokens, certificates, or registry credentials. If npm cache metadata exists but `npx --offline` or `npm pack --offline` still fails, do not claim the CLI is available offline; report that the cache is not executable and wait for registry access to recover.
+
+## Codex Plan Mode Askhuman Setup Choices
+
+When helping a Codex user install or configure OpenTag, collect these non-secret choices with `request_user_input` / askhuman only when the current Codex host is actually in Plan mode and the tool is available:
+
+- Platform: Slack, GitHub, or Lark / Feishu.
+- Coding agent: Codex, Claude Code, or Echo, using local detection from `opentag executors` when available.
+- Local project: the current working directory as the recommended option, plus a free-form path option inside askhuman for another path.
+- Platform mode choices that are not credentials, such as Slack Socket Mode vs Events API, Lark / Feishu domain, Lark scan vs manual setup, and default project binding vs bind later.
+
+If the run is still in Codex Default mode, first look for an actual runtime-provided Plan-mode transition. If none exists, stop and report that the current Codex host cannot render askhuman from Default mode. Do not claim a Plan-mode handoff is complete, do not ask the user to switch modes, do not present a plain-text fallback for the same choices, do not run `opentag setup`, and do not continue with guessed defaults.
+
+After the user chooses, run `opentag setup` with matching flags, for example `--platform`, `--executor`, `--project`, `--slack-mode`, `--lark-domain`, `--lark-setup`, and `--binding`. Stop before entering any credential, token, app ID, app secret, signing secret, channel ID, repository name, or unconfirmed project path.
 
 ## Setup Workflow
 
@@ -58,6 +100,7 @@ For platform credential steps, use the repository docs as the source of truth:
    Completion: Node.js 20+ is available and the user has a local project path.
 
 2. Install or run the CLI.
+   If npm cannot reach the published package, follow "Npm Registry And Network Failures" before treating setup as blocked.
    Completion: `opentag --help` or `npx @opentag/cli --help` works.
 
 3. Run setup.

--- a/skills/opentag/SKILL.md
+++ b/skills/opentag/SKILL.md
@@ -73,10 +73,16 @@ curl -I --max-time 15 https://registry.npmjs.org/@opentag%2fcli
 npm view @opentag/cli version --fetch-timeout=15000
 ```
 
-If DNS or registry access is flaky, say that the published CLI could not be reached yet and retry once after checking connectivity. If the user has a VPN or proxy, compare direct access with a one-command proxy-scoped retry, but do not permanently change `npm config` without explicit user confirmation:
+If DNS or registry access is flaky, say that the published CLI could not be reached yet and retry once after checking connectivity. If the user has a VPN or proxy, compare direct registry access with a one-command proxy-scoped registry retry, but do not permanently change `npm config` without explicit user confirmation:
 
 ```bash
-HTTPS_PROXY="<proxy-url>" HTTP_PROXY="<proxy-url>" npx --yes @opentag/cli --help
+HTTPS_PROXY="<proxy-url>" HTTP_PROXY="<proxy-url>" curl -I --max-time 15 https://registry.npmjs.org/@opentag%2fcli
+```
+
+Only after registry reachability is confirmed, retry the CLI help command:
+
+```bash
+npx --yes @opentag/cli --help
 ```
 
 Only use a proxy URL the user provides or that is already active in the environment. Do not invent proxy hosts, tokens, certificates, or registry credentials. If npm cache metadata exists but `npx --offline` or `npm pack --offline` still fails, do not claim the CLI is available offline; report that the cache is not executable and wait for registry access to recover.


### PR DESCRIPTION
## Summary

- Harden the OpenTag setup skill so Codex Default mode stops when askhuman / `request_user_input` choices are required but unavailable, instead of asking the same choices in plain text or continuing with CLI defaults.
- Add npm registry/network failure guidance for published CLI installation issues such as `ENOTFOUND`, timeouts, proxy/TLS errors, and unusable offline cache metadata.
- Add guidance to avoid exposing `codex exec` directly to setup users and to check `codex exec --help` before using version-sensitive debug flags.
- Pin the skill contract in `packages/cli/test/docs-contract.test.ts`.

Closes #59.

## Verification

- `corepack pnpm test packages/cli/test/docs-contract.test.ts`
- `corepack pnpm test`
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `git diff --check`

## Notes

The full interactive Plan-mode askhuman UI flow was not manually exercised because this host is currently in Codex Default mode. The local skill dry-run verified the intended stop behavior in Default mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded OpenTag “Working Rules” with stricter, user-led platform selection and execution guidance, including Codex Plan mode askhuman interaction rules and explicit halting/confirmation behavior.
  * Strengthened secret-handling expectations (no secret requests via askhuman; require explicit confirmation for credential-like inputs).
  * Added npm registry/network troubleshooting, including guidance for preserving exact npm errors, safe connectivity checks, and proxy-scoped retry, plus clarified offline/cached behavior.

* **Tests**
  * Added a contract test to verify the updated OpenTag guidance text is present and that disallowed fallback/mode-transition wording is not included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->