### PR TITLE
Add OpenClaw spawn executor

### DIFF
--- a/packages/cli/src/catalogs/capabilities.ts
+++ b/packages/cli/src/catalogs/capabilities.ts
@@ -86,6 +86,26 @@ export const EXECUTOR_CAPABILITIES: Record<ExecutorId, ExecutorCapabilityDescrip
     requiredSecrets: [],
     completionSignals: ["process_exit"]
   },
+  openclaw: {
+    id: "openclaw",
+    invocation: "spawn",
+    supportsProfile: false,
+    supportsStreaming: false,
+    supportsCancel: false,
+    supportsHookCompletion: false,
+    progressEvents: "audit",
+    approvalMode: "opentag_policy",
+    contextAccess: ["context_packet", "context_pointers", "workspace"],
+    promptAssembly: "executor_adapter",
+    writeAccess: "workspace",
+    conversationAccess: "request",
+    promptMutation: "none",
+    rawContextAccess: false,
+    writeActionAccess: "none",
+    workspaceIsolation: "branch",
+    requiredSecrets: [],
+    completionSignals: ["process_exit"]
+  },
   echo: {
     id: "echo",
     invocation: "spawn",

--- a/packages/cli/src/catalogs/executors.ts
+++ b/packages/cli/src/catalogs/executors.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { delimiter, extname, join } from "node:path";
 
-export type ExecutorId = "echo" | "codex" | "claude-code" | "hermes";
+export type ExecutorId = "echo" | "codex" | "claude-code" | "hermes" | "openclaw";
 
 export type ExecutorDescriptor = {
   id: ExecutorId;
@@ -37,6 +37,12 @@ export const EXECUTOR_CATALOG: ExecutorDescriptor[] = [
     commandEnv: "OPENTAG_HERMES_COMMAND"
   },
   {
+    id: "openclaw",
+    label: "OpenClaw",
+    command: "openclaw",
+    commandEnv: "OPENTAG_OPENCLAW_COMMAND"
+  },
+  {
     id: "echo",
     label: "Echo",
     alwaysAvailable: true,
@@ -59,7 +65,7 @@ function executorCommand(executor: ExecutorDescriptor, env: NodeJS.ProcessEnv): 
 }
 
 export function isExecutorId(value: string): value is ExecutorId {
-  return value === "echo" || value === "codex" || value === "claude-code" || value === "hermes";
+  return value === "echo" || value === "codex" || value === "claude-code" || value === "hermes" || value === "openclaw";
 }
 
 export function detectExecutors(env: NodeJS.ProcessEnv = process.env): ExecutorDetection[] {
@@ -97,6 +103,9 @@ export function defaultExecutorId(input: {
   }
   if (detections.find((executor) => executor.id === "hermes")?.available) {
     return "hermes";
+  }
+  if (detections.find((executor) => executor.id === "openclaw")?.available) {
+    return "openclaw";
   }
   return "echo";
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -158,6 +158,14 @@ const HermesSchema = z
   })
   .strict();
 
+const OpenclawSchema = z
+  .object({
+    command: z.string().trim().min(1).optional(),
+    agent: z.string().trim().min(1).optional(),
+    sessionKey: z.string().trim().min(1).optional()
+  })
+  .strict();
+
 const AgentSessionProfileSchema = z
   .object({
     profile: z.string().trim().min(1).optional(),
@@ -182,6 +190,7 @@ const DaemonConfigSchema = z
     channelBindings: z.array(ChannelBindingSchema).optional(),
     claudeCode: ClaudeCodeSchema.optional(),
     hermes: HermesSchema.optional(),
+    openclaw: OpenclawSchema.optional(),
     agentSessionProfile: AgentSessionProfileSchema.optional(),
     security: SecuritySchema.optional(),
     githubToken: SecretStringSchema.optional(),

--- a/packages/cli/test/executors.test.ts
+++ b/packages/cli/test/executors.test.ts
@@ -11,6 +11,14 @@ describe("executor catalog", () => {
     expect(defaultExecutorId({ detections })).toBe("hermes");
   });
 
+  it("uses OPENTAG_OPENCLAW_COMMAND for OpenClaw detection", () => {
+    const detections = detectExecutors({ PATH: "", OPENTAG_OPENCLAW_COMMAND: process.execPath } as NodeJS.ProcessEnv);
+    const openclaw = detections.find((executor) => executor.id === "openclaw");
+
+    expect(openclaw).toMatchObject({ available: true, reason: `Found ${process.execPath} on PATH` });
+    expect(defaultExecutorId({ detections })).toBe("openclaw");
+  });
+
   it("formats executor runtime capabilities next to executor availability", () => {
     const output = formatExecutorsCommandOutput({ PATH: "" } as NodeJS.ProcessEnv);
 
@@ -31,6 +39,7 @@ describe("executor catalog", () => {
     expect(output).toContain("write_actions=none");
     expect(output).toContain("secrets=openai_api_key");
     expect(output).toContain("Hermes: invocation=spawn, profile=yes");
+    expect(output).toContain("OpenClaw: invocation=spawn, profile=no");
     expect(output).toContain("completion=process_exit");
   });
 

--- a/packages/local-runtime/src/config.ts
+++ b/packages/local-runtime/src/config.ts
@@ -97,6 +97,12 @@ const HermesExecutorConfigSchema = z.object({
   profileTemplate: z.string().trim().min(1).optional()
 });
 
+const OpenclawExecutorConfigSchema = z.object({
+  command: z.string().trim().min(1).optional(),
+  agent: z.string().trim().min(1).optional(),
+  sessionKey: z.string().trim().min(1).optional()
+});
+
 const AgentSessionProfileConfigSchema = z.object({
   profile: z.string().trim().min(1).optional(),
   profileTemplate: z.string().trim().min(1).optional()
@@ -156,6 +162,7 @@ export const OpenTagDaemonConfigSchema = z.object({
   larkChannels: z.array(LarkChannelBindingConfigSchema).optional(),
   claudeCode: ClaudeCodeExecutorConfigSchema.optional(),
   hermes: HermesExecutorConfigSchema.optional(),
+  openclaw: OpenclawExecutorConfigSchema.optional(),
   agentSessionProfile: AgentSessionProfileConfigSchema.optional(),
   security: RunnerSecurityPolicySchema.optional(),
   githubToken: SecretStringSchema.optional(),

--- a/packages/local-runtime/src/runtime.ts
+++ b/packages/local-runtime/src/runtime.ts
@@ -1,5 +1,12 @@
 import { createDispatcherClient } from "@opentag/client";
-import { createClaudeCodeExecutor, createCodexExecutor, createEchoExecutor, createHermesExecutor, type RunnerSecurityPolicy } from "@opentag/runner";
+import {
+  createClaudeCodeExecutor,
+  createCodexExecutor,
+  createEchoExecutor,
+  createHermesExecutor,
+  createOpenclawExecutor,
+  type RunnerSecurityPolicy
+} from "@opentag/runner";
 import { runnerDispatcherToken, type OpenTagDaemonConfig } from "./config.js";
 import type { DaemonClient } from "./daemon.js";
 import type { PullRequestOptions } from "./pr.js";
@@ -38,6 +45,11 @@ export function executorsFromConfig(config: OpenTagDaemonConfig) {
       ...(config.hermes?.command ? { hermesCommand: config.hermes.command } : {}),
       ...(config.hermes?.profile ? { profile: config.hermes.profile } : {}),
       ...(config.hermes?.profileTemplate ? { profileTemplate: config.hermes.profileTemplate } : {})
+    }),
+    openclaw: createOpenclawExecutor({
+      ...(config.openclaw?.command ? { openclawCommand: config.openclaw.command } : {}),
+      ...(config.openclaw?.agent ? { agent: config.openclaw.agent } : {}),
+      ...(config.openclaw?.sessionKey ? { sessionKey: config.openclaw.sessionKey } : {})
     })
   };
 }

--- a/packages/local-runtime/test/config.test.ts
+++ b/packages/local-runtime/test/config.test.ts
@@ -16,7 +16,7 @@ function tempDir(): string {
 
 describe("parseDaemonConfig defaultExecutor", () => {
   it("accepts the built-in executors", () => {
-    for (const executor of ["echo", "codex", "claude-code", "hermes"]) {
+    for (const executor of ["echo", "codex", "claude-code", "hermes", "openclaw"]) {
       const config = parseDaemonConfig({
         repositories: [{ ...baseRepository, defaultExecutor: executor }]
       });
@@ -84,6 +84,36 @@ describe("parseDaemonConfig Hermes config", () => {
         repositories: [{ ...baseRepository, defaultExecutor: "hermes" }],
         hermes: {
           profileTemplate: "   "
+        }
+      })
+    ).toThrow();
+  });
+});
+
+describe("parseDaemonConfig OpenClaw config", () => {
+  it("trims OpenClaw config strings", () => {
+    const config = parseDaemonConfig({
+      repositories: [{ ...baseRepository, defaultExecutor: "openclaw" }],
+      openclaw: {
+        command: " /opt/tools/openclaw ",
+        agent: " ops ",
+        sessionKey: " opentag-ops "
+      }
+    });
+
+    expect(config.openclaw).toEqual({
+      command: "/opt/tools/openclaw",
+      agent: "ops",
+      sessionKey: "opentag-ops"
+    });
+  });
+
+  it("rejects whitespace-only OpenClaw config strings", () => {
+    expect(() =>
+      parseDaemonConfig({
+        repositories: [{ ...baseRepository, defaultExecutor: "openclaw" }],
+        openclaw: {
+          agent: "   "
         }
       })
     ).toThrow();

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -8,3 +8,4 @@ export * from "./result.js";
 export * from "./security.js";
 export * from "./session-profile.js";
 export * from "./hermes.js";
+export * from "./openclaw.js";

--- a/packages/runner/src/openclaw.ts
+++ b/packages/runner/src/openclaw.ts
@@ -1,0 +1,173 @@
+import { contextPointerLabel, type ContextPacket, type ContextPointer } from "@opentag/core";
+import { assertCommandSucceeded, nodeCommandRunner, type CommandResult, type CommandRunner } from "./command.js";
+import { executorPolicyPromptLines } from "./executor-report.js";
+import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
+import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
+import { createExecutorRunResult } from "./result.js";
+
+export type OpenclawExecutorOptions = {
+  runner?: CommandRunner;
+  openclawCommand?: string;
+  agent?: string;
+  sessionKey?: string;
+};
+
+const DEFAULT_OPENCLAW_AGENT = "main";
+const DEFAULT_OPENCLAW_SESSION_KEY = "opentag";
+
+function contextLines(context: ContextPointer[]): string {
+  if (!context.length) return "No additional context pointers were provided.";
+  return context.map((pointer) => `- ${contextPointerLabel(pointer)}: ${pointer.uri}`).join("\n");
+}
+
+function buildPrompt(input: {
+  runId: string;
+  rawText: string;
+  context: ContextPointer[];
+  contextPacket: ContextPacket | undefined;
+}): string {
+  return [
+    "You are executing an OpenTag run in a local checkout.",
+    `Run ID: ${input.runId}`,
+    "",
+    "User request:",
+    input.rawText,
+    "",
+    ...renderContextPacketForPrompt(input.contextPacket),
+    ...(input.contextPacket ? [""] : []),
+    "Context pointers:",
+    contextLines(input.context),
+    "",
+    ...executorPolicyPromptLines()
+  ].join("\n");
+}
+
+export function createOpenclawExecutor(options: OpenclawExecutorOptions = {}): ExecutorAdapter {
+  const runner = options.runner ?? nodeCommandRunner;
+  const openclawCommand = options.openclawCommand ?? "openclaw";
+  const openclawAgent = options.agent ?? DEFAULT_OPENCLAW_AGENT;
+  const openclawSessionKey = options.sessionKey ?? DEFAULT_OPENCLAW_SESSION_KEY;
+
+  return {
+    id: "openclaw",
+    displayName: "OpenClaw Executor",
+    capability: {
+      id: "openclaw",
+      invocation: "spawn",
+      supportsProfile: false,
+      supportsStreaming: false,
+      supportsCancel: false,
+      supportsHookCompletion: false,
+      progressEvents: "audit",
+      approvalMode: "opentag_policy",
+      contextAccess: ["context_packet", "context_pointers", "workspace"],
+      promptAssembly: "executor_adapter",
+      writeAccess: "workspace",
+      conversationAccess: "request",
+      promptMutation: "none",
+      rawContextAccess: false,
+      writeActionAccess: "none",
+      workspaceIsolation: "branch",
+      requiredSecrets: [],
+      completionSignals: [
+        {
+          type: "process_exit",
+          required: true,
+          description: "OpenTag treats a successful `openclaw agent` process exit as the normal completion signal."
+        }
+      ]
+    },
+    async canRun(input) {
+      try {
+        const openclawVersion = await runner.run(openclawCommand, ["--version"], { cwd: input.workspacePath });
+        if (openclawVersion.exitCode !== 0) {
+          return { ready: false, reason: `OpenClaw CLI is not available: ${openclawVersion.stderr || openclawVersion.stdout}` };
+        }
+      } catch (error) {
+        return { ready: false, reason: `OpenClaw CLI is not available: ${error instanceof Error ? error.message : String(error)}` };
+      }
+
+      let gitStatus: CommandResult;
+      try {
+        gitStatus = await runner.run("git", ["status", "--porcelain"], { cwd: input.workspacePath });
+      } catch (error) {
+        return { ready: false, reason: `Workspace is not a git checkout: ${error instanceof Error ? error.message : String(error)}` };
+      }
+      if (gitStatus.exitCode !== 0) {
+        return { ready: false, reason: `Workspace is not a git checkout: ${gitStatus.stderr || gitStatus.stdout}` };
+      }
+      if (gitStatus.stdout.trim().length > 0) {
+        return { ready: false, reason: "Workspace has uncommitted changes; refusing to run OpenClaw executor." };
+      }
+
+      return { ready: true };
+    },
+    async run(input, sink) {
+      const branchName = branchNameForRun(input.runId);
+      await sink.emit({
+        type: "executor.started",
+        message: `Creating isolated branch ${branchName}`,
+        at: new Date().toISOString()
+      });
+
+      await createRunBranch({
+        runner,
+        workspacePath: input.workspacePath,
+        branchName,
+        ...(input.baseBranch ? { startPoint: input.baseBranch } : {})
+      });
+
+      await sink.emit({
+        type: "executor.progress",
+        message: "Starting openclaw agent",
+        at: new Date().toISOString()
+      });
+
+      const prompt = buildPrompt({
+        runId: input.runId,
+        rawText: input.command.rawText,
+        context: input.context,
+        contextPacket: input.contextPacket
+      });
+
+      const args = ["agent", "-m", prompt, "--agent", openclawAgent, "--session-key", openclawSessionKey];
+
+      let openclawResult: CommandResult | undefined;
+      try {
+        openclawResult = await runner.run(openclawCommand, args, { cwd: input.workspacePath });
+        await assertCommandSucceeded(openclawResult, "openclaw agent");
+      } finally {
+        const cleanedArtifacts = await cleanupInternalArtifacts({ runner, workspacePath: input.workspacePath });
+        if (cleanedArtifacts.length > 0) {
+          await sink.emit({
+            type: "executor.progress",
+            message: `Cleaned internal artifacts: ${cleanedArtifacts.join(", ")}`,
+            at: new Date().toISOString()
+          });
+        }
+      }
+
+      if (!openclawResult) throw new Error("OpenClaw did not return a result.");
+
+      const files = await changedFiles({ runner, workspacePath: input.workspacePath });
+      await sink.emit({
+        type: "executor.completed",
+        message: `OpenClaw executor completed with ${files.length} changed file(s)`,
+        at: new Date().toISOString()
+      });
+
+      const output = openclawResult.stdout.trim() || openclawResult.stderr.trim() || "OpenClaw completed without textual output.";
+      return createExecutorRunResult({
+        executorName: "OpenClaw",
+        runId: input.runId,
+        branchName,
+        ...(input.baseBranch ? { baseBranch: input.baseBranch } : {}),
+        output,
+        changedFiles: files
+      });
+    },
+    async cancel() {
+      return;
+    }
+  };
+}

--- a/packages/runner/test/executor-capability.test.ts
+++ b/packages/runner/test/executor-capability.test.ts
@@ -3,6 +3,7 @@ import { createClaudeCodeExecutor } from "../src/claude-code.js";
 import { createCodexExecutor } from "../src/codex.js";
 import { createEchoExecutor } from "../src/echo.js";
 import { createHermesExecutor } from "../src/hermes.js";
+import { createOpenclawExecutor } from "../src/openclaw.js";
 
 describe("executor capability contracts", () => {
   it("exposes runtime capabilities for built-in executors", () => {
@@ -10,6 +11,7 @@ describe("executor capability contracts", () => {
       createCodexExecutor(),
       createClaudeCodeExecutor(),
       createHermesExecutor(),
+      createOpenclawExecutor(),
       createEchoExecutor()
     ];
 
@@ -39,6 +41,10 @@ describe("executor capability contracts", () => {
     expect(createClaudeCodeExecutor().capability?.workspaceIsolation).toBe("worktree");
     expect(createHermesExecutor().capability).toMatchObject({
       supportsProfile: true,
+      workspaceIsolation: "branch"
+    });
+    expect(createOpenclawExecutor().capability).toMatchObject({
+      supportsProfile: false,
       workspaceIsolation: "branch"
     });
     expect(createEchoExecutor().capability?.workspaceIsolation).toBe("none");

--- a/packages/runner/test/openclaw.test.ts
+++ b/packages/runner/test/openclaw.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import { createOpenclawExecutor } from "../src/openclaw.js";
+import type { CommandRunner } from "../src/command.js";
+import { EXECUTOR_REPORT_END, EXECUTOR_REPORT_START } from "../src/executor-report.js";
+
+describe("OpenClaw executor", () => {
+  it("creates an isolated branch, runs an OpenClaw agent turn with context, and reports changed files", async () => {
+    const calls: { command: string; args: string[] }[] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        calls.push({ command, args });
+        const joinedArgs = args.join(" ");
+
+        if (command === "openclaw" && args.includes("--version")) {
+          return { exitCode: 0, stdout: "OpenClaw 1.0.0", stderr: "" };
+        }
+
+        if (command === "git" && joinedArgs === "status --porcelain") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "git" && joinedArgs === "-c core.quotePath=false status --porcelain -z") {
+          return calls.some((call) => call.command === "openclaw" && call.args[0] === "agent")
+            ? { exitCode: 0, stdout: " M src/demo.ts\0?? test/demo.test.ts\0", stderr: "" }
+            : { exitCode: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "git" && joinedArgs === "checkout -B opentag/run_1 main") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+
+        if (command === "openclaw" && args[0] === "agent") {
+          return { exitCode: 0, stdout: "Implemented the requested OpenClaw change.", stderr: "" };
+        }
+
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+
+    const executor = createOpenclawExecutor({ runner });
+
+    await expect(
+      executor.canRun({
+        runId: "run_1",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: []
+      })
+    ).resolves.toEqual({ ready: true });
+
+    const result = await executor.run({
+      runId: "run_1",
+      workspacePath: "/tmp/demo",
+      command: { rawText: "fix this", intent: "fix", args: {} },
+      context: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+      contextPacket: {
+        summary: "Use the linked issue and propose the narrowest fix.",
+        sourcePointers: [{ kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+        intent: {
+          rawText: "fix this",
+          normalizedIntent: "fix",
+          requestedBy: { provider: "github", providerUserId: "42", handle: "octocat" }
+        },
+        sources: [
+          {
+            pointer: { kind: "github.issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" },
+            role: "primary",
+            included: true,
+            reason: "The issue is the main source for the request."
+          }
+        ],
+        facts: [{ text: "The failing test is flaky in CI." }],
+        exclusions: ["Do not modify unrelated callback code."]
+      },
+      baseBranch: "main",
+      metadata: { provider: "slack", accountId: "T123", conversationId: 456 }
+    }, {
+      emit: async () => {}
+    });
+
+    const openclawCall = calls.find((call) => call.command === "openclaw" && call.args[0] === "agent");
+    const prompt = openclawCall?.args[openclawCall.args.indexOf("-m") + 1];
+
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "checkout -B opentag/run_1 main")).toBe(true);
+    expect(openclawCall?.args).toContain("--agent");
+    expect(openclawCall?.args).toContain("main");
+    expect(openclawCall?.args).toContain("--session-key");
+    expect(openclawCall?.args).toContain("opentag");
+    expect(openclawCall?.args).not.toContain("--deliver");
+    expect(openclawCall?.args).not.toContain("--model");
+
+    expect(prompt).toContain("OpenTag context packet:");
+    expect(prompt).toContain("Use the linked issue and propose the narrowest fix.");
+    expect(prompt).toContain("fix this");
+    expect(prompt).toContain("The failing test is flaky in CI.");
+    expect(prompt).toContain("Do not modify unrelated callback code.");
+    expect(prompt).toContain("https://github.com/acme/demo/issues/1");
+    expect(prompt).toContain("OpenTag owns the source-control handoff after you finish.");
+    expect(prompt).toContain(EXECUTOR_REPORT_START);
+    expect(prompt).toContain(EXECUTOR_REPORT_END);
+
+    expect(result.changedFiles).toEqual(["src/demo.ts", "test/demo.test.ts"]);
+    expect(result.summary).toContain("Implemented the requested OpenClaw change.");
+    expect(result.artifacts).toEqual([
+      expect.objectContaining({ kind: "patch", title: "Generated patch", uri: "opentag/run_1" }),
+      expect.objectContaining({ kind: "report", title: "Run report", uri: "opentag://run/run_1/report" }),
+      expect.objectContaining({ kind: "log_summary", title: "Log summary", uri: "opentag://run/run_1/log-summary" })
+    ]);
+  });
+
+  it("returns not ready when the OpenClaw CLI is missing", async () => {
+    const runner: CommandRunner = {
+      async run(command) {
+        if (command === "openclaw") {
+          throw new Error("spawn openclaw ENOENT");
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+    };
+
+    await expect(
+      createOpenclawExecutor({ runner }).canRun({
+        runId: "run_1",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: []
+      })
+    ).resolves.toEqual({ ready: false, reason: "OpenClaw CLI is not available: spawn openclaw ENOENT" });
+  });
+
+  it("returns not ready when git status throws", async () => {
+    const runner: CommandRunner = {
+      async run(command, args) {
+        if (command === "openclaw" && args.includes("--version")) {
+          return { exitCode: 0, stdout: "OpenClaw 1.0.0", stderr: "" };
+        }
+        throw new Error("bad cwd");
+      }
+    };
+
+    await expect(
+      createOpenclawExecutor({ runner }).canRun({
+        runId: "run_1",
+        workspacePath: "/tmp/missing",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: []
+      })
+    ).resolves.toEqual({ ready: false, reason: "Workspace is not a git checkout: bad cwd" });
+  });
+
+  it("honors configured command, agent, and session key overrides", async () => {
+    const calls: { command: string; args: string[] }[] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        calls.push({ command, args });
+        const joinedArgs = args.join(" ");
+
+        if (command === "git" && args[0] === "checkout") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "/opt/tools/openclaw" && args[0] === "agent") {
+          return { exitCode: 0, stdout: "done", stderr: "" };
+        }
+        if (command === "git" && joinedArgs === "-c core.quotePath=false status --porcelain -z") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+
+    await createOpenclawExecutor({
+      runner,
+      openclawCommand: "/opt/tools/openclaw",
+      agent: "ops",
+      sessionKey: "opentag-ops"
+    }).run({
+      runId: "run_1",
+      workspacePath: "/tmp/demo",
+      command: { rawText: "fix this", intent: "fix", args: {} },
+      context: []
+    }, {
+      emit: async () => {}
+    });
+
+    const openclawCall = calls.find((call) => call.command === "/opt/tools/openclaw" && call.args[0] === "agent");
+    expect(openclawCall?.args).toContain("--agent");
+    expect(openclawCall?.args).toContain("ops");
+    expect(openclawCall?.args).toContain("--session-key");
+    expect(openclawCall?.args).toContain("opentag-ops");
+  });
+
+  it("cleans internal artifacts when OpenClaw exits unsuccessfully", async () => {
+    const calls: { command: string; args: string[] }[] = [];
+    const runner: CommandRunner = {
+      async run(command, args) {
+        calls.push({ command, args });
+        const joinedArgs = args.join(" ");
+
+        if (command === "git" && args[0] === "checkout") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "openclaw" && args[0] === "agent") {
+          return { exitCode: 1, stdout: "", stderr: "failed" };
+        }
+        if (command === "git" && joinedArgs === "-c core.quotePath=false status --porcelain -z") {
+          return { exitCode: 0, stdout: "?? .omx/session.json\0", stderr: "" };
+        }
+        if (command === "git" && joinedArgs === "clean -fd -- .omx") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+
+    await expect(
+      createOpenclawExecutor({ runner }).run({
+        runId: "run_1",
+        workspacePath: "/tmp/demo",
+        command: { rawText: "fix this", intent: "fix", args: {} },
+        context: []
+      }, {
+        emit: async () => {}
+      })
+    ).rejects.toThrow("openclaw agent failed with exit code 1: failed");
+
+    expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "clean -fd -- .omx")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds a first-class spawn executor for [OpenClaw](https://github.com/openclaw/openclaw), filling the gap between the protocol's existing `openclaw` executor-hint enum value / hook-ingest runtime label and an actual way to dispatch a run to a local OpenClaw install.

- **`@opentag/runner`**: `createOpenclawExecutor` runs one agent turn via `openclaw agent -m <prompt> --agent <agent> --session-key <key>` in the run workspace, with the same isolated-branch, clean-workspace, artifact-cleanup, and changed-files semantics as the other spawn executors. A dedicated session key (default `opentag`) keeps run traffic isolated from the operator's day-to-day OpenClaw sessions.
- **`@opentag/local-runtime`**: registers the executor; accepts `daemon.openclaw { command, agent, sessionKey }` config.
- **`@opentag/cli`**: config schema, executor catalog entry (with `OPENTAG_OPENCLAW_COMMAND` override), capability catalog entry, `isExecutorId`.

## Why

`ExecutorHintSchema` already reserves `"openclaw"` and the hook-ingest docs name it as a runtime label, so the protocol intent is clearly there — but selecting it today dead-ends in `No local executor is configured for 'openclaw'`. This implements the spawn path; a richer hook-ingest integration can layer on later without conflicting.

## Testing

- `pnpm typecheck` clean, `pnpm test` 988/988 green (adds executor unit tests mirroring the Hermes suite, config parse tests, catalog/capability tests).
- Validated end-to-end on a live deployment: Lark source thread → dispatcher → daemon → local OpenClaw gateway (2026.6.8), run succeeded and the reply card was delivered back to the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenClaw executor in the CLI and runtime.
  * The app can now auto-detect OpenClaw, use it as a default option when available, and accept its configuration in daemon settings.
  * Added executor execution support with branch-based isolation and result reporting.

* **Bug Fixes**
  * Improved config validation and trimming for OpenClaw settings.
  * Added cleanup handling so temporary run artifacts are removed after failed runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->