### PR TITLE
Require write access on public repos and harden executor runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Security
+
+- Run admission on public GitHub/GitLab repositories now requires
+  platform-reported write access by default. GitHub commenters are checked via
+  the webhook `author_association` field (`OWNER`, `MEMBER`, `COLLABORATOR`);
+  GitLab Note Hooks carry no access level, so public GitLab projects stay
+  closed until `allowedActors` is configured on the repository binding.
+  Private repositories, Slack, and Lark behavior is unchanged, and an explicit
+  `allowedActors` list still overrides the default for write-capable runs.
+- Source-thread approvals (`apply`, `approve`, ...) from public GitHub/GitLab
+  threads follow the same default: without an `allowedActors` list, only
+  actors with write access can approve or apply proposed actions.
+
 ## v0.3.0 - 2026-06-30
 
 OpenTag 0.3.0 improves the local CLI setup path and makes source-thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@
 - Source-thread approvals (`apply`, `approve`, ...) from public GitHub/GitLab
   threads follow the same default: without an `allowedActors` list, only
   actors with write access can approve or apply proposed actions.
+- The Claude Code executor now matches the Codex executor's protections: it
+  runs the pre-execution security assessment, spawns `claude` with a scrubbed
+  environment (secrets-like variables are dropped; add auth variables to
+  `security.extraSafeEnv` if the CLI authenticates from environment), and
+  executes in an isolated git worktree instead of a branch in the main
+  checkout.
+- Codex runs admitted without a write scope now use the read-only sandbox
+  (`--sandbox read-only`) instead of `--full-auto`, so granted permission
+  scopes are enforced at the executor level.
+- Enabling `dangerouslySkipPermissions` for Claude Code now emits an audit
+  warning on every run so the bypass stays visible in the run timeline.
 
 ## v0.3.0 - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Run admission on public GitHub/GitLab repositories now requires
   platform-reported write access by default. GitHub commenters are checked via
-  the webhook `author_association` field (`OWNER`, `MEMBER`, `COLLABORATOR`);
+  the repository collaborator permission API when the GitHub App path is used;
   GitLab Note Hooks carry no access level, so public GitLab projects stay
   closed until `allowedActors` is configured on the repository binding.
   Private repositories, Slack, and Lark behavior is unchanged, and an explicit
@@ -23,6 +23,9 @@
 - Codex runs admitted without a write scope now use the read-only sandbox
   (`--sandbox read-only`) instead of `--full-auto`, so granted permission
   scopes are enforced at the executor level.
+- Claude Code runs admitted without `repo:write` now use `--permission-mode
+  plan`; repo-write runs default to `acceptEdits` unless a narrower
+  `permissionMode` is configured.
 - Enabling `dangerouslySkipPermissions` for Claude Code now emits an audit
   warning on every run so the bypass stays visible in the run timeline.
 

--- a/apps/github-probot/src/app.ts
+++ b/apps/github-probot/src/app.ts
@@ -1,7 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { createOpenTagClient, type ThreadActionInput } from "@opentag/client";
 import { parseThreadActionCommand, type OpenTagEvent } from "@opentag/core";
-import { githubActorWriteAccess, normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment, renderAcknowledgement } from "@opentag/github";
+import {
+  githubPermissionHasWriteAccess,
+  normalizeGitHubIssueComment,
+  normalizeGitHubPullRequestReviewComment,
+  renderAcknowledgement,
+  type GitHubActorWriteAccessResolver
+} from "@opentag/github";
 import type { Probot } from "probot";
 
 type IssueCommentPayload = {
@@ -20,16 +26,35 @@ type PullRequestReviewCommentPayload = {
   installation?: { id: number };
 };
 
+async function resolvePayloadActorWriteAccess(input: {
+  payload: { repository: { name: string; owner: { login: string } }; sender: { login: string } };
+  resolveActorWriteAccess?: GitHubActorWriteAccessResolver;
+}): Promise<boolean | undefined> {
+  if (!input.resolveActorWriteAccess) return undefined;
+  try {
+    return await input.resolveActorWriteAccess({
+      owner: input.payload.repository.owner.login,
+      repo: input.payload.repository.name,
+      username: input.payload.sender.login
+    });
+  } catch {
+    return undefined;
+  }
+}
+
 export async function handleIssueCommentCreated(input: {
   payload: IssueCommentPayload;
   createRun(event: OpenTagEvent): Promise<{ runId?: string }>;
   submitThreadAction?(action: ThreadActionInput): Promise<unknown>;
+  resolveActorWriteAccess?: GitHubActorWriteAccessResolver;
   postComment(body: string): Promise<void>;
   now(): string;
   dispatcherOwnsCallbacks?: boolean;
 }): Promise<void> {
+  const owner = input.payload.repository.owner.login;
+  const repo = input.payload.repository.name;
   if (parseThreadActionCommand(input.payload.comment.body) && input.submitThreadAction) {
-    const actorWriteAccess = githubActorWriteAccess(input.payload.comment.author_association);
+    const actorWriteAccess = await resolvePayloadActorWriteAccess(input);
     await input.submitThreadAction({
       id: `approval_github_comment_${input.payload.comment.id}`,
       rawText: input.payload.comment.body,
@@ -42,12 +67,12 @@ export async function handleIssueCommentCreated(input: {
       callback: {
         provider: "github",
         uri: input.payload.issue.comments_url,
-        threadKey: `${input.payload.repository.owner.login}/${input.payload.repository.name}#${input.payload.issue.number}`
+        threadKey: `${owner}/${repo}#${input.payload.issue.number}`
       },
       metadata: {
         repoProvider: "github",
-        owner: input.payload.repository.owner.login,
-        repo: input.payload.repository.name,
+        owner,
+        repo,
         issueNumber: input.payload.issue.number,
         commentUrl: input.payload.comment.html_url
       }
@@ -62,8 +87,8 @@ export async function handleIssueCommentCreated(input: {
     apiCommentsUrl: input.payload.issue.comments_url,
     issueUrl: input.payload.issue.html_url,
     issueNumber: input.payload.issue.number,
-    owner: input.payload.repository.owner.login,
-    repo: input.payload.repository.name,
+    owner,
+    repo,
     actorId: input.payload.sender.id,
     actorLogin: input.payload.sender.login,
     ...(input.payload.comment.author_association ? { authorAssociation: input.payload.comment.author_association } : {}),
@@ -73,6 +98,10 @@ export async function handleIssueCommentCreated(input: {
   });
 
   if (!event) return;
+  const actorWriteAccess = await resolvePayloadActorWriteAccess(input);
+  if (actorWriteAccess !== undefined) {
+    event.actor.writeAccess = actorWriteAccess;
+  }
 
   const { runId } = await input.createRun(event);
   if (runId && !input.dispatcherOwnsCallbacks) {
@@ -84,6 +113,7 @@ export async function handlePullRequestReviewCommentCreated(input: {
   payload: PullRequestReviewCommentPayload;
   createRun(event: OpenTagEvent): Promise<{ runId?: string }>;
   submitThreadAction?(action: ThreadActionInput): Promise<unknown>;
+  resolveActorWriteAccess?: GitHubActorWriteAccessResolver;
   postComment(body: string): Promise<void>;
   now(): string;
   dispatcherOwnsCallbacks?: boolean;
@@ -91,7 +121,7 @@ export async function handlePullRequestReviewCommentCreated(input: {
   const owner = input.payload.repository.owner.login;
   const repo = input.payload.repository.name;
   if (parseThreadActionCommand(input.payload.comment.body) && input.submitThreadAction) {
-    const actorWriteAccess = githubActorWriteAccess(input.payload.comment.author_association);
+    const actorWriteAccess = await resolvePayloadActorWriteAccess(input);
     await input.submitThreadAction({
       id: `approval_github_pr_review_comment_${input.payload.comment.id}`,
       rawText: input.payload.comment.body,
@@ -135,6 +165,10 @@ export async function handlePullRequestReviewCommentCreated(input: {
   });
 
   if (!event) return;
+  const actorWriteAccess = await resolvePayloadActorWriteAccess(input);
+  if (actorWriteAccess !== undefined) {
+    event.actor.writeAccess = actorWriteAccess;
+  }
 
   const { runId } = await input.createRun(event);
   if (runId && !input.dispatcherOwnsCallbacks) {
@@ -189,6 +223,15 @@ export function createOpenTagProbotApp(app: Probot): void {
       payload: context.payload as IssueCommentPayload,
       createRun: async (event) => createDispatcherRun({ event, log: context.log }),
       submitThreadAction: async (action) => submitDispatcherThreadAction({ action, log: context.log }),
+      resolveActorWriteAccess: async ({ owner, repo, username }) => {
+        try {
+          const response = await context.octokit.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
+          return githubPermissionHasWriteAccess(response.data.permission);
+        } catch (error) {
+          context.log.warn({ error, owner, repo, username }, "Could not resolve GitHub actor repository permission; failing closed for write access");
+          return undefined;
+        }
+      },
       postComment: async (body) => {
         await context.octokit.rest.issues.createComment(context.issue({ body }));
       },
@@ -203,6 +246,15 @@ export function createOpenTagProbotApp(app: Probot): void {
       payload,
       createRun: async (event) => createDispatcherRun({ event, log: context.log }),
       submitThreadAction: async (action) => submitDispatcherThreadAction({ action, log: context.log }),
+      resolveActorWriteAccess: async ({ owner, repo, username }) => {
+        try {
+          const response = await context.octokit.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
+          return githubPermissionHasWriteAccess(response.data.permission);
+        } catch (error) {
+          context.log.warn({ error, owner, repo, username }, "Could not resolve GitHub actor repository permission; failing closed for write access");
+          return undefined;
+        }
+      },
       postComment: async (body) => {
         await context.octokit.rest.issues.createComment({
           owner: payload.repository.owner.login,

--- a/apps/github-probot/src/app.ts
+++ b/apps/github-probot/src/app.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { createOpenTagClient, type ThreadActionInput } from "@opentag/client";
 import { parseThreadActionCommand, type OpenTagEvent } from "@opentag/core";
-import { normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment, renderAcknowledgement } from "@opentag/github";
+import { githubActorWriteAccess, normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment, renderAcknowledgement } from "@opentag/github";
 import type { Probot } from "probot";
 
 type IssueCommentPayload = {
-  comment: { id: number; body: string; html_url: string };
+  comment: { id: number; body: string; html_url: string; author_association?: string };
   issue: { html_url: string; comments_url: string; number: number };
   repository: { name: string; private: boolean; owner: { login: string } };
   sender: { id: number; login: string };
@@ -13,7 +13,7 @@ type IssueCommentPayload = {
 };
 
 type PullRequestReviewCommentPayload = {
-  comment: { id: number; body: string; html_url: string };
+  comment: { id: number; body: string; html_url: string; author_association?: string };
   pull_request: { html_url: string; number: number };
   repository: { name: string; private: boolean; owner: { login: string } };
   sender: { id: number; login: string };
@@ -29,13 +29,15 @@ export async function handleIssueCommentCreated(input: {
   dispatcherOwnsCallbacks?: boolean;
 }): Promise<void> {
   if (parseThreadActionCommand(input.payload.comment.body) && input.submitThreadAction) {
+    const actorWriteAccess = githubActorWriteAccess(input.payload.comment.author_association);
     await input.submitThreadAction({
       id: `approval_github_comment_${input.payload.comment.id}`,
       rawText: input.payload.comment.body,
       actor: {
         provider: "github",
         providerUserId: String(input.payload.sender.id),
-        handle: input.payload.sender.login
+        handle: input.payload.sender.login,
+        ...(actorWriteAccess !== undefined ? { writeAccess: actorWriteAccess } : {})
       },
       callback: {
         provider: "github",
@@ -64,6 +66,7 @@ export async function handleIssueCommentCreated(input: {
     repo: input.payload.repository.name,
     actorId: input.payload.sender.id,
     actorLogin: input.payload.sender.login,
+    ...(input.payload.comment.author_association ? { authorAssociation: input.payload.comment.author_association } : {}),
     private: input.payload.repository.private,
     receivedAt: input.now(),
     ...(input.payload.installation ? { installationId: input.payload.installation.id } : {})
@@ -88,13 +91,15 @@ export async function handlePullRequestReviewCommentCreated(input: {
   const owner = input.payload.repository.owner.login;
   const repo = input.payload.repository.name;
   if (parseThreadActionCommand(input.payload.comment.body) && input.submitThreadAction) {
+    const actorWriteAccess = githubActorWriteAccess(input.payload.comment.author_association);
     await input.submitThreadAction({
       id: `approval_github_pr_review_comment_${input.payload.comment.id}`,
       rawText: input.payload.comment.body,
       actor: {
         provider: "github",
         providerUserId: String(input.payload.sender.id),
-        handle: input.payload.sender.login
+        handle: input.payload.sender.login,
+        ...(actorWriteAccess !== undefined ? { writeAccess: actorWriteAccess } : {})
       },
       callback: {
         provider: "github",
@@ -123,6 +128,7 @@ export async function handlePullRequestReviewCommentCreated(input: {
     pullRequestNumber: input.payload.pull_request.number,
     actorId: input.payload.sender.id,
     actorLogin: input.payload.sender.login,
+    ...(input.payload.comment.author_association ? { authorAssociation: input.payload.comment.author_association } : {}),
     private: input.payload.repository.private,
     receivedAt: input.now(),
     ...(input.payload.installation ? { installationId: input.payload.installation.id } : {})

--- a/apps/github-probot/test/app.test.ts
+++ b/apps/github-probot/test/app.test.ts
@@ -57,9 +57,51 @@ describe("GitHub Probot handler", () => {
     expect(postComment).toHaveBeenCalledWith("OpenTag picked this up. Run: `run_1`");
   });
 
+  it("uses resolved GitHub repository permission for run actor write access", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_permission" }));
+    const postComment = vi.fn(async () => undefined);
+    const resolveActorWriteAccess = vi.fn(async () => true);
+
+    await handleIssueCommentCreated({
+      payload: {
+        comment: {
+          id: 125,
+          body: "@opentag fix this",
+          html_url: "https://github.com/acme/demo/issues/1#issuecomment-125",
+          author_association: "COLLABORATOR"
+        },
+        issue: {
+          html_url: "https://github.com/acme/demo/issues/1",
+          comments_url: "https://api.github.com/repos/acme/demo/issues/1/comments",
+          number: 1
+        },
+        repository: {
+          name: "demo",
+          private: false,
+          owner: { login: "acme" }
+        },
+        sender: {
+          id: 42,
+          login: "octocat"
+        }
+      },
+      createRun,
+      resolveActorWriteAccess,
+      postComment,
+      now: () => "2026-06-24T00:00:00.000Z"
+    });
+
+    expect(resolveActorWriteAccess).toHaveBeenCalledWith({ owner: "acme", repo: "demo", username: "octocat" });
+    expect(createRun.mock.calls[0]![0]).toMatchObject({
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
+      metadata: { authorAssociation: "COLLABORATOR" }
+    });
+  });
+
   it("ignores comments without an opentag mention", async () => {
     const createRun = vi.fn(async () => ({ runId: "run_1" }));
     const postComment = vi.fn(async () => undefined);
+    const resolveActorWriteAccess = vi.fn(async () => true);
 
     await handleIssueCommentCreated({
       payload: {
@@ -84,11 +126,13 @@ describe("GitHub Probot handler", () => {
         }
       },
       createRun,
+      resolveActorWriteAccess,
       postComment,
       now: () => "2026-06-24T00:00:00.000Z"
     });
 
     expect(createRun).not.toHaveBeenCalled();
+    expect(resolveActorWriteAccess).not.toHaveBeenCalled();
     expect(postComment).not.toHaveBeenCalled();
   });
 
@@ -143,6 +187,48 @@ describe("GitHub Probot handler", () => {
         issueNumber: 1,
         commentUrl: "https://github.com/acme/demo/issues/1#issuecomment-124"
       }
+    });
+  });
+
+  it("uses resolved repository permission for source-thread action actors", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_1" }));
+    const submitThreadAction = vi.fn(async () => ({}));
+    const postComment = vi.fn(async () => undefined);
+    const resolveActorWriteAccess = vi.fn(async () => false);
+
+    await handleIssueCommentCreated({
+      payload: {
+        comment: {
+          id: 126,
+          body: "apply 1",
+          html_url: "https://github.com/acme/demo/issues/1#issuecomment-126",
+          author_association: "COLLABORATOR"
+        },
+        issue: {
+          html_url: "https://github.com/acme/demo/issues/1",
+          comments_url: "https://api.github.com/repos/acme/demo/issues/1/comments",
+          number: 1
+        },
+        repository: {
+          name: "demo",
+          private: false,
+          owner: { login: "acme" }
+        },
+        sender: {
+          id: 99,
+          login: "mallory"
+        }
+      },
+      createRun,
+      submitThreadAction,
+      resolveActorWriteAccess,
+      postComment,
+      now: () => "2026-06-24T00:00:00.000Z"
+    });
+
+    expect(resolveActorWriteAccess).toHaveBeenCalledWith({ owner: "acme", repo: "demo", username: "mallory" });
+    expect(submitThreadAction.mock.calls[0]![0]).toMatchObject({
+      actor: { provider: "github", providerUserId: "99", handle: "mallory", writeAccess: false }
     });
   });
 

--- a/apps/opentagd/test/integration.test.ts
+++ b/apps/opentagd/test/integration.test.ts
@@ -10,7 +10,7 @@ const event: OpenTagEvent = {
   source: "github",
   sourceEventId: "comment_integration",
   receivedAt: "2026-06-24T00:00:00.000Z",
-  actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+  actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
   target: { mention: "@opentag", agentId: "opentag" },
   command: { rawText: "summarize this", intent: "run", args: {} },
   context: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,6 +136,16 @@ Use daemon security settings to keep executor runs constrained:
 }
 ```
 
+Both built-in coding executors (Codex and Claude Code) run in an isolated git
+worktree with a scrubbed environment: variables that look like secrets
+(tokens, API keys, cloud credentials) are dropped before the executor process
+starts. If your Codex or Claude Code CLI authenticates from an environment
+variable (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), add it to
+`security.extraSafeEnv`; login-based CLI authentication works without extra
+configuration. Codex runs without a write scope use the read-only sandbox
+(`--sandbox read-only`); write-capable runs use `--full-auto`, which keeps the
+Codex OS sandbox in workspace-write mode.
+
 ## Daemon Config Fields
 
 | Field | Default | Notes |
@@ -398,7 +408,7 @@ for repeatable setups.
 | `OPENTAG_CLAUDE_COMMAND` | `claude` in executor default | Claude Code CLI command |
 | `OPENTAG_CLAUDE_MODEL` | none | Optional Claude model |
 | `OPENTAG_CLAUDE_PERMISSION_MODE` | none | `acceptEdits`, `auto`, `bypassPermissions`, `default`, or `plan` |
-| `OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` | Only for explicitly sandboxed environments |
+| `OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` | Auto-approves every Claude Code tool call. Only for explicitly sandboxed environments; each run emits an audit warning while this is on |
 | `OPENTAG_AGENT_PROFILE` | none | Fixed executor-neutral agent session identity |
 | `OPENTAG_AGENT_PROFILE_TEMPLATE` | derived per run | Executor-neutral profile template; supports tokens such as `{provider}`, `{projectTarget}`, `{accountId}`, `{conversationId}`, `{owner}`, `{repo}`, `{actorId}`, and `{runId}` |
 | `OPENTAG_SECURITY_MODE` | none | `enforce`, `audit`, or `off` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,11 @@ Add Claude Code settings when using the built-in `claude-code` executor:
 }
 ```
 
+If `permissionMode` is omitted, OpenTag derives it from the granted run scopes:
+read-only runs use `plan`, while runs granted `repo:write` use `acceptEdits`.
+A configured write-capable mode is ignored for runs that were not granted
+`repo:write`.
+
 Use daemon security settings to keep executor runs constrained:
 
 ```json
@@ -144,7 +149,8 @@ variable (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), add it to
 `security.extraSafeEnv`; login-based CLI authentication works without extra
 configuration. Codex runs without a write scope use the read-only sandbox
 (`--sandbox read-only`); write-capable runs use `--full-auto`, which keeps the
-Codex OS sandbox in workspace-write mode.
+Codex OS sandbox in workspace-write mode. Claude Code runs without `repo:write`
+use `--permission-mode plan`.
 
 ## Daemon Config Fields
 
@@ -407,7 +413,7 @@ for repeatable setups.
 | `OPENTAG_LARK_CHAT_ID` | none | Creates one env-derived Lark channel binding when paired with Project Target env |
 | `OPENTAG_CLAUDE_COMMAND` | `claude` in executor default | Claude Code CLI command |
 | `OPENTAG_CLAUDE_MODEL` | none | Optional Claude model |
-| `OPENTAG_CLAUDE_PERMISSION_MODE` | none | `acceptEdits`, `auto`, `bypassPermissions`, `default`, or `plan` |
+| `OPENTAG_CLAUDE_PERMISSION_MODE` | derived per run | `acceptEdits`, `auto`, `bypassPermissions`, `default`, or `plan`; write-capable modes are ignored on runs without `repo:write` |
 | `OPENTAG_CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` | Auto-approves every Claude Code tool call. Only for explicitly sandboxed environments; each run emits an audit warning while this is on |
 | `OPENTAG_AGENT_PROFILE` | none | Fixed executor-neutral agent session identity |
 | `OPENTAG_AGENT_PROFILE_TEMPLATE` | derived per run | Executor-neutral profile template; supports tokens such as `{provider}`, `{projectTarget}`, `{accountId}`, `{conversationId}`, `{owner}`, `{repo}`, `{actorId}`, and `{runId}` |

--- a/docs/platforms/github.en.md
+++ b/docs/platforms/github.en.md
@@ -173,10 +173,10 @@ While a run is active, you can inspect or stop the runtime from the same source 
 By default, OpenTag decides who may start runs from the repository itself:
 
 - **Private repositories**: anyone who can comment may trigger runs.
-- **Public repositories**: only commenters GitHub reports as having write
-  access to the repository (`OWNER`, `MEMBER`, or `COLLABORATOR` in the
-  webhook's `author_association` field). Drive-by commenters cannot start runs
-  or approve `apply` actions; they receive a decision-needed reply instead.
+- **Public repositories**: only commenters whose repository permission resolves
+  to `write`, `maintain`, or `admin` may trigger write-capable runs or approve
+  `apply` actions. Drive-by commenters cannot start those runs or approve those
+  actions; they receive a decision-needed reply instead.
 
 To open a public repository to specific users without granting them GitHub
 write access, configure `allowedActors` on the repository binding. When

--- a/docs/platforms/github.en.md
+++ b/docs/platforms/github.en.md
@@ -168,6 +168,20 @@ While a run is active, you can inspect or stop the runtime from the same source 
 @opentag /stop [run_id]
 ```
 
+## Who Can Trigger Runs
+
+By default, OpenTag decides who may start runs from the repository itself:
+
+- **Private repositories**: anyone who can comment may trigger runs.
+- **Public repositories**: only commenters GitHub reports as having write
+  access to the repository (`OWNER`, `MEMBER`, or `COLLABORATOR` in the
+  webhook's `author_association` field). Drive-by commenters cannot start runs
+  or approve `apply` actions; they receive a decision-needed reply instead.
+
+To open a public repository to specific users without granting them GitHub
+write access, configure `allowedActors` on the repository binding. When
+`allowedActors` is set it replaces the default policy for write-capable runs.
+
 These control commands report or cancel source-thread runtime state. They do not create another run.
 
 ## If It Does Not Work

--- a/docs/platforms/github.zh-CN.md
+++ b/docs/platforms/github.zh-CN.md
@@ -174,10 +174,9 @@ run 进行中时，你可以在同一个 source thread 里检查或停止 runtim
 默认情况下，OpenTag 根据仓库本身决定谁可以触发 run：
 
 - **私有仓库**：所有能评论的人都可以触发 run。
-- **公开仓库**：只有 GitHub 报告为对该仓库有写权限的评论者（webhook 中
-  `author_association` 为 `OWNER`、`MEMBER` 或 `COLLABORATOR`）可以触发 run
-  或批准 `apply` 动作。路人评论者会收到一条"需要人工决定"的回复，而不会
-  触发执行。
+- **公开仓库**：只有仓库权限解析为 `write`、`maintain` 或 `admin` 的评论者
+  可以触发写操作 run 或批准 `apply` 动作。路人评论者会收到一条"需要人工
+  决定"的回复，而不会触发执行。
 
 如果想在公开仓库对特定用户放行、又不想给他们 GitHub 写权限，可以在
 repository binding 上配置 `allowedActors`。配置了 `allowedActors` 后，

--- a/docs/platforms/github.zh-CN.md
+++ b/docs/platforms/github.zh-CN.md
@@ -169,6 +169,20 @@ run 进行中时，你可以在同一个 source thread 里检查或停止 runtim
 
 这些控制命令只报告或取消 source-thread runtime 状态，不会再创建一次 run。
 
+## 谁可以触发 run
+
+默认情况下，OpenTag 根据仓库本身决定谁可以触发 run：
+
+- **私有仓库**：所有能评论的人都可以触发 run。
+- **公开仓库**：只有 GitHub 报告为对该仓库有写权限的评论者（webhook 中
+  `author_association` 为 `OWNER`、`MEMBER` 或 `COLLABORATOR`）可以触发 run
+  或批准 `apply` 动作。路人评论者会收到一条"需要人工决定"的回复，而不会
+  触发执行。
+
+如果想在公开仓库对特定用户放行、又不想给他们 GitHub 写权限，可以在
+repository binding 上配置 `allowedActors`。配置了 `allowedActors` 后，
+写操作 run 以该列表为准，替代默认策略。
+
 ## 如果没有跑通
 
 先检查这些：

--- a/docs/platforms/gitlab.en.md
+++ b/docs/platforms/gitlab.en.md
@@ -128,6 +128,17 @@ The self-hosted or custom relay must be configured with:
 
 `opentag pair --relay <url>` and `opentag start` print the GitLab relay webhook URL when the config includes GitLab. Treat that URL as actionable only after the relay has the GitLab environment variables above.
 
+## Who Can Trigger Runs
+
+By default, OpenTag decides who may start runs from the project itself:
+
+- **Private and internal projects**: anyone who can comment may trigger runs.
+- **Public projects**: closed by default. GitLab Note Hooks do not report the
+  commenter's access level, so OpenTag cannot verify write access from the
+  webhook alone. Configure `allowedActors` on the repository binding to allow
+  specific GitLab usernames or user IDs to trigger runs and approve `apply`
+  actions on a public project.
+
 ## Current Scope
 
 Supported now:

--- a/docs/platforms/gitlab.zh-CN.md
+++ b/docs/platforms/gitlab.zh-CN.md
@@ -132,6 +132,16 @@ https://<你的 relay 域名>/gitlab/webhooks
 
 当 config 中包含 GitLab 时，`opentag pair --relay <url>` 和 `opentag start` 会打印 GitLab relay webhook URL。只有确认 relay 已配置上面的 GitLab 环境变量后，才把这个 URL 当成可用 webhook 地址。
 
+## 谁可以触发 run
+
+默认情况下，OpenTag 根据项目本身决定谁可以触发 run：
+
+- **私有（private）和内部（internal）项目**：所有能评论的人都可以触发 run。
+- **公开（public）项目**：默认关闭。GitLab Note Hook 不携带评论者的访问
+  级别，OpenTag 无法仅凭 webhook 验证写权限。请在 repository binding 上
+  配置 `allowedActors`（GitLab 用户名或用户 ID），放行可以在公开项目触发
+  run 和批准 `apply` 动作的用户。
+
 ## 当前范围
 
 当前已支持：

--- a/packages/cli/src/catalogs/capabilities.ts
+++ b/packages/cli/src/catalogs/capabilities.ts
@@ -62,7 +62,7 @@ export const EXECUTOR_CAPABILITIES: Record<ExecutorId, ExecutorCapabilityDescrip
     promptMutation: "none",
     rawContextAccess: false,
     writeActionAccess: "none",
-    workspaceIsolation: "branch",
+    workspaceIsolation: "worktree",
     requiredSecrets: ["anthropic_api_key"],
     completionSignals: ["process_exit"]
   },

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -367,6 +367,7 @@ export function githubIngressConfigFromCliConfig(
     webhookSecret: github.webhookSecret,
     dispatcherUrl: config.daemon.dispatcherUrl,
     ...(config.daemon.pairingToken ? { dispatcherToken: config.daemon.pairingToken } : {}),
+    ...(config.daemon.githubToken ? { githubToken: config.daemon.githubToken } : {}),
     ...(maxRequestBodyBytes ? { maxRequestBodyBytes } : {}),
     port: github.port ?? DEFAULT_GITHUB_WEBHOOK_PORT,
     ...(github.webhookPath ? { webhookPath: github.webhookPath } : {})

--- a/packages/cli/test/platform-contract.test.ts
+++ b/packages/cli/test/platform-contract.test.ts
@@ -166,6 +166,7 @@ describe("CLI platform contract smoke", () => {
       async submitThreadAction(action) {
         return client.submitThreadAction(action);
       },
+      resolveActorWriteAccess: async () => true,
       now: () => "2026-06-27T00:00:00.000Z"
     });
     const body = JSON.stringify({

--- a/packages/cli/test/platform-contract.test.ts
+++ b/packages/cli/test/platform-contract.test.ts
@@ -173,7 +173,8 @@ describe("CLI platform contract smoke", () => {
       comment: {
         id: 1001,
         body: "@opentag fix README",
-        html_url: "https://github.com/acme/demo/issues/7#issuecomment-1001"
+        html_url: "https://github.com/acme/demo/issues/7#issuecomment-1001",
+        author_association: "OWNER"
       },
       issue: {
         html_url: "https://github.com/acme/demo/issues/7",
@@ -226,7 +227,8 @@ describe("CLI platform contract smoke", () => {
       comment: {
         id: 1002,
         body: "apply 1",
-        html_url: "https://github.com/acme/demo/issues/7#issuecomment-1002"
+        html_url: "https://github.com/acme/demo/issues/7#issuecomment-1002",
+        author_association: "OWNER"
       },
       issue: {
         html_url: "https://github.com/acme/demo/issues/7",

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -43,7 +43,11 @@ export const ActorIdentitySchema = z.object({
   providerUserId: z.string().min(1),
   handle: z.string().min(1).optional(),
   displayName: z.string().min(1).optional(),
-  organizationId: z.string().min(1).optional()
+  organizationId: z.string().min(1).optional(),
+  /** Platform-reported write access to the source repository (e.g. derived from
+   * GitHub `author_association`). Absent when the platform does not report it;
+   * admission treats absent as "no write access" on public repositories. */
+  writeAccess: z.boolean().optional()
 });
 
 export const AgentTargetSchema = z.object({
@@ -248,6 +252,7 @@ export const RunAdmissionReasonCodeSchema = z.enum([
   "repo_context_missing",
   "repo_not_bound",
   "actor_not_allowed_for_write",
+  "actor_not_authorized_for_public_repo",
   "agent_access_profile_denied"
 ]);
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -44,9 +44,9 @@ export const ActorIdentitySchema = z.object({
   handle: z.string().min(1).optional(),
   displayName: z.string().min(1).optional(),
   organizationId: z.string().min(1).optional(),
-  /** Platform-reported write access to the source repository (e.g. derived from
-   * GitHub `author_association`). Absent when the platform does not report it;
-   * admission treats absent as "no write access" on public repositories. */
+  /** Platform-reported write access to the source repository (for example,
+   * GitHub's collaborator permission API). Absent when the platform does not
+   * report it; admission treats absent as "no write access" on public repos. */
   writeAccess: z.boolean().optional()
 });
 

--- a/packages/dispatcher/src/admission.ts
+++ b/packages/dispatcher/src/admission.ts
@@ -57,9 +57,64 @@ function isWriteCapable(event: OpenTagEvent): boolean {
   return event.permissions.some((permission) => ["repo:write", "pr:create", "pr:update"].includes(permission.scope));
 }
 
-function actorIsAllowed(event: OpenTagEvent, allowedActors: string[] | undefined): boolean {
-  if (!allowedActors?.length) return true;
+function actorInAllowedList(event: OpenTagEvent, allowedActors: string[]): boolean {
   return allowedActors.includes(event.actor.handle ?? "") || allowedActors.includes(event.actor.providerUserId);
+}
+
+const SOURCE_WORK_ITEM_KINDS = new Set(["issue", "pull_request", "merge_request"]);
+
+/** True when the event originated from a work item on a public GitHub/GitLab
+ * repository. Uses the work-item context pointers, whose visibility the
+ * platform adapters derive from the repository's own private/visibility flag
+ * (GitLab "internal" is already collapsed to private by its adapter). */
+export function sourceRepoIsPublic(event: OpenTagEvent): boolean {
+  if (event.source !== "github" && event.source !== "gitlab") return false;
+  return event.context.some(
+    (pointer) => SOURCE_WORK_ITEM_KINDS.has(pointer.kind) && pointer.visibility === "public"
+  );
+}
+
+type ActorGateResult =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: string;
+      reasonCode: Extract<RunAdmissionReasonCode, "actor_not_allowed_for_write" | "actor_not_authorized_for_public_repo">;
+    };
+
+/** Decides whether the requesting actor may start a run for this binding.
+ *
+ * With an explicit `allowedActors` list the operator's intent wins: the list
+ * gates write-capable runs, matching the pre-existing contract.
+ *
+ * Without a list, the default is platform-aware instead of allow-all:
+ * anyone inside a closed surface (Slack workspace, Lark tenant, private
+ * GitHub/GitLab repository) may trigger runs, but on a public repository the
+ * actor must carry platform-reported write access (`actor.writeAccess`).
+ * Platforms that cannot report access (GitLab Note Hooks) leave it unset, so
+ * public projects there stay closed until `allowedActors` is configured. */
+function evaluateActorGate(event: OpenTagEvent, allowedActors: string[] | undefined): ActorGateResult {
+  if (allowedActors?.length) {
+    if (isWriteCapable(event) && !actorInAllowedList(event, allowedActors)) {
+      return {
+        allowed: false,
+        reason: "The requesting actor is not allowed to start a write-capable run in this repository.",
+        reasonCode: "actor_not_allowed_for_write"
+      };
+    }
+    return { allowed: true };
+  }
+
+  if (sourceRepoIsPublic(event) && event.actor.writeAccess !== true) {
+    return {
+      allowed: false,
+      reason:
+        "This repository is public and the requesting actor does not have write access to it. Ask a maintainer to grant write access, or configure allowedActors on the repository binding.",
+      reasonCode: "actor_not_authorized_for_public_repo"
+    };
+  }
+
+  return { allowed: true };
 }
 
 function admissionDecision(input: {
@@ -133,13 +188,14 @@ export function createAdmissionRuntime(input: {
         };
       }
 
-      if (isWriteCapable(request.event) && !actorIsAllowed(request.event, binding.allowedActors)) {
+      const actorGate = evaluateActorGate(request.event, binding.allowedActors);
+      if (!actorGate.allowed) {
         return {
           outcome: "needs_human_decision",
           decision: admissionDecision({
             action: "needs_human_decision",
-            reason: "The requesting actor is not allowed to start a write-capable run in this repository.",
-            reasonCode: "actor_not_allowed_for_write",
+            reason: actorGate.reason,
+            reasonCode: actorGate.reasonCode,
             event: request.event
           })
         };

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -245,7 +245,7 @@ function createDispatcherRateLimitMiddleware(options: DispatcherRateLimitOptions
     await next();
   };
 }
-import { createAdmissionRuntime, type AgentAccessProfileCheck } from "./admission.js";
+import { createAdmissionRuntime, sourceRepoIsPublic, type AgentAccessProfileCheck } from "./admission.js";
 import { createDefaultCallbackPresentation, type CallbackPresentation } from "./presentation.js";
 import { createSourceThreadControlHandler } from "./source-thread-control.js";
 
@@ -1246,6 +1246,21 @@ async function authorizeThreadAction(input: {
       ok: false,
       reason: "actor_not_allowed",
       message: "This actor is not allowed to approve or apply actions for the bound repository."
+    };
+  }
+
+  // Same default as run admission: without an explicit allowlist, approvals
+  // arriving from a public GitHub/GitLab thread require platform-reported
+  // write access, so a drive-by commenter cannot approve a pending action.
+  if (
+    !binding.allowedActors?.length &&
+    sourceRepoIsPublic(input.resolved.proposal.event) &&
+    input.actor.writeAccess !== true
+  ) {
+    return {
+      ok: false,
+      reason: "actor_not_allowed",
+      message: "This repository is public, so only actors with write access can approve or apply actions."
     };
   }
 

--- a/packages/dispatcher/test/admission.test.ts
+++ b/packages/dispatcher/test/admission.test.ts
@@ -17,6 +17,111 @@ const event = {
 };
 
 describe("Admission Runtime", () => {
+  const bindingRepo = (binding: Record<string, unknown>) =>
+    ({
+      getRunByEventId: async () => null,
+      getRepoBinding: async () => binding,
+      findActiveRunForConversation: async () => null,
+      createFollowUpRequest: async () => {
+        throw new Error("should not queue follow-up");
+      },
+      appendRunEvent: async () => undefined
+    }) as never;
+
+  const publicIssueContext = [
+    { provider: "github" as const, kind: "issue" as const, uri: "https://github.com/acme/demo/issues/1", visibility: "public" as const }
+  ];
+  const privateIssueContext = [
+    { provider: "github" as const, kind: "issue" as const, uri: "https://github.com/acme/demo/issues/1", visibility: "private" as const }
+  ];
+  const githubBinding = { provider: "github", owner: "acme", repo: "demo", runnerId: "runner_1" };
+
+  it("denies public-repo runs by default when the actor has no platform-reported write access", async () => {
+    const admission = createAdmissionRuntime({ repo: bindingRepo(githubBinding) });
+
+    const result = await admission.admitRun({
+      requestId: "req_public_stranger",
+      event: { ...event, id: "evt_public_stranger", context: publicIssueContext }
+    });
+
+    expect(result).toMatchObject({
+      outcome: "needs_human_decision",
+      decision: { reasonCode: "actor_not_authorized_for_public_repo" }
+    });
+  });
+
+  it("admits public-repo runs when the actor carries platform-reported write access", async () => {
+    const admission = createAdmissionRuntime({ repo: bindingRepo(githubBinding) });
+
+    const result = await admission.admitRun({
+      requestId: "req_public_maintainer",
+      event: {
+        ...event,
+        id: "evt_public_maintainer",
+        actor: { ...event.actor, writeAccess: true },
+        context: publicIssueContext
+      }
+    });
+
+    expect(result).toMatchObject({ outcome: "start" });
+  });
+
+  it("keeps private-repo runs open to actors without reported write access", async () => {
+    const admission = createAdmissionRuntime({ repo: bindingRepo(githubBinding) });
+
+    const result = await admission.admitRun({
+      requestId: "req_private_stranger",
+      event: { ...event, id: "evt_private_stranger", context: privateIssueContext }
+    });
+
+    expect(result).toMatchObject({ outcome: "start" });
+  });
+
+  it("lets an explicit allowedActors list override the public-repo default", async () => {
+    const admission = createAdmissionRuntime({
+      repo: bindingRepo({ ...githubBinding, allowedActors: ["octocat"] })
+    });
+
+    const result = await admission.admitRun({
+      requestId: "req_public_listed",
+      event: {
+        ...event,
+        id: "evt_public_listed",
+        context: publicIssueContext,
+        permissions: [
+          ...event.permissions,
+          { scope: "repo:write" as const, reason: "commit code changes on an isolated run branch" }
+        ]
+      }
+    });
+
+    expect(result).toMatchObject({ outcome: "start" });
+  });
+
+  it("still rejects write-capable runs from actors outside a configured allowedActors list", async () => {
+    const admission = createAdmissionRuntime({
+      repo: bindingRepo({ ...githubBinding, allowedActors: ["someone-else"] })
+    });
+
+    const result = await admission.admitRun({
+      requestId: "req_listed_denied",
+      event: {
+        ...event,
+        id: "evt_listed_denied",
+        context: privateIssueContext,
+        permissions: [
+          ...event.permissions,
+          { scope: "repo:write" as const, reason: "commit code changes on an isolated run branch" }
+        ]
+      }
+    });
+
+    expect(result).toMatchObject({
+      outcome: "needs_human_decision",
+      decision: { reasonCode: "actor_not_allowed_for_write" }
+    });
+  });
+
   it("checks duplicate source events before mutable gates", async () => {
     const getRepoBinding = vi.fn(async () => {
       throw new Error("should not reach mutable gates for duplicate events");

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -5059,6 +5059,64 @@ describe("dispatcher API", () => {
     expect(events.map((event: { type: string }) => event.type)).not.toContain("apply_plan.created");
   });
 
+  it("rejects public-repo source-thread action actors without write access by default", async () => {
+    const githubRequests: unknown[] = [];
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      githubApply: {
+        token: "gh_test",
+        fetchImpl: async (url) => {
+          githubRequests.push(url);
+          return Response.json({});
+        }
+      }
+    });
+
+    await seedCompletedProposal({
+      app,
+      runId: "run_thread_public_no_write",
+      event: githubIssueEvent({ id: "evt_thread_public_no_write", sourceEventId: "comment_thread_public_no_write", threadKey: "acme/demo" }),
+      suggestedChanges: [
+        {
+          proposalId: "proposal_thread_public_no_write",
+          createdAt: "2026-06-24T00:00:00.000Z",
+          summary: "Label the bug.",
+          intents: [
+            {
+              intentId: "intent_label_bug",
+              domain: "labels",
+              action: "add_label",
+              summary: "Add the bug label.",
+              params: { label: "bug" }
+            }
+          ]
+        }
+      ]
+    });
+    githubRequests.length = 0;
+
+    const response = await app.request("/v1/thread-actions", jsonRequest({
+      rawText: "apply 1",
+      actor: { provider: "github", providerUserId: "99", handle: "mallory" },
+      callback: {
+        provider: "github",
+        uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        threadKey: "acme/demo"
+      }
+    }));
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      outcome: "unauthorized",
+      reason: "actor_not_allowed"
+    });
+    expect(githubRequests).toHaveLength(0);
+
+    const eventsResponse = await app.request("/v1/runs/run_thread_public_no_write/events");
+    const { events } = await eventsResponse.json();
+    expect(events.map((event: { type: string }) => event.type)).not.toContain("approval.decision.recorded");
+    expect(events.map((event: { type: string }) => event.type)).not.toContain("apply_plan.created");
+  });
+
   it("rejects Slack thread actions when the source channel binding is missing", async () => {
     const app = createDispatcherApp({ databasePath: ":memory:" });
     await seedCompletedProposal({

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -9,7 +9,7 @@ const validEvent = {
   source: "github",
   sourceEventId: "comment_1",
   receivedAt: "2026-06-24T00:00:00.000Z",
-  actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+  actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
   target: { mention: "@opentag", agentId: "opentag" },
   command: { rawText: "fix this", intent: "fix", args: {} },
   context: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
@@ -3949,7 +3949,7 @@ describe("dispatcher API", () => {
 
     const status = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "@opentag /status",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -4013,7 +4013,7 @@ describe("dispatcher API", () => {
 
     const doctor = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "@opentag /doctor",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -4367,7 +4367,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -4401,7 +4401,7 @@ describe("dispatcher API", () => {
     const deliveredCountAfterFirstApply = delivered.length;
     const replayResponse = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -4828,7 +4828,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -4903,7 +4903,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -4980,7 +4980,7 @@ describe("dispatcher API", () => {
 
     const action = {
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -5228,7 +5228,7 @@ describe("dispatcher API", () => {
     const first = await app.request("/v1/thread-actions", jsonRequest({
       id: "approval_ingress_retry_id",
       rawText: "approve 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -5243,7 +5243,7 @@ describe("dispatcher API", () => {
     const second = await app.request("/v1/thread-actions", jsonRequest({
       id: "approval_ingress_retry_id",
       rawText: "approve 2",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -5296,7 +5296,7 @@ describe("dispatcher API", () => {
     });
 
     const baseAction = {
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -5362,7 +5362,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "approve 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -5409,7 +5409,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply proposal_thread_cross",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/99/comments",
@@ -5465,7 +5465,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/2/comments",
@@ -5563,7 +5563,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -5877,7 +5877,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/2/comments",
@@ -5933,7 +5933,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "continue 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",
@@ -6026,7 +6026,7 @@ describe("dispatcher API", () => {
 
     const response = await app.request("/v1/thread-actions", jsonRequest({
       rawText: "apply 1",
-      actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+      actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
       callback: {
         provider: "github",
         uri: "https://api.github.com/repos/acme/demo/issues/1/comments",

--- a/packages/github/src/ingress.ts
+++ b/packages/github/src/ingress.ts
@@ -10,7 +10,7 @@ import {
   type OpenTagEvent
 } from "@opentag/core";
 import { Hono } from "hono";
-import { normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment, githubActorWriteAccess } from "./normalize.js";
+import { githubPermissionHasWriteAccess, normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment } from "./normalize.js";
 
 type GitHubActor = {
   id: number;
@@ -65,11 +65,18 @@ export type GitHubThreadActionInput = {
   metadata: Record<string, unknown>;
 };
 
+export type GitHubActorWriteAccessResolver = (input: {
+  owner: string;
+  repo: string;
+  username: string;
+}) => Promise<boolean | undefined>;
+
 export type GitHubWebhookAppInput = {
   webhookSecret: string;
   webhookPath?: string;
   createRun(event: OpenTagEvent): Promise<{ runId?: string }>;
   submitThreadAction?(action: GitHubThreadActionInput): Promise<unknown>;
+  resolveActorWriteAccess?: GitHubActorWriteAccessResolver;
   recordControlPlaneEvent?(event: {
     type: string;
     severity?: "info" | "warn" | "error";
@@ -84,6 +91,8 @@ export type GitHubIngressConfig = {
   webhookSecret: string;
   dispatcherUrl: string;
   dispatcherToken?: string;
+  githubToken?: string;
+  fetchImpl?: typeof fetch;
   port?: number;
   hostname?: string;
   webhookPath?: string;
@@ -179,6 +188,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function encodeGitHubPathSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
 function hasGitHubActor(value: unknown): value is GitHubActor {
   return isRecord(value) && typeof value.id === "number" && typeof value.login === "string";
 }
@@ -205,6 +218,47 @@ function hasGitHubComment(value: unknown): value is GitHubComment {
     typeof value.html_url === "string" &&
     (value.author_association === undefined || typeof value.author_association === "string")
   );
+}
+
+async function resolvePayloadActorWriteAccess(input: {
+  payload: { repository: GitHubRepository; sender: GitHubActor };
+  resolveActorWriteAccess?: GitHubActorWriteAccessResolver;
+}): Promise<boolean | undefined> {
+  if (!input.resolveActorWriteAccess) return undefined;
+  try {
+    return await input.resolveActorWriteAccess({
+      owner: input.payload.repository.owner.login,
+      repo: input.payload.repository.name,
+      username: input.payload.sender.login
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveGitHubActorWriteAccessWithToken(input: {
+  owner: string;
+  repo: string;
+  username: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): Promise<boolean | undefined> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(
+    `https://api.github.com/repos/${encodeGitHubPathSegment(input.owner)}/${encodeGitHubPathSegment(input.repo)}/collaborators/${encodeGitHubPathSegment(input.username)}/permission`,
+    {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${input.token}`,
+        "x-github-api-version": "2022-11-28"
+      }
+    }
+  );
+  if (response.status === 404) return false;
+  if (!response.ok) return undefined;
+  const data: unknown = await response.json();
+  if (!isRecord(data) || typeof data.permission !== "string") return undefined;
+  return githubPermissionHasWriteAccess(data.permission);
 }
 
 function isGitHubIssueCommentPayload(value: unknown): value is GitHubIssueCommentPayload {
@@ -240,6 +294,7 @@ async function handleIssueCommentCreated(input: {
   payload: GitHubIssueCommentPayload;
   createRun(event: OpenTagEvent): Promise<{ runId?: string }>;
   submitThreadAction?(action: GitHubThreadActionInput): Promise<unknown>;
+  resolveActorWriteAccess?: GitHubActorWriteAccessResolver;
   now(): string;
   deliveryId?: string;
   signatureVerified?: boolean;
@@ -249,7 +304,7 @@ async function handleIssueCommentCreated(input: {
   const actionCommand = parseThreadActionCommand(input.payload.comment.body);
   if (controlCommand || actionCommand) {
     if (input.submitThreadAction) {
-      const actorWriteAccess = githubActorWriteAccess(input.payload.comment.author_association);
+      const actorWriteAccess = await resolvePayloadActorWriteAccess(input);
       await input.submitThreadAction({
         id: `${controlCommand ? "control" : "approval"}_github_comment_${input.payload.comment.id}`,
         rawText: input.payload.comment.body,
@@ -300,6 +355,10 @@ async function handleIssueCommentCreated(input: {
   });
 
   if (event) {
+    const actorWriteAccess = await resolvePayloadActorWriteAccess(input);
+    if (actorWriteAccess !== undefined) {
+      event.actor.writeAccess = actorWriteAccess;
+    }
     await input.createRun(event);
   }
 }
@@ -308,6 +367,7 @@ async function handlePullRequestReviewCommentCreated(input: {
   payload: GitHubPullRequestReviewCommentPayload;
   createRun(event: OpenTagEvent): Promise<{ runId?: string }>;
   submitThreadAction?(action: GitHubThreadActionInput): Promise<unknown>;
+  resolveActorWriteAccess?: GitHubActorWriteAccessResolver;
   now(): string;
   deliveryId?: string;
   signatureVerified?: boolean;
@@ -319,7 +379,7 @@ async function handlePullRequestReviewCommentCreated(input: {
   const actionCommand = parseThreadActionCommand(input.payload.comment.body);
   if (controlCommand || actionCommand) {
     if (input.submitThreadAction) {
-      const actorWriteAccess = githubActorWriteAccess(input.payload.comment.author_association);
+      const actorWriteAccess = await resolvePayloadActorWriteAccess(input);
       await input.submitThreadAction({
         id: `${controlCommand ? "control" : "approval"}_github_pr_review_comment_${input.payload.comment.id}`,
         rawText: input.payload.comment.body,
@@ -370,6 +430,10 @@ async function handlePullRequestReviewCommentCreated(input: {
   });
 
   if (event) {
+    const actorWriteAccess = await resolvePayloadActorWriteAccess(input);
+    if (actorWriteAccess !== undefined) {
+      event.actor.writeAccess = actorWriteAccess;
+    }
     await input.createRun(event);
   }
 }
@@ -457,6 +521,7 @@ export function createGitHubWebhookApp(input: GitHubWebhookAppInput) {
         payload,
         createRun: input.createRun,
         ...(input.submitThreadAction ? { submitThreadAction: input.submitThreadAction } : {}),
+        ...(input.resolveActorWriteAccess ? { resolveActorWriteAccess: input.resolveActorWriteAccess } : {}),
         now: input.now,
         ...(deliveryId ? { deliveryId } : {}),
         signatureVerified: true
@@ -479,6 +544,7 @@ export function createGitHubWebhookApp(input: GitHubWebhookAppInput) {
         payload,
         createRun: input.createRun,
         ...(input.submitThreadAction ? { submitThreadAction: input.submitThreadAction } : {}),
+        ...(input.resolveActorWriteAccess ? { resolveActorWriteAccess: input.resolveActorWriteAccess } : {}),
         now: input.now,
         ...(deliveryId ? { deliveryId } : {}),
         signatureVerified: true
@@ -493,6 +559,7 @@ export function createGitHubWebhookApp(input: GitHubWebhookAppInput) {
 }
 
 export function startGitHubIngress(config: GitHubIngressConfig): GitHubIngressHandle {
+  const githubToken = config.githubToken;
   const dispatcherClient = createOpenTagClient({
     dispatcherUrl: config.dispatcherUrl,
     ...(config.dispatcherToken ? { pairingToken: config.dispatcherToken } : {})
@@ -505,6 +572,16 @@ export function startGitHubIngress(config: GitHubIngressConfig): GitHubIngressHa
       webhookSecret: config.webhookSecret,
       webhookPath,
       ...(config.maxRequestBodyBytes ? { maxRequestBodyBytes: config.maxRequestBodyBytes } : {}),
+      ...(githubToken
+        ? {
+            resolveActorWriteAccess: (input) =>
+              resolveGitHubActorWriteAccessWithToken({
+                ...input,
+                token: githubToken,
+                ...(config.fetchImpl ? { fetchImpl: config.fetchImpl } : {})
+              })
+          }
+        : {}),
       async createRun(event) {
         const runId = `run_${randomUUID()}`;
         const created = await dispatcherClient.createRun({ runId, event });

--- a/packages/github/src/ingress.ts
+++ b/packages/github/src/ingress.ts
@@ -10,7 +10,7 @@ import {
   type OpenTagEvent
 } from "@opentag/core";
 import { Hono } from "hono";
-import { normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment } from "./normalize.js";
+import { normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment, githubActorWriteAccess } from "./normalize.js";
 
 type GitHubActor = {
   id: number;
@@ -23,9 +23,16 @@ type GitHubRepository = {
   owner: { login: string };
 };
 
+type GitHubComment = {
+  id: number;
+  body: string;
+  html_url: string;
+  author_association?: string;
+};
+
 export type GitHubIssueCommentPayload = {
   action?: string;
-  comment: { id: number; body: string; html_url: string };
+  comment: GitHubComment;
   issue: { html_url: string; comments_url: string; number: number };
   repository: GitHubRepository;
   sender: GitHubActor;
@@ -34,7 +41,7 @@ export type GitHubIssueCommentPayload = {
 
 export type GitHubPullRequestReviewCommentPayload = {
   action?: string;
-  comment: { id: number; body: string; html_url: string };
+  comment: GitHubComment;
   pull_request: { html_url: string; number: number };
   repository: GitHubRepository;
   sender: GitHubActor;
@@ -48,6 +55,7 @@ export type GitHubThreadActionInput = {
     provider: "github";
     providerUserId: string;
     handle: string;
+    writeAccess?: boolean;
   };
   callback: {
     provider: "github";
@@ -189,14 +197,21 @@ function hasGitHubInstallation(value: unknown): value is { id: number } {
   return isRecord(value) && typeof value.id === "number";
 }
 
+function hasGitHubComment(value: unknown): value is GitHubComment {
+  return (
+    isRecord(value) &&
+    typeof value.id === "number" &&
+    typeof value.body === "string" &&
+    typeof value.html_url === "string" &&
+    (value.author_association === undefined || typeof value.author_association === "string")
+  );
+}
+
 function isGitHubIssueCommentPayload(value: unknown): value is GitHubIssueCommentPayload {
   return (
     isRecord(value) &&
     (value.action === undefined || typeof value.action === "string") &&
-    isRecord(value.comment) &&
-    typeof value.comment.id === "number" &&
-    typeof value.comment.body === "string" &&
-    typeof value.comment.html_url === "string" &&
+    hasGitHubComment(value.comment) &&
     isRecord(value.issue) &&
     typeof value.issue.html_url === "string" &&
     typeof value.issue.comments_url === "string" &&
@@ -211,10 +226,7 @@ function isGitHubPullRequestReviewCommentPayload(value: unknown): value is GitHu
   return (
     isRecord(value) &&
     (value.action === undefined || typeof value.action === "string") &&
-    isRecord(value.comment) &&
-    typeof value.comment.id === "number" &&
-    typeof value.comment.body === "string" &&
-    typeof value.comment.html_url === "string" &&
+    hasGitHubComment(value.comment) &&
     isRecord(value.pull_request) &&
     typeof value.pull_request.html_url === "string" &&
     typeof value.pull_request.number === "number" &&
@@ -237,13 +249,15 @@ async function handleIssueCommentCreated(input: {
   const actionCommand = parseThreadActionCommand(input.payload.comment.body);
   if (controlCommand || actionCommand) {
     if (input.submitThreadAction) {
+      const actorWriteAccess = githubActorWriteAccess(input.payload.comment.author_association);
       await input.submitThreadAction({
         id: `${controlCommand ? "control" : "approval"}_github_comment_${input.payload.comment.id}`,
         rawText: input.payload.comment.body,
         actor: {
           provider: "github",
           providerUserId: String(input.payload.sender.id),
-          handle: input.payload.sender.login
+          handle: input.payload.sender.login,
+          ...(actorWriteAccess !== undefined ? { writeAccess: actorWriteAccess } : {})
         },
         callback: {
           provider: "github",
@@ -277,6 +291,7 @@ async function handleIssueCommentCreated(input: {
     repo: input.payload.repository.name,
     actorId: input.payload.sender.id,
     actorLogin: input.payload.sender.login,
+    ...(input.payload.comment.author_association ? { authorAssociation: input.payload.comment.author_association } : {}),
     private: input.payload.repository.private,
     receivedAt: input.now(),
     ...(input.deliveryId ? { deliveryId: input.deliveryId } : {}),
@@ -304,13 +319,15 @@ async function handlePullRequestReviewCommentCreated(input: {
   const actionCommand = parseThreadActionCommand(input.payload.comment.body);
   if (controlCommand || actionCommand) {
     if (input.submitThreadAction) {
+      const actorWriteAccess = githubActorWriteAccess(input.payload.comment.author_association);
       await input.submitThreadAction({
         id: `${controlCommand ? "control" : "approval"}_github_pr_review_comment_${input.payload.comment.id}`,
         rawText: input.payload.comment.body,
         actor: {
           provider: "github",
           providerUserId: String(input.payload.sender.id),
-          handle: input.payload.sender.login
+          handle: input.payload.sender.login,
+          ...(actorWriteAccess !== undefined ? { writeAccess: actorWriteAccess } : {})
         },
         callback: {
           provider: "github",
@@ -344,6 +361,7 @@ async function handlePullRequestReviewCommentCreated(input: {
     pullRequestNumber: input.payload.pull_request.number,
     actorId: input.payload.sender.id,
     actorLogin: input.payload.sender.login,
+    ...(input.payload.comment.author_association ? { authorAssociation: input.payload.comment.author_association } : {}),
     private: input.payload.repository.private,
     receivedAt: input.now(),
     ...(input.deliveryId ? { deliveryId: input.deliveryId } : {}),

--- a/packages/github/src/normalize.ts
+++ b/packages/github/src/normalize.ts
@@ -12,6 +12,7 @@ export type GitHubIssueCommentInput = {
   repo: string;
   actorId: number;
   actorLogin: string;
+  authorAssociation?: string;
   private: boolean;
   receivedAt: string;
   installationId?: number;
@@ -30,12 +31,24 @@ export type GitHubPullRequestReviewCommentInput = {
   pullRequestNumber: number;
   actorId: number;
   actorLogin: string;
+  authorAssociation?: string;
   private: boolean;
   receivedAt: string;
   installationId?: number;
   deliveryId?: string;
   signatureVerified?: boolean;
 };
+
+/** `author_association` values GitHub reports for commenters who can push to
+ * the repository. `MEMBER` (org member) is trusted the same way GitHub Actions
+ * and most GitHub bots treat it. Everything else (`CONTRIBUTOR`, `NONE`,
+ * `FIRST_TIME_CONTRIBUTOR`, ...) maps to no write access. */
+const GITHUB_WRITE_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+export function githubActorWriteAccess(authorAssociation: string | undefined): boolean | undefined {
+  if (!authorAssociation) return undefined;
+  return GITHUB_WRITE_ASSOCIATIONS.has(authorAssociation);
+}
 
 function permissionsForIntent(intent: OpenTagCommand["intent"]): PermissionGrant[] {
   const permissions: PermissionGrant[] = [
@@ -154,6 +167,8 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
     ...(mention.parsed ? { parsed: mention.parsed } : {})
   };
 
+  const writeAccess = githubActorWriteAccess(input.authorAssociation);
+
   return {
     id: `evt_github_comment_${input.id}`,
     source: "github",
@@ -162,7 +177,8 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
     actor: {
       provider: "github",
       providerUserId: String(input.actorId),
-      handle: input.actorLogin
+      handle: input.actorLogin,
+      ...(writeAccess !== undefined ? { writeAccess } : {})
     },
     target: {
       mention: "@opentag",
@@ -203,6 +219,7 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
       owner: input.owner,
       repo: input.repo,
       issueNumber: input.issueNumber,
+      ...(input.authorAssociation ? { authorAssociation: input.authorAssociation } : {}),
       ...commandMetadata(command),
       ...(input.deliveryId ? { sourceDeliveryId: input.deliveryId, webhookDeliveryId: input.deliveryId } : {}),
       ...(typeof input.signatureVerified === "boolean"
@@ -224,6 +241,8 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
     ...(mention.parsed ? { parsed: mention.parsed } : {})
   };
 
+  const writeAccess = githubActorWriteAccess(input.authorAssociation);
+
   return {
     id: `evt_github_pr_review_comment_${input.id}`,
     source: "github",
@@ -232,7 +251,8 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
     actor: {
       provider: "github",
       providerUserId: String(input.actorId),
-      handle: input.actorLogin
+      handle: input.actorLogin,
+      ...(writeAccess !== undefined ? { writeAccess } : {})
     },
     target: {
       mention: "@opentag",
@@ -273,6 +293,7 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
       owner: input.owner,
       repo: input.repo,
       pullRequestNumber: input.pullRequestNumber,
+      ...(input.authorAssociation ? { authorAssociation: input.authorAssociation } : {}),
       ...commandMetadata(command),
       ...(input.deliveryId ? { sourceDeliveryId: input.deliveryId, webhookDeliveryId: input.deliveryId } : {}),
       ...(typeof input.signatureVerified === "boolean"

--- a/packages/github/src/normalize.ts
+++ b/packages/github/src/normalize.ts
@@ -13,6 +13,7 @@ export type GitHubIssueCommentInput = {
   actorId: number;
   actorLogin: string;
   authorAssociation?: string;
+  actorWriteAccess?: boolean;
   private: boolean;
   receivedAt: string;
   installationId?: number;
@@ -32,6 +33,7 @@ export type GitHubPullRequestReviewCommentInput = {
   actorId: number;
   actorLogin: string;
   authorAssociation?: string;
+  actorWriteAccess?: boolean;
   private: boolean;
   receivedAt: string;
   installationId?: number;
@@ -39,15 +41,11 @@ export type GitHubPullRequestReviewCommentInput = {
   signatureVerified?: boolean;
 };
 
-/** `author_association` values GitHub reports for commenters who can push to
- * the repository. `MEMBER` (org member) is trusted the same way GitHub Actions
- * and most GitHub bots treat it. Everything else (`CONTRIBUTOR`, `NONE`,
- * `FIRST_TIME_CONTRIBUTOR`, ...) maps to no write access. */
-const GITHUB_WRITE_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const GITHUB_WRITE_PERMISSION_LEVELS = new Set(["admin", "maintain", "write"]);
 
-export function githubActorWriteAccess(authorAssociation: string | undefined): boolean | undefined {
-  if (!authorAssociation) return undefined;
-  return GITHUB_WRITE_ASSOCIATIONS.has(authorAssociation);
+export function githubPermissionHasWriteAccess(permission: string | undefined): boolean | undefined {
+  if (!permission) return undefined;
+  return GITHUB_WRITE_PERMISSION_LEVELS.has(permission.toLowerCase());
 }
 
 function permissionsForIntent(intent: OpenTagCommand["intent"]): PermissionGrant[] {
@@ -167,8 +165,6 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
     ...(mention.parsed ? { parsed: mention.parsed } : {})
   };
 
-  const writeAccess = githubActorWriteAccess(input.authorAssociation);
-
   return {
     id: `evt_github_comment_${input.id}`,
     source: "github",
@@ -178,7 +174,7 @@ export function normalizeGitHubIssueComment(input: GitHubIssueCommentInput): Ope
       provider: "github",
       providerUserId: String(input.actorId),
       handle: input.actorLogin,
-      ...(writeAccess !== undefined ? { writeAccess } : {})
+      ...(input.actorWriteAccess !== undefined ? { writeAccess: input.actorWriteAccess } : {})
     },
     target: {
       mention: "@opentag",
@@ -241,8 +237,6 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
     ...(mention.parsed ? { parsed: mention.parsed } : {})
   };
 
-  const writeAccess = githubActorWriteAccess(input.authorAssociation);
-
   return {
     id: `evt_github_pr_review_comment_${input.id}`,
     source: "github",
@@ -252,7 +246,7 @@ export function normalizeGitHubPullRequestReviewComment(input: GitHubPullRequest
       provider: "github",
       providerUserId: String(input.actorId),
       handle: input.actorLogin,
-      ...(writeAccess !== undefined ? { writeAccess } : {})
+      ...(input.actorWriteAccess !== undefined ? { writeAccess: input.actorWriteAccess } : {})
     },
     target: {
       mention: "@opentag",

--- a/packages/github/test/ingress.test.ts
+++ b/packages/github/test/ingress.test.ts
@@ -104,6 +104,43 @@ describe("GitHub webhook ingress", () => {
     });
   });
 
+  it("carries comment author_association into the run event actor", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_assoc" }));
+    const app = createGitHubWebhookApp({
+      webhookSecret: "secret",
+      createRun,
+      now: () => "2026-06-27T00:00:00.000Z"
+    });
+    const body = JSON.stringify({
+      action: "created",
+      comment: {
+        id: 125,
+        body: "@opentag investigate this",
+        html_url: "https://github.com/acme/demo/issues/1#issuecomment-125",
+        author_association: "COLLABORATOR"
+      },
+      issue: {
+        html_url: "https://github.com/acme/demo/issues/1",
+        comments_url: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        number: 1
+      },
+      repository: { name: "demo", private: false, owner: { login: "acme" } },
+      sender: { id: 42, login: "octocat" }
+    });
+
+    const response = await app.request(
+      "/github/webhooks",
+      signedRequest({ body, secret: "secret", event: "issue_comment", deliveryId: "delivery_125" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(createRun).toHaveBeenCalledTimes(1);
+    expect(createRun.mock.calls[0]![0]).toMatchObject({
+      actor: { provider: "github", handle: "octocat", writeAccess: true },
+      metadata: { authorAssociation: "COLLABORATOR" }
+    });
+  });
+
   it("routes mentioned source-thread control commands without creating a run", async () => {
     const createRun = vi.fn(async () => ({ runId: "run_1" }));
     const submitThreadAction = vi.fn(async () => ({ outcome: "status" }));

--- a/packages/github/test/ingress.test.ts
+++ b/packages/github/test/ingress.test.ts
@@ -104,7 +104,7 @@ describe("GitHub webhook ingress", () => {
     });
   });
 
-  it("carries comment author_association into the run event actor", async () => {
+  it("keeps author_association metadata without inferring actor write access", async () => {
     const createRun = vi.fn(async () => ({ runId: "run_assoc" }));
     const app = createGitHubWebhookApp({
       webhookSecret: "secret",
@@ -135,6 +135,46 @@ describe("GitHub webhook ingress", () => {
 
     expect(response.status).toBe(200);
     expect(createRun).toHaveBeenCalledTimes(1);
+    expect(createRun.mock.calls[0]![0]).toMatchObject({
+      actor: { provider: "github", handle: "octocat" },
+      metadata: { authorAssociation: "COLLABORATOR" }
+    });
+    expect(createRun.mock.calls[0]![0].actor.writeAccess).toBeUndefined();
+  });
+
+  it("uses resolved repository permission as actor write access when provided", async () => {
+    const createRun = vi.fn(async () => ({ runId: "run_permission" }));
+    const resolveActorWriteAccess = vi.fn(async () => true);
+    const app = createGitHubWebhookApp({
+      webhookSecret: "secret",
+      createRun,
+      resolveActorWriteAccess,
+      now: () => "2026-06-27T00:00:00.000Z"
+    });
+    const body = JSON.stringify({
+      action: "created",
+      comment: {
+        id: 126,
+        body: "@opentag investigate this",
+        html_url: "https://github.com/acme/demo/issues/1#issuecomment-126",
+        author_association: "COLLABORATOR"
+      },
+      issue: {
+        html_url: "https://github.com/acme/demo/issues/1",
+        comments_url: "https://api.github.com/repos/acme/demo/issues/1/comments",
+        number: 1
+      },
+      repository: { name: "demo", private: false, owner: { login: "acme" } },
+      sender: { id: 42, login: "octocat" }
+    });
+
+    const response = await app.request(
+      "/github/webhooks",
+      signedRequest({ body, secret: "secret", event: "issue_comment", deliveryId: "delivery_126" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(resolveActorWriteAccess).toHaveBeenCalledWith({ owner: "acme", repo: "demo", username: "octocat" });
     expect(createRun.mock.calls[0]![0]).toMatchObject({
       actor: { provider: "github", handle: "octocat", writeAccess: true },
       metadata: { authorAssociation: "COLLABORATOR" }

--- a/packages/github/test/normalize.test.ts
+++ b/packages/github/test/normalize.test.ts
@@ -1,7 +1,78 @@
 import { describe, expect, it } from "vitest";
-import { normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment } from "../src/normalize.js";
+import { githubActorWriteAccess, normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment } from "../src/normalize.js";
+
+describe("githubActorWriteAccess", () => {
+  it("maps write-capable associations to true and the rest to false", () => {
+    expect(githubActorWriteAccess("OWNER")).toBe(true);
+    expect(githubActorWriteAccess("MEMBER")).toBe(true);
+    expect(githubActorWriteAccess("COLLABORATOR")).toBe(true);
+    expect(githubActorWriteAccess("CONTRIBUTOR")).toBe(false);
+    expect(githubActorWriteAccess("FIRST_TIME_CONTRIBUTOR")).toBe(false);
+    expect(githubActorWriteAccess("NONE")).toBe(false);
+  });
+
+  it("returns undefined when the platform did not report an association", () => {
+    expect(githubActorWriteAccess(undefined)).toBeUndefined();
+  });
+});
 
 describe("normalizeGitHubIssueComment", () => {
+  it("carries author_association into actor write access and metadata", () => {
+    const event = normalizeGitHubIssueComment({
+      id: "321",
+      commentBody: "@opentag fix this",
+      commentUrl: "https://github.com/acme/demo/issues/1#issuecomment-321",
+      apiCommentsUrl: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      issueUrl: "https://github.com/acme/demo/issues/1",
+      issueNumber: 1,
+      owner: "acme",
+      repo: "demo",
+      actorId: 42,
+      actorLogin: "octocat",
+      authorAssociation: "OWNER",
+      private: false,
+      receivedAt: "2026-06-24T00:00:00.000Z"
+    });
+
+    expect(event?.actor).toMatchObject({ handle: "octocat", writeAccess: true });
+    expect(event?.metadata).toMatchObject({ authorAssociation: "OWNER" });
+  });
+
+  it("marks non-write associations as writeAccess false and leaves it unset when absent", () => {
+    const strangerEvent = normalizeGitHubIssueComment({
+      id: "322",
+      commentBody: "@opentag fix this",
+      commentUrl: "https://github.com/acme/demo/issues/1#issuecomment-322",
+      apiCommentsUrl: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      issueUrl: "https://github.com/acme/demo/issues/1",
+      issueNumber: 1,
+      owner: "acme",
+      repo: "demo",
+      actorId: 99,
+      actorLogin: "mallory",
+      authorAssociation: "NONE",
+      private: false,
+      receivedAt: "2026-06-24T00:00:00.000Z"
+    });
+    expect(strangerEvent?.actor.writeAccess).toBe(false);
+
+    const unreportedEvent = normalizeGitHubIssueComment({
+      id: "323",
+      commentBody: "@opentag fix this",
+      commentUrl: "https://github.com/acme/demo/issues/1#issuecomment-323",
+      apiCommentsUrl: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      issueUrl: "https://github.com/acme/demo/issues/1",
+      issueNumber: 1,
+      owner: "acme",
+      repo: "demo",
+      actorId: 42,
+      actorLogin: "octocat",
+      private: false,
+      receivedAt: "2026-06-24T00:00:00.000Z"
+    });
+    expect(unreportedEvent?.actor.writeAccess).toBeUndefined();
+  });
+
   it("normalizes an @opentag GitHub issue comment", () => {
     const event = normalizeGitHubIssueComment({
       id: "123",

--- a/packages/github/test/normalize.test.ts
+++ b/packages/github/test/normalize.test.ts
@@ -1,23 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { githubActorWriteAccess, normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment } from "../src/normalize.js";
+import { githubPermissionHasWriteAccess, normalizeGitHubIssueComment, normalizeGitHubPullRequestReviewComment } from "../src/normalize.js";
 
-describe("githubActorWriteAccess", () => {
-  it("maps write-capable associations to true and the rest to false", () => {
-    expect(githubActorWriteAccess("OWNER")).toBe(true);
-    expect(githubActorWriteAccess("MEMBER")).toBe(true);
-    expect(githubActorWriteAccess("COLLABORATOR")).toBe(true);
-    expect(githubActorWriteAccess("CONTRIBUTOR")).toBe(false);
-    expect(githubActorWriteAccess("FIRST_TIME_CONTRIBUTOR")).toBe(false);
-    expect(githubActorWriteAccess("NONE")).toBe(false);
+describe("githubPermissionHasWriteAccess", () => {
+  it("maps actual GitHub repository permissions to write access", () => {
+    expect(githubPermissionHasWriteAccess("admin")).toBe(true);
+    expect(githubPermissionHasWriteAccess("maintain")).toBe(true);
+    expect(githubPermissionHasWriteAccess("write")).toBe(true);
+    expect(githubPermissionHasWriteAccess("read")).toBe(false);
+    expect(githubPermissionHasWriteAccess("triage")).toBe(false);
+    expect(githubPermissionHasWriteAccess("none")).toBe(false);
+    expect(githubPermissionHasWriteAccess("WRITE")).toBe(true);
   });
 
-  it("returns undefined when the platform did not report an association", () => {
-    expect(githubActorWriteAccess(undefined)).toBeUndefined();
+  it("returns undefined when the platform did not report a permission", () => {
+    expect(githubPermissionHasWriteAccess(undefined)).toBeUndefined();
   });
 });
 
 describe("normalizeGitHubIssueComment", () => {
-  it("carries author_association into actor write access and metadata", () => {
+  it("carries explicit actor write access and author_association metadata", () => {
     const event = normalizeGitHubIssueComment({
       id: "321",
       commentBody: "@opentag fix this",
@@ -30,6 +31,7 @@ describe("normalizeGitHubIssueComment", () => {
       actorId: 42,
       actorLogin: "octocat",
       authorAssociation: "OWNER",
+      actorWriteAccess: true,
       private: false,
       receivedAt: "2026-06-24T00:00:00.000Z"
     });
@@ -38,7 +40,28 @@ describe("normalizeGitHubIssueComment", () => {
     expect(event?.metadata).toMatchObject({ authorAssociation: "OWNER" });
   });
 
-  it("marks non-write associations as writeAccess false and leaves it unset when absent", () => {
+  it("does not derive write access from author_association alone", () => {
+    const event = normalizeGitHubIssueComment({
+      id: "324",
+      commentBody: "@opentag fix this",
+      commentUrl: "https://github.com/acme/demo/issues/1#issuecomment-324",
+      apiCommentsUrl: "https://api.github.com/repos/acme/demo/issues/1/comments",
+      issueUrl: "https://github.com/acme/demo/issues/1",
+      issueNumber: 1,
+      owner: "acme",
+      repo: "demo",
+      actorId: 42,
+      actorLogin: "octocat",
+      authorAssociation: "OWNER",
+      private: false,
+      receivedAt: "2026-06-24T00:00:00.000Z"
+    });
+
+    expect(event?.actor.writeAccess).toBeUndefined();
+    expect(event?.metadata).toMatchObject({ authorAssociation: "OWNER" });
+  });
+
+  it("marks explicit non-write permission as writeAccess false and leaves it unset when absent", () => {
     const strangerEvent = normalizeGitHubIssueComment({
       id: "322",
       commentBody: "@opentag fix this",
@@ -51,6 +74,7 @@ describe("normalizeGitHubIssueComment", () => {
       actorId: 99,
       actorLogin: "mallory",
       authorAssociation: "NONE",
+      actorWriteAccess: false,
       private: false,
       receivedAt: "2026-06-24T00:00:00.000Z"
     });

--- a/packages/local-runtime/src/pr.ts
+++ b/packages/local-runtime/src/pr.ts
@@ -46,11 +46,13 @@ export async function maybeCreatePullRequest(input: {
 
   const branchName = branchNameForRun(input.run.id);
   const runner = input.options.commandRunner ?? nodeCommandRunner;
-  // Codex commits inside its own worktree, so the daemon must not re-add/commit its
-  // files. Prefer the explicitly-resolved executor; fall back to the run row for
-  // backward compatibility when an external caller omits it.
+  // Worktree-isolated executors (Codex, Claude Code) commit inside their own
+  // worktree, so the daemon must not re-add/commit their files. Prefer the
+  // explicitly-resolved executor; fall back to the run row for backward
+  // compatibility when an external caller omits it.
   const resolvedExecutor = input.executor ?? input.run.executor;
-  if (resolvedExecutor !== "codex") {
+  const selfCommittingExecutors = new Set(["codex", "claude-code"]);
+  if (!selfCommittingExecutors.has(resolvedExecutor ?? "")) {
     await commitChangedFiles({
       runner,
       workspacePath: input.binding.checkoutPath,

--- a/packages/local-runtime/src/runtime.ts
+++ b/packages/local-runtime/src/runtime.ts
@@ -31,7 +31,8 @@ export function executorsFromConfig(config: OpenTagDaemonConfig) {
       ...(config.claudeCode?.permissionMode ? { permissionMode: config.claudeCode.permissionMode } : {}),
       ...(config.claudeCode?.dangerouslySkipPermissions !== undefined
         ? { dangerouslySkipPermissions: config.claudeCode.dangerouslySkipPermissions }
-        : {})
+        : {}),
+      ...(security ? { security } : {})
     }),
     hermes: createHermesExecutor({
       ...(config.hermes?.command ? { hermesCommand: config.hermes.command } : {}),

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -24,6 +24,19 @@ export type ClaudeCodeExecutorOptions = {
   security?: RunnerSecurityPolicy;
 };
 
+function permissionsAllowWorkspaceWriteMode(permissions: readonly { scope: string }[] | undefined): boolean {
+  return permissions?.some((permission) => permission.scope === "repo:write") ?? false;
+}
+
+function claudePermissionModeForRun(input: {
+  permissions: readonly { scope: string }[] | undefined;
+  configuredMode: ClaudeCodeExecutorOptions["permissionMode"];
+}): NonNullable<ClaudeCodeExecutorOptions["permissionMode"]> {
+  const workspaceWriteAllowed = permissionsAllowWorkspaceWriteMode(input.permissions);
+  if (!workspaceWriteAllowed) return "plan";
+  return input.configuredMode ?? "acceptEdits";
+}
+
 function contextLines(context: ContextPointer[]): string {
   if (!context.length) return "No additional context pointers were provided.";
   return context.map((pointer) => `- ${contextPointerLabel(pointer)}: ${pointer.uri}`).join("\n");
@@ -146,7 +159,22 @@ export function createClaudeCodeExecutor(options: ClaudeCodeExecutorOptions = {}
         };
       }
 
-      if (options.dangerouslySkipPermissions) {
+      const workspaceWriteAllowed = permissionsAllowWorkspaceWriteMode(input.permissions);
+      const dangerousSkipPermissions = workspaceWriteAllowed && options.dangerouslySkipPermissions === true;
+      const permissionMode = claudePermissionModeForRun({
+        permissions: input.permissions,
+        configuredMode: options.permissionMode
+      });
+
+      if (options.dangerouslySkipPermissions && !workspaceWriteAllowed) {
+        await sink.emit({
+          type: "executor.progress",
+          message: "Ignoring Claude Code --dangerously-skip-permissions because this run was not granted repo:write.",
+          at: new Date().toISOString()
+        });
+      }
+
+      if (dangerousSkipPermissions) {
         await sink.emit({
           type: "executor.progress",
           message:
@@ -189,8 +217,9 @@ export function createClaudeCodeExecutor(options: ClaudeCodeExecutorOptions = {}
           "text",
           "--no-session-persistence",
           ...(options.model ? ["--model", options.model] : []),
-          ...(options.permissionMode ? ["--permission-mode", options.permissionMode] : []),
-          ...(options.dangerouslySkipPermissions ? ["--dangerously-skip-permissions"] : [])
+          "--permission-mode",
+          permissionMode,
+          ...(dangerousSkipPermissions ? ["--dangerously-skip-permissions"] : [])
         ];
         const claudeResult = await runner.run(claudeCommand, args, {
           cwd: worktreePath,

--- a/packages/runner/src/claude-code.ts
+++ b/packages/runner/src/claude-code.ts
@@ -2,8 +2,18 @@ import { contextPointerLabel, type ContextPacket, type ContextPointer } from "@o
 import { assertCommandSucceeded, nodeCommandRunner, type CommandRunner } from "./command.js";
 import { executorPolicyPromptLines } from "./executor-report.js";
 import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
-import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
+import {
+  branchNameForRun,
+  changedFiles,
+  cleanupInternalArtifacts,
+  commitRunChanges,
+  createRunWorktree,
+  deleteRunBranch,
+  removeRunWorktree,
+  worktreePathForRun
+} from "./git.js";
 import { createExecutorRunResult } from "./result.js";
+import { assessRunnerSecurity, formatSecurityAssessment, scrubEnvironment, type RunnerSecurityPolicy } from "./security.js";
 
 export type ClaudeCodeExecutorOptions = {
   runner?: CommandRunner;
@@ -11,6 +21,7 @@ export type ClaudeCodeExecutorOptions = {
   model?: string;
   permissionMode?: "acceptEdits" | "auto" | "bypassPermissions" | "default" | "plan";
   dangerouslySkipPermissions?: boolean;
+  security?: RunnerSecurityPolicy;
 };
 
 function contextLines(context: ContextPointer[]): string {
@@ -63,14 +74,15 @@ export function createClaudeCodeExecutor(options: ClaudeCodeExecutorOptions = {}
       promptMutation: "none",
       rawContextAccess: false,
       writeActionAccess: "none",
-      workspaceIsolation: "branch",
+      workspaceIsolation: "worktree",
       requiredSecrets: [
         {
           id: "anthropic_api_key",
           label: "Anthropic API key",
           required: false,
           env: "ANTHROPIC_API_KEY",
-          description: "Needed when the local Claude Code CLI is configured to authenticate from environment."
+          description:
+            "Needed when the local Claude Code CLI is configured to authenticate from environment. The scrubbed executor environment drops it by default; add it to security.extraSafeEnv to pass it through."
         }
       ],
       completionSignals: [
@@ -90,82 +102,166 @@ export function createClaudeCodeExecutor(options: ClaudeCodeExecutorOptions = {}
       } catch (error) {
         return { ready: false, reason: `Claude Code CLI is not available: ${error instanceof Error ? error.message : String(error)}` };
       }
-      const gitStatus = await runner.run("git", ["status", "--porcelain"], { cwd: input.workspacePath });
-      if (gitStatus.exitCode !== 0) {
-        return { ready: false, reason: `Workspace is not a git checkout: ${gitStatus.stderr || gitStatus.stdout}` };
+      const gitRepo = await runner.run("git", ["rev-parse", "--show-toplevel"], { cwd: input.workspacePath });
+      if (gitRepo.exitCode !== 0) {
+        return { ready: false, reason: `Workspace is not a git checkout: ${gitRepo.stderr || gitRepo.stdout}` };
       }
-      if (gitStatus.stdout.trim().length > 0) {
-        return { ready: false, reason: "Workspace has uncommitted changes; refusing to run Claude Code executor." };
+      const baseBranch = input.baseBranch ?? "main";
+      const baseRef = await runner.run("git", ["rev-parse", "--verify", `${baseBranch}^{commit}`], {
+        cwd: input.workspacePath
+      });
+      if (baseRef.exitCode !== 0) {
+        return { ready: false, reason: `Base branch '${baseBranch}' is not available: ${baseRef.stderr || baseRef.stdout}` };
       }
       return { ready: true };
     },
     async run(input, sink) {
-      const branchName = branchNameForRun(input.runId);
-      await sink.emit({
-        type: "executor.started",
-        message: `Creating isolated branch ${branchName}`,
-        at: new Date().toISOString()
-      });
-      await createRunBranch({
-        runner,
+      const security = options.security;
+      const worktreePath = worktreePathForRun({
         workspacePath: input.workspacePath,
-        branchName,
-        ...(input.baseBranch ? { startPoint: input.baseBranch } : {})
+        runId: input.runId,
+        ...(input.worktreeRoot ? { worktreeRoot: input.worktreeRoot } : {})
       });
-
-      await sink.emit({
-        type: "executor.progress",
-        message: "Starting claude --print",
-        at: new Date().toISOString()
+      const assessment = assessRunnerSecurity({
+        executorId: "claude-code",
+        workspacePath: input.workspacePath,
+        executionPath: worktreePath,
+        command: input.command,
+        context: input.context,
+        ...(input.permissions ? { permissions: input.permissions } : {}),
+        ...(security ? { policy: security } : {})
       });
+      if (assessment.findings.length > 0) {
+        await sink.emit({
+          type: assessment.allowed ? "executor.progress" : "executor.failed",
+          message: formatSecurityAssessment(assessment),
+          at: new Date().toISOString()
+        });
+      }
+      if (!assessment.allowed) {
+        return {
+          conclusion: "needs_human",
+          summary: formatSecurityAssessment(assessment),
+          nextAction: "Review the request and rerun with a narrower prompt or an explicit local policy override if appropriate."
+        };
+      }
 
-      const args = [
-        "--print",
-        "--input-format",
-        "text",
-        "--output-format",
-        "text",
-        "--no-session-persistence",
-        ...(options.model ? ["--model", options.model] : []),
-        ...(options.permissionMode ? ["--permission-mode", options.permissionMode] : []),
-        ...(options.dangerouslySkipPermissions ? ["--dangerously-skip-permissions"] : [])
-      ];
-      const claudeResult = await runner.run(claudeCommand, args, {
-        cwd: input.workspacePath,
-        input: buildPrompt({
-          runId: input.runId,
-          rawText: input.command.rawText,
-          context: input.context,
-          contextPacket: input.contextPacket
-        })
-      });
-      await assertCommandSucceeded(claudeResult, "claude --print");
-
-      const cleanedArtifacts = await cleanupInternalArtifacts({ runner, workspacePath: input.workspacePath });
-      if (cleanedArtifacts.length > 0) {
+      if (options.dangerouslySkipPermissions) {
         await sink.emit({
           type: "executor.progress",
-          message: `Cleaned internal artifacts: ${cleanedArtifacts.join(", ")}`,
+          message:
+            "WARNING: Claude Code is running with --dangerously-skip-permissions; every tool call is auto-approved without any permission gate.",
           at: new Date().toISOString()
         });
       }
 
-      const files = await changedFiles({ runner, workspacePath: input.workspacePath });
+      const branchName = branchNameForRun(input.runId);
+      const baseBranch = input.baseBranch ?? "main";
+      const keepWorktree = input.keepWorktree ?? "on_failure";
+      let completed = false;
+      let changedFileCount: number | undefined;
+
       await sink.emit({
-        type: "executor.completed",
-        message: `Claude Code executor completed with ${files.length} changed file(s)`,
+        type: "executor.started",
+        message: `Creating isolated worktree ${worktreePath} on ${branchName}`,
         at: new Date().toISOString()
       });
+      try {
+        await createRunWorktree({
+          runner,
+          workspacePath: input.workspacePath,
+          worktreePath,
+          branchName,
+          baseBranch
+        });
 
-      const output = claudeResult.stdout.trim() || claudeResult.stderr.trim() || "Claude Code completed without textual output.";
-      return createExecutorRunResult({
-        executorName: "Claude Code",
-        runId: input.runId,
-        branchName,
-        ...(input.baseBranch ? { baseBranch: input.baseBranch } : {}),
-        output,
-        changedFiles: files
-      });
+        await sink.emit({
+          type: "executor.progress",
+          message: "Starting claude --print",
+          at: new Date().toISOString()
+        });
+
+        const args = [
+          "--print",
+          "--input-format",
+          "text",
+          "--output-format",
+          "text",
+          "--no-session-persistence",
+          ...(options.model ? ["--model", options.model] : []),
+          ...(options.permissionMode ? ["--permission-mode", options.permissionMode] : []),
+          ...(options.dangerouslySkipPermissions ? ["--dangerously-skip-permissions"] : [])
+        ];
+        const claudeResult = await runner.run(claudeCommand, args, {
+          cwd: worktreePath,
+          env: scrubEnvironment(undefined, security),
+          input: buildPrompt({
+            runId: input.runId,
+            rawText: input.command.rawText,
+            context: input.context,
+            contextPacket: input.contextPacket
+          })
+        });
+        await assertCommandSucceeded(claudeResult, "claude --print");
+
+        const cleanedArtifacts = await cleanupInternalArtifacts({ runner, workspacePath: worktreePath });
+        if (cleanedArtifacts.length > 0) {
+          await sink.emit({
+            type: "executor.progress",
+            message: `Cleaned internal artifacts: ${cleanedArtifacts.join(", ")}`,
+            at: new Date().toISOString()
+          });
+        }
+
+        const files = await changedFiles({ runner, workspacePath: worktreePath });
+        changedFileCount = files.length;
+        if (files.length > 0) {
+          await sink.emit({
+            type: "executor.progress",
+            message: `Committing ${files.length} changed file(s) to ${branchName}`,
+            at: new Date().toISOString()
+          });
+          await commitRunChanges({
+            runner,
+            workspacePath: worktreePath,
+            message: `OpenTag run ${input.runId}`
+          });
+        }
+        completed = true;
+
+        await sink.emit({
+          type: "executor.completed",
+          message: `Claude Code executor completed with ${files.length} changed file(s)`,
+          at: new Date().toISOString()
+        });
+
+        const output = claudeResult.stdout.trim() || claudeResult.stderr.trim() || "Claude Code completed without textual output.";
+        return createExecutorRunResult({
+          executorName: "Claude Code",
+          runId: input.runId,
+          branchName,
+          ...(input.baseBranch ? { baseBranch: input.baseBranch } : {}),
+          output,
+          changedFiles: files,
+          extraArtifacts: keepWorktree === "always" ? [{ title: "Run worktree", uri: worktreePath }] : []
+        });
+      } finally {
+        const shouldRemove = keepWorktree === "never" || (keepWorktree === "on_failure" && completed);
+        if (shouldRemove) {
+          try {
+            await removeRunWorktree({ runner, workspacePath: input.workspacePath, worktreePath });
+            if (completed && changedFileCount === 0) {
+              await deleteRunBranch({ runner, workspacePath: input.workspacePath, branchName });
+            }
+          } catch (error) {
+            await sink.emit({
+              type: "executor.progress",
+              message: `Could not clean up run worktree or branch for ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`,
+              at: new Date().toISOString()
+            });
+          }
+        }
+      }
     },
     async cancel() {
       return;

--- a/packages/runner/src/codex.ts
+++ b/packages/runner/src/codex.ts
@@ -165,11 +165,18 @@ export function createCodexExecutor(options: CodexExecutorOptions = {}): Executo
           at: new Date().toISOString()
         });
 
+        // Sandbox level follows the granted permission scopes: runs admitted
+        // without a write scope (e.g. `investigate`) get Codex's read-only
+        // sandbox, so a prompt-injected read run cannot modify the worktree.
+        // `--full-auto` keeps the OS sandbox in workspace-write mode with
+        // network disabled; OpenTag never uses the sandbox-bypass flags.
+        const writeCapable =
+          input.permissions?.some((permission) => ["repo:write", "pr:create", "pr:update"].includes(permission.scope)) ?? false;
         const args = [
           "exec",
           "--cd",
           worktreePath,
-          "--full-auto",
+          ...(writeCapable ? ["--full-auto"] : ["--sandbox", "read-only"]),
           "--ephemeral",
           ...(options.model ? ["--model", options.model] : []),
           "-"

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -196,6 +196,47 @@ describe("Claude Code executor", () => {
     expect(events.some((event) => event.type === "executor.failed")).toBe(true);
   });
 
+  it("uses Claude plan permission mode for runs without repo:write", async () => {
+    const calls: { command: string; args: string[] }[] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        calls.push({ command, args });
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && (args[0] === "worktree" || args[0] === "branch")) {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "claude" && args.includes("--print")) {
+          return { exitCode: 0, stdout: "Read-only analysis complete.", stderr: "" };
+        }
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+
+    await createClaudeCodeExecutor({ runner, permissionMode: "acceptEdits" }).run(
+      {
+        runId: "run_read_only",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "investigate this", intent: "investigate", args: {} },
+        context: [],
+        permissions: [
+          { scope: "repo:read", reason: "inspect repository" },
+          { scope: "pr:update", reason: "request reviewers after approval" }
+        ],
+        baseBranch: "main",
+        keepWorktree: "on_failure"
+      },
+      { emit: async () => undefined }
+    );
+
+    const claudePrintCall = calls.find((call) => call.command === "claude" && call.args.includes("--print"));
+    expect(claudePrintCall?.args).toContain("--permission-mode");
+    expect(claudePrintCall?.args).toContain("plan");
+    expect(claudePrintCall?.args).not.toContain("acceptEdits");
+    expect(claudePrintCall?.args).not.toContain("--dangerously-skip-permissions");
+  });
+
   it("emits an audit warning when --dangerously-skip-permissions is enabled", async () => {
     const calls: { command: string; args: string[] }[] = [];
     const runner: CommandRunner = {
@@ -221,6 +262,7 @@ describe("Claude Code executor", () => {
         workspacePath: "/tmp/demo",
         command: { rawText: "summarize this repo", intent: "unknown", args: {} },
         context: [],
+        permissions: [{ scope: "repo:write", reason: "allow write-capable Claude mode" }],
         baseBranch: "main",
         keepWorktree: "on_failure"
       },

--- a/packages/runner/test/claude-code.test.ts
+++ b/packages/runner/test/claude-code.test.ts
@@ -1,19 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createClaudeCodeExecutor } from "../src/claude-code.js";
 import type { CommandRunner } from "../src/command.js";
+import { worktreePathForRun } from "../src/git.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("Claude Code executor", () => {
-  it("creates an isolated branch, runs claude print mode, and reports changed files", async () => {
-    const calls: { command: string; args: string[]; input?: string }[] = [];
+  it("creates an isolated worktree, runs claude print mode, and reports changed files", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-secret");
+    const calls: { command: string; args: string[]; input?: string; cwd?: string; env?: Record<string, string | undefined> }[] = [];
     const runner: CommandRunner = {
       async run(command, args, options) {
-        calls.push({ command, args, input: options?.input });
+        calls.push({ command, args, input: options?.input, cwd: options?.cwd, env: options?.env });
         if (command === "claude" && args.includes("--version")) {
           return { exitCode: 0, stdout: "1.0.0", stderr: "" };
         }
-        // The canRun dirty-check uses plain `status --porcelain`; the git
-        // helpers (cleanup + changedFiles) use the NUL-delimited `-z` form.
-        if (command === "git" && args.join(" ") === "status --porcelain") {
+        if (command === "git" && args.join(" ") === "rev-parse --show-toplevel") {
+          return { exitCode: 0, stdout: "/tmp/demo\n", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "rev-parse --verify main^{commit}") {
+          return { exitCode: 0, stdout: "abc123\n", stderr: "" };
+        }
+        if (command === "git" && args[0] === "worktree" && args[1] === "add") {
           return { exitCode: 0, stdout: "", stderr: "" };
         }
         if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
@@ -21,11 +31,17 @@ describe("Claude Code executor", () => {
             ? { exitCode: 0, stdout: " M src/demo.ts\0?? test/demo.test.ts\0", stderr: "" }
             : { exitCode: 0, stdout: "?? .claude/\0 M src/demo.ts\0?? test/demo.test.ts\0", stderr: "" };
         }
-        if (command === "git" && args[0] === "checkout") {
-          return { exitCode: 0, stdout: "", stderr: "" };
-        }
         if (command === "git" && args.join(" ") === "clean -fd -- .claude") {
           return { exitCode: 0, stdout: "Removing .claude/\n", stderr: "" };
+        }
+        if (command === "git" && args[0] === "add") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && args[0] === "commit") {
+          return { exitCode: 0, stdout: "[opentag/run_1 abc123] commit\n", stderr: "" };
+        }
+        if (command === "git" && args[0] === "worktree" && args[1] === "remove") {
+          return { exitCode: 0, stdout: "", stderr: "" };
         }
         if (command === "claude" && args.includes("--print")) {
           return { exitCode: 0, stdout: "Implemented the requested Claude Code change.", stderr: "" };
@@ -74,7 +90,9 @@ describe("Claude Code executor", () => {
           facts: [{ text: "The failing test is flaky in CI." }],
           exclusions: ["Do not modify unrelated callback code."]
         },
-        baseBranch: "main"
+        permissions: [{ scope: "repo:write", reason: "commit code changes on an isolated run branch" }],
+        baseBranch: "main",
+        keepWorktree: "on_failure"
       },
       {
         emit: async (event) => {
@@ -83,9 +101,19 @@ describe("Claude Code executor", () => {
       }
     );
 
+    const worktreePath = worktreePathForRun({ workspacePath: "/tmp/demo", runId: "run_1" });
     const claudePrintCall = calls.find((call) => call.command === "claude" && call.args.includes("--print"));
-    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "checkout -B opentag/run_1 main")).toBe(true);
+    expect(
+      calls.some(
+        (call) => call.command === "git" && call.args.join(" ") === `worktree add -B opentag/run_1 ${worktreePath} main`
+      )
+    ).toBe(true);
     expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .claude")).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "add -- src/demo.ts test/demo.test.ts")).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "commit -m OpenTag run run_1")).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === `worktree remove --force ${worktreePath}`)).toBe(true);
+    expect(claudePrintCall?.cwd).toBe(worktreePath);
+    expect(claudePrintCall?.env?.ANTHROPIC_API_KEY).toBeUndefined();
     expect(claudePrintCall?.args).toContain("--input-format");
     expect(claudePrintCall?.args).toContain("text");
     expect(claudePrintCall?.args).toContain("--output-format");
@@ -94,6 +122,7 @@ describe("Claude Code executor", () => {
     expect(claudePrintCall?.args).toContain("acceptEdits");
     expect(claudePrintCall?.args).toContain("--model");
     expect(claudePrintCall?.args).toContain("sonnet");
+    expect(claudePrintCall?.args).not.toContain("--dangerously-skip-permissions");
     expect(claudePrintCall?.input).toContain("OpenTag context packet:");
     expect(claudePrintCall?.input).toContain("Use the linked issue and propose the narrowest fix.");
     expect(claudePrintCall?.input).toContain("intent: fix");
@@ -106,7 +135,13 @@ describe("Claude Code executor", () => {
     expect(claudePrintCall?.input).toContain("OPENTAG_EXECUTOR_REPORT_START");
     expect(claudePrintCall?.input).toContain('"outcome": "passed"');
     expect(claudePrintCall?.input).toContain("OPENTAG_EXECUTOR_REPORT_END");
-    expect(events).toEqual(["executor.started", "executor.progress", "executor.progress", "executor.completed"]);
+    expect(events).toEqual([
+      "executor.started",
+      "executor.progress",
+      "executor.progress",
+      "executor.progress",
+      "executor.completed"
+    ]);
     expect(result.changedFiles).toEqual(["src/demo.ts", "test/demo.test.ts"]);
     expect(result.summary).toContain("Implemented the requested Claude Code change.");
     expect(result.suggestedChanges?.[0]).toMatchObject({
@@ -134,14 +169,88 @@ describe("Claude Code executor", () => {
     });
   });
 
-  it("refuses to run when the workspace has uncommitted changes", async () => {
+  it("blocks write-capable commands without a repo:write permission grant", async () => {
+    const runner: CommandRunner = {
+      async run() {
+        throw new Error("no command should run when the security assessment blocks");
+      }
+    };
+
+    const events: { type: string; message: string }[] = [];
+    const result = await createClaudeCodeExecutor({ runner }).run(
+      {
+        runId: "run_blocked",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: []
+      },
+      {
+        emit: async (event) => {
+          events.push({ type: event.type, message: event.message });
+        }
+      }
+    );
+
+    expect(result.conclusion).toBe("needs_human");
+    expect(result.summary).toContain("permission.repo_write_required");
+    expect(events.some((event) => event.type === "executor.failed")).toBe(true);
+  });
+
+  it("emits an audit warning when --dangerously-skip-permissions is enabled", async () => {
+    const calls: { command: string; args: string[] }[] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        calls.push({ command, args });
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && (args[0] === "worktree" || args[0] === "branch")) {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "claude" && args.includes("--print")) {
+          return { exitCode: 0, stdout: "Answered without changes.", stderr: "" };
+        }
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+
+    const events: { type: string; message: string }[] = [];
+    await createClaudeCodeExecutor({ runner, dangerouslySkipPermissions: true }).run(
+      {
+        runId: "run_skip",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "summarize this repo", intent: "unknown", args: {} },
+        context: [],
+        baseBranch: "main",
+        keepWorktree: "on_failure"
+      },
+      {
+        emit: async (event) => {
+          events.push({ type: event.type, message: event.message });
+        }
+      }
+    );
+
+    const claudePrintCall = calls.find((call) => call.command === "claude" && call.args.includes("--print"));
+    expect(claudePrintCall?.args).toContain("--dangerously-skip-permissions");
+    expect(
+      events.some(
+        (event) => event.type === "executor.progress" && event.message.includes("--dangerously-skip-permissions")
+      )
+    ).toBe(true);
+  });
+
+  it("returns not ready when the base branch is missing", async () => {
     const runner: CommandRunner = {
       async run(command, args) {
         if (command === "claude" && args.includes("--version")) {
           return { exitCode: 0, stdout: "1.0.0", stderr: "" };
         }
-        if (command === "git" && args.join(" ") === "status --porcelain") {
-          return { exitCode: 0, stdout: " M dirty.ts\n", stderr: "" };
+        if (command === "git" && args.join(" ") === "rev-parse --show-toplevel") {
+          return { exitCode: 0, stdout: "/tmp/demo\n", stderr: "" };
+        }
+        if (command === "git" && args.join(" ") === "rev-parse --verify main^{commit}") {
+          return { exitCode: 1, stdout: "", stderr: "fatal: Needed a single revision\n" };
         }
         return { exitCode: 0, stdout: "", stderr: "" };
       }
@@ -154,7 +263,7 @@ describe("Claude Code executor", () => {
         command: { rawText: "fix this", intent: "fix", args: {} },
         context: []
       })
-    ).resolves.toEqual({ ready: false, reason: "Workspace has uncommitted changes; refusing to run Claude Code executor." });
+    ).resolves.toEqual({ ready: false, reason: "Base branch 'main' is not available: fatal: Needed a single revision\n" });
   });
 
   it("returns not ready when the Claude Code CLI is missing", async () => {

--- a/packages/runner/test/codex.test.ts
+++ b/packages/runner/test/codex.test.ts
@@ -206,6 +206,42 @@ describe("Codex executor", () => {
     expect(result.nextAction).toBe("No file changes were detected.");
   });
 
+  it("selects the read-only sandbox for runs without a write scope", async () => {
+    const codexExecCalls: string[][] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && (args[0] === "worktree" || args[0] === "branch")) {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "codex" && args[0] === "exec") {
+          codexExecCalls.push(args);
+          return { exitCode: 0, stdout: "Summary of the repository.", stderr: "" };
+        }
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+
+    await createCodexExecutor({ runner }).run(
+      {
+        runId: "run_read_sandbox",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "summarize this repo", intent: "unknown", args: {} },
+        context: [],
+        permissions: [{ scope: "repo:read", reason: "read-only summary" }],
+        baseBranch: "main",
+        keepWorktree: "on_failure"
+      },
+      { emit: async () => undefined }
+    );
+
+    expect(codexExecCalls[0]).toContain("--sandbox");
+    expect(codexExecCalls[0]).toContain("read-only");
+    expect(codexExecCalls[0]).not.toContain("--full-auto");
+  });
+
   it("preserves Codex read-only answers when the executor report has no file changes", async () => {
     const runner: CommandRunner = {
       async run(command, args) {

--- a/packages/runner/test/executor-capability.test.ts
+++ b/packages/runner/test/executor-capability.test.ts
@@ -36,7 +36,7 @@ describe("executor capability contracts", () => {
     }
 
     expect(createCodexExecutor().capability?.workspaceIsolation).toBe("worktree");
-    expect(createClaudeCodeExecutor().capability?.workspaceIsolation).toBe("branch");
+    expect(createClaudeCodeExecutor().capability?.workspaceIsolation).toBe("worktree");
     expect(createHermesExecutor().capability).toMatchObject({
       supportsProfile: true,
       workspaceIsolation: "branch"

--- a/scripts/test/protocol-runtime-smoke.ts
+++ b/scripts/test/protocol-runtime-smoke.ts
@@ -59,7 +59,7 @@ try {
     source: "github",
     sourceEventId: "comment_smoke_1",
     receivedAt: "2026-06-24T00:00:00.000Z",
-    actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+    actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
     target: { mention: "@opentag", agentId: "opentag" },
     command: { rawText: "triage this issue", intent: "run", args: {} },
     context: [
@@ -153,7 +153,7 @@ try {
   const threadAction = await client.submitThreadAction({
     id: "approval_smoke_1",
     rawText: "apply 1",
-    actor: { provider: "github", providerUserId: "42", handle: "octocat" },
+    actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
     callback: event.callback,
     metadata: { source: "smoke", owner: "acme", repo: "demo", issueNumber: 9 }
   });


### PR DESCRIPTION
## Summary

Two related security hardenings from the pre-commercialization review, both changing unsafe defaults without adding any approval friction for normal use:

**Platform-aware default authorization.** Without an explicit `allowedActors` list, admission previously accepted any commenter — on a public GitHub/GitLab repository a drive-by comment could start a coding-agent run on the operator's machine. Admission now requires platform-reported write access on public repositories: GitHub ingress derives `actor.writeAccess` from the webhook `author_association` field (`OWNER`/`MEMBER`/`COLLABORATOR`); GitLab Note Hooks carry no access level, so public GitLab projects stay closed until `allowedActors` is configured. Source-thread approvals (`apply 1`, ...) from public threads follow the same rule. Private repositories, Slack, and Lark are unchanged, and an explicit `allowedActors` list still overrides the default for write-capable runs. Denied actors get a `needs_human_decision` reply with a new `actor_not_authorized_for_public_repo` reason code.

**Executor hardening.** The Claude Code executor now matches Codex's protections: scrubbed spawn environment (auth-from-env users add their key to `security.extraSafeEnv`), pre-execution security assessment, and isolated git worktree execution with the same commit/cleanup semantics (PR branch preparation now treats both executors as self-committing). Codex runs admitted without a write scope use `--sandbox read-only` instead of `--full-auto`, so granted permission scopes are enforced at the executor level. Enabling `dangerouslySkipPermissions` for Claude Code emits an audit warning on every run.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (885 tests, includes new admission-policy, author-association mapping, sandbox-selection, and skip-permissions-warning cases)
- `git diff origin/main...HEAD --check`

## Notes

- Behavior change for operators of public repositories: non-collaborator mentions no longer start runs. Documented in the GitHub/GitLab platform guides ("Who Can Trigger Runs") and the changelog.
- `MEMBER` (org member) is treated as trusted, matching GitHub Actions and common bot conventions; organizations with many read-only members may want a stricter mapping later.
- Claude Code environment scrubbing means `ANTHROPIC_API_KEY`-based CLI auth needs `security.extraSafeEnv`; login-based auth is unaffected (same trade-off Codex already made).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer run-trigger rules for GitHub and GitLab, including default public-repo closures and support for explicit allowlists.
  * Executor behavior now enforces stricter security defaults, using read-only sandboxes when write scopes are not granted.

* **Bug Fixes**
  * Improved actor authorization consistency across admissions and thread actions, including platform-reported write access for public repositories.
  * Public-repo actions and source-thread approvals now deny/allow correctly based on reported access and configuration.

* **Documentation**
  * Expanded permissions, sandbox, isolated worktree behavior, and audit-warning guidance for security-related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->