### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,8 +27,11 @@ import {
 import { runSetupCommand } from "./commands/setup.js";
 import { runStartCommand } from "./start.js";
 import { runStatusCommand } from "./status.js";
+import { CLI_VERSION } from "./version.js";
 
 const program = new Command();
+
+program.version(CLI_VERSION);
 
 function handleError(error: unknown): never {
   console.error(formatCliConfigError(error));

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,6 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version: string };
+
+export const CLI_VERSION = packageJson.version;

--- a/packages/cli/test/version.test.ts
+++ b/packages/cli/test/version.test.ts
@@ -1,0 +1,12 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+import { CLI_VERSION } from "../src/version.js";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version: string };
+
+describe("CLI version", () => {
+  it("matches package.json", () => {
+    expect(CLI_VERSION).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--version` / `-V` flag to the OpenTag CLI so users can quickly check the installed version.

## Validation

- `pnpm typecheck` passes
- `packages/cli/test/version.test.ts` passes (`pnpm exec vitest run packages/cli/test/version.test.ts`)
- `node packages/cli/dist/index.js --version` outputs the current package version
- `node packages/cli/dist/index.js --help` shows `-V, --version`

Note: The full `pnpm test` suite has unrelated failures on my Node 26 environment due to `better-sqlite3` native bindings (this repo pins Node 22). CI runs Node 22 and previously ran this PR green pre-rebase.

## Notes

Rebased onto latest `main` after upstream `712c451` ("Make chat adapters setup-ready for local-first use") landed the "Telegram/Discord experimental" README clarification independently, so this PR now focuses solely on the `--version` flag.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI now reports its package version when you run `--version`.
  * Version output is aligned with the version published for the CLI package.
* **Tests**
  * Added coverage to verify the CLI version matches the package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->