### PR TITLE
Use npm metadata lookup for setup proxy retry

### DIFF
--- a/packages/cli/test/docs-contract.test.ts
+++ b/packages/cli/test/docs-contract.test.ts
@@ -36,9 +36,11 @@ describe("platform setup docs contract", () => {
     expect(skill).toContain("npm config get https-proxy");
     expect(skill).toContain("registry.npmjs.org");
     expect(skill).toContain("npm view @opentag/cli version --fetch-timeout=15000");
-    expect(skill).toContain("proxy-scoped registry retry");
-    expect(skill).toContain('HTTPS_PROXY="<proxy-url>" HTTP_PROXY="<proxy-url>" curl -I');
-    expect(skill).toContain("Only after registry reachability is confirmed");
+    expect(skill).toContain("proxy-scoped npm registry retry");
+    expect(skill).toContain(
+      'HTTPS_PROXY="<proxy-url>" HTTP_PROXY="<proxy-url>" npm view @opentag/cli version --fetch-timeout=15000'
+    );
+    expect(skill).toContain("Only after npm registry metadata is reachable");
     expect(skill).toContain("npx --yes @opentag/cli --help");
     expect(skill).toContain("do not permanently change `npm config` without explicit user confirmation");
     expect(skill).toContain("Only use a proxy URL the user provides or that is already active in the environment");

--- a/skills/opentag/SKILL.md
+++ b/skills/opentag/SKILL.md
@@ -73,13 +73,13 @@ curl -I --max-time 15 https://registry.npmjs.org/@opentag%2fcli
 npm view @opentag/cli version --fetch-timeout=15000
 ```
 
-If DNS or registry access is flaky, say that the published CLI could not be reached yet and retry once after checking connectivity. If the user has a VPN or proxy, compare direct registry access with a one-command proxy-scoped registry retry, but do not permanently change `npm config` without explicit user confirmation:
+If DNS or registry access is flaky, say that the published CLI could not be reached yet and retry once after checking connectivity. If the user has a VPN or proxy, compare direct npm metadata access with a one-command proxy-scoped npm registry retry, but do not permanently change `npm config` without explicit user confirmation:
 
 ```bash
-HTTPS_PROXY="<proxy-url>" HTTP_PROXY="<proxy-url>" curl -I --max-time 15 https://registry.npmjs.org/@opentag%2fcli
+HTTPS_PROXY="<proxy-url>" HTTP_PROXY="<proxy-url>" npm view @opentag/cli version --fetch-timeout=15000
 ```
 
-Only after registry reachability is confirmed, retry the CLI help command:
+Only after npm registry metadata is reachable, retry the CLI help command:
 
 ```bash
 npx --yes @opentag/cli --help


### PR DESCRIPTION
## Summary

- Updates the OpenTag setup skill's proxy-scoped retry to use npm's package metadata path instead of `curl`.
- Keeps `npx --yes @opentag/cli --help` as a separate follow-up only after npm registry metadata is reachable.
- Updates the docs contract test so the skill stays pinned to `npm view @opentag/cli version --fetch-timeout=15000` for package-delivery diagnosis.

This is a follow-up to #61, which merged before the final review comment was applied.

## Verification

- `corepack pnpm test packages/cli/test/docs-contract.test.ts`
- `corepack pnpm test`
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `git diff --check origin/main...HEAD`
