### PR TITLE
Add Discord readiness follow-up after setup-ready merge

### DIFF
--- a/packages/cli/src/pair.ts
+++ b/packages/cli/src/pair.ts
@@ -80,10 +80,15 @@ function gitlabRelayWebhookUrl(relayUrl: string, webhookPath = "/gitlab/webhooks
   return `${stripTrailingSlash(relayUrl)}${webhookPath}`;
 }
 
+function discordRelayInteractionsUrl(relayUrl: string, webhookPath = "/discord/interactions"): string {
+  return `${stripTrailingSlash(relayUrl)}${webhookPath}`;
+}
+
 export function formatPairRelaySummary(input: PairRelaySummaryInput): string {
   const projectTargets = input.config.daemon.repositories.map((repository) => {
     return `  ${formatConfiguredProjectTargetSummary(repository)}`;
   });
+  const discord = input.config.platforms.discord;
   return [
     "OpenTag relay pairing updated.",
     `Config: ${input.configPath}`,
@@ -97,6 +102,7 @@ export function formatPairRelaySummary(input: PairRelaySummaryInput): string {
     ...(input.config.platforms.gitlab
       ? [`GitLab webhook URL: ${gitlabRelayWebhookUrl(input.relayUrl, input.config.platforms.gitlab.webhookPath)}`]
       : []),
+    ...(discord?.mode === "webhook" ? [`Discord Interactions Endpoint URL: ${discordRelayInteractionsUrl(input.relayUrl, discord.webhookPath)}`] : []),
     "Next steps:",
     `  opentag start --config ${input.configPath}`,
     "  opentag service start"

--- a/packages/cli/src/relay-security.ts
+++ b/packages/cli/src/relay-security.ts
@@ -107,6 +107,15 @@ export function relaySecurityChecksFromConfig(config: OpenTagCliConfig): RelaySe
     });
   }
 
+  if (config.platforms.discord?.mode === "webhook") {
+    const webhookPath = config.platforms.discord.webhookPath ?? "/discord/interactions";
+    checks.push({
+      status: "ok",
+      name: "Discord interaction signature",
+      message: `Configured locally; the relay ${webhookPath} endpoint must verify the Ed25519 signature before creating runs.`
+    });
+  }
+
   if (config.platforms.slack || config.platforms.lark) {
     const unsupported = [
       config.platforms.slack ? "Slack" : undefined,

--- a/packages/cli/src/secret-readiness.ts
+++ b/packages/cli/src/secret-readiness.ts
@@ -76,5 +76,9 @@ export function formatSecretReadiness(redactedConfig: unknown): string[] {
     add("platforms.gitlab.webhookSecret", ["platforms", "gitlab", "webhookSecret"]);
   }
 
+  if (hasPath(redactedConfig, ["platforms", "discord"])) {
+    add("platforms.discord.botToken", ["platforms", "discord", "botToken"]);
+  }
+
   return rows;
 }

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -508,6 +508,18 @@ function formatConnectorReadiness(config: OpenTagCliConfig): string[] {
     );
   }
 
+  const discord = config.platforms.discord;
+  if (discord) {
+    const mode = discord.mode ?? "gateway";
+    if (mode === "webhook") {
+      lines.push(
+        `  discord: ingress=dispatcher_interactions path=${discord.webhookPath ?? "/discord/interactions"}, callback=${connectorStatus(configured(discord.botToken), "botToken")}, signature=${connectorStatus(configured(discord.publicKey), "publicKey")}`
+      );
+    } else {
+      lines.push(`  discord: ingress=gateway ${connectorStatus(configured(discord.botToken), "botToken")}, callback=${connectorStatus(configured(discord.botToken), "botToken")}, tunnel=not required`);
+    }
+  }
+
   const slack = config.platforms.slack;
   if (slack) {
     const mode = slack.mode ?? "events_api";

--- a/packages/cli/test/pair.test.ts
+++ b/packages/cli/test/pair.test.ts
@@ -47,6 +47,36 @@ function gitlabConfig() {
   });
 }
 
+function discordWebhookConfig() {
+  return createSetupConfig({
+    language: "en",
+    platform: "discord",
+    projectPath: tempDir(),
+    executor: "echo",
+    stateDirectory: join(tempDir(), "state"),
+    discord: {
+      mode: "webhook",
+      publicKey: "discord_public_key",
+      botToken: "discord_bot_token",
+      webhookPath: "/discord/interactions"
+    }
+  });
+}
+
+function discordGatewayConfig() {
+  return createSetupConfig({
+    language: "en",
+    platform: "discord",
+    projectPath: tempDir(),
+    executor: "echo",
+    stateDirectory: join(tempDir(), "state"),
+    discord: {
+      mode: "gateway",
+      botToken: "discord_bot_token"
+    }
+  });
+}
+
 function okFetch(): typeof fetch {
   return vi.fn(async () => Response.json({ ok: true })) as unknown as typeof fetch;
 }
@@ -229,5 +259,23 @@ describe("OpenTag CLI pair relay", () => {
 
     expect(formatted).toContain("GitLab webhook URL: https://relay.example/gitlab/webhooks");
     expect(formatted).toContain("gitlab:acme/team/demo (hasWorkspacePath=yes)");
+  });
+
+  it("includes the Discord relay Interactions Endpoint URL only for webhook mode", () => {
+    const webhook = formatPairRelaySummary({
+      configPath: "/tmp/config.json",
+      config: discordWebhookConfig(),
+      relayUrl: "https://relay.example",
+      registered: true
+    });
+    const gateway = formatPairRelaySummary({
+      configPath: "/tmp/config.json",
+      config: discordGatewayConfig(),
+      relayUrl: "https://relay.example",
+      registered: true
+    });
+
+    expect(webhook).toContain("Discord Interactions Endpoint URL: https://relay.example/discord/interactions");
+    expect(gateway).not.toContain("Discord Interactions Endpoint URL:");
   });
 });

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -479,6 +479,12 @@ describe("OpenTag CLI service", () => {
         domain: "lark",
         botOpenId: "ou_bot"
       };
+      config.platforms.discord = {
+        mode: "webhook",
+        publicKey: "discord_public_key",
+        botToken: "discord_bot_secret",
+        webhookPath: "/discord/interactions"
+      };
     });
     installService({ config: configPath }, { platform: "darwin", homeDir: home, launchctl: launchctl(0) });
 
@@ -490,9 +496,12 @@ describe("OpenTag CLI service", () => {
     expect(formatted).toContain("slack: ingress=events_api ready (signingSecret port=3060), callback=ready (botToken), source=T123/C456");
     expect(formatted).toContain("lark: ingress=long_connection tenant=lark ready (appId/appSecret), callback=ready (appId/appSecret)");
     expect(formatted).toContain("addressing=bot_open_id configured");
+    expect(formatted).toContain("discord: ingress=dispatcher_interactions path=/discord/interactions, callback=ready (botToken), signature=ready (publicKey)");
+    expect(formatted).toContain("platforms.discord.botToken: inline (redacted)");
     expect(formatted).not.toContain("slack_signing_secret");
     expect(formatted).not.toContain("xoxb_secret");
     expect(formatted).not.toContain("lark_secret");
+    expect(formatted).not.toContain("discord_bot_secret");
   });
 
   it("marks a running service ready only after dispatcher health succeeds", async () => {

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -87,6 +87,29 @@ function gitlabRelayConfig() {
   return built;
 }
 
+function discordWebhookRelayConfig() {
+  const built = createSetupConfig({
+    language: "en",
+    platform: "discord",
+    projectPath: tempDir(),
+    executor: "echo",
+    stateDirectory: join(tempDir(), "state"),
+    discord: {
+      mode: "webhook",
+      publicKey: "discord_public_key",
+      botToken: "discord_bot_token",
+      webhookPath: "/discord/interactions"
+    }
+  });
+  built.runtime = {
+    mode: "relay",
+    relayUrl: "https://relay.example",
+    relayProvider: "custom"
+  };
+  built.daemon.dispatcherUrl = "https://relay.example";
+  return built;
+}
+
 function hangingFetch(): typeof fetch {
   return vi.fn((_url: string | URL | Request, init?: RequestInit) => {
     return new Promise<Response>((_resolve, reject) => {
@@ -254,6 +277,18 @@ describe("OpenTag CLI status", () => {
     expect(formatted).toContain("Runtime: relay");
     expect(formatted).toContain("OK GitLab webhook secret: Configured locally; the relay /gitlab/webhooks endpoint must verify X-Gitlab-Token before creating runs.");
     expect(formatted).not.toContain("GitLab relay mode is not supported");
+  });
+
+  it("formats Discord relay signature requirements for webhook mode", async () => {
+    const summary = await statusFromConfig({
+      config: discordWebhookRelayConfig(),
+      configPath: "/tmp/opentag/config.json",
+      fetchImpl: vi.fn(async () => Response.json({ ok: true }))
+    });
+
+    const formatted = formatStatus(summary);
+    expect(formatted).toContain("Runtime: relay");
+    expect(formatted).toContain("OK Discord interaction signature: Configured locally; the relay /discord/interactions endpoint must verify the Ed25519 signature before creating runs.");
   });
 
   it("formats relay token scope as split when runnerToken is configured", async () => {


### PR DESCRIPTION
## Summary

Follow-up after closing #73 as superseded by #75. This keeps the small Discord operational-readiness pieces that still fit the new Gateway-first Discord baseline:

- Show the Discord Interactions Endpoint URL in `opentag pair --relay` summaries only when Discord is configured for webhook mode.
- Add a relay security check reminding webhook-mode deployments to verify Discord Ed25519 signatures before creating runs.
- Include `platforms.discord.botToken` in secret readiness output without printing the token.
- Include Discord connector readiness in `opentag service status` for both Gateway and webhook modes.

## Implementation boundary

This intentionally does not rebase or revive #73. It does not change Discord setup schema, Gateway behavior, dispatcher runtime wiring, or Telegram support from #75.

## Validation

- `corepack pnpm test packages/cli/test/pair.test.ts packages/cli/test/status.test.ts packages/cli/test/service.test.ts`
- `git diff --check`
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`

## Notes

Gateway mode remains the default and does not show a relay Interactions Endpoint URL because it does not require a public webhook endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord support to relay and service status summaries, including a Discord Interactions endpoint URL when webhook mode is used.
  * Expanded readiness output to show Discord connector status and required credentials.

* **Bug Fixes**
  * Added a security notice for Discord webhook mode to highlight signature verification requirements.
  * Improved secret redaction so Discord tokens are not displayed in status output.

* **Tests**
  * Added coverage for Discord webhook and gateway configurations across pairing, service, and status outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->