### PR TITLE
Let the source-thread executor hint override the binding default

### DIFF
--- a/packages/local-runtime/src/daemon.ts
+++ b/packages/local-runtime/src/daemon.ts
@@ -196,7 +196,7 @@ export async function runOneDaemonIteration(input: {
     });
     return true;
   }
-  const executorId = binding.defaultExecutor ?? claimed.event.target.executorHint ?? "echo";
+  const executorId = claimed.event.target.executorHint ?? binding.defaultExecutor ?? "echo";
   const executor = input.executors[executorId];
   if (!executor) {
     await input.client.complete(claimed.run.id, {

--- a/packages/local-runtime/test/daemon-executor-selection.test.ts
+++ b/packages/local-runtime/test/daemon-executor-selection.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { OpenTagEvent, OpenTagRun, OpenTagRunResult } from "@opentag/core";
+import { createExecutorRunResult, type ExecutorAdapter } from "@opentag/runner";
+import { runOneDaemonIteration, type DaemonClient } from "../src/daemon.js";
+
+function eventWithExecutorHint(executorHint?: string): OpenTagEvent {
+  return {
+    id: "evt_slack",
+    source: "slack",
+    sourceEventId: "source_slack",
+    receivedAt: "2026-06-29T00:00:00.000Z",
+    actor: { provider: "slack", providerUserId: "user_1", handle: "octocat" },
+    target: { mention: "@opentag", agentId: "opentag", ...(executorHint ? { executorHint } : {}) },
+    command: { rawText: "fix this", intent: "fix", args: {} },
+    context: [],
+    permissions: [{ scope: "repo:write", reason: "The executor needs to edit the local checkout for this run." }],
+    callback: { provider: "slack", uri: "https://example.com/callback" },
+    metadata: { teamId: "T123", channelId: "C456", repoProvider: "github", owner: "acme", repo: "demo" }
+  };
+}
+
+function recordingExecutor(id: string, ran: string[]): ExecutorAdapter {
+  return {
+    id,
+    displayName: `${id} recording executor`,
+    async canRun() {
+      return { ready: true };
+    },
+    async run(input) {
+      ran.push(id);
+      return createExecutorRunResult({
+        executorName: id,
+        runId: input.runId,
+        branchName: `opentag/${input.runId}`,
+        output: `ran:${id}`,
+        changedFiles: []
+      });
+    },
+    async cancel() {
+      return;
+    }
+  };
+}
+
+async function iterate(input: { event: OpenTagEvent; defaultExecutor: string }) {
+  const ran: string[] = [];
+  const run: OpenTagRun = {
+    id: "run_selection",
+    eventId: input.event.id,
+    status: "assigned",
+    assignedRunnerId: "runner_local",
+    createdAt: "2026-06-29T00:00:00.000Z",
+    updatedAt: "2026-06-29T00:00:00.000Z"
+  };
+  let completed: OpenTagRunResult | undefined;
+  const client: DaemonClient = {
+    claim: async () => ({ run, event: input.event }),
+    markRunning: async () => {},
+    heartbeat: async () => {},
+    progress: async () => {},
+    complete: async (_runId, result) => {
+      completed = result;
+    }
+  };
+
+  await runOneDaemonIteration({
+    runnerId: "runner_local",
+    repositories: [
+      {
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        checkoutPath: "/tmp/demo",
+        defaultExecutor: input.defaultExecutor,
+        baseBranch: "main",
+        pushRemote: "origin",
+        keepWorktree: "on_failure"
+      }
+    ],
+    executors: {
+      "claude-code": recordingExecutor("claude-code", ran),
+      openclaw: recordingExecutor("openclaw", ran)
+    },
+    client
+  });
+
+  return { ran, completed };
+}
+
+describe("daemon executor selection", () => {
+  it("prefers the source-thread executor hint over the binding default", async () => {
+    const { ran, completed } = await iterate({
+      event: eventWithExecutorHint("openclaw"),
+      defaultExecutor: "claude-code"
+    });
+
+    expect(ran).toEqual(["openclaw"]);
+    expect(completed?.conclusion).toBe("success");
+  });
+
+  it("falls back to the binding default executor when no hint is provided", async () => {
+    const { ran, completed } = await iterate({
+      event: eventWithExecutorHint(undefined),
+      defaultExecutor: "claude-code"
+    });
+
+    expect(ran).toEqual(["claude-code"]);
+    expect(completed?.conclusion).toBe("success");
+  });
+
+  it("reports needs_human when the hinted executor is not registered locally", async () => {
+    const { ran, completed } = await iterate({
+      event: eventWithExecutorHint("hermes"),
+      defaultExecutor: "claude-code"
+    });
+
+    expect(ran).toEqual([]);
+    expect(completed?.conclusion).toBe("needs_human");
+    expect(completed?.summary).toContain("hermes");
+  });
+});


### PR DESCRIPTION
## What

One-line precedence fix in the daemon's executor selection, plus daemon-level selection tests:

```diff
- const executorId = binding.defaultExecutor ?? claimed.event.target.executorHint ?? "echo";
+ const executorId = claimed.event.target.executorHint ?? binding.defaultExecutor ?? "echo";
```

## Why

The mention parser accepts an `--executor` flag and stores it as `target.executorHint`, but because the setup wizard always writes a `defaultExecutor` for every repository binding, the current precedence means the hint can never take effect in practice — the flag parses, validates against the hint enum, and is then silently ignored. No existing test pinned the old order.

With this change an explicit per-message request wins over the configured default (explicit-beats-default), and a hint naming an executor that is not registered on the runner still fails closed with `needs_human`, so operators keep control over which executors exist at all.

If the original order was intentional (config-wins as a governance posture), happy to rework this into an operator opt-in (e.g. an allowed-hints list) instead — but as shipped the flag is dead code, which seems unintended.

## Testing

- `pnpm typecheck` clean, `pnpm test` 983/983 green.
- New `daemon-executor-selection.test.ts` covers: hint overrides default, fallback to default without hint, and needs_human for an unregistered hinted executor.
- Validated live: Lark thread messages with `--executor codex` / `--executor openclaw` routed to the hinted executors; audit trail confirms `run.executor` matches the hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executor selection so the system now prefers an event’s suggested executor when available, while still using the configured default or a safe fallback if needed.
  * If a suggested executor isn’t available locally, the run now ends with a clear needs-human-needed outcome and includes the requested executor name in the summary.
* **Tests**
  * Added coverage for executor selection behavior across hinted, default, and missing-executor cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->