### PR TITLE
Make source-thread actions capability-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ https://github.com/user-attachments/assets/86edc4e1-7de9-4d07-a0ba-847fa6438191
 
 ![OpenTag overview](./assets/readme-hero.png)
 
+## Source-Thread Action Receipts
+
+OpenTag treats the thread where a request starts as the approval surface for agent-proposed system-of-record mutations. When an agent suggests a change, OpenTag renders a compact receipt that shows what will change, whether it is ready to apply, and which decision is safe now.
+
+`Apply` appears only when the dispatcher confirms a configured adapter can execute the action. Otherwise the receipt shows setup or attention needed, and the local audit trail stays available through commands such as `opentag status --run <run_id>`.
+
 ## Quick Start
 
 Requires Node.js 20 or newer.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ https://github.com/user-attachments/assets/86edc4e1-7de9-4d07-a0ba-847fa6438191
 
 ![OpenTag overview](./assets/readme-hero.png)
 
-## Source-thread action receipts
+## 源线程操作回执
 
 OpenTag 把请求发生的原始 thread 当成审批 agent 建议变更的地方。agent 提出要修改系统记录时，OpenTag 会渲染一个简洁的 action receipt，说明将要改什么、现在是否可以 apply，以及当前最安全的决策是什么。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,6 +35,12 @@ https://github.com/user-attachments/assets/86edc4e1-7de9-4d07-a0ba-847fa6438191
 
 ![OpenTag overview](./assets/readme-hero.png)
 
+## Source-thread action receipts
+
+OpenTag 把请求发生的原始 thread 当成审批 agent 建议变更的地方。agent 提出要修改系统记录时，OpenTag 会渲染一个简洁的 action receipt，说明将要改什么、现在是否可以 apply，以及当前最安全的决策是什么。
+
+只有 dispatcher 确认已有 adapter 可以执行该 action 时，OpenTag 才会显示 `Apply`。否则 receipt 会显示需要 setup 或需要注意的原因，同时保留本地 audit 入口，例如 `opentag status --run <run_id>`。
+
 ## 快速开始
 
 需要 Node.js 20 或更新版本。

--- a/apps/slack-events/src/index.ts
+++ b/apps/slack-events/src/index.ts
@@ -1,4 +1,9 @@
-import { startSlackIngress, type SlackIngressConfig } from "@opentag/slack";
+import {
+  startSlackIngress,
+  startSlackSocketModeIngress,
+  type SlackEventsApiIngressConfig,
+  type SlackSocketModeIngressConfig
+} from "@opentag/slack";
 
 function positivePort(value: string | undefined, fallback: number): number {
   const port = Number(value ?? String(fallback));
@@ -8,19 +13,13 @@ function positivePort(value: string | undefined, fallback: number): number {
   return port;
 }
 
-function configFromEnv(env: NodeJS.ProcessEnv): SlackIngressConfig {
-  const signingSecret = env.SLACK_SIGNING_SECRET;
+function sharedConfigFromEnv(env: NodeJS.ProcessEnv) {
   const dispatcherUrl = env.OPENTAG_DISPATCHER_URL;
   if (!dispatcherUrl) {
     throw new Error("OPENTAG_DISPATCHER_URL is required");
   }
-  if (!signingSecret) {
-    throw new Error("SLACK_SIGNING_SECRET is required");
-  }
   return {
-    signingSecret,
     dispatcherUrl,
-    port: positivePort(env.PORT, 3040),
     agentId: env.OPENTAG_SLACK_AGENT_ID ?? "opentag",
     ...(env.OPENTAG_DISPATCHER_TOKEN ? { dispatcherToken: env.OPENTAG_DISPATCHER_TOKEN } : {}),
     ...(env.OPENTAG_SLACK_APP_ID ? { appId: env.OPENTAG_SLACK_APP_ID } : {}),
@@ -28,5 +27,49 @@ function configFromEnv(env: NodeJS.ProcessEnv): SlackIngressConfig {
   };
 }
 
-const ingress = startSlackIngress(configFromEnv(process.env));
-console.log(`OpenTag Slack events ingress listening on ${ingress.url}`);
+function eventsApiConfigFromEnv(env: NodeJS.ProcessEnv): SlackEventsApiIngressConfig {
+  const signingSecret = env.SLACK_SIGNING_SECRET;
+  if (!signingSecret) {
+    throw new Error("SLACK_SIGNING_SECRET is required for Slack Events API mode");
+  }
+  return {
+    ...sharedConfigFromEnv(env),
+    signingSecret,
+    port: positivePort(env.PORT, 3040)
+  };
+}
+
+function socketModeConfigFromEnv(env: NodeJS.ProcessEnv): SlackSocketModeIngressConfig {
+  const appToken = env.OPENTAG_SLACK_APP_TOKEN ?? env.SLACK_APP_TOKEN;
+  if (!appToken) {
+    throw new Error("OPENTAG_SLACK_APP_TOKEN is required for Slack Socket Mode");
+  }
+  return {
+    ...sharedConfigFromEnv(env),
+    appToken
+  };
+}
+
+function slackModeFromEnv(env: NodeJS.ProcessEnv): "socket_mode" | "events_api" {
+  if (env.OPENTAG_SLACK_MODE === "socket_mode" || env.OPENTAG_SLACK_MODE === "events_api") {
+    return env.OPENTAG_SLACK_MODE;
+  }
+  if (env.OPENTAG_SLACK_MODE) {
+    throw new Error(`OPENTAG_SLACK_MODE must be socket_mode or events_api, received ${env.OPENTAG_SLACK_MODE}`);
+  }
+  return env.OPENTAG_SLACK_APP_TOKEN || env.SLACK_APP_TOKEN ? "socket_mode" : "events_api";
+}
+
+const mode = slackModeFromEnv(process.env);
+
+if (mode === "socket_mode") {
+  const ingress = startSlackSocketModeIngress(socketModeConfigFromEnv(process.env));
+  ingress.startPromise.catch((error: unknown) => {
+    console.error("OpenTag Slack Socket Mode ingress failed:", error);
+    process.exitCode = 1;
+  });
+  console.log("OpenTag Slack Socket Mode ingress connecting");
+} else {
+  const ingress = startSlackIngress(eventsApiConfigFromEnv(process.env));
+  console.log(`OpenTag Slack events ingress listening on ${ingress.url}`);
+}

--- a/docs/agent-work-protocol.md
+++ b/docs/agent-work-protocol.md
@@ -22,16 +22,18 @@ The primary product path is:
 
 ```text
 mention -> run -> executor -> final callback with suggested actions
-       -> source-thread reply such as apply 1
-       -> ApprovalDecision -> ApplyPlan or ChildRun fallback
+       -> source-thread reply such as apply 1 or continue 1
+       -> ApprovalDecision -> ApplyPlan or explicit continuation run
 ```
 
 Ingress apps and product integrations should prefer
 `@opentag/client.submitThreadAction(...)` for source-thread replies. That path
 preserves the user's thread context, applies actor authorization against the
 existing Project Target binding, uses stable approval/apply identifiers for
-webhook retry safety, and falls back to a child run when an adapter cannot apply
-the model's intent directly.
+webhook retry safety, and only presents direct apply as the primary path when a
+capability/preflight check proves the adapter can execute the model's intent.
+When direct apply is not available, the same thread can still carry an explicit
+continuation request.
 
 The lower-level proposal, approval, apply-plan, policy-rule, and
 adapter-mapping HTTP routes are **experimental protocol APIs**. They are useful
@@ -53,6 +55,9 @@ The next design step is to make three ideas first-class:
 - **Attention Budget**: human attention is a scarce system resource.
 - **Context Packet**: executor input should be curated, bounded, and auditable.
 - **Quiet Agent Protocol**: agents should know when not to speak.
+
+For the concrete Slack and GitHub approval rendering pattern that follows these
+principles, see [Source-Thread Action Receipts](./source-thread-action-receipts.md).
 
 Together, these shift OpenTag from a mention router to a protocol for bringing
 agents into real team workflows without flooding people, leaking context, or
@@ -113,7 +118,7 @@ and auditable execution in real team workflows.
 
 That means:
 
-- It is not just an open-source Claude Tag clone.
+- It is not a clone of any single chat-to-agent workflow.
 - It is not a hosted IDE or a general agent framework.
 - It is not an AI project management system.
 - It is a protocol layer between workspace surfaces and approved agent runners.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,7 @@ Use daemon security settings to keep executor runs constrained:
 | `claudeCode` | none | Claude Code executor settings |
 | `security` | none | Runner security policy |
 | `githubToken` | none | GitHub token for callback comments, dispatcher GitHub apply helpers, and optional legacy PR creation |
+| `githubApplyToken` | `githubToken` | Optional dispatcher direct-apply token override. Set to `null` to keep GitHub callbacks enabled while rendering direct-apply actions as setup-required. |
 | `preparePullRequestBranch` | `false` | Commits and pushes executor run branches so a later source-thread `apply 1` can create the PR through an ApplyPlan |
 | `allowAutoCreatePullRequest` | `false` | Legacy mode that creates a PR immediately when executor results include changes |
 | `pollIntervalMs` | `5000` | Poll interval for `serve` |
@@ -199,6 +200,8 @@ for repeatable setups.
 | `OPENTAG_ALLOW_UNSAFE_PROMPTS` | `false` | Allows prompts normally rejected by runner security |
 | `OPENTAG_EXTRA_SAFE_ENV` | none | Comma-separated env names preserved for executor processes |
 | `OPENTAG_GITHUB_TOKEN` | none | GitHub token for callback comments, dispatcher GitHub apply helpers, and optional legacy PR creation |
+| `OPENTAG_GITHUB_APPLY_TOKEN` | `OPENTAG_GITHUB_TOKEN` | Optional token override for dispatcher direct-apply helpers |
+| `OPENTAG_GITHUB_APPLY_DISABLED` | `false` | Set to `true` to keep callbacks enabled while forcing direct-apply receipts into setup-required state |
 | `OPENTAG_PREPARE_PR_BRANCH` | `false` | Pushes executor run branches for thread-native PR creation after approval |
 | `OPENTAG_ALLOW_AUTO_CREATE_PR` | `false` | Allows legacy immediate daemon PR creation |
 | `OPENTAG_PAIRING_TOKEN` | none | Shared dispatcher token |
@@ -212,7 +215,10 @@ for repeatable setups.
 | `PORT` | `3030` | Dispatcher HTTP port |
 | `OPENTAG_DATABASE_PATH` | `opentag.db` | SQLite database path |
 | `OPENTAG_PAIRING_TOKEN` | none | Requires `Authorization: Bearer <token>` for `/v1/*` |
-| `OPENTAG_GITHUB_TOKEN` | none | Enables GitHub callback posting and GitHub apply helpers |
+| `OPENTAG_GITHUB_TOKEN` | none | Backward-compatible token used for GitHub callback posting and GitHub apply helpers unless more specific env vars are set |
+| `OPENTAG_GITHUB_CALLBACK_TOKEN` | `OPENTAG_GITHUB_TOKEN` | Optional token override for GitHub callback posting |
+| `OPENTAG_GITHUB_APPLY_TOKEN` | `OPENTAG_GITHUB_TOKEN` | Optional token override for GitHub direct apply |
+| `OPENTAG_GITHUB_APPLY_DISABLED` | `false` | Set to `true` to disable GitHub direct apply while keeping callbacks enabled |
 | `OPENTAG_SLACK_BOT_TOKEN` | none | Single Slack bot token for callback posting |
 | `OPENTAG_SLACK_BOT_TOKENS_JSON` | none | JSON object mapping `agentId` to Slack bot token |
 | `LARK_APP_ID` | none | Lark app id for the callback sink that posts replies via the Lark API |

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,12 +14,14 @@ OpenTag is the open mention layer for agents: tag any approved agent from a work
 
 ## Why Now
 
-Claude Tag makes agent mentions feel natural inside team collaboration tools. The opportunity for OpenTag is to turn that interaction pattern into an open, vendor-neutral layer:
+Agent mentions are becoming a natural interaction pattern inside team
+collaboration tools. The opportunity for OpenTag is to make that pattern open,
+vendor-neutral, and protocol-first:
 
-- Claude Tag brings Claude into Slack.
-- OpenTag brings any agent into any workspace.
-- Claude Tag is one model, one vendor, one collaboration surface first.
-- OpenTag should be protocol-first, executor-neutral, and local-runner friendly.
+- OpenTag brings approved agents into existing workspace surfaces.
+- OpenTag supports multiple executors instead of binding the workflow to one model.
+- OpenTag treats local runners and auditable source-thread context as core product boundaries.
+- OpenTag should stay protocol-first, executor-neutral, and local-runner friendly.
 
 The first release should move fast enough to ride the conversation while still proving the idea with a real end-to-end task flow.
 
@@ -696,7 +698,7 @@ Tag Claude Code, Codex, Hermes, OpenClaw, or your own local runner from GitHub o
 ```
 
 ```text
-Claude Tag brings Claude into Slack. OpenTag brings any agent into any workspace.
+Bring approved agents into the workspace where the request already has context.
 ```
 
 ```text

--- a/docs/platforms/slack.en.md
+++ b/docs/platforms/slack.en.md
@@ -11,7 +11,7 @@ Both modes support the same core product flow: mention the Slack app, let OpenTa
 
 Slack-only setup proves the Slack loop. It does not by itself grant GitHub write access. If a run proposes a pull request action, `apply 1` can create a GitHub PR only when OpenTag also has a GitHub repository target and GitHub token configured.
 
-Suggested action buttons use Slack Block Kit interactivity. Enable **Interactivity & Shortcuts** in the Slack app so buttons such as **Apply 1** can submit the same source-thread action as a typed `apply 1` reply.
+Suggested action buttons use Slack Block Kit interactivity. Enable **Interactivity & Shortcuts** in the Slack app so state-driven buttons such as **Apply 1**, **Continue**, and **Reject** can submit the same source-thread action as a typed thread reply.
 
 ## Official Links
 
@@ -101,7 +101,7 @@ Do not enter a Request URL for Socket Mode. Slack delivers the event through the
 3. Do not enter a Request URL for Socket Mode. Slack sends Block Kit button actions over the same Socket Mode WebSocket connection.
 4. Save changes.
 
-This is what makes Slack buttons such as **Apply 1**, **Approve**, and **Reject** work. If Interactivity is off, OpenTag can still receive typed thread replies like `apply 1`, but clicking a button will fail in Slack before it reaches OpenTag.
+This is what makes Slack buttons such as **Apply 1**, **Continue**, and **Reject** work. If Interactivity is off, OpenTag can still receive typed thread replies, but clicking a button will fail in Slack before it reaches OpenTag.
 
 ## Advanced: Public Events API
 
@@ -233,9 +233,9 @@ Then mention the app in the bound channel:
 OpenTag should acknowledge the request and later reply in the same Slack thread.
 By default, the acknowledgement is a lightweight `eyes` reaction on your source message instead of a new thread reply.
 
-When OpenTag posts suggested actions, click **Apply 1** in Slack or type `apply 1` in the thread. Both paths apply the same source-thread action.
+When OpenTag posts suggested actions, follow the receipt state. If it says **Ready to apply**, click **Apply 1** in Slack or type `apply 1` in the thread. Both paths apply the same source-thread action.
 
-If the reply includes a pull request action, but your config only contains Slack credentials, OpenTag will continue with a follow-up run instead of creating the GitHub PR directly. Configure GitHub as a repository target before expecting Slack `apply 1` replies to create PRs.
+If the receipt says **Needs setup**, OpenTag will show **Continue** or a setup hint instead of presenting **Apply 1** as the primary path. Configure GitHub as a repository target before expecting Slack receipts to create PRs directly.
 
 If suggested action buttons are visible but clicking them shows an error in Slack, re-check **Interactivity & Shortcuts**:
 

--- a/docs/platforms/slack.zh-CN.md
+++ b/docs/platforms/slack.zh-CN.md
@@ -11,7 +11,7 @@ OpenTag 支持两种 Slack 连接方式：
 
 Slack-only setup 证明的是 Slack 这条链路。它不会自动获得 GitHub 写权限。如果某次 run 产出了 pull request action，只有在 OpenTag 同时配置了 GitHub repository target 和 GitHub token 时，Slack thread 里的 `apply 1` 才能直接创建 GitHub PR。
 
-Suggested action 按钮依赖 Slack Block Kit interactivity。需要在 Slack app 里开启 **Interactivity & Shortcuts**，这样 **Apply 1** 这类按钮才会提交和手动回复 `apply 1` 相同的 source-thread action。
+Suggested action 按钮依赖 Slack Block Kit interactivity。需要在 Slack app 里开启 **Interactivity & Shortcuts**，这样 **Apply 1**、**Continue**、**Reject** 这类状态驱动按钮才会提交和手动 thread reply 相同的 source-thread action。
 
 ## 官方入口
 
@@ -101,7 +101,7 @@ Socket Mode 不需要填写 Request URL。`opentag start` 会主动连到 Slack 
 3. Socket Mode 不需要填写 Request URL。Slack 会通过同一条 Socket Mode WebSocket 连接发送 Block Kit button action。
 4. 保存设置。
 
-这一步会让 Slack 里的 **Apply 1**、**Approve**、**Reject** 按钮真正可用。如果没有开启 Interactivity，OpenTag 仍然可以接收用户手打的 `apply 1` thread reply，但点击按钮会在 Slack 侧失败，事件不会到达 OpenTag。
+这一步会让 Slack 里的 **Apply 1**、**Continue**、**Reject** 按钮真正可用。如果没有开启 Interactivity，OpenTag 仍然可以接收用户手打的 thread reply，但点击按钮会在 Slack 侧失败，事件不会到达 OpenTag。
 
 ## 高级：公网 Events API
 
@@ -233,9 +233,9 @@ opentag start
 OpenTag 应该会先确认收到请求，执行完成后再回到同一个 Slack thread 里回复。
 默认确认方式是在你的源消息上加一个轻量的 `eyes` reaction，而不是额外发一条 thread reply。
 
-当 OpenTag 发出 suggested actions 时，可以在 Slack 里点击 **Apply 1**，也可以在线程里手动回复 `apply 1`。两种方式都会应用同一个 source-thread action。
+当 OpenTag 发出 suggested actions 时，先看 receipt state。如果显示 **Ready to apply**，可以在 Slack 里点击 **Apply 1**，也可以在线程里手动回复 `apply 1`。两种方式都会应用同一个 source-thread action。
 
-如果回复里出现 pull request action，但你的配置里只有 Slack 凭据，OpenTag 会创建一个 follow-up run，而不是直接创建 GitHub PR。想让 Slack 里的 `apply 1` 直接创建 PR，需要先配置 GitHub repository target。
+如果 receipt 显示 **Needs setup**，OpenTag 会显示 **Continue** 或 setup hint，而不是把 **Apply 1** 当成主路径。想让 Slack receipt 直接创建 PR，需要先配置 GitHub repository target。
 
 如果 suggested action 按钮能看到，但点击后 Slack 提示失败，优先检查 **Interactivity & Shortcuts**：
 

--- a/docs/real-integration-smoke-test.md
+++ b/docs/real-integration-smoke-test.md
@@ -128,6 +128,46 @@ OPENTAG_GH_APPLY_PR_ACTION=true \
 scripts/dev/run-gh-claude-local-test.sh
 ```
 
+### GitHub Repository Webhook Live Test
+
+Use this when you need to prove the real GitHub repository webhook ingress, not
+only the dispatcher-assisted path. The script starts the local CLI stack,
+exposes the GitHub webhook listener through ngrok, creates a temporary
+repository webhook, posts a real issue comment, replies `apply 1`, waits for the
+PR, and deletes the temporary webhook on exit.
+
+```bash
+OPENTAG_GH_REPO=amplifthq/opentag-test \
+scripts/dev/run-github-webhook-live-test.sh
+```
+
+Expected evidence:
+
+- GitHub issue comment creates a dispatcher run through `/github/webhooks`.
+- Final GitHub comment renders `### Ready to apply`.
+- Replying `apply 1` through GitHub creates an `ApprovalDecision` and `ApplyPlan`.
+- Apply executes through GitHub and comments with the created PR URL.
+- The temporary repository webhook is deleted after the run.
+
+To prove the missing-apply-credentials path while keeping GitHub callbacks live,
+run the same script with direct apply disabled:
+
+```bash
+OPENTAG_GH_REPO=amplifthq/opentag-test \
+OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN=true \
+scripts/dev/run-github-webhook-live-test.sh
+```
+
+Expected evidence for that branch:
+
+- The final GitHub comment renders `### Needs setup`.
+- The comment does not advertise `apply 1` as an available direct-apply command.
+- The script skips the apply reply because the dispatcher has no GitHub apply
+  token.
+
+This path requires `gh` admin or maintain access for the target repository so
+the script can create and delete the temporary webhook.
+
 This lets the daemon commit and push the executor-produced run branch, but it does not open the PR immediately. The final callback should render a `create_pull_request` suggested action with the PR title, head branch, base branch, changed files, risks, executor conditions, and any real verification the executor reported. Reply in the source thread with:
 
 ```text
@@ -317,11 +357,12 @@ Expected Slack thread shape:
 - OpenTag `eyes` reaction receipt on the source message
 - OpenTag final result
 - optional `apply 1` reply when validating the action loop
-- optional apply result callback containing the PR URL or child-run fallback context
+- optional apply result callback containing the PR URL
+- if direct apply is not available, the receipt should show `Needs setup` or `Continue` instead of presenting `Apply` as the primary path
 
 Routine acknowledgement and progress stay out of Slack thread replies by default, so they should not produce additional Slack messages.
 
-### Slack Events API App Setup
+### Slack App Setup
 
 Required bot scopes:
 
@@ -335,16 +376,31 @@ Required bot event:
 
 Install the app to the workspace, then collect:
 
-- `Signing Secret`
+- `App-Level Token` for Socket Mode, or `Signing Secret` for Events API
 - `Bot User OAuth Token`
 - target `teamId`
 - target `channelId`
 
 Invite the bot user into the test channel before sending any mention.
 
+### Socket Mode Transport
+
+For local README recordings, prefer Socket Mode. It avoids public Request URL
+drift and sends app mentions plus Block Kit button actions through Slack's
+WebSocket connection:
+
+```bash
+OPENTAG_SLACK_APP_TOKEN=xapp-... \
+  scripts/dev/run-slack-ui-trigger-local-test.sh
+```
+
+Slack Interactivity still needs to be enabled, but Socket Mode does not require
+an Interactivity Request URL.
+
 ### Events API Transport
 
-This smoke path uses Events API over a public Request URL. Disable Socket Mode for this specific app setup.
+Use Events API only when you intentionally want to validate a public Request URL
+or hosted ingress. Disable Socket Mode for that specific app setup.
 
 If Socket Mode is still enabled, Slack may give confusing signals in the dashboard and you end up debugging the wrong transport.
 
@@ -473,24 +529,181 @@ Use this trace when validating the model action layer against a real GitHub issu
 | Approval/apply reply | Source-thread reply text such as `apply 1` and actor identity |
 | ApprovalDecision | `approval.decision.recorded` event and selected intent IDs |
 | ApplyPlan | `apply_plan.created` event, adapter, selected intent IDs, and preflight outcomes |
-| Adapter or fallback | PR URL when applied, or child run ID plus fallback reason when the adapter cannot apply |
+| Adapter or setup path | PR URL when applied, or a `Needs setup` / continuation reason when the adapter cannot apply |
 | Final callback | Source-thread callback containing the PR URL or child-run continuation context |
 | Metrics | `approvalDecisionCount`, `applyPlanCount`, `childRunCount`, and `applyOutcomeCounts` |
 
 Expected GitHub create-PR success shape:
 
 ```text
-mention -> run -> executor changed files -> final callback with Suggested action #1 create_pull_request
+mention -> run -> executor changed files -> final callback with Ready to apply source-thread action receipt
 apply 1 -> approval decision -> apply plan -> POST /pulls -> callback with https://github.com/<owner>/<repo>/pull/<number>
 ```
 
-Expected fallback shape when the branch is not pushed or the adapter cannot apply:
+Expected unavailable-apply shape when the branch is not pushed or the adapter cannot apply:
 
 ```text
-apply 1 -> approval decision -> apply plan -> child run
+final callback -> Needs setup or Continue -> no primary Apply button
 ```
 
-The fallback callback must explain why the direct apply was not possible, show the child run ID, and list the context carried forward: proposal ID, selected intents, previous run, previous result, apply plan, and fallback reason.
+The receipt must explain why direct apply is not possible. A manually typed
+`continue 1` can still start a follow-up run when a human explicitly chooses to
+carry the proposal context forward.
+
+### Recorded Trace: 2026-06-30 GitHub repository webhook receipt preflight
+
+This trace validated both sides of the source-thread receipt state machine
+against the real `amplifthq/opentag-test` repository webhook path.
+
+#### Ready-to-apply path
+
+| Field | Value |
+| --- | --- |
+| Source issue | `https://github.com/amplifthq/opentag-test/issues/46` |
+| Mention comment | `https://github.com/amplifthq/opentag-test/issues/46#issuecomment-4837078185` |
+| Apply comment | `https://github.com/amplifthq/opentag-test/issues/46#issuecomment-4837085850` |
+| Run ID | `run_afeb0d55-7f40-473e-887d-fb652750881b` |
+| Created PR | `https://github.com/amplifthq/opentag-test/pull/47` |
+| Head branch | `opentag/run_afeb0d55-7f40-473e-887d-fb652750881b` |
+| Base branch | `main` |
+
+Observed behavior:
+
+- The real GitHub issue comment triggered the dispatcher through
+  `/github/webhooks`.
+- The final GitHub callback rendered `### Ready to apply`.
+- The real `apply 1` reply created an `ApprovalDecision` and `ApplyPlan`.
+- The GitHub adapter created PR #47.
+- The apply receipt included `Applied:` and the created PR URL.
+
+Observed metrics after apply:
+
+```json
+{
+  "approvalDecisionCount": 1,
+  "applyPlanCount": 1,
+  "childRunCount": 0,
+  "applyOutcomeCounts": {
+    "applied": 1,
+    "failed": 0,
+    "skipped": 0,
+    "stale": 0,
+    "unsupported": 0
+  },
+  "suggestedChangesCount": 3,
+  "threadNoiseRatio": 0.2857142857142857
+}
+```
+
+#### Missing-apply-token path
+
+| Field | Value |
+| --- | --- |
+| Source issue | `https://github.com/amplifthq/opentag-test/issues/48` |
+| Mention comment | `https://github.com/amplifthq/opentag-test/issues/48#issuecomment-4837099441` |
+| Run ID | `run_08c68db8-36d0-44ba-8f06-954ecb40b5bc` |
+| Head branch | `opentag/run_08c68db8-36d0-44ba-8f06-954ecb40b5bc` |
+
+Command shape:
+
+```bash
+OPENTAG_GH_REPO=amplifthq/opentag-test \
+OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN=true \
+scripts/dev/run-github-webhook-live-test.sh
+```
+
+Observed behavior:
+
+- GitHub callbacks still worked because the callback token remained configured.
+- Dispatcher direct apply was unavailable because the apply token was disabled.
+- The final GitHub callback rendered `### Needs setup`.
+- The receipt did not advertise `apply 1` as an available command.
+- No approval decision, apply plan, child run, or external write was created.
+
+Observed metrics:
+
+```json
+{
+  "approvalDecisionCount": 0,
+  "applyPlanCount": 0,
+  "childRunCount": 0,
+  "applyOutcomeCounts": {
+    "applied": 0,
+    "failed": 0,
+    "skipped": 0,
+    "stale": 0,
+    "unsupported": 0
+  },
+  "suggestedChangesCount": 3,
+  "threadNoiseRatio": 0.25
+}
+```
+
+Repository cleanup:
+
+- Temporary repository webhook `647717865` was deleted by the ready-to-apply run.
+- Temporary repository webhook `647718589` was deleted by the missing-apply-token
+  run.
+- The live script removed temporary config files after each run because they
+  contain local credentials.
+
+### Recorded Trace: 2026-06-30 GitHub repository webhook `create_pull_request`
+
+This trace validated the repository-webhook path against the real
+`amplifthq/opentag-test` repository. Unlike the CLI-assisted smoke test, both
+the initial mention and `apply 1` reply entered through the real GitHub
+repository webhook listener.
+
+| Field | Value |
+| --- | --- |
+| Source issue | `https://github.com/amplifthq/opentag-test/issues/44` |
+| Mention comment | `https://github.com/amplifthq/opentag-test/issues/44#issuecomment-4836858128` |
+| Apply comment | `https://github.com/amplifthq/opentag-test/issues/44#issuecomment-4836863316` |
+| Run ID | `run_5384bdb9-9b6e-4639-94f4-2b2055be6e56` |
+| Proposal ID | `proposal_run_5384bdb9-9b6e-4639-94f4-2b2055be6e56` |
+| Applied intent | `proposal_run_5384bdb9-9b6e-4639-94f4-2b2055be6e56_create_pr` |
+| Approval ID | `approval_github_comment_4836863316` |
+| ApplyPlan ID | `apply_ef9146b4f45d` |
+| Created PR | `https://github.com/amplifthq/opentag-test/pull/45` |
+| Head branch | `opentag/run_5384bdb9-9b6e-4639-94f4-2b2055be6e56` |
+| Base branch | `main` |
+
+Command shape:
+
+```bash
+OPENTAG_GH_LIVE_KILL_PORTS=true \
+scripts/dev/run-github-webhook-live-test.sh
+```
+
+Observed source-thread callbacks:
+
+- Mention comment: `@opentag run Add one short sentence to README.md saying GitHub can trigger local Claude Code through OpenTag. Keep the change small and do not modify anything else.`
+- Final run callback rendered `### Ready to apply` and described the source-thread action receipt.
+- Real `apply 1` issue comment returned `Applied: Create a pull request for branch opentag/run_5384bdb9-9b6e-4639-94f4-2b2055be6e56.` plus the PR URL.
+
+Observed metrics after apply:
+
+```json
+{
+  "approvalDecisionCount": 1,
+  "applyPlanCount": 1,
+  "childRunCount": 0,
+  "applyOutcomeCounts": {
+    "applied": 1,
+    "skipped": 0,
+    "failed": 0,
+    "stale": 0,
+    "unsupported": 0
+  },
+  "suggestedChangesCount": 3,
+  "threadNoiseRatio": 0.2857142857142857
+}
+```
+
+Repository cleanup:
+
+- Temporary repository webhook `647712049` was deleted by the script.
+- `gh api repos/amplifthq/opentag-test/hooks` returned `[]` after cleanup.
 
 ### Recorded Trace: 2026-06-27 GitHub `create_pull_request`
 

--- a/docs/real-integration-smoke-test.md
+++ b/docs/real-integration-smoke-test.md
@@ -144,7 +144,8 @@ scripts/dev/run-github-webhook-live-test.sh
 Expected evidence:
 
 - GitHub issue comment creates a dispatcher run through `/github/webhooks`.
-- Final GitHub comment renders `### Ready to apply`.
+- Final GitHub comment renders a ready or mixed-state action receipt and
+  advertises `apply 1` only for actions the dispatcher can currently apply.
 - Replying `apply 1` through GitHub creates an `ApprovalDecision` and `ApplyPlan`.
 - Apply executes through GitHub and comments with the created PR URL.
 - The temporary repository webhook is deleted after the run.
@@ -678,7 +679,8 @@ scripts/dev/run-github-webhook-live-test.sh
 Observed source-thread callbacks:
 
 - Mention comment: `@opentag run Add one short sentence to README.md saying GitHub can trigger local Claude Code through OpenTag. Keep the change small and do not modify anything else.`
-- Final run callback rendered `### Ready to apply` and described the source-thread action receipt.
+- Final run callback rendered a source-thread action receipt with `apply 1`
+  available for the create-PR action.
 - Real `apply 1` issue comment returned `Applied: Create a pull request for branch opentag/run_5384bdb9-9b6e-4639-94f4-2b2055be6e56.` plus the PR URL.
 
 Observed metrics after apply:

--- a/docs/source-thread-action-receipts.md
+++ b/docs/source-thread-action-receipts.md
@@ -262,6 +262,7 @@ Slack copy guidelines:
   that action;
 - show at most the first few high-value details in the thread;
 - keep proposal and intent identifiers out of visible copy.
+- expose local audit as low-prominence context, not as another primary action.
 
 Typed commands remain supported for portability:
 

--- a/docs/source-thread-action-receipts.md
+++ b/docs/source-thread-action-receipts.md
@@ -1,0 +1,399 @@
+# Source-Thread Action Receipts
+
+## Status
+
+Draft design, 2026-06-30.
+
+This document defines the user-facing receipt pattern for OpenTag suggested
+actions in Slack and GitHub. It narrows the broader Agent Work Protocol into an
+interaction model that makes protocolized mutations easy to understand, approve,
+reject, and audit from the source thread.
+
+For the long-horizon protocol model, see
+[Agent Work Protocol](./agent-work-protocol.md). For the runtime architecture,
+see [Thread Runtime Alignment](./thread-runtime-design.md).
+
+## Recommendation
+
+Keep this design in the public repository.
+
+The interaction governs public product behavior, platform adapters, and tests,
+so it should be reviewable next to the code. Competitive research, launch
+strategy, and private screenshots should stay outside the public repo. The
+public design should describe OpenTag's own product language and constraints
+without naming or imitating other systems.
+
+## Problem
+
+OpenTag can already turn a source-thread mention into a local executor run and
+return suggested actions. The risk is that the approval moment still feels like
+raw protocol output:
+
+- humans see internal identifiers instead of decisions;
+- Slack and GitHub render the same intent with different clarity;
+- `Apply`, `Approve only`, and `Reject` are easy to confuse;
+- long executor summaries compete with the actual decision;
+- the audit trail is strong, but the human-facing surface can feel noisy.
+
+The product goal is not to build a custom workspace UI. The goal is to make the
+native source thread feel like a clear control surface for a bounded external
+write.
+
+## Product Thesis
+
+OpenTag should render each suggested action as an **action receipt**.
+
+An action receipt is a compact, human-readable record that says:
+
+```text
+What OpenTag proposes to change.
+Where the change will be applied.
+Why the action is safe or blocked.
+Which explicit decision the human can make now.
+Where the durable audit record lives.
+```
+
+This keeps the system protocol-first while making the approval moment legible in
+Slack, GitHub, and future adapters.
+
+## Design Principles
+
+### Native, Not Custom
+
+Use Slack Block Kit buttons and GitHub Markdown comments. Do not introduce a
+separate OpenTag web console as the default approval surface.
+
+### Receipt, Not Transcript
+
+Show the proposed action and decision controls. Keep full executor reasoning,
+raw proposal identifiers, and long internal context in audit unless the user
+explicitly asks for it.
+
+### Action Before Metadata
+
+The primary line should describe the action in human language:
+
+```text
+Create a pull request for branch opentag/run_123.
+```
+
+Internal concepts such as proposal IDs, intent IDs, apply plan IDs, and run IDs
+are audit metadata. They should not lead the human-facing surface.
+
+### Differentiate Decisions
+
+`Apply`, `Approve only`, and `Reject` are not synonyms:
+
+| Decision | Meaning |
+| --- | --- |
+| `Apply` | Approve and execute the selected action against the system of record now. |
+| `Approve only` | Record approval, but do not execute the external write yet. |
+| `Reject` | Mark the selected action as rejected and do not execute it. |
+| `Continue` | Start a follow-up run using the proposal context, usually when direct apply is unavailable or more work is needed. |
+
+The UI should use these labels consistently. In a ready-to-apply state, make
+`Apply` and `Reject` the first two visible decisions; keep `Approve only`
+available but visually secondary.
+
+### Quiet By Default
+
+The source thread should receive:
+
+- a lightweight source receipt when OpenTag accepts the request;
+- one final result;
+- action receipts when a human decision is needed;
+- blockers when the human must intervene.
+
+Routine progress, raw logs, internal plans, and repeated "working" messages
+belong in audit.
+
+### Protocol Truth Under UI Clarity
+
+The visible card can be simple, but every button or command must resolve to the
+same protocol path:
+
+```text
+SuggestedChangesSnapshot -> ApprovalDecision -> ApplyPlan -> per-intent outcome
+```
+
+The UI must never create a hidden side path that bypasses proposal lineage,
+authority checks, or adapter preflight.
+
+## Interaction Model
+
+### 1. Source Receipt
+
+When OpenTag accepts a mention, the source surface should acknowledge it without
+adding conversational clutter.
+
+Slack default:
+
+- add an `eyes` reaction to the triggering message;
+- do not post a separate "I picked this up" reply unless reaction delivery
+  fails or the run is blocked before it starts.
+
+GitHub default:
+
+- post one short acknowledgement when useful for latency or webhook clarity;
+- avoid repeated progress comments.
+
+The receipt means only "OpenTag received the request." It does not imply that
+the task will succeed, that a runner has claimed it, or that any write is
+authorized.
+
+### 2. Final Result
+
+The final result should answer three questions in order:
+
+1. What happened?
+2. What was verified?
+3. What decision is now available?
+
+Preferred shape:
+
+```text
+Finished: success.
+
+Changed README.md by adding one short sentence about Slack-triggered local
+Claude Code.
+
+Verified: edit applied cleanly.
+
+Ready to apply:
+1. Create a pull request for branch opentag/run_123.
+```
+
+Avoid leading with run IDs, proposal IDs, or executor implementation details.
+
+### 3. Action Receipt
+
+Each suggested action should render as a compact receipt.
+
+Human-facing fields:
+
+| Field | Purpose |
+| --- | --- |
+| Action | The proposed mutation in one sentence. |
+| Target | The system of record or artifact that will change. |
+| Evidence | Minimal verification, changed files, or preconditions. |
+| Risk | Only material risks, stale state, or permission blockers. |
+| Controls | Native buttons or typed commands. |
+| Audit link or hint | Where full lineage can be inspected, when available. |
+
+Audit-only fields:
+
+- proposal ID;
+- intent ID;
+- approval decision ID;
+- apply plan ID;
+- child run ID unless the user needs it to continue work;
+- full executor prompt or log;
+- raw adapter payloads.
+
+### 4. Decision Feedback
+
+After a human decision, the reply should be short and state the consequence.
+
+Apply success:
+
+```text
+Applied: Create a pull request.
+Result: https://github.com/org/repo/pull/123
+```
+
+Apply blocked:
+
+```text
+Could not apply: GitHub write credentials are not configured.
+Next: connect a GitHub token with pull request creation scope, then apply again.
+```
+
+Apply replay:
+
+```text
+Already applied: Create a pull request.
+No external write was repeated.
+```
+
+Approve only:
+
+```text
+Approved only. No external write was performed.
+Next: use Apply when this should be written to GitHub.
+```
+
+Reject:
+
+```text
+Rejected. OpenTag will not apply this action.
+```
+
+Do not paste the full carried-forward context into Slack unless the action falls
+back to a child run and the user needs a concise reason.
+
+## Slack Rendering
+
+Slack should optimize for scanning and low thread noise.
+
+Recommended Block Kit structure:
+
+1. One section for the final result summary.
+2. One optional context line for verification.
+3. One section per action receipt.
+4. One actions block per action with available decisions.
+
+Button labels:
+
+| Button | Style | When shown |
+| --- | --- | --- |
+| `Apply` or `Apply 1` | primary | The adapter can execute the action now. |
+| `Reject` | danger | The action can be explicitly rejected. |
+| `Approve only` | default | The approval can be recorded separately from execution. |
+| `Continue` | default | Direct apply is unavailable or follow-up work is the intended path. |
+
+Slack copy guidelines:
+
+- use `Ready to apply` instead of `Suggested actions` when at least one action
+  is marked executable by dispatcher capability and preflight context;
+- use `Needs approval` when execution is blocked on human authority;
+- use `Needs setup` when adapter credentials or scopes are missing;
+- hide `Apply` unless the dispatcher has confirmed a direct adapter path for
+  that action;
+- show at most the first few high-value details in the thread;
+- keep proposal and intent identifiers out of visible copy.
+
+Typed commands remain supported for portability:
+
+```text
+apply 1
+approve 1
+reject 1
+continue 1
+```
+
+Buttons and typed commands must produce equivalent `submitThreadAction`
+requests.
+
+## GitHub Rendering
+
+GitHub should optimize for reviewability and durable context.
+
+Recommended Markdown structure:
+
+```markdown
+### Ready to apply
+
+OpenTag prepared a source-thread action. Choose one command in this thread.
+
+#### 1. Create a pull request for branch `opentag/run_123`
+
+| Field | Value |
+| --- | --- |
+| Target | GitHub pull request |
+| Branch | `opentag/run_123` -> `main` |
+| Changed files | `README.md` |
+| Verification | Edit applied cleanly |
+
+| Decision | Comment command |
+| --- | --- |
+| Apply now | `apply 1` |
+| Reject | `reject 1` |
+| Approve only | `approve 1` |
+```
+
+GitHub can show more detail than Slack, but should still avoid exposing raw
+protocol IDs by default. If audit identifiers are needed, place them in a
+collapsed details section or an audit link rather than the main action body.
+
+## State Language
+
+Adapters should use a small shared vocabulary:
+
+| State | Human copy |
+| --- | --- |
+| `received` | OpenTag received the request. |
+| `running` | OpenTag is working. Usually audit-only. |
+| `needs_approval` | A human decision is required. |
+| `ready_to_apply` | The action can be applied now. |
+| `applying` | OpenTag is executing the approved action. Usually audit-only unless slow. |
+| `applied` | The external write succeeded. |
+| `approved_only` | Approval was recorded without execution. |
+| `rejected` | The human rejected the action. |
+| `blocked` | OpenTag cannot proceed without setup or permission. |
+| `stale` | The proposal no longer matches the current system-of-record state. |
+
+This vocabulary should guide both visible copy and test fixtures.
+
+## Accessibility And Trust
+
+Action receipts should be usable without relying on color, emoji, or animation.
+
+Requirements:
+
+- buttons must have explicit text labels;
+- destructive actions use both label and Slack `danger` style;
+- every button path has an equivalent text command;
+- failure messages state whether anything was written;
+- final callbacks distinguish local file edits, branch creation, PR creation,
+  and external system mutation;
+- stale or unsupported actions should not look visually equivalent to ready
+  actions.
+
+## Implementation Direction
+
+### Minimal Near-Term Changes
+
+- Rename visible Slack/GitHub headings from generic `Suggested actions` to
+  state-specific headings such as `Ready to apply`, `Needs approval`, or
+  `Needs setup`.
+- Drive those headings and visible decisions from a shared action receipt model
+  instead of provider-local action-name heuristics.
+- Show `Apply` only when dispatcher capability and preflight context says the
+  action can be written to the system of record now.
+- Rename visible `Approve` button text to `Approve only` when it does not apply.
+- Keep `Apply` as the primary action only when an adapter can execute now.
+- Hide proposal and intent IDs from primary GitHub comments, or move them into
+  optional audit detail.
+- Normalize apply/approve/reject result messages across Slack and GitHub.
+- Add regression tests for the decision labels and hidden metadata rules.
+
+### Later Enhancements
+
+- Add an audit URL or local audit command hint to each action receipt.
+- Render stale/conflicted proposals with explicit disabled controls where the
+  provider supports it.
+- Add adapter-provided preflight summaries before showing `Apply`.
+- Add a compact receipt renderer shared by Slack and GitHub, with provider
+  formatters layered on top.
+
+## Non-Goals
+
+- Do not build a custom approval dashboard for v0.x.
+- Do not turn Slack into a full run log.
+- Do not make every executor thought visible to humans.
+- Do not hard-code provider-specific labels into the core protocol.
+- Do not use external product language, names, screenshots, or visual motifs
+  in public docs or UI copy.
+
+## Success Criteria
+
+The design is working when:
+
+- a first-time user can tell what will happen before clicking `Apply`;
+- `Apply`, `Approve only`, and `Reject` are not confused in user testing;
+- Slack live e2e shows one lightweight receipt, one final result, and one clear
+  decision surface;
+- GitHub comments are reviewable without reading internal IDs;
+- every visible decision can be traced to an `ApprovalDecision` and `ApplyPlan`;
+- noisy details remain available in audit but do not flood the source thread.
+
+## Open Questions
+
+- Should Slack hide `Approve only` by default until there is a real delayed-apply
+  workflow?
+- Should GitHub expose audit identifiers in a collapsed details block, or only
+  through local CLI/audit commands?
+- Should `Apply all` be visible by default, or reserved for typed commands after
+  users understand individual action receipts?
+- What is the minimum audit-link story for local-first deployments without a
+  hosted console?

--- a/docs/source-thread-action-receipts.md
+++ b/docs/source-thread-action-receipts.md
@@ -92,8 +92,8 @@ are audit metadata. They should not lead the human-facing surface.
 | `Continue` | Start a follow-up run using the proposal context, usually when direct apply is unavailable or more work is needed. |
 
 The UI should use these labels consistently. In a ready-to-apply state, make
-`Apply` and `Reject` the first two visible decisions; keep `Approve only`
-available but visually secondary.
+`Apply` and `Reject` the visible decisions. `Approve only` remains a supported
+typed command, but it should not compete with the primary happy path.
 
 ### Quiet By Default
 
@@ -242,19 +242,20 @@ Recommended Block Kit structure:
 3. One section per action receipt.
 4. One actions block per action with available decisions.
 
-Button labels:
+Decision labels:
 
 | Button | Style | When shown |
 | --- | --- | --- |
 | `Apply` or `Apply 1` | primary | The adapter can execute the action now. |
 | `Reject` | danger | The action can be explicitly rejected. |
-| `Approve only` | default | The approval can be recorded separately from execution. |
+| `Approve only` | typed command | The approval can be recorded separately from execution. |
 | `Continue` | default | Direct apply is unavailable or follow-up work is the intended path. |
 
 Slack copy guidelines:
 
-- use `Ready to apply` instead of `Suggested actions` when at least one action
-  is marked executable by dispatcher capability and preflight context;
+- use `Ready to apply` instead of `Suggested actions` only when every visible
+  action is marked executable by dispatcher capability and preflight context;
+- use `Some actions need setup` or `Needs review` for mixed-state receipts;
 - use `Needs approval` when execution is blocked on human authority;
 - use `Needs setup` when adapter credentials or scopes are missing;
 - hide `Apply` unless the dispatcher has confirmed a direct adapter path for
@@ -298,7 +299,6 @@ OpenTag prepared a source-thread action. Choose one command in this thread.
 | --- | --- |
 | Apply now | `apply 1` |
 | Reject | `reject 1` |
-| Approve only | `approve 1` |
 ```
 
 GitHub can show more detail than Slack, but should still avoid exposing raw
@@ -350,7 +350,8 @@ Requirements:
   instead of provider-local action-name heuristics.
 - Show `Apply` only when dispatcher capability and preflight context says the
   action can be written to the system of record now.
-- Rename visible `Approve` button text to `Approve only` when it does not apply.
+- Keep `Approve only` as a typed command unless a state specifically calls for
+  approval without execution.
 - Keep `Apply` as the primary action only when an adapter can execute now.
 - Hide proposal and intent IDs from primary GitHub comments, or move them into
   optional audit detail.
@@ -389,8 +390,6 @@ The design is working when:
 
 ## Open Questions
 
-- Should Slack hide `Approve only` by default until there is a real delayed-apply
-  workflow?
 - Should GitHub expose audit identifiers in a collapsed details block, or only
   through local CLI/audit commands?
 - Should `Apply all` be visible by default, or reserved for typed commands after

--- a/docs/superpowers/plans/2026-06-24-opentag-v0.md
+++ b/docs/superpowers/plans/2026-06-24-opentag-v0.md
@@ -2067,7 +2067,7 @@ Tag Codex, Claude Code, Pi, or your own local runner from GitHub, Slack, or Lark
 
 ## Why
 
-Claude Tag brings Claude into Slack. OpenTag brings any agent into any workspace.
+OpenTag brings approved agents into the workspace where the request already has context.
 
 ## V0 Direction
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -83,6 +83,7 @@ const DaemonConfigSchema = z
     hermes: HermesSchema.optional(),
     security: SecuritySchema.optional(),
     githubToken: z.string().min(1).optional(),
+    githubApplyToken: z.string().min(1).nullable().optional(),
     preparePullRequestBranch: z.boolean().optional(),
     allowAutoCreatePullRequest: z.boolean().optional(),
     pairingToken: z.string().min(1),
@@ -274,7 +275,12 @@ export function assertPrivateConfigFile(path: string): void {
 }
 
 function redactValue(key: string, value: unknown): unknown {
-  if (["appSecret", "appToken", "botToken", "githubToken", "pairingToken", "signingSecret", "webhookSecret"].includes(key)) {
+  if (
+    ["appSecret", "appToken", "botToken", "githubToken", "githubApplyToken", "pairingToken", "signingSecret", "webhookSecret"].includes(
+      key
+    )
+  ) {
+    if (value === null || value === undefined) return value;
     return "[REDACTED]";
   }
   if (Array.isArray(value)) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -82,6 +82,7 @@ program
   .command("status")
   .description("Show the local OpenTag status")
   .option("--config <path>", "Config file path")
+  .option("--run <runId>", "Show audit details for one run")
   .action(async (options) => {
     try {
       await runStatusCommand(options);

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -191,6 +191,12 @@ export function dispatcherRuntimeInputFromCliConfig(config: OpenTagCliConfig): L
     databasePath: config.state.databasePath,
     ...(config.daemon.pairingToken ? { pairingToken: config.daemon.pairingToken } : {}),
     ...(config.daemon.githubToken ? { githubToken: config.daemon.githubToken } : {}),
+    ...(config.daemon.githubToken ? { githubCallbackToken: config.daemon.githubToken } : {}),
+    ...(config.daemon.githubApplyToken !== undefined
+      ? { githubApplyToken: config.daemon.githubApplyToken }
+      : config.daemon.githubToken
+        ? { githubApplyToken: config.daemon.githubToken }
+        : {}),
     ...(lark
       ? {
           lark: {

--- a/packages/cli/src/status.ts
+++ b/packages/cli/src/status.ts
@@ -1,8 +1,11 @@
+import { createOpenTagClient, type RunMetrics } from "@opentag/client";
+import type { OpenTagEvent, OpenTagRun } from "@opentag/core";
 import { defaultConfigPath, readCliConfig, type OpenTagCliConfig } from "./config.js";
 import { probeDispatcherHealth } from "./health.js";
 
 export type StatusCommandOptions = {
   config?: string;
+  run?: string;
 };
 
 export type StatusSummary = {
@@ -12,6 +15,23 @@ export type StatusSummary = {
   runnerId: string;
   repositories: string[];
   platforms: string[];
+};
+
+type RunAuditEvent = {
+  type?: unknown;
+  visibility?: unknown;
+  importance?: unknown;
+  message?: unknown;
+  createdAt?: unknown;
+};
+
+export type RunStatusSummary = {
+  configPath: string;
+  dispatcherUrl: string;
+  run: OpenTagRun;
+  event: OpenTagEvent;
+  metrics: RunMetrics;
+  events: RunAuditEvent[];
 };
 
 export async function getStatusSummary(input: {
@@ -51,6 +71,47 @@ export async function statusFromConfig(input: {
   };
 }
 
+export async function getRunStatusSummary(input: {
+  runId: string;
+  configPath?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<RunStatusSummary> {
+  const configPath = input.configPath ?? defaultConfigPath();
+  const config = readCliConfig(configPath);
+  return runStatusFromConfig({
+    config,
+    configPath,
+    runId: input.runId,
+    ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {})
+  });
+}
+
+export async function runStatusFromConfig(input: {
+  config: OpenTagCliConfig;
+  configPath: string;
+  runId: string;
+  fetchImpl?: typeof fetch;
+}): Promise<RunStatusSummary> {
+  const client = createOpenTagClient({
+    dispatcherUrl: input.config.daemon.dispatcherUrl,
+    ...(input.config.daemon.pairingToken ? { pairingToken: input.config.daemon.pairingToken } : {}),
+    ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {})
+  });
+  const [claimed, events, metrics] = await Promise.all([
+    client.getRun({ runId: input.runId }),
+    client.listRunEvents({ runId: input.runId }),
+    client.getRunMetrics({ runId: input.runId })
+  ]);
+  return {
+    configPath: input.configPath,
+    dispatcherUrl: input.config.daemon.dispatcherUrl,
+    run: claimed.run,
+    event: claimed.event,
+    metrics: metrics.metrics,
+    events: events.events as RunAuditEvent[]
+  };
+}
+
 export function formatStatus(summary: StatusSummary): string {
   return [
     `Config: ${summary.configPath}`,
@@ -62,6 +123,39 @@ export function formatStatus(summary: StatusSummary): string {
   ].join("\n");
 }
 
+function displayValue(value: unknown, fallback = "unknown"): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function formatRunEvent(event: RunAuditEvent): string {
+  const createdAt = displayValue(event.createdAt);
+  const visibility = displayValue(event.visibility);
+  const importance = displayValue(event.importance);
+  const message = typeof event.message === "string" && event.message.length > 0 ? ` - ${event.message}` : "";
+  return `  ${createdAt} ${visibility}/${importance} ${displayValue(event.type)}${message}`;
+}
+
+export function formatRunStatus(summary: RunStatusSummary): string {
+  const latestEvents = summary.events.slice(-5);
+  const conclusion = summary.run.result?.conclusion;
+  return [
+    `Config: ${summary.configPath}`,
+    `Dispatcher: ${summary.dispatcherUrl}`,
+    `Run: ${summary.run.id}`,
+    `Status: ${summary.run.status}${conclusion ? ` (${conclusion})` : ""}`,
+    `Source: ${summary.event.source} (${summary.event.sourceEventId})`,
+    `Command: ${summary.event.command.rawText}`,
+    `Updated: ${summary.run.updatedAt}`,
+    `Metrics: ${summary.metrics.totalEventCount} events, ${summary.metrics.suggestedChangesCount} suggested action(s), ${summary.metrics.applyPlanCount} apply plan(s), ${summary.metrics.staleIntentCount} stale intent(s)`,
+    "Recent Events:",
+    ...(latestEvents.length ? latestEvents.map(formatRunEvent) : ["  none"])
+  ].join("\n");
+}
+
 export async function runStatusCommand(options: StatusCommandOptions): Promise<void> {
+  if (options.run) {
+    console.log(formatRunStatus(await getRunStatusSummary({ runId: options.run, ...(options.config ? { configPath: options.config } : {}) })));
+    return;
+  }
   console.log(formatStatus(await getStatusSummary({ ...(options.config ? { configPath: options.config } : {}) })));
 }

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -107,10 +107,22 @@ describe("OpenTag CLI config", () => {
   });
 
   it("redacts secrets in config output", () => {
-    const redacted = redactedCliConfig(config());
+    const source = config();
+    source.daemon.githubApplyToken = "apply_secret";
+    const redacted = redactedCliConfig(source);
 
     expect(JSON.stringify(redacted)).toContain("[REDACTED]");
     expect(JSON.stringify(redacted)).not.toContain("secret_test");
+    expect(JSON.stringify(redacted)).not.toContain("apply_secret");
+  });
+
+  it("keeps an explicit null GitHub apply token visible in redacted config output", () => {
+    const source = config();
+    source.daemon.githubApplyToken = null;
+
+    const redacted = redactedCliConfig(source) as { daemon: { githubApplyToken: null } };
+
+    expect(redacted.daemon.githubApplyToken).toBeNull();
   });
 
   it("normalizes Hermes daemon config strings", () => {

--- a/packages/cli/test/platform-contract.test.ts
+++ b/packages/cli/test/platform-contract.test.ts
@@ -249,6 +249,16 @@ describe("CLI platform contract smoke", () => {
 
     expect(githubRequests).toEqual([
       {
+        url: "https://api.github.com/repos/acme/demo/branches/opentag%2Frun_github_contract",
+        method: "GET",
+        authorization: "Bearer ghp_contract"
+      },
+      {
+        url: "https://api.github.com/repos/acme/demo/branches/main",
+        method: "GET",
+        authorization: "Bearer ghp_contract"
+      },
+      {
         url: "https://api.github.com/repos/acme/demo/pulls",
         method: "POST",
         authorization: "Bearer ghp_contract",

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -174,13 +174,26 @@ describe("OpenTag CLI start wiring", () => {
       port: 3030,
       databasePath: built.state.databasePath,
       pairingToken: built.daemon.pairingToken,
-      githubToken: "ghp_token"
+      githubToken: "ghp_token",
+      githubCallbackToken: "ghp_token",
+      githubApplyToken: "ghp_token"
     });
     expect(githubIngressConfigFromCliConfig(built)).toMatchObject({
       webhookSecret: "github_webhook_secret",
       dispatcherUrl: "http://localhost:3030",
       dispatcherToken: built.daemon.pairingToken,
       webhookPath: "/github/webhooks"
+    });
+  });
+
+  it("can keep GitHub callbacks enabled while disabling direct apply capability", () => {
+    const built = githubConfig();
+    built.daemon.githubApplyToken = null;
+
+    expect(dispatcherRuntimeInputFromCliConfig(built)).toMatchObject({
+      githubToken: "ghp_token",
+      githubCallbackToken: "ghp_token",
+      githubApplyToken: null
     });
   });
 

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -1,9 +1,10 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { OpenTagEvent } from "@opentag/core";
 import { describe, expect, it, vi } from "vitest";
 import { createSetupConfig } from "../src/setup.js";
-import { formatStatus, statusFromConfig } from "../src/status.js";
+import { formatRunStatus, formatStatus, runStatusFromConfig, statusFromConfig } from "../src/status.js";
 
 function tempDir(): string {
   return mkdtempSync(join(tmpdir(), "opentag-cli-test-"));
@@ -34,6 +35,20 @@ function hangingFetch(): typeof fetch {
   }) as unknown as typeof fetch;
 }
 
+const runEvent: OpenTagEvent = {
+  id: "evt_status_run",
+  source: "github",
+  sourceEventId: "comment_status_run",
+  receivedAt: "2026-06-24T00:00:00.000Z",
+  actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+  target: { mention: "@opentag", agentId: "opentag" },
+  command: { rawText: "label this bug", intent: "fix", args: {} },
+  context: [],
+  permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
+  callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
+  metadata: { owner: "acme", repo: "demo" }
+};
+
 describe("OpenTag CLI status", () => {
   it("reports offline dispatcher without failing the config summary", async () => {
     const summary = await statusFromConfig({
@@ -61,5 +76,85 @@ describe("OpenTag CLI status", () => {
 
     expect(summary.dispatcher).toBe("offline");
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("formats one run audit summary from dispatcher status endpoints", async () => {
+    const requests: string[] = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      requests.push(href);
+      if (href.endsWith("/v1/runs/run_status_1")) {
+        return Response.json({
+          run: {
+            id: "run_status_1",
+            eventId: "evt_status_run",
+            status: "succeeded",
+            createdAt: "2026-06-24T00:00:00.000Z",
+            updatedAt: "2026-06-24T00:01:00.000Z",
+            result: { conclusion: "success", summary: "Done." }
+          },
+          event: runEvent
+        });
+      }
+      if (href.endsWith("/v1/runs/run_status_1/events")) {
+        return Response.json({
+          events: [
+            {
+              type: "run.created",
+              visibility: "audit",
+              importance: "normal",
+              message: "Queued run.",
+              createdAt: "2026-06-24T00:00:00.000Z"
+            },
+            {
+              type: "callback.final.delivered",
+              visibility: "human",
+              importance: "normal",
+              message: "Delivered final receipt.",
+              createdAt: "2026-06-24T00:01:00.000Z"
+            }
+          ]
+        });
+      }
+      if (href.endsWith("/v1/runs/run_status_1/metrics")) {
+        return Response.json({
+          metrics: {
+            runId: "run_status_1",
+            totalEventCount: 2,
+            humanEventCount: 1,
+            auditEventCount: 1,
+            debugEventCount: 0,
+            humanCallbackCount: 1,
+            threadNoiseRatio: 0.5,
+            suggestedChangesCount: 1,
+            approvalDecisionCount: 0,
+            applyPlanCount: 0,
+            childRunCount: 0,
+            applyOutcomeCounts: { applied: 0, skipped: 0, failed: 0, stale: 0, unsupported: 0 },
+            staleIntentCount: 0
+          }
+        });
+      }
+      return Response.json({ error: "unexpected_url" }, { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const summary = await runStatusFromConfig({
+      config: config(),
+      configPath: "/tmp/opentag/config.json",
+      runId: "run_status_1",
+      fetchImpl
+    });
+
+    expect(requests).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("/v1/runs/run_status_1"),
+        expect.stringContaining("/v1/runs/run_status_1/events"),
+        expect.stringContaining("/v1/runs/run_status_1/metrics")
+      ])
+    );
+    expect(formatRunStatus(summary)).toContain("Run: run_status_1");
+    expect(formatRunStatus(summary)).toContain("Status: succeeded (success)");
+    expect(formatRunStatus(summary)).toContain("Metrics: 2 events, 1 suggested action(s), 0 apply plan(s), 0 stale intent(s)");
+    expect(formatRunStatus(summary)).toContain("callback.final.delivered - Delivered final receipt.");
   });
 });

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -25,6 +25,31 @@ export type SuggestedActionCandidate = {
   intent: MutationIntent;
 };
 
+export type ActionReceiptState = "ready_to_apply" | "needs_approval" | "needs_setup" | "unsupported";
+export type ActionReceiptDecision = "apply" | "approve" | "reject" | "continue";
+export type ActionReceiptPrimaryDecision = "apply" | "continue" | "none";
+
+export type ActionReceiptCapability = {
+  state?: ActionReceiptState;
+  targetLabel?: string;
+  setupReason?: string;
+  visibleDecisions?: ActionReceiptDecision[];
+  primaryDecision?: ActionReceiptPrimaryDecision;
+};
+
+export type ActionReceiptContext = {
+  capabilityByIntentId?: Record<string, ActionReceiptCapability>;
+};
+
+export type ActionReceipt = {
+  candidate: SuggestedActionCandidate;
+  state: ActionReceiptState;
+  targetLabel: string;
+  setupReason?: string;
+  visibleDecisions: ActionReceiptDecision[];
+  primaryDecision: ActionReceiptPrimaryDecision;
+};
+
 const ENGLISH_VERBS: Record<string, ThreadActionVerb> = {
   approve: "approve",
   approved: "approve",
@@ -164,4 +189,51 @@ export function suggestedActionCandidatesFromSnapshots(
 
 export function suggestedActionCandidatesFromResult(result: OpenTagRunResult): SuggestedActionCandidate[] {
   return suggestedActionCandidatesFromSnapshots(result.suggestedChanges ?? []);
+}
+
+function defaultActionTargetLabel(intent: MutationIntent): string {
+  if (intent.action === "create_pull_request") return "GitHub pull request";
+  if (intent.domain === "labels") return "GitHub labels";
+  if (intent.domain === "assignee" || intent.domain === "assignees") return "GitHub assignees";
+  if (intent.domain === "review") return "GitHub review request";
+  if (intent.domain === "artifact_links") return "Artifact link";
+  if (intent.domain === "follow_up") return "OpenTag follow-up run";
+  return `${intent.domain} / ${intent.action}`;
+}
+
+function defaultVisibleDecisionsForState(state: ActionReceiptState): ActionReceiptDecision[] {
+  if (state === "ready_to_apply") return ["apply", "reject", "approve"];
+  if (state === "needs_approval") return ["approve", "reject"];
+  if (state === "needs_setup") return ["continue", "reject"];
+  return ["continue", "reject"];
+}
+
+function defaultPrimaryDecisionForState(state: ActionReceiptState): ActionReceiptPrimaryDecision {
+  if (state === "ready_to_apply") return "apply";
+  if (state === "needs_setup" || state === "unsupported") return "continue";
+  return "none";
+}
+
+export function actionReceiptHeading(receipts: ActionReceipt[]): string {
+  if (receipts.some((receipt) => receipt.state === "ready_to_apply")) return "Ready to apply";
+  if (receipts.some((receipt) => receipt.state === "needs_setup")) return "Needs setup";
+  if (receipts.some((receipt) => receipt.state === "unsupported")) return "Needs attention";
+  return "Needs approval";
+}
+
+export function buildActionReceipt(candidate: SuggestedActionCandidate, context: ActionReceiptContext = {}): ActionReceipt {
+  const capability = context.capabilityByIntentId?.[candidate.intent.intentId];
+  const state = capability?.state ?? "needs_approval";
+  return {
+    candidate,
+    state,
+    targetLabel: capability?.targetLabel ?? defaultActionTargetLabel(candidate.intent),
+    ...(capability?.setupReason ? { setupReason: capability.setupReason } : {}),
+    visibleDecisions: capability?.visibleDecisions ?? defaultVisibleDecisionsForState(state),
+    primaryDecision: capability?.primaryDecision ?? defaultPrimaryDecisionForState(state)
+  };
+}
+
+export function buildActionReceiptsFromResult(result: OpenTagRunResult, context: ActionReceiptContext = {}): ActionReceipt[] {
+  return suggestedActionCandidatesFromResult(result).map((candidate) => buildActionReceipt(candidate, context));
 }

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -202,7 +202,7 @@ function defaultActionTargetLabel(intent: MutationIntent): string {
 }
 
 function defaultVisibleDecisionsForState(state: ActionReceiptState): ActionReceiptDecision[] {
-  if (state === "ready_to_apply") return ["apply", "reject", "approve"];
+  if (state === "ready_to_apply") return ["apply", "reject"];
   if (state === "needs_approval") return ["approve", "reject"];
   if (state === "needs_setup") return ["continue", "reject"];
   return ["continue", "reject"];
@@ -215,9 +215,13 @@ function defaultPrimaryDecisionForState(state: ActionReceiptState): ActionReceip
 }
 
 export function actionReceiptHeading(receipts: ActionReceipt[]): string {
-  if (receipts.some((receipt) => receipt.state === "ready_to_apply")) return "Ready to apply";
-  if (receipts.some((receipt) => receipt.state === "needs_setup")) return "Needs setup";
-  if (receipts.some((receipt) => receipt.state === "unsupported")) return "Needs attention";
+  const states = new Set(receipts.map((receipt) => receipt.state));
+  if (states.size === 1 && states.has("ready_to_apply")) return "Ready to apply";
+  if (states.has("ready_to_apply") && states.has("needs_setup")) return "Some actions need setup";
+  if (states.has("ready_to_apply") && states.has("unsupported")) return "Some actions need attention";
+  if (states.has("needs_setup")) return "Needs setup";
+  if (states.has("unsupported")) return "Needs attention";
+  if (states.has("ready_to_apply")) return "Needs review";
   return "Needs approval";
 }
 

--- a/packages/core/test/action.test.ts
+++ b/packages/core/test/action.test.ts
@@ -109,7 +109,7 @@ describe("action receipts", () => {
     expect(receipt).toMatchObject({
       state: "ready_to_apply",
       primaryDecision: "apply",
-      visibleDecisions: ["apply", "reject", "approve"]
+      visibleDecisions: ["apply", "reject"]
     });
     expect(actionReceiptHeading([receipt])).toBe("Ready to apply");
   });
@@ -131,6 +131,31 @@ describe("action receipts", () => {
       visibleDecisions: ["continue", "reject"]
     });
     expect(actionReceiptHeading([receipt])).toBe("Needs setup");
+  });
+
+  it("does not overstate readiness when receipt states are mixed", () => {
+    const ready = buildActionReceipt(candidate, {
+      capabilityByIntentId: {
+        intent_label: { state: "ready_to_apply" }
+      }
+    });
+    const setup = buildActionReceipt({
+      ...candidate,
+      index: 2,
+      intent: { ...candidate.intent, intentId: "intent_setup", summary: "Create a pull request." }
+    }, {
+      capabilityByIntentId: {
+        intent_setup: { state: "needs_setup", setupReason: "GitHub apply is not configured on this dispatcher." }
+      }
+    });
+    const approval = buildActionReceipt({
+      ...candidate,
+      index: 3,
+      intent: { ...candidate.intent, intentId: "intent_approval", summary: "Request human review." }
+    });
+
+    expect(actionReceiptHeading([ready, setup])).toBe("Some actions need setup");
+    expect(actionReceiptHeading([ready, approval])).toBe("Needs review");
   });
 });
 

--- a/packages/core/test/action.test.ts
+++ b/packages/core/test/action.test.ts
@@ -153,8 +153,19 @@ describe("action receipts", () => {
       index: 3,
       intent: { ...candidate.intent, intentId: "intent_approval", summary: "Request human review." }
     });
+    const unsupported = buildActionReceipt({
+      ...candidate,
+      index: 4,
+      intent: { ...candidate.intent, intentId: "intent_unsupported", summary: "Needs manual intervention." }
+    }, {
+      capabilityByIntentId: {
+        intent_unsupported: { state: "unsupported", setupReason: "This action is audit-only for now." }
+      }
+    });
 
     expect(actionReceiptHeading([ready, setup])).toBe("Some actions need setup");
+    expect(actionReceiptHeading([unsupported])).toBe("Needs attention");
+    expect(actionReceiptHeading([ready, unsupported])).toBe("Some actions need attention");
     expect(actionReceiptHeading([ready, approval])).toBe("Needs review");
   });
 });

--- a/packages/core/test/action.test.ts
+++ b/packages/core/test/action.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseThreadActionCommand, suggestedActionCandidatesFromResult } from "../src/action.js";
+import {
+  actionReceiptHeading,
+  buildActionReceipt,
+  parseThreadActionCommand,
+  suggestedActionCandidatesFromResult
+} from "../src/action.js";
 
 describe("thread action commands", () => {
   it("parses explicit English action replies", () => {
@@ -66,6 +71,66 @@ describe("thread action commands", () => {
   it("ignores ambiguous conversational text", () => {
     expect(parseThreadActionCommand("looks good to me")).toBeNull();
     expect(parseThreadActionCommand("maybe apply this later")).toBeNull();
+  });
+});
+
+describe("action receipts", () => {
+  const candidate = {
+    index: 1,
+    proposalId: "proposal_1",
+    proposalSummary: "Move issue forward.",
+    intent: {
+      intentId: "intent_label",
+      domain: "labels",
+      action: "add_label",
+      summary: "Add bug label."
+    }
+  };
+
+  it("defaults to approval-only when direct apply capability is not proven", () => {
+    const receipt = buildActionReceipt(candidate);
+
+    expect(receipt).toMatchObject({
+      state: "needs_approval",
+      targetLabel: "GitHub labels",
+      primaryDecision: "none",
+      visibleDecisions: ["approve", "reject"]
+    });
+    expect(actionReceiptHeading([receipt])).toBe("Needs approval");
+  });
+
+  it("uses capability context to expose ready-to-apply decisions", () => {
+    const receipt = buildActionReceipt(candidate, {
+      capabilityByIntentId: {
+        intent_label: { state: "ready_to_apply" }
+      }
+    });
+
+    expect(receipt).toMatchObject({
+      state: "ready_to_apply",
+      primaryDecision: "apply",
+      visibleDecisions: ["apply", "reject", "approve"]
+    });
+    expect(actionReceiptHeading([receipt])).toBe("Ready to apply");
+  });
+
+  it("uses setup context to hide apply and guide follow-up", () => {
+    const receipt = buildActionReceipt(candidate, {
+      capabilityByIntentId: {
+        intent_label: {
+          state: "needs_setup",
+          setupReason: "GitHub apply is not configured on this dispatcher."
+        }
+      }
+    });
+
+    expect(receipt).toMatchObject({
+      state: "needs_setup",
+      primaryDecision: "continue",
+      setupReason: "GitHub apply is not configured on this dispatcher.",
+      visibleDecisions: ["continue", "reject"]
+    });
+    expect(actionReceiptHeading([receipt])).toBe("Needs setup");
   });
 });
 

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -1,4 +1,4 @@
-import type { OpenTagRunResult } from "@opentag/core";
+import type { ActionReceiptContext, OpenTagRunResult } from "@opentag/core";
 import { renderAcknowledgement, renderFinalResult, renderProgress } from "@opentag/github";
 import { renderLarkAcknowledgement, renderLarkFinalResult } from "@opentag/lark";
 import { createSlackFinalResultBlocks, renderSlackAcknowledgement, renderSlackFinalResult, type SlackBlock } from "@opentag/slack";
@@ -17,7 +17,7 @@ export type CallbackPresentation = {
   shouldDeliverProgress(provider: CallbackProvider): boolean;
   acknowledgement(input: { provider: CallbackProvider; runId: string }): string;
   progress(input: { provider: CallbackProvider; runId: string; message: string }): string;
-  final(input: { provider: CallbackProvider; result: OpenTagRunResult }): PresentedCallbackBody;
+  final(input: { provider: CallbackProvider; result: OpenTagRunResult; runId?: string; receiptContext?: ActionReceiptContext }): PresentedCallbackBody;
 };
 
 export function createDefaultCallbackPresentation(): CallbackPresentation {
@@ -51,10 +51,14 @@ export function createDefaultCallbackPresentation(): CallbackPresentation {
     },
 
     final(input) {
+      const renderOptions = {
+        ...(input.receiptContext ? { receiptContext: input.receiptContext } : {}),
+        ...(input.provider === "github" && input.runId ? { auditRunId: input.runId } : {})
+      };
       if (input.provider === "slack") {
         return {
-          body: renderSlackFinalResult(input.result),
-          blocks: createSlackFinalResultBlocks(input.result)
+          body: renderSlackFinalResult(input.result, renderOptions),
+          blocks: createSlackFinalResultBlocks(input.result, renderOptions)
         };
       }
       if (input.provider === "lark") {
@@ -63,7 +67,7 @@ export function createDefaultCallbackPresentation(): CallbackPresentation {
       if (input.provider === "telegram") {
         return { body: renderTelegramFinalResult(input.result) };
       }
-      return { body: renderFinalResult(input.result) };
+      return { body: renderFinalResult(input.result, renderOptions) };
     }
   };
 }

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -53,7 +53,7 @@ export function createDefaultCallbackPresentation(): CallbackPresentation {
     final(input) {
       const renderOptions = {
         ...(input.receiptContext ? { receiptContext: input.receiptContext } : {}),
-        ...(input.provider === "github" && input.runId ? { auditRunId: input.runId } : {})
+        ...((input.provider === "github" || input.provider === "slack") && input.runId ? { auditRunId: input.runId } : {})
       };
       if (input.provider === "slack") {
         return {

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -3,15 +3,20 @@ import {
   AdapterMutationMappingSchema,
   ActorIdentitySchema,
   ActionHintSchema,
+  capabilityForMutationIntent,
   conversationKeysFromEvent,
   parseThreadActionCommand,
+  permissionScopesAllowCapability,
   projectTargetRefFromEvent,
   suggestedActionCandidatesFromSnapshots,
   type ActorIdentity,
+  type ActionReceiptCapability,
+  type ActionReceiptContext,
   type ApplyIntentOutcome,
   type ApplyPlan,
   type MutationIntent,
   type OpenTagEvent,
+  type OpenTagRunResult,
   type OpenTagRun,
   type PermissionGrant,
   type SuggestedChangesSnapshot,
@@ -389,6 +394,35 @@ async function resolveThreadAction(input: {
   });
   const primaryConversationKey = conversationKeys[0];
   const targetWorkItemExternalId = githubIssueWorkItemExternalId(input.metadata);
+  const metadataProposalId = metadataString(input.metadata, "proposalId");
+  const metadataIntentId = metadataString(input.metadata, "intentId");
+  if (
+    metadataProposalId &&
+    (input.command.selection.kind === "index" || input.command.selection.kind === "latest")
+  ) {
+    const stored = await input.repo.getSuggestedChanges({ proposalId: metadataProposalId });
+    if (!stored) {
+      return { ok: false, reason: "no_proposal", message: `I could not find proposal \`${metadataProposalId}\`.` };
+    }
+    const claimed = await input.repo.getRun({ runId: stored.runId });
+    if (!claimed) {
+      return { ok: false, reason: "no_proposal", message: "I found the proposal but not its source run." };
+    }
+    const proposalConversationKeys = conversationKeysFromEvent(claimed.event);
+    if (!proposalConversationKeys.some((key) => conversationKeys.includes(key))) {
+      return { ok: false, reason: "no_match", runId: stored.runId, message: "That proposal does not belong to this source thread." };
+    }
+    const proposal = { runId: stored.runId, run: claimed.run, event: claimed.event, snapshot: stored.snapshot };
+    if (targetWorkItemExternalId && !proposalMatchesWorkItem(proposal, targetWorkItemExternalId)) {
+      return { ok: false, reason: "no_match", runId: stored.runId, message: "That proposal does not belong to this source thread." };
+    }
+    return resolveCandidateSelection({
+      command: metadataIntentId
+        ? { ...input.command, selection: { kind: "intent", intentId: metadataIntentId } }
+        : { ...input.command, selection: { kind: "proposal", proposalId: metadataProposalId } },
+      proposals: [proposal]
+    });
+  }
   if (input.command.selection.kind === "proposal") {
     const stored = await input.repo.getSuggestedChanges({ proposalId: input.command.selection.proposalId });
     if (!stored) {
@@ -446,6 +480,228 @@ function adapterForAction(input: { event: OpenTagEvent; callbackProvider: string
       (input.selectedIntents.length > 0 && input.selectedIntents.every((intent) => isRepoLevelGitHubIntent(intent))))
     ? "github"
     : input.callbackProvider;
+}
+
+function executorConditionsFromIntent(intent: { params?: Record<string, unknown> | undefined }): string[] {
+  const value = intent.params?.["executorConditions"];
+  if (!Array.isArray(value)) return [];
+  return value.filter((condition): condition is string => typeof condition === "string" && condition.length > 0);
+}
+
+async function githubPreflight(input: {
+  githubApply: GitHubApplyOptions;
+  owner: string;
+  repo: string;
+  path: string;
+  description: string;
+  notFoundReason: string;
+}): Promise<ActionReceiptCapability | null> {
+  let response: Response;
+  try {
+    response = await (input.githubApply.fetchImpl ?? fetch)(`https://api.github.com/repos/${input.owner}/${input.repo}${input.path}`, {
+      method: "GET",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${input.githubApply.token}`,
+        "x-github-api-version": "2022-11-28"
+      }
+    });
+  } catch (error) {
+    return {
+      state: "needs_setup",
+      setupReason: `GitHub preflight failed for ${input.description}: ${error instanceof Error ? error.message : String(error)}.`
+    };
+  }
+
+  if (response.ok) return null;
+
+  if (response.status === 401 || response.status === 403) {
+    return {
+      state: "needs_setup",
+      setupReason: `GitHub apply token cannot access ${input.description}. Check repository permissions and token scopes.`
+    };
+  }
+  if (response.status === 404) {
+    return {
+      state: "needs_setup",
+      setupReason: input.notFoundReason
+    };
+  }
+  return {
+    state: "needs_setup",
+    setupReason: `GitHub preflight failed for ${input.description}: HTTP ${response.status}.`
+  };
+}
+
+async function preflightGitHubOperation(input: {
+  githubApply: GitHubApplyOptions;
+  target: NonNullable<ReturnType<typeof githubTargetFromEvent>>;
+  operation: GitHubIssueMutationOperation;
+}): Promise<ActionReceiptCapability | null> {
+  const base = {
+    githubApply: input.githubApply,
+    owner: input.target.owner,
+    repo: input.target.repoName
+  };
+
+  if (input.operation.kind === "create_pull_request") {
+    const head = encodeURIComponent(input.operation.head);
+    const baseBranch = encodeURIComponent(input.operation.base);
+    return (
+      (await githubPreflight({
+        ...base,
+        path: `/branches/${head}`,
+        description: `GitHub branch ${input.operation.head}`,
+        notFoundReason: `GitHub branch ${input.operation.head} was not found.`
+      })) ??
+      (await githubPreflight({
+        ...base,
+        path: `/branches/${baseBranch}`,
+        description: `GitHub base branch ${input.operation.base}`,
+        notFoundReason: `GitHub base branch ${input.operation.base} was not found.`
+      }))
+    );
+  }
+
+  if (input.operation.kind === "request_review") {
+    if (typeof input.target.pullRequestNumber !== "number") {
+      return {
+        state: "needs_setup",
+        setupReason: "The source thread does not include a GitHub pull request target."
+      };
+    }
+    return await githubPreflight({
+      ...base,
+      path: `/pulls/${input.target.pullRequestNumber}`,
+      description: `GitHub pull request #${input.target.pullRequestNumber}`,
+      notFoundReason: `GitHub pull request #${input.target.pullRequestNumber} was not found.`
+    });
+  }
+
+  if (typeof input.target.issueNumber !== "number") {
+    return {
+      state: "needs_setup",
+      setupReason: "The source thread does not include a GitHub issue or pull request target."
+    };
+  }
+  return await githubPreflight({
+    ...base,
+    path: `/issues/${input.target.issueNumber}`,
+    description: `GitHub issue or pull request #${input.target.issueNumber}`,
+    notFoundReason: `GitHub issue or pull request #${input.target.issueNumber} was not found.`
+  });
+}
+
+async function directApplyReceiptCapability(input: {
+  event: OpenTagEvent;
+  callbackProvider: string;
+  intent: MutationIntent;
+  githubApply?: GitHubApplyOptions;
+}): Promise<ActionReceiptCapability> {
+  const capability = capabilityForMutationIntent(input.intent);
+  if (!capability) {
+    return {
+      state: "unsupported",
+      setupReason: `No source-thread apply capability is registered for ${input.intent.action}.`
+    };
+  }
+  if (capability.capabilityClass !== "external_write") {
+    return {
+      state: "unsupported",
+      setupReason: "This action is audit-only for now; continue if a follow-up run should handle it."
+    };
+  }
+
+  const adapter = adapterForAction({
+    event: input.event,
+    callbackProvider: input.callbackProvider,
+    selectedIntents: [input.intent]
+  });
+  if (adapter !== "github") {
+    return {
+      state: "needs_setup",
+      setupReason: `Direct apply for ${adapter} actions is not configured on this dispatcher.`
+    };
+  }
+  if (!input.githubApply) {
+    return {
+      state: "needs_setup",
+      setupReason: "GitHub apply is not configured on this dispatcher."
+    };
+  }
+  if (!hasGitHubRepoTarget(input.event)) {
+    return {
+      state: "needs_setup",
+      setupReason: "The source thread does not include a GitHub repository target."
+    };
+  }
+  if (!isRepoLevelGitHubIntent(input.intent) && !hasGitHubIssueOrPullTarget(input.event)) {
+    return {
+      state: "needs_setup",
+      setupReason: "The source thread does not include a GitHub issue or pull request target."
+    };
+  }
+  if (!permissionScopesAllowCapability(input.event.permissions ?? [], capability)) {
+    return {
+      state: "needs_setup",
+      setupReason: `Missing platform permission for ${capability.id}.`
+    };
+  }
+
+  const missingExecutorConditions = (capability.requiredExecutorConditions ?? []).filter(
+    (condition) => !executorConditionsFromIntent(input.intent).includes(condition)
+  );
+  if (missingExecutorConditions.length > 0) {
+    return {
+      state: "needs_setup",
+      setupReason: `Missing executor condition: ${missingExecutorConditions.join(", ")}.`
+    };
+  }
+
+  const githubTarget = githubTargetFromEvent(input.event);
+  if (!githubTarget) {
+    return {
+      state: "needs_setup",
+      setupReason: "The source thread does not include a GitHub repository target."
+    };
+  }
+  const compilation = createGitHubIssueMutationCompiler({
+    ...(githubTarget?.targetKind ? { targetKind: githubTarget.targetKind } : {})
+  }).compile(input.intent);
+  if (!compilation.ok) {
+    return {
+      state: compilation.outcome.outcome === "unsupported" ? "unsupported" : "needs_setup",
+      setupReason: compilation.outcome.message ?? "GitHub cannot apply this action from the current source thread."
+    };
+  }
+
+  const preflight = await preflightGitHubOperation({
+    githubApply: input.githubApply,
+    target: githubTarget,
+    operation: compilation.operation as GitHubIssueMutationOperation
+  });
+  if (preflight) return preflight;
+
+  return { state: "ready_to_apply" };
+}
+
+async function actionReceiptContextForFinal(input: {
+  event: OpenTagEvent;
+  result: OpenTagRunResult;
+  githubApply?: GitHubApplyOptions;
+}): Promise<ActionReceiptContext> {
+  const capabilityByIntentId: Record<string, ActionReceiptCapability> = {};
+  for (const snapshot of input.result.suggestedChanges ?? []) {
+    for (const intent of snapshot.intents) {
+      capabilityByIntentId[intent.intentId] = await directApplyReceiptCapability({
+        event: input.event,
+        callbackProvider: input.event.callback.provider,
+        intent,
+        ...(input.githubApply ? { githubApply: input.githubApply } : {})
+      });
+    }
+  }
+  return { capabilityByIntentId };
 }
 
 async function authorizeThreadAction(input: {
@@ -574,6 +830,15 @@ function selectedIntentsAlreadyApplied(input: { plan: ApplyPlan; selectedIntentI
   );
 }
 
+function selectedPlanOutcomes(input: { plan: ApplyPlan; selectedIntentIds: string[] }): ApplyIntentOutcome[] {
+  return (input.plan.outcomes ?? []).filter((outcome) => input.selectedIntentIds.includes(outcome.intentId));
+}
+
+function selectedIntentsHaveStaleOutcome(input: { plan: ApplyPlan; selectedIntentIds: string[] }): boolean {
+  const outcomes = selectedPlanOutcomes(input);
+  return outcomes.some((outcome) => outcome.outcome === "stale") && outcomes.every((outcome) => outcome.outcome !== "applied");
+}
+
 function githubTargetFromEvent(event: OpenTagEvent):
   | {
       owner: string;
@@ -602,6 +867,18 @@ function selectedActionSummary(candidates: ResolvedThreadAction["selectedCandida
   return candidates.map((candidate) => `${candidate.index}. ${candidate.intent.summary}`).join("; ");
 }
 
+function selectedActionReceiptTitle(selectionText: string): string {
+  return selectionText
+    .split(";")
+    .map((part) => part.trim().replace(/^\d+\.\s*/, ""))
+    .filter(Boolean)
+    .join("; ");
+}
+
+function sentenceWithTerminalPunctuation(value: string): string {
+  return /[.!?。！？]$/u.test(value) ? value : `${value}.`;
+}
+
 function addPermissionGrant(permissions: PermissionGrant[], grant: PermissionGrant): PermissionGrant[] {
   if (permissions.some((permission) => permission.scope === grant.scope)) return permissions;
   return [...permissions, grant];
@@ -628,99 +905,126 @@ function childRunPermissionsForThreadAction(input: { resolved: ResolvedThreadAct
   return permissions;
 }
 
-function childRunContextLines(input: {
-  resolved: ResolvedThreadAction;
-  approvalDecisionId?: string;
-  sourceApplyPlanId?: string;
-  fallbackReason?: string;
-}): string[] {
-  const previousSummary = input.resolved.proposal.run.result?.summary ?? input.resolved.proposal.snapshot.summary;
-  return [
-    `- Proposal: \`${input.resolved.proposal.snapshot.proposalId}\``,
-    `- Selected intents: ${input.resolved.selectedIntentIds.map((intentId) => `\`${intentId}\``).join(", ")}`,
-    `- Previous run: \`${input.resolved.proposal.runId}\``,
-    ...(input.approvalDecisionId ? [`- Approval decision: \`${input.approvalDecisionId}\``] : []),
-    `- Previous result: ${previousSummary}`,
-    ...(input.sourceApplyPlanId ? [`- Apply plan: \`${input.sourceApplyPlanId}\``] : []),
-    ...(input.fallbackReason ? [`- Fallback reason: ${input.fallbackReason}`] : [])
-  ];
-}
-
 function renderChildRunCreatedBody(input: {
   lead: string;
   resolved: ResolvedThreadAction;
   childRun: OpenTagRun;
   provider?: string;
+  selectionText?: string;
   approvalDecisionId?: string;
   sourceApplyPlanId?: string;
   fallbackReason?: string;
 }): string {
+  const title = selectedActionReceiptTitle(input.selectionText ?? selectedActionSummary(input.resolved.selectedCandidates));
   if (input.provider === "slack") {
     return [
-      "Approved. OpenTag will continue from this proposal in a follow-up run.",
+      input.lead,
+      `Action: ${title}`,
       ...(input.fallbackReason ? [`Reason: ${input.fallbackReason}`] : [])
     ].join("\n");
   }
   return [
     input.lead,
     "",
+    `Action: ${title}`,
+    "",
     `Child run: \`${input.childRun.id}\``,
     "",
-    "Context carried into the child run:",
-    ...childRunContextLines(input),
-    "",
-    "The model will continue from this approved proposal instead of starting from a fresh mention."
+    ...(input.fallbackReason ? [`Reason: ${input.fallbackReason}`, ""] : []),
+    `Audit: run \`opentag status --run ${input.childRun.id}\` locally.`
   ].join("\n");
 }
 
+function applyOutcomeSummary(outcome: ApplyIntentOutcome): string {
+  if (outcome.externalUri) return `${outcome.outcome}: ${outcome.externalUri}`;
+  if (outcome.message) return `${outcome.outcome}: ${outcome.message}`;
+  return `${outcome.outcome}.`;
+}
+
+function applyOutcomeReceiptLines(outcomes: ApplyIntentOutcome[]): string[] {
+  if (outcomes.length === 0) return ["Result: applied."];
+  if (outcomes.length === 1) {
+    const outcome = outcomes[0]!;
+    if (outcome.externalUri) return [`Result: ${outcome.externalUri}`];
+    if (outcome.message) return [`Result: ${outcome.outcome}. ${outcome.message}`];
+    return [`Result: ${outcome.outcome}.`];
+  }
+  return ["Results:", ...outcomes.map((outcome) => `- ${applyOutcomeSummary(outcome)}`)];
+}
+
 function renderAppliedThreadActionBody(input: {
-  provider: string;
   selectionText: string;
-  proposalId: string;
   selectedIntentIds: string[];
   outcomes: ApplyIntentOutcome[];
 }): string {
   const selectedOutcomes = input.outcomes.filter((outcome) => input.selectedIntentIds.includes(outcome.intentId));
-  if (input.provider === "slack") {
-    const lines = [`Applied ${input.selectionText}.`];
-    for (const outcome of selectedOutcomes) {
-      if (outcome.externalUri) {
-        lines.push(`Result: ${outcome.externalUri}`);
-      } else if (outcome.message) {
-        lines.push(`Result: ${outcome.outcome}. ${outcome.message}`);
-      } else {
-        lines.push(`Result: ${outcome.outcome}.`);
-      }
-    }
-    return lines.join("\n");
-  }
+  return [`Applied: ${sentenceWithTerminalPunctuation(selectedActionReceiptTitle(input.selectionText))}`, ...applyOutcomeReceiptLines(selectedOutcomes)].join("\n");
+}
 
+function renderAlreadyAppliedThreadActionBody(input: { selectionText: string }): string {
+  return [`Already applied: ${sentenceWithTerminalPunctuation(selectedActionReceiptTitle(input.selectionText))}`, "No external write was repeated."].join("\n");
+}
+
+function renderAlreadyPlannedThreadActionBody(input: { selectionText: string }): string {
+  return [`Already planned: ${sentenceWithTerminalPunctuation(selectedActionReceiptTitle(input.selectionText))}`, "OpenTag did not execute this repeated reply."].join("\n");
+}
+
+function renderStaleThreadActionBody(input: { selectionText: string; continueIndex: number }): string {
   return [
-    `Applied ${input.selectionText} from \`${input.proposalId}\`.`,
-    "",
-    "Result:",
-    ...selectedOutcomes.map((outcome) => `- \`${outcome.intentId}\`: ${outcome.outcome}${outcome.externalUri ? ` (${outcome.externalUri})` : ""}`)
+    `Stale: ${sentenceWithTerminalPunctuation(selectedActionReceiptTitle(input.selectionText))}`,
+    "The target changed since this action was proposed.",
+    `Reply \`continue ${input.continueIndex}\` to refresh from the current thread state.`
   ].join("\n");
 }
 
 function renderThreadActionRecordedBody(input: {
-  provider: string;
   verb: "approve" | "reject";
   selectionText: string;
-  proposalId: string;
   applyIndex?: number;
+  directApply?: { ready: boolean; reason?: string };
 }): string {
-  const pastTense = input.verb === "approve" ? "Approved" : "Rejected";
-  if (input.provider === "slack") {
-    if (input.verb === "approve") {
-      return `${pastTense} ${input.selectionText}.\nNext: use Apply ${input.applyIndex ?? 1} when you want OpenTag to perform it.`;
-    }
-    return `${pastTense} ${input.selectionText}.`;
-  }
+  const title = selectedActionReceiptTitle(input.selectionText);
   if (input.verb === "approve") {
-    return `${pastTense} ${input.selectionText} from \`${input.proposalId}\`.\n\nReply with \`apply ${input.applyIndex ?? 1}\` to apply it, or \`continue ${input.applyIndex ?? 1}\` to continue with a follow-up run.`;
+    const index = input.applyIndex ?? 1;
+    const nextLines = input.directApply?.ready
+      ? [`Next: reply \`apply ${index}\` to write it to the system of record, or \`continue ${index}\` to continue in OpenTag.`]
+      : [
+          ...(input.directApply?.reason
+            ? [`Direct apply is not available yet: ${sentenceWithTerminalPunctuation(input.directApply.reason)}`]
+            : ["Direct apply is not available yet."]),
+          `Next: reply \`continue ${index}\` to continue in OpenTag.`
+        ];
+    return [
+      `Approved only: ${sentenceWithTerminalPunctuation(title)}`,
+      "No external write was performed.",
+      ...nextLines
+    ].join("\n");
   }
-  return `${pastTense} ${input.selectionText} from \`${input.proposalId}\`.`;
+  return [`Rejected: ${sentenceWithTerminalPunctuation(title)}`, "No external write will be performed for this action."].join("\n");
+}
+
+async function selectedDirectApplyStatus(input: {
+  event: OpenTagEvent;
+  callbackProvider: string;
+  candidates: ResolvedThreadAction["selectedCandidates"];
+  githubApply?: GitHubApplyOptions;
+}): Promise<{ ready: boolean; reason?: string }> {
+  if (input.candidates.length === 0) return { ready: false, reason: "No selected action was found." };
+  for (const candidate of input.candidates) {
+    const capability = await directApplyReceiptCapability({
+      event: input.event,
+      callbackProvider: input.callbackProvider,
+      intent: candidate.intent,
+      ...(input.githubApply ? { githubApply: input.githubApply } : {})
+    });
+    if (capability.state !== "ready_to_apply") {
+      return {
+        ready: false,
+        reason: capability.setupReason ?? `Receipt state is ${capability.state}.`
+      };
+    }
+  }
+  return { ready: true };
 }
 
 function actionContextPointer(input: {
@@ -1387,22 +1691,24 @@ export function createDispatcherApp(input: {
       if (existingPlan) {
         const existingDecision = await repo.getApprovalDecision({ id: existingPlan.approvalDecisionId });
         if (selectedIntentsAlreadyApplied({ plan: existingPlan, selectedIntentIds: resolved.resolved.selectedIntentIds })) {
+          await deliverAndAudit({
+            repo,
+            sink: callbackSink,
+            retry: callbackRetry,
+            message: {
+              runId: resolved.resolved.proposal.runId,
+              kind: "final",
+              provider: parsed.callback.provider,
+              uri: parsed.callback.uri,
+              body: renderAlreadyAppliedThreadActionBody({ selectionText }),
+              ...(parsed.callback.threadKey ? { threadKey: parsed.callback.threadKey } : {})
+            }
+          });
           return c.json({ outcome: "already_applied", decision: existingDecision, plan: existingPlan }, 200);
         }
-        const fallbackReason = "An apply plan already exists for this selected action; OpenTag will not execute it again from a repeated thread reply.";
-        const childRun = await createChildRunForThreadAction({
-          repo,
-          command,
-          resolved: resolved.resolved,
-          runId: stableChildRunId({
-            command,
-            resolved: resolved.resolved,
-            sourceApplyPlanId: existingPlan.id,
-            fallbackReason
-          }),
-          approvalDecisionId: existingPlan.approvalDecisionId,
-          sourceApplyPlanId: existingPlan.id,
-          fallbackReason
+        const isStale = selectedIntentsHaveStaleOutcome({
+          plan: existingPlan,
+          selectedIntentIds: resolved.resolved.selectedIntentIds
         });
         await deliverAndAudit({
           repo,
@@ -1413,19 +1719,16 @@ export function createDispatcherApp(input: {
             kind: "final",
             provider: parsed.callback.provider,
             uri: parsed.callback.uri,
-            body: renderChildRunCreatedBody({
-              lead: "This action was already planned, so OpenTag will not execute the external write again.",
-              resolved: resolved.resolved,
-              childRun,
-              provider: parsed.callback.provider,
-              approvalDecisionId: existingPlan.approvalDecisionId,
-              sourceApplyPlanId: existingPlan.id,
-              fallbackReason
-            }),
+            body: isStale
+              ? renderStaleThreadActionBody({
+                  selectionText,
+                  continueIndex: resolved.resolved.selectedCandidates[0]?.index ?? 1
+                })
+              : renderAlreadyPlannedThreadActionBody({ selectionText }),
             ...(parsed.callback.threadKey ? { threadKey: parsed.callback.threadKey } : {})
           }
         });
-        return c.json({ outcome: "already_planned", decision: existingDecision, plan: existingPlan, run: childRun }, 200);
+        return c.json({ outcome: isStale ? "stale" : "already_planned", decision: existingDecision, plan: existingPlan }, 200);
       }
     }
 
@@ -1475,10 +1778,8 @@ export function createDispatcherApp(input: {
         return c.json({ outcome: "already_rejected", decision }, 200);
       }
       const body = renderThreadActionRecordedBody({
-        provider: parsed.callback.provider,
         verb: "reject",
-        selectionText,
-        proposalId: resolved.resolved.proposal.snapshot.proposalId
+        selectionText
       });
       await deliverAndAudit({
         repo,
@@ -1500,12 +1801,17 @@ export function createDispatcherApp(input: {
       if (existingDecision) {
         return c.json({ outcome: "already_approved", decision }, 200);
       }
+      const directApply = await selectedDirectApplyStatus({
+        event: resolved.resolved.proposal.event,
+        callbackProvider: parsed.callback.provider,
+        candidates: resolved.resolved.selectedCandidates,
+        ...(input.githubApply ? { githubApply: input.githubApply } : {})
+      });
       const body = renderThreadActionRecordedBody({
-        provider: parsed.callback.provider,
         verb: "approve",
         selectionText,
-        proposalId: resolved.resolved.proposal.snapshot.proposalId,
-        applyIndex: resolved.resolved.selectedCandidates[0]?.index ?? 1
+        applyIndex: resolved.resolved.selectedCandidates[0]?.index ?? 1,
+        directApply
       });
       await deliverAndAudit({
         repo,
@@ -1532,10 +1838,11 @@ export function createDispatcherApp(input: {
         approvalDecisionId: decision.id
       });
       const body = renderChildRunCreatedBody({
-        lead: `Continuing from ${selectionText} in \`${resolved.resolved.proposal.snapshot.proposalId}\`.`,
+        lead: "Continuing in OpenTag from this approved action.",
         resolved: resolved.resolved,
         childRun,
         provider: parsed.callback.provider,
+        selectionText,
         approvalDecisionId: decision.id
       });
       await deliverAndAudit({
@@ -1566,22 +1873,24 @@ export function createDispatcherApp(input: {
     }
     if (!planResult.created) {
       if (selectedIntentsAlreadyApplied({ plan: planResult.plan, selectedIntentIds: resolved.resolved.selectedIntentIds })) {
+        await deliverAndAudit({
+          repo,
+          sink: callbackSink,
+          retry: callbackRetry,
+          message: {
+            runId: resolved.resolved.proposal.runId,
+            kind: "final",
+            provider: parsed.callback.provider,
+            uri: parsed.callback.uri,
+            body: renderAlreadyAppliedThreadActionBody({ selectionText }),
+            ...(parsed.callback.threadKey ? { threadKey: parsed.callback.threadKey } : {})
+          }
+        });
         return c.json({ outcome: "already_applied", decision, plan: planResult.plan }, 200);
       }
-      const fallbackReason = "An apply plan already exists for this selected action; OpenTag will not execute it again from a repeated thread reply.";
-      const childRun = await createChildRunForThreadAction({
-        repo,
-        command,
-        resolved: resolved.resolved,
-        runId: stableChildRunId({
-          command,
-          resolved: resolved.resolved,
-          sourceApplyPlanId: planResult.plan.id,
-          fallbackReason
-        }),
-        approvalDecisionId: decision.id,
-        sourceApplyPlanId: planResult.plan.id,
-        fallbackReason
+      const isStale = selectedIntentsHaveStaleOutcome({
+        plan: planResult.plan,
+        selectedIntentIds: resolved.resolved.selectedIntentIds
       });
       await deliverAndAudit({
         repo,
@@ -1592,19 +1901,16 @@ export function createDispatcherApp(input: {
           kind: "final",
           provider: parsed.callback.provider,
           uri: parsed.callback.uri,
-          body: renderChildRunCreatedBody({
-            lead: "This action was already planned, so OpenTag will not execute the external write again.",
-            resolved: resolved.resolved,
-            childRun,
-            provider: parsed.callback.provider,
-            approvalDecisionId: decision.id,
-            sourceApplyPlanId: planResult.plan.id,
-            fallbackReason
-          }),
+          body: isStale
+            ? renderStaleThreadActionBody({
+                selectionText,
+                continueIndex: resolved.resolved.selectedCandidates[0]?.index ?? 1
+              })
+            : renderAlreadyPlannedThreadActionBody({ selectionText }),
           ...(parsed.callback.threadKey ? { threadKey: parsed.callback.threadKey } : {})
         }
       });
-      return c.json({ outcome: "already_planned", decision, plan: planResult.plan, run: childRun }, 200);
+      return c.json({ outcome: isStale ? "stale" : "already_planned", decision, plan: planResult.plan }, 200);
     }
     const plan = planResult.plan;
 
@@ -1617,9 +1923,7 @@ export function createDispatcherApp(input: {
     if (execution.executed) {
       const outcomes = execution.plan.outcomes ?? [];
       const body = renderAppliedThreadActionBody({
-        provider: parsed.callback.provider,
         selectionText,
-        proposalId: resolved.resolved.proposal.snapshot.proposalId,
         selectedIntentIds: resolved.resolved.selectedIntentIds,
         outcomes
       });
@@ -1639,6 +1943,26 @@ export function createDispatcherApp(input: {
       return c.json({ outcome: "applied", decision, plan: execution.plan }, 201);
     }
 
+    if (selectedIntentsHaveStaleOutcome({ plan: execution.plan, selectedIntentIds: resolved.resolved.selectedIntentIds })) {
+      await deliverAndAudit({
+        repo,
+        sink: callbackSink,
+        retry: callbackRetry,
+        message: {
+          runId: resolved.resolved.proposal.runId,
+          kind: "final",
+          provider: parsed.callback.provider,
+          uri: parsed.callback.uri,
+          body: renderStaleThreadActionBody({
+            selectionText,
+            continueIndex: resolved.resolved.selectedCandidates[0]?.index ?? 1
+          }),
+          ...(parsed.callback.threadKey ? { threadKey: parsed.callback.threadKey } : {})
+        }
+      });
+      return c.json({ outcome: "stale", decision, plan: execution.plan }, 200);
+    }
+
     const childRun = await createChildRunForThreadAction({
       repo,
       command,
@@ -1654,10 +1978,11 @@ export function createDispatcherApp(input: {
       fallbackReason: execution.fallbackReason ?? "OpenTag cannot directly apply this intent yet."
     });
     const body = renderChildRunCreatedBody({
-      lead: `Action ${selectionText} was approved, but OpenTag cannot directly apply it yet.`,
+      lead: "Needs setup before OpenTag can apply this action directly.",
       resolved: resolved.resolved,
       childRun,
       provider: parsed.callback.provider,
+      selectionText,
       approvalDecisionId: decision.id,
       sourceApplyPlanId: execution.plan.id,
       fallbackReason: execution.fallbackReason ?? "The adapter could not execute the selected intent."
@@ -1809,7 +2134,17 @@ export function createDispatcherApp(input: {
     if (!ok) return c.json({ error: "run_not_claimed_by_runner" }, 404);
     const stored = await repo.getRun({ runId });
     if (!stored) return c.json({ error: "run_not_found" }, 404);
-    const finalPresentation = presentation.final({ provider: stored.event.callback.provider, result: parsed.result });
+    const receiptContext = await actionReceiptContextForFinal({
+      event: stored.event,
+      result: parsed.result,
+      ...(input.githubApply ? { githubApply: input.githubApply } : {})
+    });
+    const finalPresentation = presentation.final({
+      provider: stored.event.callback.provider,
+      result: parsed.result,
+      runId,
+      receiptContext
+    });
     await deliverAndAudit({
       repo,
       sink: callbackSink,

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -488,15 +488,54 @@ function executorConditionsFromIntent(intent: { params?: Record<string, unknown>
   return value.filter((condition): condition is string => typeof condition === "string" && condition.length > 0);
 }
 
-async function githubPreflight(input: {
+const GITHUB_PREFLIGHT_TIMEOUT_MS = 5_000;
+
+type GitHubPreflightCache = Map<string, Promise<ActionReceiptCapability | null>>;
+
+function githubPreflightCacheKey(input: { owner: string; repo: string; path: string }): string {
+  return `${input.owner}/${input.repo}${input.path}`;
+}
+
+function createGitHubPreflightDeadline(timeoutMs: number): { signal?: AbortSignal; clear: () => void; didTimeout: () => boolean } {
+  if (typeof AbortController === "undefined") return { clear: () => {}, didTimeout: () => false };
+  const controller = new AbortController();
+  let didTimeout = false;
+  const timeout = setTimeout(() => {
+    didTimeout = true;
+    controller.abort();
+  }, timeoutMs);
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timeout),
+    didTimeout: () => didTimeout
+  };
+}
+
+type GitHubPreflightInput = {
   githubApply: GitHubApplyOptions;
   owner: string;
   repo: string;
   path: string;
   description: string;
   notFoundReason: string;
-}): Promise<ActionReceiptCapability | null> {
+  cache?: GitHubPreflightCache;
+};
+
+async function githubPreflight(input: GitHubPreflightInput): Promise<ActionReceiptCapability | null> {
+  if (input.cache) {
+    const cacheKey = githubPreflightCacheKey(input);
+    const cached = input.cache.get(cacheKey);
+    if (cached) return await cached;
+    const pending = githubPreflightUncached(input);
+    input.cache.set(cacheKey, pending);
+    return await pending;
+  }
+  return await githubPreflightUncached(input);
+}
+
+async function githubPreflightUncached(input: Omit<GitHubPreflightInput, "cache">): Promise<ActionReceiptCapability | null> {
   let response: Response;
+  const deadline = createGitHubPreflightDeadline(GITHUB_PREFLIGHT_TIMEOUT_MS);
   try {
     response = await (input.githubApply.fetchImpl ?? fetch)(`https://api.github.com/repos/${input.owner}/${input.repo}${input.path}`, {
       method: "GET",
@@ -504,13 +543,22 @@ async function githubPreflight(input: {
         accept: "application/vnd.github+json",
         authorization: `Bearer ${input.githubApply.token}`,
         "x-github-api-version": "2022-11-28"
-      }
+      },
+      ...(deadline.signal ? { signal: deadline.signal } : {})
     });
   } catch (error) {
+    if (deadline.didTimeout()) {
+      return {
+        state: "needs_setup",
+        setupReason: `GitHub preflight timed out for ${input.description} after ${GITHUB_PREFLIGHT_TIMEOUT_MS}ms.`
+      };
+    }
     return {
       state: "needs_setup",
       setupReason: `GitHub preflight failed for ${input.description}: ${error instanceof Error ? error.message : String(error)}.`
     };
+  } finally {
+    deadline.clear();
   }
 
   if (response.ok) return null;
@@ -537,11 +585,13 @@ async function preflightGitHubOperation(input: {
   githubApply: GitHubApplyOptions;
   target: NonNullable<ReturnType<typeof githubTargetFromEvent>>;
   operation: GitHubIssueMutationOperation;
+  preflightCache?: GitHubPreflightCache;
 }): Promise<ActionReceiptCapability | null> {
   const base = {
     githubApply: input.githubApply,
     owner: input.target.owner,
-    repo: input.target.repoName
+    repo: input.target.repoName,
+    ...(input.preflightCache ? { cache: input.preflightCache } : {})
   };
 
   if (input.operation.kind === "create_pull_request") {
@@ -597,6 +647,7 @@ async function directApplyReceiptCapability(input: {
   callbackProvider: string;
   intent: MutationIntent;
   githubApply?: GitHubApplyOptions;
+  preflightCache?: GitHubPreflightCache;
 }): Promise<ActionReceiptCapability> {
   const capability = capabilityForMutationIntent(input.intent);
   if (!capability) {
@@ -678,7 +729,8 @@ async function directApplyReceiptCapability(input: {
   const preflight = await preflightGitHubOperation({
     githubApply: input.githubApply,
     target: githubTarget,
-    operation: compilation.operation as GitHubIssueMutationOperation
+    operation: compilation.operation as GitHubIssueMutationOperation,
+    ...(input.preflightCache ? { preflightCache: input.preflightCache } : {})
   });
   if (preflight) return preflight;
 
@@ -690,18 +742,22 @@ async function actionReceiptContextForFinal(input: {
   result: OpenTagRunResult;
   githubApply?: GitHubApplyOptions;
 }): Promise<ActionReceiptContext> {
-  const capabilityByIntentId: Record<string, ActionReceiptCapability> = {};
-  for (const snapshot of input.result.suggestedChanges ?? []) {
-    for (const intent of snapshot.intents) {
-      capabilityByIntentId[intent.intentId] = await directApplyReceiptCapability({
-        event: input.event,
-        callbackProvider: input.event.callback.provider,
-        intent,
-        ...(input.githubApply ? { githubApply: input.githubApply } : {})
-      });
-    }
-  }
-  return { capabilityByIntentId };
+  const preflightCache: GitHubPreflightCache = new Map();
+  const capabilityEntries = await Promise.all(
+    (input.result.suggestedChanges ?? []).flatMap((snapshot) =>
+      snapshot.intents.map(async (intent) => {
+        const capability = await directApplyReceiptCapability({
+          event: input.event,
+          callbackProvider: input.event.callback.provider,
+          intent,
+          ...(input.githubApply ? { githubApply: input.githubApply } : {}),
+          preflightCache
+        });
+        return [intent.intentId, capability] as const;
+      })
+    )
+  );
+  return { capabilityByIntentId: Object.fromEntries(capabilityEntries) };
 }
 
 async function authorizeThreadAction(input: {
@@ -1010,12 +1066,14 @@ async function selectedDirectApplyStatus(input: {
   githubApply?: GitHubApplyOptions;
 }): Promise<{ ready: boolean; reason?: string }> {
   if (input.candidates.length === 0) return { ready: false, reason: "No selected action was found." };
+  const preflightCache: GitHubPreflightCache = new Map();
   for (const candidate of input.candidates) {
     const capability = await directApplyReceiptCapability({
       event: input.event,
       callbackProvider: input.callbackProvider,
       intent: candidate.intent,
-      ...(input.githubApply ? { githubApply: input.githubApply } : {})
+      ...(input.githubApply ? { githubApply: input.githubApply } : {}),
+      preflightCache
     });
     if (capability.state !== "ready_to_apply") {
       return {

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -158,12 +158,16 @@ describe("default callback presentation", () => {
     expect(slack.body).toContain("Target: GitHub labels");
     expect(slack.body).not.toContain("Proposal:");
     expect(slack.body).not.toContain("Intent ID:");
-    expect(slack.blocks?.at(-1)).toMatchObject({
+    expect(slack.blocks?.at(-2)).toMatchObject({
       type: "actions",
       elements: [
         { type: "button", text: { type: "plain_text", text: "Apply 1" }, action_id: "opentag:apply:1", style: "primary" },
         { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" }
       ]
+    });
+    expect(slack.blocks?.at(-1)).toEqual({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: "Audit: `opentag status --run run_receipt_1`" }]
     });
   });
 

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -132,27 +132,38 @@ describe("default callback presentation", () => {
         }
       ]
     };
+    const receiptContext = {
+      capabilityByIntentId: {
+        intent_label_1: { state: "ready_to_apply" as const }
+      }
+    };
 
-    const github = presentation.final({ provider: "github", result }).body;
-    expect(github).toContain("Suggested actions:");
-    expect(github).toContain("Source-thread approval:");
-    expect(github).toContain("#### Action 1: Add the bug label.");
-    expect(github).toContain("System-of-record action: `add_label` (`labels`)");
-    expect(github).toContain("Proposal: `proposal_1`");
-    expect(github).toContain("Intent ID: `intent_label_1`");
+    const github = presentation.final({ provider: "github", result, runId: "run_receipt_1", receiptContext }).body;
+    expect(github).toContain("### Ready to apply");
+    expect(github).toContain("source-thread action receipt");
+    expect(github).toContain("Audit: run `opentag status --run run_receipt_1` locally.");
+    expect(github).toContain("#### 1. Add the bug label.");
+    expect(github).toContain("| Target | GitHub labels |");
+    expect(github).toContain("| Preconditions | The issue is still open. |");
     expect(github).toContain("| Apply now | `apply 1` |");
+    expect(github).toContain("| Approve only | `approve 1` |");
+    expect(github).not.toContain("| Continue | `continue 1` |");
+    expect(github).not.toContain("Proposal: `proposal_1`");
+    expect(github).not.toContain("Intent ID: `intent_label_1`");
 
-    const slack = presentation.final({ provider: "slack", result });
-    expect(slack.body).toContain("*Suggested actions*");
+    const slack = presentation.final({ provider: "slack", result, runId: "run_receipt_1", receiptContext });
+    expect(slack.body).toContain("*Ready to apply*");
+    expect(slack.body).not.toContain("opentag status --run");
     expect(slack.body).toContain("1. *Add the bug label.*");
+    expect(slack.body).toContain("Target: GitHub labels");
     expect(slack.body).not.toContain("Proposal:");
     expect(slack.body).not.toContain("Intent ID:");
     expect(slack.blocks?.at(-1)).toMatchObject({
       type: "actions",
       elements: [
         { type: "button", text: { type: "plain_text", text: "Apply 1" }, action_id: "opentag:apply:1", style: "primary" },
-        { type: "button", text: { type: "plain_text", text: "Approve" }, action_id: "opentag:approve:1" },
-        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" }
+        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" },
+        { type: "button", text: { type: "plain_text", text: "Approve only" }, action_id: "opentag:approve:1" }
       ]
     });
   });
@@ -188,11 +199,12 @@ describe("default callback presentation", () => {
     };
 
     const github = presentation.final({ provider: "github", result }).body;
-    expect(github).toContain("- Title: OpenTag run run_1");
-    expect(github).toContain("- Branch: `opentag/run_1` -> `main`");
-    expect(github).toContain("- Changed files: `src/demo.ts`");
-    expect(github).toContain("- Verification:\n  - `pnpm test`: passed");
-    expect(github).not.toContain("   Title:");
+    expect(github).toContain("| Target | GitHub pull request |");
+    expect(github).toContain("| Title | OpenTag run run_1 |");
+    expect(github).toContain("| Branch | `opentag/run_1` -> `main` |");
+    expect(github).toContain("| Changed files | `src/demo.ts` |");
+    expect(github).toContain("| Verification | `pnpm test`: passed |");
+    expect(github).toContain("| Risks | Review before merge. |");
 
     const slack = presentation.final({ provider: "slack", result });
     expect(slack.body).toContain("Branch: `opentag/run_1` -> `main`");

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -146,7 +146,7 @@ describe("default callback presentation", () => {
     expect(github).toContain("| Target | GitHub labels |");
     expect(github).toContain("| Preconditions | The issue is still open. |");
     expect(github).toContain("| Apply now | `apply 1` |");
-    expect(github).toContain("| Approve only | `approve 1` |");
+    expect(github).not.toContain("| Approve only | `approve 1` |");
     expect(github).not.toContain("| Continue | `continue 1` |");
     expect(github).not.toContain("Proposal: `proposal_1`");
     expect(github).not.toContain("Intent ID: `intent_label_1`");
@@ -162,8 +162,7 @@ describe("default callback presentation", () => {
       type: "actions",
       elements: [
         { type: "button", text: { type: "plain_text", text: "Apply 1" }, action_id: "opentag:apply:1", style: "primary" },
-        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" },
-        { type: "button", text: { type: "plain_text", text: "Approve only" }, action_id: "opentag:approve:1" }
+        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" }
       ]
     });
   });

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -686,6 +686,15 @@ describe("dispatcher API", () => {
               type: "mrkdwn",
               text: "Verified: `echo` passed"
             }
+          },
+          {
+            type: "context",
+            elements: [
+              {
+                type: "mrkdwn",
+                text: "Audit: `opentag status --run run_slack_1`"
+              }
+            ]
           }
         ]
       }
@@ -2164,7 +2173,7 @@ describe("dispatcher API", () => {
 
   it("renders needs-setup receipts when GitHub preflight cannot access the target", async () => {
     const delivered: Array<{ kind: string; body: string }> = [];
-    const githubRequests: Array<{ url: string; method?: string; authorization?: string | null }> = [];
+    const githubRequests: Array<{ url: string; method?: string; authorization?: string | null; hasSignal: boolean }> = [];
     const app = createDispatcherApp({
       databasePath: ":memory:",
       callbackSink: {
@@ -2178,7 +2187,8 @@ describe("dispatcher API", () => {
           githubRequests.push({
             url: String(url),
             method: init?.method,
-            authorization: new Headers(init?.headers).get("authorization")
+            authorization: new Headers(init?.headers).get("authorization"),
+            hasSignal: Boolean(init?.signal)
           });
           return new Response("forbidden", { status: 403 });
         }
@@ -2211,7 +2221,8 @@ describe("dispatcher API", () => {
       {
         url: "https://api.github.com/repos/acme/demo/issues/1",
         method: "GET",
-        authorization: "Bearer gh_test"
+        authorization: "Bearer gh_test",
+        hasSignal: true
       }
     ]);
     const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("Add the bug label."));
@@ -2219,6 +2230,61 @@ describe("dispatcher API", () => {
     expect(finalMessage?.body).toContain("GitHub apply token cannot access GitHub issue or pull request #1.");
     expect(finalMessage?.body).not.toContain("`apply 1`");
     expect(finalMessage?.body).toContain("`continue 1`");
+  });
+
+  it("deduplicates receipt preflight requests for multiple intents on the same target", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const githubRequests: string[] = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      },
+      githubApply: {
+        token: "gh_test",
+        fetchImpl: async (url) => {
+          githubRequests.push(String(url));
+          return Response.json({});
+        }
+      }
+    });
+
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_preflight_dedupe",
+      event: githubIssueEvent({ id: "evt_thread_preflight_dedupe", sourceEventId: "comment_thread_preflight_dedupe", threadKey: "acme/demo" }),
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_preflight_dedupe",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the bug.",
+          intents: [
+            {
+              intentId: "intent_label_bug_dedupe",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            },
+            {
+              intentId: "intent_label_help_dedupe",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the help wanted label.",
+              params: { label: "help wanted" }
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(githubRequests).toEqual(["https://api.github.com/repos/acme/demo/issues/1"]);
+    const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("Add the bug label."));
+    expect(finalMessage?.body).toContain("### Ready to apply");
+    expect(finalMessage?.body).toContain("`apply 1`");
+    expect(finalMessage?.body).toContain("`apply 2`");
   });
 
   it("renders needs-setup receipts when GitHub preflight cannot find the target issue or branch", async () => {

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -1216,6 +1216,7 @@ describe("dispatcher API", () => {
         }
       })
     });
+    githubRequests.length = 0;
     await app.request("/v1/proposals/proposal_execute/approvals", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -1956,6 +1957,7 @@ describe("dispatcher API", () => {
         }
       ]
     });
+    githubRequests.length = 0;
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
@@ -1985,8 +1987,10 @@ describe("dispatcher API", () => {
         authorization: "Bearer gh_test"
       }
     ]);
-    expect(delivered.some((message) => message.body.includes("Suggested actions:"))).toBe(true);
-    expect(delivered.at(-1)?.body).toContain("Applied 1. Add the bug label.");
+    expect(delivered.some((message) => message.body.includes("### Ready to apply"))).toBe(true);
+    expect(delivered.at(-1)?.body).toContain("Applied: Add the bug label.");
+    expect(delivered.at(-1)?.body).not.toContain("proposal_thread_apply");
+    expect(delivered.at(-1)?.body).not.toContain("intent_label_bug");
 
     const deliveredCountAfterFirstApply = delivered.length;
     const replayResponse = await app.request("/v1/thread-actions", jsonRequest({
@@ -2007,7 +2011,386 @@ describe("dispatcher API", () => {
       }
     });
     expect(githubRequests).toHaveLength(1);
-    expect(delivered).toHaveLength(deliveredCountAfterFirstApply);
+    expect(delivered).toHaveLength(deliveredCountAfterFirstApply + 1);
+    expect(delivered.at(-1)?.body).toContain("Already applied: Add the bug label.");
+    expect(delivered.at(-1)?.body).toContain("No external write was repeated.");
+    expect(delivered.at(-1)?.body).not.toContain("proposal_thread_apply");
+  });
+
+  it("renders needs-setup receipts without apply commands when GitHub apply is not configured", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      }
+    });
+
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_apply_not_configured",
+      event: githubIssueEvent({ id: "evt_thread_apply_not_configured", sourceEventId: "comment_thread_apply_not_configured", threadKey: "acme/demo" }),
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_apply_not_configured",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the bug.",
+          intents: [
+            {
+              intentId: "intent_label_bug_not_configured",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+
+    const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("Add the bug label."));
+    expect(finalMessage?.body).toContain("### Needs setup");
+    expect(finalMessage?.body).toContain("GitHub apply is not configured on this dispatcher.");
+    expect(finalMessage?.body).not.toContain("`apply 1`");
+    expect(finalMessage?.body).toContain("`continue 1`");
+    expect(finalMessage?.body).toContain("`reject 1`");
+  });
+
+  it("renders needs-setup receipts when create PR lacks the branch-exists executor condition", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const event = githubIssueEvent({ id: "evt_thread_pr_missing_condition", sourceEventId: "comment_thread_pr_missing_condition", threadKey: "acme/demo" });
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      },
+      githubApply: {
+        token: "gh_test",
+        fetchImpl: async () => {
+          throw new Error("missing executor condition should prevent apply from looking ready");
+        }
+      }
+    });
+
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_pr_missing_condition",
+      event: {
+        ...event,
+        permissions: [...event.permissions, { scope: "pr:create", reason: "create an approved pull request" }]
+      },
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_pr_missing_condition",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Create a pull request.",
+          intents: [
+            {
+              intentId: "intent_pr_missing_condition",
+              domain: "pull_request",
+              action: "create_pull_request",
+              summary: "Create a pull request for branch opentag/missing-condition.",
+              params: {
+                title: "OpenTag run missing condition",
+                head: "opentag/missing-condition",
+                base: "main"
+              }
+            }
+          ]
+        }
+      ]
+    });
+
+    const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("Create a pull request for branch"));
+    expect(finalMessage?.body).toContain("### Needs setup");
+    expect(finalMessage?.body).toContain("Missing executor condition: isolated branch exists.");
+    expect(finalMessage?.body).not.toContain("`apply 1`");
+    expect(finalMessage?.body).toContain("`continue 1`");
+  });
+
+  it("renders needs-setup receipts before GitHub preflight when platform write permission is missing", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      },
+      githubApply: {
+        token: "gh_test",
+        fetchImpl: async () => {
+          throw new Error("missing platform permission should prevent GitHub preflight");
+        }
+      }
+    });
+    const event = githubIssueEvent({ id: "evt_thread_missing_permission", sourceEventId: "comment_thread_missing_permission", threadKey: "acme/demo" });
+
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_missing_permission",
+      event: {
+        ...event,
+        permissions: [{ scope: "issue:comment", reason: "reply to source thread" }]
+      },
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_missing_permission",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the bug.",
+          intents: [
+            {
+              intentId: "intent_label_missing_permission",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+
+    const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("Add the bug label."));
+    expect(finalMessage?.body).toContain("### Needs setup");
+    expect(finalMessage?.body).toContain("Missing platform permission for set_labels.");
+    expect(finalMessage?.body).not.toContain("`apply 1`");
+    expect(finalMessage?.body).toContain("`continue 1`");
+  });
+
+  it("renders needs-setup receipts when GitHub preflight cannot access the target", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const githubRequests: Array<{ url: string; method?: string; authorization?: string | null }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      },
+      githubApply: {
+        token: "gh_test",
+        fetchImpl: async (url, init) => {
+          githubRequests.push({
+            url: String(url),
+            method: init?.method,
+            authorization: new Headers(init?.headers).get("authorization")
+          });
+          return new Response("forbidden", { status: 403 });
+        }
+      }
+    });
+
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_preflight_forbidden",
+      event: githubIssueEvent({ id: "evt_thread_preflight_forbidden", sourceEventId: "comment_thread_preflight_forbidden", threadKey: "acme/demo" }),
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_preflight_forbidden",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the bug.",
+          intents: [
+            {
+              intentId: "intent_label_preflight_forbidden",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(githubRequests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/1",
+        method: "GET",
+        authorization: "Bearer gh_test"
+      }
+    ]);
+    const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("Add the bug label."));
+    expect(finalMessage?.body).toContain("### Needs setup");
+    expect(finalMessage?.body).toContain("GitHub apply token cannot access GitHub issue or pull request #1.");
+    expect(finalMessage?.body).not.toContain("`apply 1`");
+    expect(finalMessage?.body).toContain("`continue 1`");
+  });
+
+  it("renders needs-setup receipts when GitHub preflight cannot find the target issue or branch", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const githubRequests: string[] = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      },
+      githubApply: {
+        token: "gh_test",
+        fetchImpl: async (url) => {
+          githubRequests.push(String(url));
+          return new Response("not found", { status: 404 });
+        }
+      }
+    });
+
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_preflight_not_found",
+      event: {
+        ...githubIssueEvent({ id: "evt_thread_preflight_not_found", sourceEventId: "comment_thread_preflight_not_found", threadKey: "acme/demo" }),
+        permissions: [
+          { scope: "issue:comment", reason: "reply to source thread" },
+          { scope: "repo:write", reason: "apply approved issue metadata" },
+          { scope: "pr:create", reason: "create an approved pull request" }
+        ]
+      },
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_preflight_not_found_issue",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the missing issue.",
+          intents: [
+            {
+              intentId: "intent_label_preflight_not_found",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        },
+        {
+          proposalId: "proposal_thread_preflight_not_found_branch",
+          createdAt: "2026-06-24T00:00:01.000Z",
+          summary: "Create a pull request.",
+          intents: [
+            {
+              intentId: "intent_pr_preflight_not_found",
+              domain: "pull_request",
+              action: "create_pull_request",
+              summary: "Create a pull request for branch opentag/missing-branch.",
+              params: {
+                title: "OpenTag missing branch",
+                head: "opentag/missing-branch",
+                base: "main",
+                executorConditions: ["isolated branch exists"]
+              }
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(githubRequests).toEqual([
+      "https://api.github.com/repos/acme/demo/issues/1",
+      "https://api.github.com/repos/acme/demo/branches/opentag%2Fmissing-branch"
+    ]);
+    const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("Add the bug label."));
+    expect(finalMessage?.body).toContain("### Needs setup");
+    expect(finalMessage?.body).toContain("GitHub issue or pull request #1 was not found.");
+    expect(finalMessage?.body).toContain("GitHub branch opentag/missing-branch was not found.");
+    expect(finalMessage?.body).not.toContain("`apply 1`");
+  });
+
+  it("renders a stale receipt when applying a superseded source-thread action", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const githubRequests: unknown[] = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      },
+      githubApply: {
+        token: "gh_test",
+        fetchImpl: async (url) => {
+          githubRequests.push(url);
+          return Response.json({});
+        }
+      }
+    });
+
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_stale_1",
+      event: githubIssueEvent({ id: "evt_thread_stale_1", sourceEventId: "comment_thread_stale_1", threadKey: "acme/demo" }),
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_stale_1",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the bug.",
+          intents: [
+            {
+              intentId: "intent_label_bug_stale",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_stale_2",
+      event: githubIssueEvent({ id: "evt_thread_stale_2", sourceEventId: "comment_thread_stale_2", threadKey: "acme/demo" }),
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_stale_2",
+          createdAt: "2026-06-24T00:00:01.000Z",
+          summary: "Refine the label.",
+          intents: [
+            {
+              intentId: "intent_label_triaged_current",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the triaged label.",
+              params: { label: "triaged" }
+            }
+          ]
+        }
+      ]
+    });
+    githubRequests.length = 0;
+
+    const response = await app.request("/v1/thread-actions", jsonRequest({
+      rawText: "apply 1",
+      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      callback: {
+        provider: "github",
+        uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        threadKey: "acme/demo"
+      },
+      metadata: {
+        source: "slack_button",
+        proposalId: "proposal_thread_stale_1",
+        intentId: "intent_label_bug_stale"
+      }
+    }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      outcome: "stale",
+      plan: {
+        proposalId: "proposal_thread_stale_1",
+        outcomes: [{ intentId: "intent_label_bug_stale", outcome: "stale" }]
+      }
+    });
+    expect(githubRequests).toHaveLength(0);
+    expect(delivered.at(-1)?.body).toContain("Stale: Add the bug label.");
+    expect(delivered.at(-1)?.body).toContain("The target changed since this action was proposed.");
+    expect(delivered.at(-1)?.body).toContain("Reply `continue 1` to refresh");
+    expect(delivered.at(-1)?.body).not.toContain("Child run:");
+    expect(delivered.at(-1)?.body).not.toContain("proposal_thread_stale_1");
   });
 
   it("resolves issue-scoped action replies against legacy repo-scoped GitHub issue proposals", async () => {
@@ -2052,6 +2435,7 @@ describe("dispatcher API", () => {
         }
       ]
     });
+    githubRequests.length = 0;
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
@@ -2088,9 +2472,15 @@ describe("dispatcher API", () => {
   });
 
   it("does not execute the adapter twice for concurrent duplicate apply replies", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
     const githubRequests: unknown[] = [];
     const app = createDispatcherApp({
       databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      },
       githubApply: {
         token: "gh_test",
         fetchImpl: async (url) => {
@@ -2122,6 +2512,7 @@ describe("dispatcher API", () => {
         }
       ]
     });
+    githubRequests.length = 0;
 
     const action = {
       rawText: "apply 1",
@@ -2141,6 +2532,8 @@ describe("dispatcher API", () => {
     expect(responses.map((response) => response.status).sort()).toEqual([200, 201]);
     expect(bodies.map((body) => body.outcome).sort()).toEqual(["already_planned", "applied"]);
     expect(githubRequests).toHaveLength(1);
+    expect(delivered.some((message) => message.body.includes("Already planned: Add the bug label."))).toBe(true);
+    expect(delivered.some((message) => message.body.includes("OpenTag did not execute this repeated reply."))).toBe(true);
   });
 
   it("rejects unauthorized source-thread action actors before approval or adapter execution", async () => {
@@ -2178,6 +2571,7 @@ describe("dispatcher API", () => {
         }
       ]
     });
+    githubRequests.length = 0;
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
@@ -2316,6 +2710,133 @@ describe("dispatcher API", () => {
     expect(secondBody.decision.id).not.toBe("approval_ingress_retry_id");
   });
 
+  it("records approve-only and reject replies with compact source-thread receipts", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      }
+    });
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_record_receipts",
+      event: githubIssueEvent({ id: "evt_thread_record_receipts", sourceEventId: "comment_thread_record_receipts", threadKey: "acme/demo" }),
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_record_receipts",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the issue.",
+          intents: [
+            {
+              intentId: "intent_label_bug_receipt",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add bug label.",
+              params: { label: "bug" }
+            },
+            {
+              intentId: "intent_label_help_receipt",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add help wanted label.",
+              params: { label: "help wanted" }
+            }
+          ]
+        }
+      ]
+    });
+
+    const baseAction = {
+      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      callback: {
+        provider: "github",
+        uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        threadKey: "acme/demo"
+      }
+    };
+    const approve = await app.request("/v1/thread-actions", jsonRequest({ ...baseAction, rawText: "approve 1" }));
+    const reject = await app.request("/v1/thread-actions", jsonRequest({ ...baseAction, rawText: "reject 2" }));
+
+    expect(approve.status).toBe(201);
+    expect(reject.status).toBe(201);
+    expect(delivered.some((message) => message.body.includes("Approved only: Add bug label."))).toBe(true);
+    expect(delivered.some((message) => message.body.includes("No external write was performed."))).toBe(true);
+    expect(delivered.some((message) => message.body.includes("Direct apply is not available yet: GitHub apply is not configured on this dispatcher."))).toBe(true);
+    expect(delivered.some((message) => message.body.includes("Next: reply `continue 1`"))).toBe(true);
+    expect(delivered.some((message) => message.body.includes("Next: reply `apply 1`"))).toBe(false);
+    expect(delivered.some((message) => message.body.includes("Rejected: Add help wanted label."))).toBe(true);
+    expect(delivered.some((message) => message.body.includes("No external write will be performed for this action."))).toBe(true);
+    expect(delivered.some((message) => message.body.includes("proposal_thread_record_receipts"))).toBe(false);
+    expect(delivered.some((message) => message.body.includes("intent_label_bug_receipt"))).toBe(false);
+  });
+
+  it("keeps the approve-only apply hint only when direct apply preflight is ready", async () => {
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const githubRequests: Array<{ url: string; method?: string }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      },
+      githubApply: {
+        token: "gh_test",
+        fetchImpl: async (url, init) => {
+          githubRequests.push({ url: String(url), method: init?.method });
+          return Response.json({});
+        }
+      }
+    });
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_approve_ready",
+      event: githubIssueEvent({ id: "evt_thread_approve_ready", sourceEventId: "comment_thread_approve_ready", threadKey: "acme/demo" }),
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_approve_ready",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the issue.",
+          intents: [
+            {
+              intentId: "intent_label_bug_approve_ready",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+    githubRequests.length = 0;
+
+    const response = await app.request("/v1/thread-actions", jsonRequest({
+      rawText: "approve 1",
+      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      callback: {
+        provider: "github",
+        uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        threadKey: "acme/demo"
+      }
+    }));
+
+    expect(response.status).toBe(201);
+    expect(githubRequests).toEqual([
+      {
+        url: "https://api.github.com/repos/acme/demo/issues/1",
+        method: "GET"
+      }
+    ]);
+    expect(delivered.at(-1)?.body).toContain("Approved only: Add bug label.");
+    expect(delivered.at(-1)?.body).toContain("No external write was performed.");
+    expect(delivered.at(-1)?.body).toContain("Next: reply `apply 1` to write it to the system of record");
+    expect(delivered.at(-1)?.body).not.toContain("Direct apply is not available yet");
+  });
+
   it("rejects explicit proposal action replies from the wrong source thread", async () => {
     const app = createDispatcherApp({ databasePath: ":memory:" });
     await seedCompletedProposal({
@@ -2394,6 +2915,7 @@ describe("dispatcher API", () => {
         }
       ]
     });
+    githubRequests.length = 0;
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
@@ -2491,6 +3013,7 @@ describe("dispatcher API", () => {
         }
       ]
     });
+    githubRequests.length = 0;
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
@@ -2605,6 +3128,7 @@ describe("dispatcher API", () => {
       repo: "demo"
     }));
     expect(bindingResponse.status).toBe(201);
+    githubRequests.length = 0;
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
@@ -2644,7 +3168,8 @@ describe("dispatcher API", () => {
       }
     ]);
     const finalMessage = delivered.find((message) => message.kind === "final" && message.body.includes("https://github.com/acme/demo/pull/43"));
-    expect(finalMessage?.body).toContain("Applied 1. Create PR for branch opentag/run_slack_create_pr.");
+    expect(finalMessage?.body).toContain("Applied: Create PR for branch opentag/run_slack_create_pr.");
+    expect(finalMessage?.body).not.toContain("..");
     expect(finalMessage?.body).not.toContain("proposal_slack_create_pr");
     expect(finalMessage?.body).not.toContain("intent_slack_create_pr");
   });
@@ -2713,7 +3238,15 @@ describe("dispatcher API", () => {
   });
 
   it("creates a child run with proposal context when the user replies continue", async () => {
-    const app = createDispatcherApp({ databasePath: ":memory:" });
+    const delivered: Array<{ kind: string; body: string }> = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      callbackSink: {
+        async deliver(message) {
+          delivered.push({ kind: message.kind, body: message.body });
+        }
+      }
+    });
     await seedCompletedProposal({
       app,
       runId: "run_thread_continue",
@@ -2778,6 +3311,17 @@ describe("dispatcher API", () => {
         "Action loop previous result: Prepared suggested actions."
       ])
     );
+    expect(
+      delivered.some(
+        (message) =>
+          message.body.includes("Continuing in OpenTag from this approved action.") &&
+          message.body.includes("Action: Continue fixing the failing test.") &&
+          message.body.includes(`Child run: \`${body.run.id}\``) &&
+          message.body.includes(`Audit: run \`opentag status --run ${body.run.id}\` locally.`) &&
+          !message.body.includes("proposal_thread_continue") &&
+          !message.body.includes(body.decision.id)
+      )
+    ).toBe(true);
   });
 
   it("falls back to a child run when an approved action has no direct adapter operation", async () => {
@@ -2873,10 +3417,12 @@ describe("dispatcher API", () => {
       delivered.some(
         (message) =>
           message.kind === "final" &&
-          message.body.includes("Context carried into the child run:") &&
+          message.body.includes("Needs setup before OpenTag can apply this action directly.") &&
+          message.body.includes("Action: Request a reviewer.") &&
           message.body.includes(`Child run: \`${body.run.id}\``) &&
-          message.body.includes(`Approval decision: \`${body.decision.id}\``) &&
-          message.body.includes("Fallback reason:")
+          message.body.includes("Reason:") &&
+          message.body.includes(`Audit: run \`opentag status --run ${body.run.id}\` locally.`) &&
+          !message.body.includes(`Approval decision: \`${body.decision.id}\``)
       )
     ).toBe(true);
   });

--- a/packages/github/src/render.ts
+++ b/packages/github/src/render.ts
@@ -1,4 +1,16 @@
-import { suggestedActionCandidatesFromResult, type OpenTagRunResult } from "@opentag/core";
+import {
+  actionReceiptHeading,
+  buildActionReceiptsFromResult,
+  type ActionReceipt,
+  type ActionReceiptContext,
+  type ActionReceiptDecision,
+  type OpenTagRunResult
+} from "@opentag/core";
+
+export type GitHubRenderOptions = {
+  receiptContext?: ActionReceiptContext;
+  auditRunId?: string;
+};
 
 function nextActionSummary(result: OpenTagRunResult): string | undefined {
   if (!result.nextAction) return undefined;
@@ -28,75 +40,102 @@ function renderVerificationParams(params: Record<string, unknown> | undefined): 
       const summary = (item as Record<string, unknown>)["summary"];
       if (typeof outcome !== "string") return undefined;
       const prefix = typeof command === "string" && command.length > 0 ? `\`${command}\`: ${outcome}` : outcome;
-      return typeof summary === "string" && summary.length > 0 ? `  - ${prefix} - ${summary}` : `  - ${prefix}`;
+      return typeof summary === "string" && summary.length > 0 ? `${prefix} - ${summary}` : prefix;
     })
     .filter((line): line is string => Boolean(line));
 }
 
-function renderSuggestedActionDetails(params: Record<string, unknown> | undefined, action: string): string[] {
-  if (action !== "create_pull_request") return [];
-  const lines: string[] = [];
+function inlineCode(value: string): string {
+  return `\`${value.replace(/`/g, "\\`")}\``;
+}
+
+function tableValue(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, "<br>");
+}
+
+function tableList(values: string[]): string {
+  return values.map(tableValue).join("<br>");
+}
+
+function renderSuggestedActionDetails(receipt: ActionReceipt): Array<[string, string]> {
+  const candidate = receipt.candidate;
+  const params = candidate.intent.params;
+  const rows: Array<[string, string]> = [["Target", receipt.targetLabel]];
+  if (receipt.setupReason) rows.push(["Status", receipt.setupReason]);
+  if (candidate.intent.action !== "create_pull_request") {
+    if (candidate.proposalPreconditions?.length) {
+      rows.push(["Preconditions", tableList(candidate.proposalPreconditions)]);
+    }
+    return rows;
+  }
+
   const title = stringParam(params, "title");
   const head = stringParam(params, "head") ?? stringParam(params, "branch");
   const base = stringParam(params, "base") ?? stringParam(params, "baseBranch");
   const changedFiles = stringArrayParam(params, "changedFiles");
   const risks = stringArrayParam(params, "risks");
   const verification = renderVerificationParams(params);
-  if (title) lines.push(`- Title: ${title}`);
-  if (head || base) lines.push(`- Branch: \`${head ?? "unknown"}\` -> \`${base ?? "main"}\``);
-  if (changedFiles.length > 0) lines.push(`- Changed files: ${changedFiles.map((file) => `\`${file}\``).join(", ")}`);
-  if (risks.length > 0) {
-    lines.push("- Risks:");
-    for (const risk of risks) {
-      lines.push(`  - ${risk}`);
-    }
+  if (title) rows.push(["Title", title]);
+  if (head || base) rows.push(["Branch", `${inlineCode(head ?? "unknown")} -> ${inlineCode(base ?? "main")}`]);
+  if (changedFiles.length > 0) rows.push(["Changed files", changedFiles.map(inlineCode).join(", ")]);
+  if (verification.length > 0) rows.push(["Verification", tableList(verification)]);
+  if (risks.length > 0) rows.push(["Risks", tableList(risks)]);
+  if (candidate.proposalPreconditions?.length) {
+    rows.push(["Preconditions", tableList(candidate.proposalPreconditions)]);
   }
-  if (verification.length > 0) {
-    lines.push("- Verification:");
-    lines.push(...verification);
-  }
-  return lines;
+  return rows;
 }
 
-function renderSuggestedActions(result: OpenTagRunResult): string[] {
-  const candidates = suggestedActionCandidatesFromResult(result);
-  if (candidates.length === 0) return [];
+function decisionLabel(decision: ActionReceiptDecision): string {
+  if (decision === "apply") return "Apply now";
+  if (decision === "approve") return "Approve only";
+  if (decision === "continue") return "Continue";
+  return "Reject";
+}
+
+function decisionEffect(decision: ActionReceiptDecision): string {
+  if (decision === "apply") return "Approves and applies this action to the system of record.";
+  if (decision === "approve") return "Records approval without applying yet.";
+  if (decision === "continue") return "Starts a follow-up run from this approved action.";
+  return "Rejects this action.";
+}
+
+function renderSuggestedActions(result: OpenTagRunResult, options: GitHubRenderOptions = {}): string[] {
+  const receipts = buildActionReceiptsFromResult(result, options.receiptContext);
+  if (receipts.length === 0) return [];
 
   const lines = [
-    "### Suggested actions:",
+    `### ${actionReceiptHeading(receipts)}`,
     "",
-    "Source-thread approval: choose one command in this GitHub thread to apply a protocolized mutation or PR action to the system of record."
+    "OpenTag prepared a source-thread action receipt. Choose one command in this GitHub thread; full protocol lineage stays in the audit log."
   ];
-  for (const candidate of candidates) {
+  if (options.auditRunId) {
+    lines.push("", `Audit: run ${inlineCode(`opentag status --run ${options.auditRunId}`)} locally.`);
+  }
+  for (const receipt of receipts) {
+    const candidate = receipt.candidate;
     lines.push(
       "",
-      `#### Action ${candidate.index}: ${candidate.intent.summary}`,
+      `#### ${candidate.index}. ${candidate.intent.summary}`,
       "",
-      `- System-of-record action: \`${candidate.intent.action}\` (\`${candidate.intent.domain}\`)`,
-      `- Proposal: \`${candidate.proposalId}\``,
-      `- Intent ID: \`${candidate.intent.intentId}\``
+      "| Field | Value |",
+      "| --- | --- |"
     );
-    lines.push(...renderSuggestedActionDetails(candidate.intent.params, candidate.intent.action));
-    if (candidate.proposalPreconditions?.length) {
-      lines.push("- Preconditions:");
-      for (const precondition of candidate.proposalPreconditions) {
-        lines.push(`  - ${precondition}`);
-      }
+    for (const [label, value] of renderSuggestedActionDetails(receipt)) {
+      lines.push(`| ${label} | ${tableValue(value)} |`);
     }
     lines.push(
       "",
-      "**Approve in this thread**",
+      "**Choose in this thread**",
       "",
       `| Decision | Comment command | Effect |`,
-      `| --- | --- | --- |`,
-      `| Apply now | \`apply ${candidate.index}\` | Applies this action to the system of record. |`,
-      `| Approve only | \`approve ${candidate.index}\` | Records approval without applying yet. |`,
-      `| Continue | \`continue ${candidate.index}\` | Starts a follow-up run from this proposal. |`,
-      `| Reject | \`reject ${candidate.index}\` | Rejects this action. |`
+      `| --- | --- | --- |`
     );
+    for (const decision of receipt.visibleDecisions) {
+      lines.push(`| ${decisionLabel(decision)} | \`${decision} ${candidate.index}\` | ${decisionEffect(decision)} |`);
+    }
   }
 
-  lines.push("", "Bulk shortcut: comment `apply all` to apply every supported approved action in this thread.");
   return lines;
 }
 
@@ -108,7 +147,7 @@ export function renderProgress(input: { runId: string; message: string }): strin
   return `OpenTag progress for \`${input.runId}\`: ${input.message}`;
 }
 
-export function renderFinalResult(result: OpenTagRunResult): string {
+export function renderFinalResult(result: OpenTagRunResult, options: GitHubRenderOptions = {}): string {
   const lines = [`OpenTag finished with **${result.conclusion}**.`, "", result.summary];
 
   if (result.verification?.length) {
@@ -118,14 +157,14 @@ export function renderFinalResult(result: OpenTagRunResult): string {
     }
   }
 
-  const nextAction = nextActionSummary(result);
-  if (nextAction) {
-    lines.push("", `Next action: ${nextAction}`);
-  }
-
-  const suggestedActions = renderSuggestedActions(result);
+  const suggestedActions = renderSuggestedActions(result, options);
   if (suggestedActions.length > 0) {
     lines.push("", ...suggestedActions);
+  } else {
+    const nextAction = nextActionSummary(result);
+    if (nextAction) {
+      lines.push("", `Next action: ${nextAction}`);
+    }
   }
 
   return lines.join("\n");

--- a/packages/github/test/render.test.ts
+++ b/packages/github/test/render.test.ts
@@ -46,7 +46,7 @@ describe("GitHub result rendering", () => {
     expect(body).toContain("| Verification | `pnpm test`: passed<br>passed - Structured report parsed successfully. |");
     expect(body).toContain("| Apply now | `apply 1` |");
     expect(body.indexOf("| Apply now | `apply 1` |")).toBeLessThan(body.indexOf("| Reject | `reject 1` |"));
-    expect(body.indexOf("| Reject | `reject 1` |")).toBeLessThan(body.indexOf("| Approve only | `approve 1` |"));
+    expect(body).not.toContain("| Approve only | `approve 1` |");
     expect(body).not.toContain("Proposal:");
     expect(body).not.toContain("Intent ID:");
     expect(body).not.toContain("Next action:");

--- a/packages/github/test/render.test.ts
+++ b/packages/github/test/render.test.ts
@@ -3,7 +3,7 @@ import { renderFinalResult } from "../src/render.js";
 
 describe("GitHub result rendering", () => {
   it("renders suggested-action verification rows without requiring a command", () => {
-    const body = renderFinalResult({
+    const result = {
       conclusion: "success",
       summary: "Prepared a branch.",
       suggestedChanges: [
@@ -32,8 +32,51 @@ describe("GitHub result rendering", () => {
           ]
         }
       ]
+    } as const;
+    const body = renderFinalResult(result, {
+      receiptContext: {
+        capabilityByIntentId: {
+          intent_create_pr: { state: "ready_to_apply" }
+        }
+      }
     });
 
-    expect(body).toContain("- Verification:\n  - `pnpm test`: passed\n  - passed - Structured report parsed successfully.");
+    expect(body).toContain("### Ready to apply");
+    expect(body).toContain("| Target | GitHub pull request |");
+    expect(body).toContain("| Verification | `pnpm test`: passed<br>passed - Structured report parsed successfully. |");
+    expect(body).toContain("| Apply now | `apply 1` |");
+    expect(body.indexOf("| Apply now | `apply 1` |")).toBeLessThan(body.indexOf("| Reject | `reject 1` |"));
+    expect(body.indexOf("| Reject | `reject 1` |")).toBeLessThan(body.indexOf("| Approve only | `approve 1` |"));
+    expect(body).not.toContain("Proposal:");
+    expect(body).not.toContain("Intent ID:");
+    expect(body).not.toContain("Next action:");
+  });
+
+  it("does not render apply commands without receipt capability proof", () => {
+    const body = renderFinalResult({
+      conclusion: "needs_human",
+      summary: "Prepared a label change.",
+      suggestedChanges: [
+        {
+          proposalId: "proposal_1",
+          createdAt: "2026-06-29T00:00:00.000Z",
+          summary: "Label issue.",
+          intents: [
+            {
+              intentId: "intent_label",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(body).toContain("### Needs approval");
+    expect(body).not.toContain("`apply 1`");
+    expect(body).toContain("| Approve only | `approve 1` |");
+    expect(body).toContain("| Reject | `reject 1` |");
   });
 });

--- a/packages/local-runtime/src/config.ts
+++ b/packages/local-runtime/src/config.ts
@@ -79,6 +79,7 @@ export const OpenTagDaemonConfigSchema = z.object({
   hermes: HermesExecutorConfigSchema.optional(),
   security: RunnerSecurityPolicySchema.optional(),
   githubToken: z.string().min(1).optional(),
+  githubApplyToken: z.string().min(1).nullable().optional(),
   preparePullRequestBranch: z.boolean().optional(),
   allowAutoCreatePullRequest: z.boolean().optional(),
   pairingToken: z.string().min(1).optional(),
@@ -328,6 +329,11 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
         }
       : {}),
     ...(process.env.OPENTAG_GITHUB_TOKEN ? { githubToken: process.env.OPENTAG_GITHUB_TOKEN } : {}),
+    ...(process.env.OPENTAG_GITHUB_APPLY_DISABLED === "true"
+      ? { githubApplyToken: null }
+      : process.env.OPENTAG_GITHUB_APPLY_TOKEN
+        ? { githubApplyToken: process.env.OPENTAG_GITHUB_APPLY_TOKEN }
+        : {}),
     ...(process.env.OPENTAG_PREPARE_PR_BRANCH ? { preparePullRequestBranch: process.env.OPENTAG_PREPARE_PR_BRANCH === "true" } : {}),
     ...(process.env.OPENTAG_ALLOW_AUTO_CREATE_PR ? { allowAutoCreatePullRequest: process.env.OPENTAG_ALLOW_AUTO_CREATE_PR === "true" } : {}),
     ...(process.env.OPENTAG_PAIRING_TOKEN ? { pairingToken: process.env.OPENTAG_PAIRING_TOKEN } : {}),

--- a/packages/local-runtime/src/dispatcher.ts
+++ b/packages/local-runtime/src/dispatcher.ts
@@ -13,7 +13,13 @@ export type LocalDispatcherRuntimeInput = {
   port: number;
   databasePath: string;
   pairingToken?: string;
+  /**
+   * Backward-compatible GitHub token. When specific callback/apply tokens are
+   * omitted, this token is used for both callback delivery and direct apply.
+   */
   githubToken?: string;
+  githubCallbackToken?: string;
+  githubApplyToken?: string | null;
   lark?: {
     appId: string;
     appSecret: string;
@@ -81,11 +87,20 @@ export function dispatcherRuntimeInputFromEnv(env: NodeJS.ProcessEnv): LocalDisp
     env.OPENTAG_TELEGRAM_BOT_TOKENS_JSON
   );
 
+  const githubApplyToken =
+    env.OPENTAG_GITHUB_APPLY_DISABLED === "true"
+      ? null
+      : env.OPENTAG_GITHUB_APPLY_TOKEN
+        ? env.OPENTAG_GITHUB_APPLY_TOKEN
+        : undefined;
+
   return {
     port,
     databasePath: env.OPENTAG_DATABASE_PATH ?? "opentag.db",
     ...(env.OPENTAG_PAIRING_TOKEN ? { pairingToken: env.OPENTAG_PAIRING_TOKEN } : {}),
     ...(env.OPENTAG_GITHUB_TOKEN ? { githubToken: env.OPENTAG_GITHUB_TOKEN } : {}),
+    ...(env.OPENTAG_GITHUB_CALLBACK_TOKEN ? { githubCallbackToken: env.OPENTAG_GITHUB_CALLBACK_TOKEN } : {}),
+    ...(githubApplyToken !== undefined ? { githubApplyToken } : {}),
     ...(env.LARK_APP_ID && env.LARK_APP_SECRET
       ? {
           lark: {
@@ -103,18 +118,21 @@ export function dispatcherRuntimeInputFromEnv(env: NodeJS.ProcessEnv): LocalDisp
 }
 
 export function startDispatcher(input: LocalDispatcherRuntimeInput): LocalDispatcherHandle {
+  const githubCallbackToken = input.githubCallbackToken ?? input.githubToken;
+  const githubApplyToken = input.githubApplyToken === null ? undefined : (input.githubApplyToken ?? input.githubToken);
+
   const server: ClosableServer = serve({
     fetch: createDispatcherApp({
       databasePath: input.databasePath,
       ...(input.pairingToken ? { pairingToken: input.pairingToken } : {}),
-      ...(input.githubToken ? { githubApply: { token: input.githubToken } } : {}),
+      ...(githubApplyToken ? { githubApply: { token: githubApplyToken } } : {}),
       sourceReceiptSink: createSlackSourceReceiptSink({
         ...(input.slackBotToken ? { botToken: input.slackBotToken } : {}),
         ...(input.slackBotTokensByAgentId ? { botTokensByAgentId: input.slackBotTokensByAgentId } : {})
       }),
       callbackSink: createCompositeCallbackSink([
         createGitHubCallbackSink({
-          ...(input.githubToken ? { token: input.githubToken } : {})
+          ...(githubCallbackToken ? { token: githubCallbackToken } : {})
         }),
         createSlackCallbackSink({
           ...(input.slackBotToken ? { botToken: input.slackBotToken } : {}),

--- a/packages/local-runtime/src/doctor.ts
+++ b/packages/local-runtime/src/doctor.ts
@@ -226,6 +226,8 @@ export async function runDoctor(input: {
     }
   }
 
+  const githubApplyToken = input.config.githubApplyToken === null ? undefined : (input.config.githubApplyToken ?? input.config.githubToken);
+
   if (input.config.allowAutoCreatePullRequest) {
     checks.push(
       input.config.githubToken
@@ -234,9 +236,13 @@ export async function runDoctor(input: {
     );
   } else if (input.config.preparePullRequestBranch) {
     checks.push(
-      input.config.githubToken
+      githubApplyToken
         ? check("ok", "GitHub PR actions", "Configured for thread-native `apply 1` PR creation")
-        : check("warn", "GitHub PR actions", "Run branches will be pushed, but githubToken is required for `apply 1` PR creation")
+        : check(
+            "warn",
+            "GitHub PR actions",
+            "Run branches can be pushed, but a GitHub apply token is required for direct `apply 1` PR creation"
+          )
     );
   } else if (input.config.githubToken) {
     checks.push(check("warn", "GitHub PR actions", "githubToken is configured, but run branch preparation is disabled"));

--- a/packages/local-runtime/test/dispatcher.test.ts
+++ b/packages/local-runtime/test/dispatcher.test.ts
@@ -17,4 +17,30 @@ describe("local dispatcher runtime", () => {
       })
     ).toThrow("Token for agent reviewer must be a non-empty string");
   });
+
+  it("can split GitHub callback and apply tokens from env", () => {
+    expect(
+      dispatcherRuntimeInputFromEnv({
+        OPENTAG_GITHUB_TOKEN: "ghp_callback_and_apply",
+        OPENTAG_GITHUB_CALLBACK_TOKEN: "ghp_callback",
+        OPENTAG_GITHUB_APPLY_TOKEN: "ghp_apply"
+      })
+    ).toMatchObject({
+      githubToken: "ghp_callback_and_apply",
+      githubCallbackToken: "ghp_callback",
+      githubApplyToken: "ghp_apply"
+    });
+  });
+
+  it("can disable GitHub direct apply while leaving callback token configured", () => {
+    expect(
+      dispatcherRuntimeInputFromEnv({
+        OPENTAG_GITHUB_TOKEN: "ghp_callback",
+        OPENTAG_GITHUB_APPLY_DISABLED: "true"
+      })
+    ).toMatchObject({
+      githubToken: "ghp_callback",
+      githubApplyToken: null
+    });
+  });
 });

--- a/packages/local-runtime/test/doctor.test.ts
+++ b/packages/local-runtime/test/doctor.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { CommandRunner, ExecutorAdapter } from "@opentag/runner";
+import type { OpenTagDaemonConfig } from "../src/config.js";
 import { doctorHasFailures, formatDoctorChecks, runDoctor } from "../src/doctor.js";
 
 const commandRunner: CommandRunner = {
@@ -26,7 +27,7 @@ const codexExecutor: ExecutorAdapter = {
   async cancel() {}
 };
 
-async function runCodexDoctor(codexConfig: string) {
+async function runCodexDoctor(codexConfig: string, configOverrides: Partial<OpenTagDaemonConfig> = {}) {
   const root = mkdtempSync(join(tmpdir(), "opentag-local-runtime-doctor-"));
   const checkoutPath = join(root, "demo");
   const codexConfigPath = join(root, "codex-config.toml");
@@ -53,7 +54,8 @@ async function runCodexDoctor(codexConfig: string) {
         ],
         githubToken: "ghs_test",
         pollIntervalMs: 5000,
-        heartbeatIntervalMs: 15000
+        heartbeatIntervalMs: 15000,
+        ...configOverrides
       },
       executors: { codex: codexExecutor },
       commandRunner,
@@ -115,5 +117,16 @@ describe("local-runtime doctor", () => {
 
     expect(doctorHasFailures(checks)).toBe(false);
     expect(formatDoctorChecks(checks)).toContain("OK   Codex config: service_tier=acme-enterprise-tier");
+  });
+
+  it("warns when direct GitHub apply is explicitly disabled", async () => {
+    const checks = await runCodexDoctor('service_tier = "fast"\n', {
+      preparePullRequestBranch: true,
+      githubApplyToken: null
+    });
+
+    expect(formatDoctorChecks(checks)).toContain(
+      "WARN GitHub PR actions: Run branches can be pushed, but a GitHub apply token is required for direct `apply 1` PR creation"
+    );
   });
 });

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -297,12 +297,11 @@ export function renderSlackFinalResult(result: OpenTagRunResult, options: SlackR
     );
   }
 
+  const suggestedActions = renderSuggestedActionsMarkdown(result, options);
   const nextAction = nextActionSummary(result);
-  if (nextAction && !result.suggestedChanges?.length) {
+  if (nextAction && suggestedActions.length === 0) {
     lines.push(`Next: ${markdownToSlackMrkdwn(compactNextAction(nextAction))}`);
   }
-
-  const suggestedActions = renderSuggestedActionsMarkdown(result, options);
   if (suggestedActions.length > 0) {
     lines.push("", ...suggestedActions);
   }
@@ -383,17 +382,18 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult, options: 
         }
       });
     }
-    if (options.auditRunId) {
-      blocks.push({
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: markdownToSlackMrkdwn(`Audit: \`opentag status --run ${options.auditRunId}\``)
-          }
-        ]
-      });
-    }
+  }
+
+  if (options.auditRunId) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: markdownToSlackMrkdwn(`Audit: \`opentag status --run ${options.auditRunId}\``)
+        }
+      ]
+    });
   }
 
   return blocks;

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -19,6 +19,14 @@ export type SlackDividerBlock = {
   type: "divider";
 };
 
+export type SlackContextBlock = {
+  type: "context";
+  elements: Array<{
+    type: "mrkdwn";
+    text: string;
+  }>;
+};
+
 export type SlackButtonElement = {
   type: "button";
   text: {
@@ -37,7 +45,7 @@ export type SlackActionsBlock = {
   elements: SlackButtonElement[];
 };
 
-export type SlackBlock = SlackTextBlock | SlackDividerBlock | SlackActionsBlock;
+export type SlackBlock = SlackTextBlock | SlackDividerBlock | SlackContextBlock | SlackActionsBlock;
 
 export type SlackSuggestedActionButtonValue = {
   version: 1;
@@ -66,6 +74,7 @@ const MAX_SLACK_SUGGESTED_ACTION_CANDIDATES = 20;
 
 export type SlackRenderOptions = {
   receiptContext?: ActionReceiptContext;
+  auditRunId?: string;
 };
 
 export function buildSlackSuggestedActionButtonValue(input: SlackSuggestedActionButtonValue): string {
@@ -372,6 +381,17 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult, options: 
           type: "mrkdwn",
           text: `Showing first ${visibleReceipts.length} of ${receipts.length} actions. Reply with an action number for the rest.`
         }
+      });
+    }
+    if (options.auditRunId) {
+      blocks.push({
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: markdownToSlackMrkdwn(`Audit: \`opentag status --run ${options.auditRunId}\``)
+          }
+        ]
       });
     }
   }

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -1,4 +1,11 @@
-import { suggestedActionCandidatesFromResult, type OpenTagRunResult, type SuggestedActionCandidate } from "@opentag/core";
+import {
+  actionReceiptHeading,
+  buildActionReceiptsFromResult,
+  type ActionReceipt,
+  type ActionReceiptContext,
+  type ActionReceiptDecision,
+  type OpenTagRunResult
+} from "@opentag/core";
 
 export type SlackTextBlock = {
   type: "section";
@@ -56,6 +63,10 @@ export type SlackReactionPayload = {
 export type SlackSourceReceiptState = "received";
 
 const MAX_SLACK_SUGGESTED_ACTION_CANDIDATES = 20;
+
+export type SlackRenderOptions = {
+  receiptContext?: ActionReceiptContext;
+};
 
 export function buildSlackSuggestedActionButtonValue(input: SlackSuggestedActionButtonValue): string {
   return JSON.stringify(input);
@@ -202,8 +213,13 @@ function compactNextAction(nextAction: string): string {
   return truncateSlackText(nextAction, 180);
 }
 
-function renderSuggestedActionCandidateLines(candidate: SuggestedActionCandidate): string[] {
+function renderSuggestedActionCandidateLines(receipt: ActionReceipt): string[] {
+  const candidate = receipt.candidate;
   const lines = [`${candidate.index}. *${markdownToSlackMrkdwn(candidate.intent.summary)}*`];
+  lines.push(`Target: ${markdownToSlackMrkdwn(receipt.targetLabel)}`);
+  if (receipt.setupReason) {
+    lines.push(`Status: ${markdownToSlackMrkdwn(receipt.setupReason)}`);
+  }
   const details = renderSuggestedActionDetails(candidate.intent.params, candidate.intent.action)
     .filter((line) => line.trim().startsWith("Branch:") || line.trim().startsWith("Changed files:"))
     .map((line) => line.replace(/^\s+/, ""));
@@ -214,65 +230,53 @@ function renderSuggestedActionCandidateLines(candidate: SuggestedActionCandidate
   return lines;
 }
 
-function renderSuggestedActionsMarkdown(result: OpenTagRunResult): string[] {
-  const candidates = suggestedActionCandidatesFromResult(result);
-  if (candidates.length === 0) return [];
+function renderSuggestedActionsMarkdown(result: OpenTagRunResult, options: SlackRenderOptions = {}): string[] {
+  const receipts = buildActionReceiptsFromResult(result, options.receiptContext);
+  if (receipts.length === 0) return [];
 
-  const lines = ["*Suggested actions*"];
-  const visibleCandidates = candidates.slice(0, MAX_SLACK_SUGGESTED_ACTION_CANDIDATES);
-  for (const candidate of visibleCandidates) {
-    lines.push("", ...renderSuggestedActionCandidateLines(candidate));
+  const heading = actionReceiptHeading(receipts);
+  const lines = [`*${heading}*`, "Choose an action in this thread. Details stay in the OpenTag audit log."];
+  const visibleReceipts = receipts.slice(0, MAX_SLACK_SUGGESTED_ACTION_CANDIDATES);
+  for (const receipt of visibleReceipts) {
+    lines.push("", ...renderSuggestedActionCandidateLines(receipt));
   }
 
-  const remainingCount = candidates.length - visibleCandidates.length;
+  const remainingCount = receipts.length - visibleReceipts.length;
   if (remainingCount > 0) {
-    lines.push("", `Showing first ${visibleCandidates.length} of ${candidates.length} actions. Reply with an action number for the rest.`);
+    lines.push("", `Showing first ${visibleReceipts.length} of ${receipts.length} actions. Reply with an action number for the rest.`);
   }
-  lines.push("", "Use the buttons below, or reply `apply 1`, `approve 1`, or `reject 1`.");
+  lines.push("", "Use the buttons below, or reply with the matching command.");
   return lines;
 }
 
-function createSuggestedActionButtons(candidate: SuggestedActionCandidate): SlackButtonElement[] {
-  return [
-    {
-      type: "button",
-      text: { type: "plain_text", text: `Apply ${candidate.index}`, emoji: true },
-      action_id: `opentag:apply:${candidate.index}`,
-      value: buildSlackSuggestedActionButtonValue({
-        version: 1,
-        command: `apply ${candidate.index}`,
-        proposalId: candidate.proposalId,
-        intentId: candidate.intent.intentId
-      }),
-      style: "primary"
-    },
-    {
-      type: "button",
-      text: { type: "plain_text", text: "Approve", emoji: true },
-      action_id: `opentag:approve:${candidate.index}`,
-      value: buildSlackSuggestedActionButtonValue({
-        version: 1,
-        command: `approve ${candidate.index}`,
-        proposalId: candidate.proposalId,
-        intentId: candidate.intent.intentId
-      })
-    },
-    {
-      type: "button",
-      text: { type: "plain_text", text: "Reject", emoji: true },
-      action_id: `opentag:reject:${candidate.index}`,
-      value: buildSlackSuggestedActionButtonValue({
-        version: 1,
-        command: `reject ${candidate.index}`,
-        proposalId: candidate.proposalId,
-        intentId: candidate.intent.intentId
-      }),
-      style: "danger"
-    }
-  ];
+function createSuggestedActionButton(receipt: ActionReceipt, decision: ActionReceiptDecision): SlackButtonElement {
+  const index = receipt.candidate.index;
+  const labels: Record<ActionReceiptDecision, string> = {
+    apply: `Apply ${index}`,
+    approve: "Approve only",
+    continue: "Continue",
+    reject: "Reject"
+  };
+  return {
+    type: "button",
+    text: { type: "plain_text", text: labels[decision], emoji: true },
+    action_id: `opentag:${decision}:${index}`,
+    value: buildSlackSuggestedActionButtonValue({
+      version: 1,
+      command: `${decision} ${index}`,
+      proposalId: receipt.candidate.proposalId,
+      intentId: receipt.candidate.intent.intentId
+    }),
+    ...(decision === "apply" ? { style: "primary" as const } : {}),
+    ...(decision === "reject" ? { style: "danger" as const } : {})
+  };
 }
 
-export function renderSlackFinalResult(result: OpenTagRunResult): string {
+function createSuggestedActionButtons(receipt: ActionReceipt): SlackButtonElement[] {
+  return receipt.visibleDecisions.map((decision) => createSuggestedActionButton(receipt, decision));
+}
+
+export function renderSlackFinalResult(result: OpenTagRunResult, options: SlackRenderOptions = {}): string {
   const lines = [`*Finished: ${result.conclusion}.*`, markdownToSlackMrkdwn(compactSlackSummary(result.summary))];
 
   if (result.verification?.length) {
@@ -289,7 +293,7 @@ export function renderSlackFinalResult(result: OpenTagRunResult): string {
     lines.push(`Next: ${markdownToSlackMrkdwn(compactNextAction(nextAction))}`);
   }
 
-  const suggestedActions = renderSuggestedActionsMarkdown(result);
+  const suggestedActions = renderSuggestedActionsMarkdown(result, options);
   if (suggestedActions.length > 0) {
     lines.push("", ...suggestedActions);
   }
@@ -297,7 +301,7 @@ export function renderSlackFinalResult(result: OpenTagRunResult): string {
   return lines.join("\n");
 }
 
-export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlock[] {
+export function createSlackFinalResultBlocks(result: OpenTagRunResult, options: SlackRenderOptions = {}): SlackBlock[] {
   const blocks: SlackBlock[] = [
     {
       type: "section",
@@ -324,8 +328,8 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlo
   }
 
   const nextAction = nextActionSummary(result);
-  const suggestedActionCandidates = suggestedActionCandidatesFromResult(result);
-  if (nextAction && suggestedActionCandidates.length === 0) {
+  const receipts = buildActionReceiptsFromResult(result, options.receiptContext);
+  if (nextAction && receipts.length === 0) {
     blocks.push({
       type: "section",
       text: {
@@ -335,37 +339,38 @@ export function createSlackFinalResultBlocks(result: OpenTagRunResult): SlackBlo
     });
   }
 
-  if (suggestedActionCandidates.length > 0) {
+  if (receipts.length > 0) {
+    const heading = actionReceiptHeading(receipts);
     blocks.push({ type: "divider" });
     blocks.push({
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "*Suggested actions*\nChoose an action in this thread. Details stay in the OpenTag audit log."
+        text: `*${heading}*\nChoose an action in this thread. Details stay in the OpenTag audit log.`
       }
     });
-    const visibleCandidates = suggestedActionCandidates.slice(0, MAX_SLACK_SUGGESTED_ACTION_CANDIDATES);
-    for (const candidate of visibleCandidates) {
+    const visibleReceipts = receipts.slice(0, MAX_SLACK_SUGGESTED_ACTION_CANDIDATES);
+    for (const receipt of visibleReceipts) {
       blocks.push({
         type: "section",
         text: {
           type: "mrkdwn",
-          text: renderSuggestedActionCandidateLines(candidate).join("\n")
+          text: renderSuggestedActionCandidateLines(receipt).join("\n")
         }
       });
       blocks.push({
         type: "actions",
-        block_id: `opentag_actions_${candidate.index}`,
-        elements: createSuggestedActionButtons(candidate)
+        block_id: `opentag_actions_${receipt.candidate.index}`,
+        elements: createSuggestedActionButtons(receipt)
       });
     }
-    const remainingCount = suggestedActionCandidates.length - visibleCandidates.length;
+    const remainingCount = receipts.length - visibleReceipts.length;
     if (remainingCount > 0) {
       blocks.push({
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `Showing first ${visibleCandidates.length} of ${suggestedActionCandidates.length} actions. Reply with an action number for the rest.`
+          text: `Showing first ${visibleReceipts.length} of ${receipts.length} actions. Reply with an action number for the rest.`
         }
       });
     }

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -125,8 +125,7 @@ describe("Slack callback rendering", () => {
       block_id: "opentag_actions_1",
       elements: [
         { type: "button", text: { type: "plain_text", text: "Apply 1" }, action_id: "opentag:apply:1", style: "primary" },
-        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" },
-        { type: "button", text: { type: "plain_text", text: "Approve only" }, action_id: "opentag:approve:1" }
+        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" }
       ]
     });
 
@@ -141,12 +140,6 @@ describe("Slack callback rendering", () => {
       {
         version: 1,
         command: "reject 1",
-        proposalId: "proposal_1",
-        intentId: "intent_label_1"
-      },
-      {
-        version: 1,
-        command: "approve 1",
         proposalId: "proposal_1",
         intentId: "intent_label_1"
       }

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -30,6 +30,24 @@ describe("Slack callback rendering", () => {
     expect(text).not.toContain("**success**");
   });
 
+  it("keeps the text fallback when suggested changes render no receipts", () => {
+    const text = renderSlackFinalResult({
+      conclusion: "needs_human",
+      summary: "Prepared a follow-up.",
+      nextAction: "Reply continue 1 to refresh.",
+      suggestedChanges: [
+        {
+          proposalId: "proposal_empty",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "No visible actions.",
+          intents: []
+        }
+      ]
+    });
+
+    expect(text).toContain("Next: Reply continue 1 to refresh.");
+  });
+
   it("converts common Markdown to Slack mrkdwn", () => {
     expect(markdownToSlackMrkdwn("**bold** and [docs](https://example.com)")).toBe("*bold* and <https://example.com|docs>");
     expect(markdownToSlackMrkdwn("Use <tag> & [docs & api](https://example.com?a=1&b=2)")).toBe(
@@ -82,6 +100,25 @@ describe("Slack callback rendering", () => {
         }
       }
     ]);
+  });
+
+  it("adds the quiet audit context even when no receipts render", () => {
+    const blocks = createSlackFinalResultBlocks({
+      conclusion: "success",
+      summary: "Done."
+    }, {
+      auditRunId: "run_without_receipts"
+    });
+
+    expect(blocks.at(-1)).toEqual({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "Audit: `opentag status --run run_without_receipts`"
+        }
+      ]
+    });
   });
 
   it("adds Block Kit buttons for suggested source-thread actions", () => {
@@ -182,6 +219,8 @@ describe("Slack callback rendering", () => {
     const rendered = JSON.stringify(blocks);
     expect(rendered).toContain("Needs approval");
     expect(rendered).not.toContain("Apply 1");
+    expect(rendered).not.toContain("opentag:apply:1");
+    expect(rendered).not.toContain('"command":"apply 1"');
     expect(rendered).toContain("Approve only");
     expect(rendered).toContain("Reject");
   });

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -105,6 +105,7 @@ describe("Slack callback rendering", () => {
         }
       ]
     }, {
+      auditRunId: "run_receipt_1",
       receiptContext: {
         capabilityByIntentId: {
           intent_label_1: { state: "ready_to_apply" }
@@ -116,10 +117,20 @@ describe("Slack callback rendering", () => {
     expect(rendered).toContain("Ready to apply");
     expect(rendered).toContain("1. *Add the bug label.*");
     expect(rendered).toContain("Target: GitHub labels");
+    expect(rendered).toContain("Audit: `opentag status --run run_receipt_1`");
     expect(rendered).not.toContain("Proposal:");
     expect(rendered).not.toContain("Intent ID:");
 
     const actionsBlock = blocks.find((block) => block.type === "actions");
+    expect(blocks.at(-1)).toEqual({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "Audit: `opentag status --run run_receipt_1`"
+        }
+      ]
+    });
     expect(actionsBlock).toMatchObject({
       type: "actions",
       block_id: "opentag_actions_1",

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -104,10 +104,18 @@ describe("Slack callback rendering", () => {
           ]
         }
       ]
+    }, {
+      receiptContext: {
+        capabilityByIntentId: {
+          intent_label_1: { state: "ready_to_apply" }
+        }
+      }
     });
 
     const rendered = JSON.stringify(blocks);
+    expect(rendered).toContain("Ready to apply");
     expect(rendered).toContain("1. *Add the bug label.*");
+    expect(rendered).toContain("Target: GitHub labels");
     expect(rendered).not.toContain("Proposal:");
     expect(rendered).not.toContain("Intent ID:");
 
@@ -117,8 +125,8 @@ describe("Slack callback rendering", () => {
       block_id: "opentag_actions_1",
       elements: [
         { type: "button", text: { type: "plain_text", text: "Apply 1" }, action_id: "opentag:apply:1", style: "primary" },
-        { type: "button", text: { type: "plain_text", text: "Approve" }, action_id: "opentag:approve:1" },
-        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" }
+        { type: "button", text: { type: "plain_text", text: "Reject" }, action_id: "opentag:reject:1", style: "danger" },
+        { type: "button", text: { type: "plain_text", text: "Approve only" }, action_id: "opentag:approve:1" }
       ]
     });
 
@@ -132,22 +140,51 @@ describe("Slack callback rendering", () => {
       },
       {
         version: 1,
-        command: "approve 1",
+        command: "reject 1",
         proposalId: "proposal_1",
         intentId: "intent_label_1"
       },
       {
         version: 1,
-        command: "reject 1",
+        command: "approve 1",
         proposalId: "proposal_1",
         intentId: "intent_label_1"
       }
     ]);
   });
 
-  it("caps suggested action blocks to stay under Slack's Block Kit limit", () => {
+  it("does not show Apply when receipt capability is not proven", () => {
     const blocks = createSlackFinalResultBlocks({
       conclusion: "needs_human",
+      summary: "Prepared a proposal.",
+      suggestedChanges: [
+        {
+          proposalId: "proposal_1",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Move issue forward.",
+          intents: [
+            {
+              intentId: "intent_label_1",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+
+    const rendered = JSON.stringify(blocks);
+    expect(rendered).toContain("Needs approval");
+    expect(rendered).not.toContain("Apply 1");
+    expect(rendered).toContain("Approve only");
+    expect(rendered).toContain("Reject");
+  });
+
+  it("caps suggested action blocks to stay under Slack's Block Kit limit", () => {
+    const result = {
+      conclusion: "needs_human" as const,
       summary: "Prepared many proposals.",
       suggestedChanges: Array.from({ length: 30 }, (_item, index) => ({
         proposalId: `proposal_${index + 1}`,
@@ -163,6 +200,13 @@ describe("Slack callback rendering", () => {
           }
         ]
       }))
+    };
+    const blocks = createSlackFinalResultBlocks(result, {
+      receiptContext: {
+        capabilityByIntentId: Object.fromEntries(
+          result.suggestedChanges.flatMap((snapshot) => snapshot.intents.map((intent) => [intent.intentId, { state: "ready_to_apply" as const }]))
+        )
+      }
     });
 
     const rendered = JSON.stringify(blocks);

--- a/scripts/dev/run-github-webhook-live-test.sh
+++ b/scripts/dev/run-github-webhook-live-test.sh
@@ -149,7 +149,6 @@ if [[ -z "$OWNER" || -z "$REPO" || "$OWNER" == "$REPO" ]]; then
 fi
 export OWNER REPO
 
-REPO_URL="$(gh repo view "$OWNER/$REPO" --json url --jq '.url')"
 PERMISSION="$(gh repo view "$OWNER/$REPO" --json viewerPermission --jq '.viewerPermission')"
 if [[ "$PERMISSION" != "ADMIN" && "$PERMISSION" != "MAINTAIN" ]]; then
   echo "GitHub repository webhook creation requires ADMIN or MAINTAIN access; current permission is $PERMISSION." >&2
@@ -317,8 +316,10 @@ applied_receipt_has_double_period() {
   ' | grep -E '\.\.$' >/dev/null
 }
 
-latest_apply_plan() {
-  sqlite_one "select plan_json from apply_plans order by created_at desc limit 1;"
+latest_apply_plan_for_run() {
+  local run_id_sql
+  run_id_sql="$(sql_escape "$1")"
+  sqlite_one "select ap.plan_json from apply_plans ap join suggested_changes sc on sc.proposal_id = ap.proposal_id where sc.run_id = '$run_id_sql' order by ap.created_at desc limit 1;"
 }
 
 if [[ ! -d "$CHECKOUT_PATH/.git" ]]; then
@@ -559,7 +560,7 @@ if bool_true "$OPENTAG_GH_LIVE_APPLY"; then
   PR_URL=""
   deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
   while (( SECONDS < deadline )); do
-    plan_json="$(latest_apply_plan)"
+    plan_json="$(latest_apply_plan_for_run "$RUN_ID")"
     if [[ -n "$plan_json" ]]; then
       PR_URL="$(python3 - "$plan_json" <<'PY' || true
 import json
@@ -586,7 +587,7 @@ PY
   done
   if [[ -z "$PR_URL" ]]; then
     echo "Timed out waiting for applied PR URL." >&2
-    latest_apply_plan | python3 -m json.tool || true
+    latest_apply_plan_for_run "$RUN_ID" | python3 -m json.tool || true
     exit 1
   fi
   echo "Created PR: $PR_URL"

--- a/scripts/dev/run-github-webhook-live-test.sh
+++ b/scripts/dev/run-github-webhook-live-test.sh
@@ -517,12 +517,23 @@ EXPECTED_HEADING="### Ready to apply"
 if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN"; then
   EXPECTED_HEADING="### Needs setup"
 fi
-if ! issue_comments_contain "$EXPECTED_HEADING"; then
-  echo "Expected the final GitHub receipt to render '$EXPECTED_HEADING'." >&2
+if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN"; then
+  if ! issue_comments_contain "$EXPECTED_HEADING"; then
+    echo "Expected the final GitHub receipt to render '$EXPECTED_HEADING'." >&2
+    exit 1
+  fi
+  if issue_comments_contain '`apply 1`'; then
+    echo "Expected the missing-apply-token receipt not to advertise the apply command." >&2
+    exit 1
+  fi
+elif ! issue_comments_contain "### Ready to apply" &&
+  ! issue_comments_contain "### Some actions need setup" &&
+  ! issue_comments_contain "### Some actions need attention" &&
+  ! issue_comments_contain "### Needs review"; then
+  echo "Expected the final GitHub receipt to render a ready or mixed-state action heading." >&2
   exit 1
-fi
-if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN" && issue_comments_contain '`apply 1`'; then
-  echo "Expected the missing-apply-token receipt not to advertise the apply command." >&2
+elif ! issue_comments_contain '`apply 1`'; then
+  echo "Expected the final GitHub receipt to advertise apply 1 for the ready action." >&2
   exit 1
 fi
 

--- a/scripts/dev/run-github-webhook-live-test.sh
+++ b/scripts/dev/run-github-webhook-live-test.sh
@@ -1,0 +1,602 @@
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo "Script failed at line $LINENO." >&2' ERR
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Run a real GitHub repository-webhook OpenTag dogfood session.
+
+This starts the local OpenTag CLI stack, exposes the GitHub webhook listener
+through ngrok, creates a temporary repository webhook, posts a real GitHub issue
+comment, waits for OpenTag to finish, replies `apply 1`, and waits for the
+created pull request.
+
+Required:
+  gh CLI authenticated as a user with admin access to the target repository.
+  claude CLI installed and logged in, unless OPENTAG_GH_LIVE_EXECUTOR is changed.
+  ngrok installed when OPENTAG_GH_LIVE_START_NGROK=true.
+
+Helpful env:
+  OPENTAG_GH_REPO                 owner/repo, default amplifthq/opentag-test
+  OPENTAG_GH_PUBLIC_URL           fixed public tunnel URL, if already running
+  OPENTAG_GH_LIVE_COMMAND         prompt after `@opentag run`
+  OPENTAG_GH_LIVE_APPLY           true/false, default true
+  OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN
+                                     true/false, default false. Keeps GitHub
+                                     callbacks working but verifies Needs setup
+                                     when direct apply is unavailable.
+  OPENTAG_GH_LIVE_KEEP_WEBHOOK    true/false, default false
+  OPENTAG_GH_LIVE_KILL_PORTS      true/false, default false
+
+Example:
+  OPENTAG_GH_REPO=amplifthq/opentag-test \
+    scripts/dev/run-github-webhook-live-test.sh
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+: "${OPENTAG_PAIRING_TOKEN:=dev_pairing_token}"
+: "${OPENTAG_DISPATCHER_PORT:=3033}"
+: "${OPENTAG_GITHUB_PORT:=3050}"
+: "${OPENTAG_RUNNER_ID:=runner_github_webhook_live}"
+: "${OPENTAG_CLAUDE_COMMAND:=claude}"
+: "${OPENTAG_CLAUDE_PERMISSION_MODE:=acceptEdits}"
+: "${OPENTAG_GH_REPO:=amplifthq/opentag-test}"
+: "${OPENTAG_GH_LIVE_START_NGROK:=true}"
+: "${OPENTAG_GH_LIVE_APPLY:=true}"
+: "${OPENTAG_GH_LIVE_TIMEOUT_SECONDS:=900}"
+: "${OPENTAG_GH_LIVE_COMMAND:=Add one short sentence to README.md saying GitHub can trigger local Claude Code through OpenTag. Keep the change small and do not modify anything else.}"
+: "${OPENTAG_GH_LIVE_EXECUTOR:=claude-code}"
+: "${OPENTAG_GH_LIVE_KEEP_WEBHOOK:=false}"
+: "${OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN:=false}"
+
+cd "$ROOT_DIR"
+
+CLI_PID=""
+NGROK_PID=""
+TMP_ROOT=""
+CONFIG_PATH=""
+DATABASE_PATH=""
+NGROK_LOG=""
+HOOK_ID=""
+ISSUE_NUMBER=""
+PUBLIC_URL=""
+
+bool_true() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|y|Y) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+sql_escape() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+sqlite_one() {
+  sqlite3 -cmd ".timeout 5000" -noheader "$DATABASE_PATH" "$1" 2>/dev/null || true
+}
+
+kill_pid() {
+  local pid="$1"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+
+  if [[ -n "$HOOK_ID" ]] && ! bool_true "$OPENTAG_GH_LIVE_KEEP_WEBHOOK"; then
+    echo "Deleting temporary GitHub webhook $HOOK_ID..."
+    gh api "repos/${OWNER}/${REPO}/hooks/${HOOK_ID}" --method DELETE >/dev/null 2>&1 || true
+  fi
+
+  kill_pid "$CLI_PID"
+  kill_pid "$NGROK_PID"
+
+  if [[ -n "$CONFIG_PATH" && -f "$CONFIG_PATH" ]]; then
+    rm -f "$CONFIG_PATH"
+  fi
+
+  if [[ -n "$TMP_ROOT" ]]; then
+    echo "Preserved temp root: $TMP_ROOT"
+    echo "Removed temporary config file because it contains local credentials."
+  fi
+  if [[ -n "$DATABASE_PATH" ]]; then
+    echo "Dispatcher DB: $DATABASE_PATH"
+  fi
+  if [[ -n "$ISSUE_NUMBER" ]]; then
+    echo "Issue: https://github.com/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}"
+  fi
+
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+require_cmd curl
+require_cmd gh
+require_cmd lsof
+require_cmd node
+require_cmd python3
+require_cmd sqlite3
+if [[ "$OPENTAG_GH_LIVE_EXECUTOR" == "claude-code" ]]; then
+  require_cmd "$OPENTAG_CLAUDE_COMMAND"
+fi
+if bool_true "$OPENTAG_GH_LIVE_START_NGROK"; then
+  require_cmd ngrok
+fi
+
+OWNER="${OPENTAG_GH_REPO%%/*}"
+REPO="${OPENTAG_GH_REPO#*/}"
+if [[ -z "$OWNER" || -z "$REPO" || "$OWNER" == "$REPO" ]]; then
+  echo "OPENTAG_GH_REPO must be owner/repo." >&2
+  exit 1
+fi
+export OWNER REPO
+
+REPO_URL="$(gh repo view "$OWNER/$REPO" --json url --jq '.url')"
+PERMISSION="$(gh repo view "$OWNER/$REPO" --json viewerPermission --jq '.viewerPermission')"
+if [[ "$PERMISSION" != "ADMIN" && "$PERMISSION" != "MAINTAIN" ]]; then
+  echo "GitHub repository webhook creation requires ADMIN or MAINTAIN access; current permission is $PERMISSION." >&2
+  exit 1
+fi
+GITHUB_TOKEN="$(gh auth token)"
+export GITHUB_TOKEN
+export OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN
+
+if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN" && bool_true "$OPENTAG_GH_LIVE_APPLY"; then
+  echo "GitHub apply token is disabled for this run; skipping apply-comment execution and expecting Needs setup."
+  OPENTAG_GH_LIVE_APPLY=false
+fi
+
+TMP_ROOT="$(mktemp -d /tmp/opentag-gh-webhook-live.XXXXXX)"
+CONFIG_PATH="$TMP_ROOT/opentag-github-webhook-live.config.json"
+DATABASE_PATH="${OPENTAG_DATABASE_PATH:-$TMP_ROOT/opentag-github-webhook-live.db}"
+CHECKOUT_PATH="${OPENTAG_WORKSPACE_PATH:-$TMP_ROOT/$REPO}"
+WORKTREE_ROOT="$TMP_ROOT/worktrees"
+STATE_DIR="$TMP_ROOT/state"
+NGROK_LOG="$TMP_ROOT/ngrok.log"
+WEBHOOK_SECRET="$(node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))')"
+BASE_BRANCH="${OPENTAG_BASE_BRANCH:-main}"
+PUSH_REMOTE="${OPENTAG_PUSH_REMOTE:-origin}"
+export CHECKOUT_PATH WORKTREE_ROOT STATE_DIR CONFIG_PATH DATABASE_PATH WEBHOOK_SECRET BASE_BRANCH PUSH_REMOTE
+export OPENTAG_PAIRING_TOKEN OPENTAG_DISPATCHER_PORT OPENTAG_GITHUB_PORT OPENTAG_RUNNER_ID
+export OPENTAG_CLAUDE_COMMAND OPENTAG_CLAUDE_PERMISSION_MODE OPENTAG_GH_LIVE_EXECUTOR
+
+ensure_port_free() {
+  local port="$1"
+  local label="$2"
+  local pids
+  pids="$(lsof -ti "tcp:${port}" 2>/dev/null || true)"
+  if [[ -z "$pids" ]]; then
+    return 0
+  fi
+  if bool_true "${OPENTAG_GH_LIVE_KILL_PORTS:-false}"; then
+    echo "Killing existing $label process(es) on :$port: $pids"
+    for pid in $pids; do
+      kill "$pid" 2>/dev/null || true
+    done
+    sleep 1
+    return 0
+  fi
+  echo "Port :$port is already in use by: $pids" >&2
+  echo "Stop that process or rerun with OPENTAG_GH_LIVE_KILL_PORTS=true." >&2
+  exit 1
+}
+
+wait_for_http() {
+  local url="$1"
+  local deadline=$((SECONDS + 60))
+  while (( SECONDS < deadline )); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for $url." >&2
+  exit 1
+}
+
+wait_for_github_ingress() {
+  local deadline=$((SECONDS + 60))
+  local code
+  while (( SECONDS < deadline )); do
+    code="$(curl -sS -o /dev/null -w "%{http_code}" -X POST "http://127.0.0.1:${OPENTAG_GITHUB_PORT}/github/webhooks" -H "content-type: application/json" --data '{}' || true)"
+    if [[ "$code" == "401" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for local GitHub ingress on :${OPENTAG_GITHUB_PORT}." >&2
+  exit 1
+}
+
+ngrok_url_for_port() {
+  local port="$1"
+  python3 - "$port" <<'PY' 2>/dev/null || true
+import json
+import sys
+import urllib.request
+
+port = sys.argv[1]
+with urllib.request.urlopen("http://127.0.0.1:4040/api/tunnels", timeout=2) as resp:
+    payload = json.loads(resp.read())
+for tunnel in payload.get("tunnels", []):
+    public_url = tunnel.get("public_url", "")
+    addr = str(tunnel.get("config", {}).get("addr", ""))
+    if public_url.startswith("https://") and (addr.endswith(":" + port) or addr.endswith("//localhost:" + port) or addr.endswith("//127.0.0.1:" + port)):
+        print(public_url.rstrip("/"))
+        break
+PY
+}
+
+wait_for_ngrok_url() {
+  local port="$1"
+  local deadline=$((SECONDS + 45))
+  local url=""
+  while (( SECONDS < deadline )); do
+    url="$(ngrok_url_for_port "$port")"
+    if [[ -n "$url" ]]; then
+      printf "%s" "$url"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ngrok did not expose an HTTPS tunnel for port $port." >&2
+  if [[ -n "$NGROK_LOG" && -f "$NGROK_LOG" ]]; then
+    tail -n 80 "$NGROK_LOG" >&2 || true
+  fi
+  exit 1
+}
+
+public_ingress_probe() {
+  local public_url="$1"
+  local code
+  code="$(curl -sS -o "$TMP_ROOT/github-ingress-probe.json" -w "%{http_code}" -X POST "$public_url/github/webhooks" -H "content-type: application/json" --data '{}' || true)"
+  if [[ "$code" == "401" ]]; then
+    echo "Public GitHub ingress probe reached OpenTag (401 without GitHub signature is expected)."
+    return 0
+  fi
+  echo "Public GitHub ingress probe returned HTTP $code, expected 401." >&2
+  exit 1
+}
+
+print_metrics() {
+  local run_id="$1"
+  local payload
+  payload="$(curl -fsS -H "authorization: Bearer $OPENTAG_PAIRING_TOKEN" "http://localhost:${OPENTAG_DISPATCHER_PORT}/v1/runs/${run_id}/metrics" || true)"
+  if [[ -z "$payload" ]]; then
+    echo "Could not fetch run metrics."
+    return 0
+  fi
+  python3 - "$payload" <<'PY' || true
+import json
+import sys
+payload = json.loads(sys.argv[1])
+metrics = payload.get("metrics", {})
+summary = {
+    "humanCallbackCount": metrics.get("humanCallbackCount"),
+    "suggestedChangesCount": metrics.get("suggestedChangesCount"),
+    "approvalDecisionCount": metrics.get("approvalDecisionCount"),
+    "applyPlanCount": metrics.get("applyPlanCount"),
+    "childRunCount": metrics.get("childRunCount"),
+    "threadNoiseRatio": metrics.get("threadNoiseRatio"),
+    "applyOutcomeCounts": metrics.get("applyOutcomeCounts"),
+}
+print("Run metrics:", json.dumps(summary, sort_keys=True))
+PY
+}
+
+issue_comments_contain() {
+  local pattern="$1"
+  gh issue view "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --json comments --jq '[
+    .comments[].body
+  ] | join("\n--- opentag-comment-boundary ---\n")' | grep -F "$pattern" >/dev/null
+}
+
+applied_receipt_has_double_period() {
+  gh issue view "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --json comments --jq '
+    .comments[].body
+    | split("\n")[]
+    | select(startswith("Applied:"))
+  ' | grep -E '\.\.$' >/dev/null
+}
+
+latest_apply_plan() {
+  sqlite_one "select plan_json from apply_plans order by created_at desc limit 1;"
+}
+
+if [[ ! -d "$CHECKOUT_PATH/.git" ]]; then
+  echo "Cloning $OWNER/$REPO into temporary checkout..."
+  gh repo clone "$OWNER/$REPO" "$CHECKOUT_PATH" >/dev/null
+fi
+if [[ -n "$(git -C "$CHECKOUT_PATH" status --porcelain)" ]]; then
+  echo "Checkout is dirty: $CHECKOUT_PATH" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+config = {
+    "schemaVersion": 1,
+    "state": {
+        "directory": os.environ["STATE_DIR"],
+        "databasePath": os.environ["DATABASE_PATH"],
+        "worktreeRoot": os.environ["WORKTREE_ROOT"],
+    },
+    "preferences": {
+        "language": "en",
+        "lastSetup": {
+            "platforms": ["github"],
+            "executor": os.environ["OPENTAG_GH_LIVE_EXECUTOR"],
+            "projectPath": os.environ["CHECKOUT_PATH"],
+            "githubOwner": os.environ["OWNER"],
+            "githubRepo": os.environ["REPO"],
+            "githubPort": int(os.environ["OPENTAG_GITHUB_PORT"]),
+        },
+    },
+    "daemon": {
+        "runnerId": os.environ["OPENTAG_RUNNER_ID"],
+        "dispatcherUrl": f"http://localhost:{os.environ['OPENTAG_DISPATCHER_PORT']}",
+        "repositories": [
+            {
+                "provider": "github",
+                "owner": os.environ["OWNER"],
+                "repo": os.environ["REPO"],
+                "checkoutPath": os.environ["CHECKOUT_PATH"],
+                "defaultExecutor": os.environ["OPENTAG_GH_LIVE_EXECUTOR"],
+                "baseBranch": os.environ["BASE_BRANCH"],
+                "pushRemote": os.environ["PUSH_REMOTE"],
+                "worktreeRoot": os.environ["WORKTREE_ROOT"],
+                "keepWorktree": "on_failure",
+            }
+        ],
+        "claudeCode": {
+            "command": os.environ["OPENTAG_CLAUDE_COMMAND"],
+            "permissionMode": os.environ["OPENTAG_CLAUDE_PERMISSION_MODE"],
+        },
+        "githubToken": os.environ["GITHUB_TOKEN"],
+        **(
+            {"githubApplyToken": None}
+            if os.environ.get("OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN", "").lower() in {"1", "true", "yes", "y"}
+            else {}
+        ),
+        "preparePullRequestBranch": True,
+        "pairingToken": os.environ["OPENTAG_PAIRING_TOKEN"],
+        "pollIntervalMs": 1000,
+        "heartbeatIntervalMs": 15000,
+    },
+    "platforms": {
+        "github": {
+            "webhookSecret": os.environ["WEBHOOK_SECRET"],
+            "owner": os.environ["OWNER"],
+            "repo": os.environ["REPO"],
+            "webhookPath": "/github/webhooks",
+            "port": int(os.environ["OPENTAG_GITHUB_PORT"]),
+        }
+    },
+}
+
+path = Path(os.environ["CONFIG_PATH"])
+path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+path.chmod(0o600)
+PY
+
+ensure_port_free "$OPENTAG_DISPATCHER_PORT" "dispatcher"
+ensure_port_free "$OPENTAG_GITHUB_PORT" "GitHub ingress"
+
+echo "Starting OpenTag CLI stack on dispatcher :${OPENTAG_DISPATCHER_PORT}, GitHub ingress :${OPENTAG_GITHUB_PORT}"
+NODE_OPTIONS='--conditions=development' packages/cli/node_modules/.bin/tsx packages/cli/src/index.ts start --config "$CONFIG_PATH" &
+CLI_PID=$!
+
+wait_for_http "http://localhost:${OPENTAG_DISPATCHER_PORT}/healthz"
+wait_for_github_ingress
+
+PUBLIC_URL="${OPENTAG_GH_PUBLIC_URL:-}"
+if bool_true "$OPENTAG_GH_LIVE_START_NGROK"; then
+  existing_tunnel="$(ngrok_url_for_port "$OPENTAG_GITHUB_PORT")"
+  if [[ -n "$existing_tunnel" && -z "$PUBLIC_URL" ]]; then
+    PUBLIC_URL="$existing_tunnel"
+    echo "Using existing ngrok tunnel for GitHub ingress: $PUBLIC_URL"
+  elif [[ -z "$existing_tunnel" ]]; then
+    if [[ -n "$(lsof -ti tcp:4040 2>/dev/null || true)" ]]; then
+      echo "ngrok API port :4040 is in use, but no tunnel points at :${OPENTAG_GITHUB_PORT}." >&2
+      echo "Stop that ngrok process, or set OPENTAG_GH_PUBLIC_URL to a tunnel that points at this GitHub ingress." >&2
+      exit 1
+    fi
+    echo "Starting ngrok for GitHub ingress"
+    if [[ -n "$PUBLIC_URL" ]]; then
+      ngrok http "$OPENTAG_GITHUB_PORT" --url "${PUBLIC_URL#https://}" --log stdout >"$NGROK_LOG" 2>&1 &
+    else
+      ngrok http "$OPENTAG_GITHUB_PORT" --log stdout >"$NGROK_LOG" 2>&1 &
+    fi
+    NGROK_PID=$!
+    STARTED_URL="$(wait_for_ngrok_url "$OPENTAG_GITHUB_PORT")"
+    if [[ -z "$PUBLIC_URL" ]]; then
+      PUBLIC_URL="$STARTED_URL"
+    fi
+  fi
+fi
+if [[ -z "$PUBLIC_URL" ]]; then
+  echo "Set OPENTAG_GH_PUBLIC_URL or enable OPENTAG_GH_LIVE_START_NGROK=true." >&2
+  exit 1
+fi
+PUBLIC_URL="${PUBLIC_URL%/}"
+public_ingress_probe "$PUBLIC_URL"
+
+echo "Creating temporary GitHub repository webhook for ${OWNER}/${REPO}"
+HOOK_ID="$(
+  python3 - <<PY | gh api "repos/${OWNER}/${REPO}/hooks" --method POST --input - --jq '.id'
+import json
+print(json.dumps({
+    "name": "web",
+    "active": True,
+    "events": ["issue_comment", "pull_request_review_comment"],
+    "config": {
+        "url": "${PUBLIC_URL}/github/webhooks",
+        "content_type": "json",
+        "secret": "${WEBHOOK_SECRET}",
+        "insecure_ssl": "0",
+    },
+}))
+PY
+)"
+echo "Temporary webhook id: $HOOK_ID"
+
+ISSUE_URL="$(gh issue create --repo "${OWNER}/${REPO}" \
+  --title "OpenTag GitHub webhook live test" \
+  --body "Temporary issue for validating OpenTag repository webhook -> local agent -> GitHub source-thread action receipts.")"
+ISSUE_NUMBER="${ISSUE_URL##*/}"
+echo "Created issue: $ISSUE_URL"
+
+WAIT_STARTED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+MENTION_BODY="@opentag run ${OPENTAG_GH_LIVE_COMMAND}"
+echo "Posting mention comment through GitHub..."
+MENTION_URL="$(gh issue comment "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --body "$MENTION_BODY")"
+echo "Mention comment: $MENTION_URL"
+
+RUN_ID=""
+ISSUE_SQL="$(sql_escape "$ISSUE_NUMBER")"
+STARTED_SQL="$(sql_escape "$WAIT_STARTED_AT")"
+deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+while (( SECONDS < deadline )); do
+  RUN_ID="$(
+    sqlite_one "select id from runs where json_extract(event_json, '$.source') = 'github' and json_extract(event_json, '$.metadata.issueNumber') = $ISSUE_SQL and created_at >= '$STARTED_SQL' order by created_at desc limit 1;"
+  )"
+  if [[ -n "$RUN_ID" ]]; then
+    break
+  fi
+  sleep 2
+done
+if [[ -z "$RUN_ID" ]]; then
+  echo "Timed out waiting for GitHub webhook-created run." >&2
+  exit 1
+fi
+echo "Detected GitHub webhook-created run: $RUN_ID"
+
+last_status=""
+deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+while (( SECONDS < deadline )); do
+  status="$(sqlite_one "select status from runs where id = '$(sql_escape "$RUN_ID")';")"
+  if [[ "$status" != "$last_status" && -n "$status" ]]; then
+    echo "Run status: $status"
+    last_status="$status"
+  fi
+  case "$status" in
+    succeeded|failed|cancelled|needs_approval) break ;;
+  esac
+  sleep 3
+done
+if [[ -z "${status:-}" || "$status" == "queued" || "$status" == "assigned" || "$status" == "running" ]]; then
+  echo "Timed out waiting for run completion. Last status: ${status:-unknown}" >&2
+  exit 1
+fi
+print_metrics "$RUN_ID"
+
+echo "Recent issue comments after final receipt:"
+gh issue view "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --json comments --jq '.comments[-4:][] | {author: .author.login, body: (.body | split("\n")[0:8] | join("\n"))}'
+EXPECTED_HEADING="### Ready to apply"
+if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN"; then
+  EXPECTED_HEADING="### Needs setup"
+fi
+if ! issue_comments_contain "$EXPECTED_HEADING"; then
+  echo "Expected the final GitHub receipt to render '$EXPECTED_HEADING'." >&2
+  exit 1
+fi
+if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN" && issue_comments_contain '`apply 1`'; then
+  echo "Expected the missing-apply-token receipt not to advertise the apply command." >&2
+  exit 1
+fi
+
+if bool_true "$OPENTAG_GH_LIVE_APPLY"; then
+  before_count="$(sqlite_one "select count(*) from approval_decisions;")"
+  echo "Replying apply 1 through GitHub..."
+  APPLY_URL="$(gh issue comment "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --body "apply 1")"
+  echo "Apply comment: $APPLY_URL"
+
+  deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    after_count="$(sqlite_one "select count(*) from approval_decisions;")"
+    if [[ -n "$after_count" && -n "$before_count" && "$after_count" -gt "$before_count" ]]; then
+      break
+    fi
+    sleep 2
+  done
+  if [[ "${after_count:-0}" -le "${before_count:-0}" ]]; then
+    echo "Timed out waiting for approval decision from GitHub apply comment." >&2
+    exit 1
+  fi
+
+  PR_URL=""
+  deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    plan_json="$(latest_apply_plan)"
+    if [[ -n "$plan_json" ]]; then
+      PR_URL="$(python3 - "$plan_json" <<'PY' || true
+import json
+import sys
+plan = json.loads(sys.argv[1])
+for outcome in plan.get("outcomes", []):
+    if outcome.get("externalUri"):
+        print(outcome["externalUri"])
+        break
+PY
+)"
+      executed="$(python3 - "$plan_json" <<'PY' || true
+import json
+import sys
+plan = json.loads(sys.argv[1])
+print("true" if plan.get("adapterPlan", {}).get("externalWritesExecuted") else "false")
+PY
+)"
+      if [[ -n "$PR_URL" && "$executed" == "true" ]]; then
+        break
+      fi
+    fi
+    sleep 2
+  done
+  if [[ -z "$PR_URL" ]]; then
+    echo "Timed out waiting for applied PR URL." >&2
+    latest_apply_plan | python3 -m json.tool || true
+    exit 1
+  fi
+  echo "Created PR: $PR_URL"
+  gh pr view "$PR_URL" --json number,state,headRefName,baseRefName,url --jq '{number,state,headRefName,baseRefName,url}'
+  print_metrics "$RUN_ID"
+  echo "Recent issue comments after apply receipt:"
+  gh issue view "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --json comments --jq '.comments[-5:][] | {author: .author.login, body: (.body | split("\n")[0:8] | join("\n"))}'
+  if ! issue_comments_contain "Applied:"; then
+    echo "Expected the GitHub thread to contain an applied receipt." >&2
+    exit 1
+  fi
+  if applied_receipt_has_double_period; then
+    echo "Applied receipt ended with duplicate punctuation." >&2
+    exit 1
+  fi
+fi
+
+echo
+echo "GitHub repository-webhook live test completed."
+echo "- Issue: https://github.com/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}"
+echo "- Run ID: $RUN_ID"
+if [[ -n "${PR_URL:-}" ]]; then
+  echo "- Pull request: $PR_URL"
+fi

--- a/scripts/dev/run-slack-ui-trigger-local-test.sh
+++ b/scripts/dev/run-slack-ui-trigger-local-test.sh
@@ -8,20 +8,30 @@ usage() {
   cat <<'EOF'
 Run a real Slack UI-triggered OpenTag dogfood session.
 
-This starts the local dispatcher, daemon, Slack Events ingress, ngrok, and an
-optional macOS screen recording. After the stack is ready, mention the Slack
-bot in the real Slack UI. The script then watches the local dispatcher DB for
-the run that Slack created, waits for completion, and optionally waits for a
-Slack Block Kit approval/rejection button click.
+This starts the local dispatcher, daemon, Slack ingress, and an optional macOS
+screen recording. When OPENTAG_SLACK_APP_TOKEN is set, Slack uses Socket Mode
+and no public URL is required. Otherwise, the script starts Slack Events API
+ingress and ngrok. After the stack is ready, mention the Slack bot in the real
+Slack UI. The script then watches the local dispatcher DB for the run that
+Slack created, waits for completion, and optionally waits for a Slack Block Kit
+approval/rejection button click.
 
 Required env, usually via .env.slack-test:
   OPENTAG_CONFIG_PATH          Local OpenTag daemon config with slackChannels.
-  SLACK_SIGNING_SECRET         Slack App signing secret.
   OPENTAG_SLACK_BOT_TOKEN      Slack bot token.
 
 Helpful env:
+  OPENTAG_SLACK_APP_TOKEN      Slack app-level token. Enables Socket Mode and
+                               avoids ngrok / Slack Request URL setup.
+  SLACK_SIGNING_SECRET         Slack App signing secret, required only for
+                               Events API mode.
+  OPENTAG_UI_TRIGGER_SLACK_MODE
+                               socket_mode or events_api. Defaults to
+                               socket_mode when OPENTAG_SLACK_APP_TOKEN is set,
+                               otherwise events_api.
   OPENTAG_SLACK_PUBLIC_URL     Fixed ngrok URL already saved in Slack, for
-                               example https://example.ngrok-free.app.
+                               example https://example.ngrok-free.app. Events
+                               API mode only.
   OPENTAG_UI_TRIGGER_COMMAND   Prompt to send after the @bot mention.
   OPENTAG_UI_TRIGGER_RECORD    true/false, default true on macOS.
   OPENTAG_UI_TRIGGER_WAIT_FOR_ACTION
@@ -73,11 +83,33 @@ if [[ -f "$OPENTAG_ENV_FILE" ]]; then
 fi
 
 : "${OPENTAG_CONFIG_PATH:?Set OPENTAG_CONFIG_PATH or OPENTAG_ENV_FILE}"
-: "${SLACK_SIGNING_SECRET:?Set SLACK_SIGNING_SECRET or OPENTAG_ENV_FILE}"
 : "${OPENTAG_SLACK_BOT_TOKEN:?Set OPENTAG_SLACK_BOT_TOKEN or OPENTAG_ENV_FILE}"
+
+SLACK_MODE="${OPENTAG_UI_TRIGGER_SLACK_MODE:-${OPENTAG_SLACK_MODE:-}}"
+if [[ -z "$SLACK_MODE" ]]; then
+  if [[ -n "${OPENTAG_SLACK_APP_TOKEN:-${SLACK_APP_TOKEN:-}}" ]]; then
+    SLACK_MODE="socket_mode"
+  else
+    SLACK_MODE="events_api"
+  fi
+fi
+case "$SLACK_MODE" in
+  socket_mode|events_api) ;;
+  *)
+    echo "OPENTAG_UI_TRIGGER_SLACK_MODE must be socket_mode or events_api, received: $SLACK_MODE" >&2
+    exit 1
+    ;;
+esac
+if [[ "$SLACK_MODE" == "socket_mode" ]]; then
+  : "${OPENTAG_SLACK_APP_TOKEN:=${SLACK_APP_TOKEN:-}}"
+  : "${OPENTAG_SLACK_APP_TOKEN:?Set OPENTAG_SLACK_APP_TOKEN for Socket Mode, or set OPENTAG_UI_TRIGGER_SLACK_MODE=events_api}"
+else
+  : "${SLACK_SIGNING_SECRET:?Set SLACK_SIGNING_SECRET for Events API mode, or set OPENTAG_SLACK_APP_TOKEN for Socket Mode}"
+fi
 
 cd "$ROOT_DIR"
 echo "Using OpenTag repo: $ROOT_DIR"
+echo "Slack ingress mode: $SLACK_MODE"
 
 DISPATCHER_PID=""
 DAEMON_PID=""
@@ -102,6 +134,15 @@ require_cmd() {
     echo "Missing required command: $1" >&2
     exit 1
   fi
+}
+
+screen_is_locked() {
+  if ! command -v ioreg >/dev/null 2>&1; then
+    return 1
+  fi
+  local session_state
+  session_state="$(ioreg -n Root -d1 2>/dev/null)" || return 1
+  grep -q 'CGSSessionScreenIsLocked.*Yes' <<<"$session_state"
 }
 
 sql_escape() {
@@ -161,9 +202,14 @@ require_cmd lsof
 require_cmd "$OPENTAG_CLAUDE_COMMAND"
 echo "Required local commands are available."
 
-if bool_true "$OPENTAG_UI_TRIGGER_START_NGROK"; then
+if [[ "$SLACK_MODE" == "events_api" ]] && bool_true "$OPENTAG_UI_TRIGGER_START_NGROK"; then
   require_cmd ngrok
   echo "ngrok command is available."
+fi
+if bool_true "$OPENTAG_UI_TRIGGER_RECORD" && screen_is_locked; then
+  echo "Screen recording requested, but the macOS session is locked." >&2
+  echo "Unlock the screen and keep Slack visible before rerunning the README recording flow." >&2
+  exit 1
 fi
 
 ensure_port_free() {
@@ -500,7 +546,7 @@ if bool_true "$OPENTAG_UI_TRIGGER_ENABLE_GITHUB_APPLY"; then
     EFFECTIVE_GITHUB_APPLY=true
     echo "GitHub apply is enabled; runner will prepare a pushed PR branch."
   else
-    echo "GitHub apply is disabled because no token is available; Apply buttons may fall back to a follow-up run."
+    echo "GitHub apply is disabled because no token is available; direct-apply actions should render as Needs setup/Continue."
   fi
 elif [[ "$PREPARE_PR_BRANCH" == "true" && -z "$GITHUB_TOKEN" ]]; then
   require_cmd gh
@@ -558,7 +604,9 @@ with open(os.environ["CONFIG_PATH"], "w", encoding="utf-8") as f:
 PY
 
 ensure_port_free "$OPENTAG_DISPATCHER_PORT" "dispatcher"
-ensure_port_free "$OPENTAG_SLACK_PORT" "Slack ingress"
+if [[ "$SLACK_MODE" == "events_api" ]]; then
+  ensure_port_free "$OPENTAG_SLACK_PORT" "Slack ingress"
+fi
 
 echo "Starting dispatcher on :${OPENTAG_DISPATCHER_PORT}"
 PORT="$OPENTAG_DISPATCHER_PORT" \
@@ -589,18 +637,29 @@ NODE_OPTIONS='--conditions=development' \
 apps/opentagd/node_modules/.bin/tsx apps/opentagd/src/index.ts serve &
 DAEMON_PID=$!
 
-echo "Starting Slack Events ingress on :${OPENTAG_SLACK_PORT}"
-SLACK_SIGNING_SECRET="$SLACK_SIGNING_SECRET" \
-OPENTAG_DISPATCHER_URL="http://localhost:${OPENTAG_DISPATCHER_PORT}" \
-OPENTAG_DISPATCHER_TOKEN="$OPENTAG_PAIRING_TOKEN" \
-PORT="$OPENTAG_SLACK_PORT" \
-NODE_OPTIONS='--conditions=development' \
-apps/slack-events/node_modules/.bin/tsx apps/slack-events/src/index.ts &
+if [[ "$SLACK_MODE" == "socket_mode" ]]; then
+  echo "Starting Slack Socket Mode ingress"
+  OPENTAG_SLACK_MODE="socket_mode" \
+  OPENTAG_SLACK_APP_TOKEN="$OPENTAG_SLACK_APP_TOKEN" \
+  OPENTAG_DISPATCHER_URL="http://localhost:${OPENTAG_DISPATCHER_PORT}" \
+  OPENTAG_DISPATCHER_TOKEN="$OPENTAG_PAIRING_TOKEN" \
+  NODE_OPTIONS='--conditions=development' \
+  apps/slack-events/node_modules/.bin/tsx apps/slack-events/src/index.ts &
+else
+  echo "Starting Slack Events ingress on :${OPENTAG_SLACK_PORT}"
+  OPENTAG_SLACK_MODE="events_api" \
+  SLACK_SIGNING_SECRET="$SLACK_SIGNING_SECRET" \
+  OPENTAG_DISPATCHER_URL="http://localhost:${OPENTAG_DISPATCHER_PORT}" \
+  OPENTAG_DISPATCHER_TOKEN="$OPENTAG_PAIRING_TOKEN" \
+  PORT="$OPENTAG_SLACK_PORT" \
+  NODE_OPTIONS='--conditions=development' \
+  apps/slack-events/node_modules/.bin/tsx apps/slack-events/src/index.ts &
+fi
 SLACK_PID=$!
 sleep 2
 
 PUBLIC_URL="${OPENTAG_SLACK_PUBLIC_URL:-}"
-if bool_true "$OPENTAG_UI_TRIGGER_START_NGROK"; then
+if [[ "$SLACK_MODE" == "events_api" ]] && bool_true "$OPENTAG_UI_TRIGGER_START_NGROK"; then
   existing_tunnel="$(get_ngrok_url_once)"
   if [[ -n "$existing_tunnel" && -z "$PUBLIC_URL" ]]; then
     PUBLIC_URL="$existing_tunnel"
@@ -636,13 +695,17 @@ if bool_true "$OPENTAG_UI_TRIGGER_START_NGROK"; then
   fi
 fi
 
-if [[ -z "$PUBLIC_URL" ]]; then
+if [[ "$SLACK_MODE" == "events_api" && -z "$PUBLIC_URL" ]]; then
   echo "Set OPENTAG_SLACK_PUBLIC_URL or enable OPENTAG_UI_TRIGGER_START_NGROK=true." >&2
   exit 1
 fi
-PUBLIC_URL="${PUBLIC_URL%/}"
+if [[ -n "$PUBLIC_URL" ]]; then
+  PUBLIC_URL="${PUBLIC_URL%/}"
+fi
 
-public_ingress_probe "$PUBLIC_URL"
+if [[ "$SLACK_MODE" == "events_api" ]]; then
+  public_ingress_probe "$PUBLIC_URL"
+fi
 
 BOT_USER_ID="$(fetch_slack_bot_identity)"
 
@@ -661,8 +724,13 @@ export WAIT_STARTED_AT
 
 echo
 echo "Slack UI trigger stack is ready."
-echo "- Slack Request URL must be: $PUBLIC_URL/slack/events"
-echo "- Event Subscriptions and Interactivity should both use that same URL."
+if [[ "$SLACK_MODE" == "socket_mode" ]]; then
+  echo "- Slack uses Socket Mode; no Request URL or ngrok tunnel is required."
+  echo "- Slack Interactivity must be enabled, but Socket Mode does not need an Interactivity Request URL."
+else
+  echo "- Slack Request URL must be: $PUBLIC_URL/slack/events"
+  echo "- Event Subscriptions and Interactivity should both use that same URL."
+fi
 echo "- Bound Slack channel id: $CHANNEL_ID"
 echo "- Bound repository: $REPO_PROVIDER:$OWNER/$REPO"
 echo "- Temporary checkout: $CHECKOUT_PATH"
@@ -692,7 +760,11 @@ done
 
 if [[ -z "$RUN_ID" ]]; then
   echo "Timed out waiting for a Slack-created run." >&2
-  echo "Check Slack Request URL, app_mention subscription, signing secret, and ngrok log: $NGROK_LOG" >&2
+  if [[ "$SLACK_MODE" == "socket_mode" ]]; then
+    echo "Check Socket Mode, app_mention subscription, bot scopes, app token, and channel invite." >&2
+  else
+    echo "Check Slack Request URL, app_mention subscription, signing secret, and ngrok log: $NGROK_LOG" >&2
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add source-thread action receipts that render Slack/GitHub suggested actions from dispatcher capability and preflight state.
- Show Apply only when the relevant system-of-record write is configured and ready; otherwise render safer Continue/Approve/Reject paths with audit guidance.
- Split GitHub callback and apply credentials so operators can keep status callbacks enabled while disabling direct writes.
- Add Slack Socket Mode ingress support plus live GitHub/Slack dogfood scripts and docs for the ready-to-apply and needs-setup paths.
- Add `opentag status --run <run_id>` for local audit lookup.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test`
- Real Slack Socket Mode mention -> local runner -> Slack Block Kit `Apply 1` -> GitHub PR creation against `amplifthq/opentag-test#49`

## Notes

- Slack Events API public Request URL mode was not re-run after adding Socket Mode fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-thread “action receipts” for suggested thread actions with “Ready to apply” / “Needs setup” and decision controls (Apply/Continue/Reject/Approve only), aligned across Slack and GitHub.
  * Slack ingestion can now run in Socket Mode or Events API based on configuration.
  * CLI `status` now supports per-run inspection via `--run <runId>`.
* **Bug Fixes**
  * Improved direct-apply gating and receipt outcomes for repeated and stale approval flows; enhanced thread-action resolution.
* **Documentation**
  * Added “Source-Thread Action Receipts” docs; updated protocol, Slack button naming, and direct-apply token configuration guidance; expanded the live integration test procedure.
* **Tests / Chores**
  * Updated and expanded rendering, server, status, and live end-to-end coverage for receipts and run-level status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->