### PR TITLE
Add role-based integration protocol prototype

### DIFF
--- a/docs/executor-protocol.md
+++ b/docs/executor-protocol.md
@@ -12,7 +12,7 @@ Today each built-in executor translates an OpenTag run into a vendor-specific
 CLI invocation. That keeps the first integration simple, but it also repeats the
 same hard parts in every adapter:
 
-- Create an isolated branch or worktree.
+- Create an isolated worktree.
 - Assemble the request, context packet, policy text, and report expectations.
 - Ensure the agent's real file tools use the OpenTag run workspace.
 - Ensure session or conversation history is scoped to the current run unless
@@ -37,10 +37,17 @@ Only one profile is implemented in this prototype:
   stdin, then reads JSON Lines events from stdout. Stderr is treated as diagnostic
   text. The child must emit one terminal `completed` or `failed` event.
 
+This profile is deliberately narrow: it is worktree-only, request-context-only,
+uses audit progress events, and does not claim cancellation or streaming. A
+manifest that advertises broader capabilities is rejected by the canonical
+manifest schema.
+
 Only one binding kind is implemented in this prototype:
 
 - `stdio-jsonl`: a local command, optional args, optional cwd, and optional
-  non-secret environment values. Future bindings can add HTTP, long-running
+  explicitly configured environment values. The child inherits only OpenTag's
+  safe environment allowlist, never the complete host process environment.
+  Future bindings can add HTTP, long-running
   runtimes, MCP, containers, or hook-ingest callbacks without changing the run
   contract.
 
@@ -202,8 +209,10 @@ The generic OpenTag protocol executor must:
 - Accept an `opentag.integration.v1` manifest with `roles.executor.profile` set
   to `stdio-jsonl-basic`.
 - Resolve the executor role's named `stdio-jsonl` binding.
-- Create the run branch or worktree before launching the shim.
+- Create the run worktree before launching the shim.
 - Validate protocol events and fail on malformed JSONL.
+- Preserve valid structured progress and failure diagnostics even when the child
+  exits non-zero.
 - Reject workspace mismatches.
 - Clean internal `.omx`, `.codex`, and `.claude` artifacts.
 - Preserve the primary child failure if cleanup also fails.

--- a/docs/executor-protocol.md
+++ b/docs/executor-protocol.md
@@ -150,6 +150,32 @@ executor where the request came from, what it is acting on, and where progress o
 final output should return. They do not carry provider credentials, workspace or
 account connection state, raw webhook payloads, or API tokens.
 
+### Reply Routing
+
+`replyTo` is a runner-owned delivery plan, not permission for a shim to call
+Slack, GitHub, or another provider. The runner or control plane selects every
+entry whose `purpose` is either `all` or the purpose assigned to the event:
+
+| Executor event | Delivery purpose | Matching `replyTo` entries |
+| --- | --- | --- |
+| `started` | `progress` | `all`, `progress` |
+| `progress` | `progress` | `all`, `progress` |
+| `completed` | `final` | `all`, `final` |
+| `failed` | `error` | `all`, `error` |
+
+The canonical core helpers `replyDeliveryPurposeForExecutorEventType` and
+`selectReplyTargetsForExecutorEventType` define this mapping for runners and
+conformance tests. `approval` follows the same general selection rule (`all` or
+`approval`) for control-plane approval deliveries, but `opentag.executor.v1`
+does not currently define an approval event.
+
+Each matching entry is an independent delivery target and keeps its request
+order. The event payload remains flat: the same semantic progress, completion,
+or failure result is rendered appropriately for each selected channel. Version
+1 does not split `summary`, `artifacts`, `risks`, or `verification` into
+target-specific deliverables. A shim must not perform these deliveries or
+receive provider credentials to do so.
+
 ## Events
 
 The child stdout is JSON Lines. Each line is one event.

--- a/docs/executor-protocol.md
+++ b/docs/executor-protocol.md
@@ -1,0 +1,227 @@
+# OpenTag Executor Protocol
+
+`opentag.executor.v1` is the first role protocol for replacing one-off executor
+adapters with one governed run contract. New executors are declared through an
+`opentag.integration.v1` manifest, then the executor role uses this runtime
+contract for workspace isolation, session isolation, semantic run refs,
+permission context, progress, completion, and source-control handoff.
+
+## Why This Exists
+
+Today each built-in executor translates an OpenTag run into a vendor-specific
+CLI invocation. That keeps the first integration simple, but it also repeats the
+same hard parts in every adapter:
+
+- Create an isolated branch or worktree.
+- Assemble the request, context packet, policy text, and report expectations.
+- Ensure the agent's real file tools use the OpenTag run workspace.
+- Ensure session or conversation history is scoped to the current run unless
+  reuse is explicit.
+- Parse progress and final output.
+- Clean internal artifacts without hiding the real executor failure.
+- Read changed files and let OpenTag own commit, push, and pull-request handoff.
+
+The OpenClaw review exposed why process `cwd` alone is not enough. A CLI can run
+from one directory while its agent file tools use another configured workspace
+or a long-lived gateway session. The protocol makes that failure mode explicit:
+the shim must acknowledge the actual workspace used by its tools, and OpenTag
+rejects the run when it does not match the requested run workspace.
+
+## Version, Profile, And Binding
+
+The executor role protocol is `opentag.executor.v1`.
+
+Only one profile is implemented in this prototype:
+
+- `stdio-jsonl-basic`: OpenTag starts a child process, writes one JSON request line to
+  stdin, then reads JSON Lines events from stdout. Stderr is treated as diagnostic
+  text. The child must emit one terminal `completed` or `failed` event.
+
+Only one binding kind is implemented in this prototype:
+
+- `stdio-jsonl`: a local command, optional args, optional cwd, and optional
+  non-secret environment values. Future bindings can add HTTP, long-running
+  runtimes, MCP, containers, or hook-ingest callbacks without changing the run
+  contract.
+
+## Manifest
+
+A protocol executor is registered as the `executor` role inside an integration
+manifest:
+
+```json
+{
+  "protocol": "opentag.integration.v1",
+  "id": "example-agent",
+  "label": "Example Agent",
+  "bindings": {
+    "executorStdio": {
+      "kind": "stdio-jsonl",
+      "command": "example-agent",
+      "args": ["opentag-exec"]
+    }
+  },
+  "roles": {
+    "executor": {
+      "protocol": "opentag.executor.v1",
+      "profile": "stdio-jsonl-basic",
+      "binding": "executorStdio",
+      "capabilities": {
+        "workspaceIsolation": "worktree",
+        "conversationAccess": "request",
+        "progressEvents": "audit",
+        "supportsCancel": false,
+        "supportsStreaming": false
+      }
+    }
+  }
+}
+```
+
+The manifest says which role protocol/profile the integration implements and
+which named binding launches it. It does not make policy decisions. OpenTag still
+owns admission, workspace setup, changed-file detection, and source-control
+handoff. See [Integration Taxonomy](./integration-taxonomy.md) for the role,
+resource-domain, binding, and connection-instance boundaries.
+
+## Run Request
+
+OpenTag writes one request JSON line to the child stdin:
+
+```json
+{
+  "protocol": "opentag.executor.v1",
+  "runId": "run_123",
+  "workspace": {
+    "path": "/tmp/opentag/worktrees/run_123",
+    "baseBranch": "main",
+    "branchName": "opentag/run_123",
+    "isolation": "worktree"
+  },
+  "session": {
+    "scope": "run",
+    "key": "opentag:example-agent:run_123"
+  },
+  "command": {
+    "rawText": "fix this bug",
+    "intent": "fix",
+    "args": {}
+  },
+  "source": {
+    "kind": "channel_message",
+    "channel": { "provider": "slack", "id": "C123" },
+    "thread": { "provider": "slack", "id": "171234.5678" },
+    "actor": { "provider": "slack", "id": "U123" }
+  },
+  "targets": {
+    "repo": { "provider": "github", "owner": "amplifthq", "name": "opentag" },
+    "changeRequest": { "provider": "github", "id": "79", "number": 79 }
+  },
+  "replyTo": [
+    {
+      "channel": { "provider": "slack", "id": "C123" },
+      "thread": { "provider": "slack", "id": "171234.5678" },
+      "purpose": "all"
+    }
+  ],
+  "context": [],
+  "permissions": [],
+  "metadata": {},
+  "sourceControl": {
+    "owner": "opentag",
+    "forbiddenCommands": ["git add", "git commit", "git push", "gh pr create"]
+  }
+}
+```
+
+Session keys default to per-run scope and include the run id. A shim can support
+other scopes later, but cross-run conversation reuse must be explicit. A global
+default session key is not valid for this protocol.
+
+`source`, `targets`, and `replyTo` are sanitized semantic refs. They tell the
+executor where the request came from, what it is acting on, and where progress or
+final output should return. They do not carry provider credentials, workspace or
+account connection state, raw webhook payloads, or API tokens.
+
+## Events
+
+The child stdout is JSON Lines. Each line is one event.
+
+Progress events:
+
+```json
+{"type":"started","message":"Starting example agent"}
+{"type":"progress","message":"Editing files"}
+```
+
+Completed event:
+
+```json
+{
+  "type": "completed",
+  "message": "Done",
+  "actualWorkspacePath": "/tmp/opentag/worktrees/run_123",
+  "summary": "Implemented the fix.",
+  "verification": [
+    {"command":"corepack pnpm test","outcome":"passed","summary":"Tests passed."}
+  ],
+  "artifacts": [],
+  "risks": []
+}
+```
+
+Failed event:
+
+```json
+{
+  "type": "failed",
+  "message": "Agent failed before editing files",
+  "actualWorkspacePath": "/tmp/opentag/worktrees/run_123"
+}
+```
+
+The completed or failed event must include the actual workspace path when the
+shim knows it. For successful completion, OpenTag requires
+`actualWorkspacePath` to resolve to exactly the requested `workspace.path`.
+
+## Conformance Rules
+
+A conforming shim must:
+
+- Read one `opentag.executor.v1` request from stdin.
+- Bind its real file tools to `request.workspace.path`.
+- Return `actualWorkspacePath` in the final event.
+- Treat `request.session.key` as the only default conversation/session key.
+- Keep source-control handoff with OpenTag. The shim must not run or recommend
+  `git add`, `git commit`, `git push`, or `gh pr create`.
+- Emit a final `completed` or `failed` event.
+- Avoid secrets in progress, artifacts, and summaries.
+
+The generic OpenTag protocol executor must:
+
+- Accept an `opentag.integration.v1` manifest with `roles.executor.profile` set
+  to `stdio-jsonl-basic`.
+- Resolve the executor role's named `stdio-jsonl` binding.
+- Create the run branch or worktree before launching the shim.
+- Validate protocol events and fail on malformed JSONL.
+- Reject workspace mismatches.
+- Clean internal `.omx`, `.codex`, and `.claude` artifacts.
+- Preserve the primary child failure if cleanup also fails.
+- Read changed files after completion and build the normal OpenTag run result.
+
+## Migration Plan
+
+This prototype deliberately does not migrate Codex, Claude Code, Hermes, or
+OpenClaw. The migration path should be staged:
+
+1. Fake conformance shim and generic executor tests using
+   `opentag.integration.v1` plus the `stdio-jsonl-basic` executor profile.
+2. One real external-agent shim, likely OpenClaw or Hermes, to prove workspace
+   and session isolation against a real agent runtime.
+3. Codex and Claude Code after parity tests cover sandbox mode, permission mode,
+   environment scrubbing, no session persistence, report parsing, and
+   source-control handoff.
+
+That order keeps the protocol from becoming a thin wrapper around one existing
+CLI's flags while still moving the codebase toward one generic executor plus
+small shims.

--- a/docs/integration-taxonomy.md
+++ b/docs/integration-taxonomy.md
@@ -152,3 +152,9 @@ credentials:
 
 The executor receives sanitized semantic refs. The runner or future control
 plane resolves connection IDs, credentials, permissions, and concrete API calls.
+It also owns response routing: for each semantic delivery, it selects every
+`replyTo` entry whose purpose is `all` or the matching `progress`, `final`,
+`error`, or `approval` purpose. Executor `started` and `progress` events map to
+`progress`, `completed` maps to `final`, and `failed` maps to `error`. The flat
+event result is shared across the selected targets and rendered by their channel
+adapters; executors do not split payloads or deliver to providers directly.

--- a/docs/integration-taxonomy.md
+++ b/docs/integration-taxonomy.md
@@ -1,0 +1,154 @@
+# OpenTag Integration Taxonomy
+
+OpenTag integrations are role-based, not vendor-based. A vendor integration can
+implement one or more roles and expose one or more resource domains. This keeps
+new platform work bounded: each adapter implements the boundary it owns instead
+of re-creating the whole OpenTag runner loop.
+
+## Integration Definition
+
+`opentag.integration.v1` is a manifest and discovery envelope. It answers:
+
+- who the integration is;
+- which role protocols it implements;
+- which resource domains it can reference or operate on;
+- which named bindings OpenTag can use to connect to it.
+
+It is not a runtime event protocol. Runtime semantics stay in role protocols
+such as `opentag.executor.v1` and future `opentag.channel.v1`.
+
+```json
+{
+  "protocol": "opentag.integration.v1",
+  "id": "example-agent",
+  "label": "Example Agent",
+  "bindings": {
+    "executorStdio": {
+      "kind": "stdio-jsonl",
+      "command": "example-agent",
+      "args": ["opentag-exec"]
+    }
+  },
+  "roles": {
+    "executor": {
+      "protocol": "opentag.executor.v1",
+      "profile": "stdio-jsonl-basic",
+      "binding": "executorStdio"
+    }
+  }
+}
+```
+
+## Roles
+
+Roles describe the active part an integration plays in the OpenTag work loop.
+
+| Role | Responsibility | Examples |
+| --- | --- | --- |
+| `executor` | Executes a governed run in a workspace and returns progress, completion, verification, and artifacts. | Codex, Claude Code, Hermes, OpenClaw |
+| `channel` | Receives human messages or actions and replies to the source thread. | Slack, Lark, Discord, Telegram, GitHub comments |
+
+Only `executor` is implemented in the first prototype. Future roles should add
+their own role protocol and conformance profiles instead of overloading
+`opentag.integration.v1`.
+
+## Resource Domains
+
+Resource domains are not active roles. They are semantic domains that a run can
+reference or an adapter can operate on.
+
+| Domain | Meaning |
+| --- | --- |
+| `repo` | repository, branch, commit, working tree, file refs |
+| `changeRequest` | pull request, merge request, review, checks, merge readiness |
+| `workItem` | issue, ticket, task, assignee, labels, state |
+| `context` | docs, wiki, search results, memory, source links |
+| `identity` | user, team, account, installation, permission boundary |
+
+For example, GitHub can be a channel, repo provider, change-request provider,
+work-item provider, and identity provider. Slack is usually a channel plus
+identity provider. Linear is usually a work-item provider, and may be a channel
+only if Linear comments are used as the source thread.
+
+## Bindings
+
+Bindings describe how OpenTag connects to an integration. They are declared once
+on the integration manifest and referenced by roles:
+
+```json
+{
+  "bindings": {
+    "executorStdio": {
+      "kind": "stdio-jsonl",
+      "command": "example-agent",
+      "args": ["opentag-exec"],
+      "env": {
+        "EXAMPLE_NON_SECRET_MODE": "1"
+      }
+    }
+  },
+  "roles": {
+    "executor": {
+      "protocol": "opentag.executor.v1",
+      "profile": "stdio-jsonl-basic",
+      "binding": "executorStdio"
+    }
+  }
+}
+```
+
+The first prototype implements only `stdio-jsonl`. Future bindings can model
+HTTP, webhook, socket, MCP, local service, or container-based connections without
+changing the executor run contract.
+
+Manifests must not include workspace, account, or installation secrets. Literal `env` values are for
+non-secret launch configuration only.
+
+## Connection Instances
+
+Hosted or managed OpenTag deployments should separate integration definitions
+from workspace connection state:
+
+- `IntegrationDefinition`: versioned manifest, roles, resource domains, bindings,
+  profiles, and conformance expectations. It is reusable and contains no workspace
+  secrets.
+- `ConnectionInstance`: a workspace connection to one external account for
+  one integration, such as a GitHub App installation, Slack workspace, Lark tenant,
+  Linear workspace, or remote executor account.
+- `ResolvedBinding`: runner-internal runtime handle after the control plane has
+  resolved the connection, credential, scopes, and installation boundary.
+
+`ConnectionInstance` is intentionally not part of this prototype schema. The
+current code standardizes integration definitions and sanitized run refs first;
+workspace-scoped credential and hosted connect lifecycle can be added in the
+control plane when there is a real runtime consumer.
+
+## Run Semantics
+
+A run can reference multiple systems without giving the executor direct platform
+credentials:
+
+```json
+{
+  "source": {
+    "kind": "channel_message",
+    "channel": { "provider": "slack", "id": "C123" },
+    "thread": { "provider": "slack", "id": "171234.5678" },
+    "actor": { "provider": "slack", "id": "U123" }
+  },
+  "targets": {
+    "repo": { "provider": "github", "owner": "amplifthq", "name": "opentag" },
+    "changeRequest": { "provider": "github", "id": "79", "number": 79 }
+  },
+  "replyTo": [
+    {
+      "channel": { "provider": "slack", "id": "C123" },
+      "thread": { "provider": "slack", "id": "171234.5678" },
+      "purpose": "all"
+    }
+  ]
+}
+```
+
+The executor receives sanitized semantic refs. The runner or future control
+plane resolves connection IDs, credentials, permissions, and concrete API calls.

--- a/packages/core/src/executor-protocol.ts
+++ b/packages/core/src/executor-protocol.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+import {
+  ContextPacketSchema,
+  ContextPointerSchema,
+  OpenTagCommandSchema,
+  PermissionGrantSchema,
+  ResultArtifactSchema
+} from "./schema.js";
+import {
+  OpenTagExecutorWorkspaceIsolationSchema,
+  OpenTagReplyTargetRefSchema,
+  OpenTagRunSourceRefSchema,
+  OpenTagRunTargetsSchema
+} from "./integration-protocol.js";
+
+export const OpenTagExecutorProtocolVersionSchema = z.literal("opentag.executor.v1");
+export const OpenTagExecutorSessionScopeSchema = z.enum(["run", "source_thread", "custom"]);
+
+export const OpenTagExecutorProtocolWorkspaceSchema = z
+  .object({
+    path: z.string().min(1),
+    baseBranch: z.string().min(1),
+    branchName: z.string().min(1),
+    isolation: OpenTagExecutorWorkspaceIsolationSchema
+  })
+  .strict();
+
+export const OpenTagExecutorProtocolSessionSchema = z
+  .object({
+    scope: OpenTagExecutorSessionScopeSchema,
+    key: z.string().min(1)
+  })
+  .strict();
+
+export const OpenTagExecutorProtocolSourceControlSchema = z
+  .object({
+    owner: z.literal("opentag"),
+    forbiddenCommands: z.array(z.string().min(1))
+  })
+  .strict();
+
+export const OpenTagExecutorRunRequestSchema = z
+  .object({
+    protocol: OpenTagExecutorProtocolVersionSchema,
+    runId: z.string().min(1),
+    workspace: OpenTagExecutorProtocolWorkspaceSchema,
+    session: OpenTagExecutorProtocolSessionSchema,
+    command: OpenTagCommandSchema,
+    source: OpenTagRunSourceRefSchema.optional(),
+    targets: OpenTagRunTargetsSchema.optional(),
+    replyTo: z.array(OpenTagReplyTargetRefSchema).default([]),
+    context: z.array(ContextPointerSchema),
+    contextPacket: ContextPacketSchema.optional(),
+    permissions: z.array(PermissionGrantSchema).default([]),
+    metadata: z.record(z.unknown()).default({}),
+    sourceControl: OpenTagExecutorProtocolSourceControlSchema
+  })
+  .strict();
+
+export const OpenTagExecutorProtocolVerificationSchema = z
+  .object({
+    command: z.string().min(1).optional(),
+    outcome: z.enum(["passed", "failed", "not_run"]),
+    summary: z.string().min(1).optional()
+  })
+  .strict();
+
+const BaseProtocolEventSchema = z
+  .object({
+    message: z.string().min(1),
+    at: z.string().datetime().optional()
+  })
+  .strict();
+
+export const OpenTagExecutorStartedEventSchema = BaseProtocolEventSchema.extend({
+  type: z.literal("started")
+});
+
+export const OpenTagExecutorProgressEventSchema = BaseProtocolEventSchema.extend({
+  type: z.literal("progress")
+});
+
+export const OpenTagExecutorCompletedEventSchema = BaseProtocolEventSchema.extend({
+  type: z.literal("completed"),
+  actualWorkspacePath: z.string().min(1),
+  summary: z.string().min(1),
+  verification: z.array(OpenTagExecutorProtocolVerificationSchema).default([]),
+  artifacts: z.array(ResultArtifactSchema).default([]),
+  notes: z.array(z.string().min(1)).default([]),
+  risks: z.array(z.string().min(1)).default([])
+});
+
+export const OpenTagExecutorFailedEventSchema = BaseProtocolEventSchema.extend({
+  type: z.literal("failed"),
+  actualWorkspacePath: z.string().min(1).optional()
+});
+
+export const OpenTagExecutorProtocolEventSchema = z.discriminatedUnion("type", [
+  OpenTagExecutorStartedEventSchema,
+  OpenTagExecutorProgressEventSchema,
+  OpenTagExecutorCompletedEventSchema,
+  OpenTagExecutorFailedEventSchema
+]);
+
+export type OpenTagExecutorProtocolVersion = z.infer<typeof OpenTagExecutorProtocolVersionSchema>;
+export type OpenTagExecutorSessionScope = z.infer<typeof OpenTagExecutorSessionScopeSchema>;
+export type OpenTagExecutorProtocolWorkspace = z.infer<typeof OpenTagExecutorProtocolWorkspaceSchema>;
+export type OpenTagExecutorProtocolSession = z.infer<typeof OpenTagExecutorProtocolSessionSchema>;
+export type OpenTagExecutorRunRequest = z.infer<typeof OpenTagExecutorRunRequestSchema>;
+export type OpenTagExecutorProtocolVerification = z.infer<typeof OpenTagExecutorProtocolVerificationSchema>;
+export type OpenTagExecutorStartedEvent = z.infer<typeof OpenTagExecutorStartedEventSchema>;
+export type OpenTagExecutorProgressEvent = z.infer<typeof OpenTagExecutorProgressEventSchema>;
+export type OpenTagExecutorCompletedEvent = z.infer<typeof OpenTagExecutorCompletedEventSchema>;
+export type OpenTagExecutorFailedEvent = z.infer<typeof OpenTagExecutorFailedEventSchema>;
+export type OpenTagExecutorProtocolEvent = z.infer<typeof OpenTagExecutorProtocolEventSchema>;

--- a/packages/core/src/executor-protocol.ts
+++ b/packages/core/src/executor-protocol.ts
@@ -68,7 +68,7 @@ export const OpenTagExecutorProtocolVerificationSchema = z
 const BaseProtocolEventSchema = z
   .object({
     message: z.string().min(1),
-    at: z.string().datetime().optional()
+    at: z.string().datetime({ offset: true }).optional()
   })
   .strict();
 

--- a/packages/core/src/executor-protocol.ts
+++ b/packages/core/src/executor-protocol.ts
@@ -10,7 +10,10 @@ import {
   OpenTagExecutorWorkspaceIsolationSchema,
   OpenTagReplyTargetRefSchema,
   OpenTagRunSourceRefSchema,
-  OpenTagRunTargetsSchema
+  OpenTagRunTargetsSchema,
+  selectReplyTargetsForPurpose,
+  type OpenTagReplyDeliveryPurpose,
+  type OpenTagReplyTargetRef
 } from "./integration-protocol.js";
 
 export const OpenTagExecutorProtocolVersionSchema = z.literal("opentag.executor.v1");
@@ -113,3 +116,25 @@ export type OpenTagExecutorProgressEvent = z.infer<typeof OpenTagExecutorProgres
 export type OpenTagExecutorCompletedEvent = z.infer<typeof OpenTagExecutorCompletedEventSchema>;
 export type OpenTagExecutorFailedEvent = z.infer<typeof OpenTagExecutorFailedEventSchema>;
 export type OpenTagExecutorProtocolEvent = z.infer<typeof OpenTagExecutorProtocolEventSchema>;
+export type OpenTagExecutorReplyDeliveryPurpose = Exclude<OpenTagReplyDeliveryPurpose, "approval">;
+
+export function replyDeliveryPurposeForExecutorEventType(
+  eventType: OpenTagExecutorProtocolEvent["type"]
+): OpenTagExecutorReplyDeliveryPurpose {
+  switch (eventType) {
+    case "started":
+    case "progress":
+      return "progress";
+    case "completed":
+      return "final";
+    case "failed":
+      return "error";
+  }
+}
+
+export function selectReplyTargetsForExecutorEventType(
+  replyTo: readonly OpenTagReplyTargetRef[],
+  eventType: OpenTagExecutorProtocolEvent["type"]
+): OpenTagReplyTargetRef[] {
+  return selectReplyTargetsForPurpose(replyTo, replyDeliveryPurposeForExecutorEventType(eventType));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./action.js";
 export * from "./capability.js";
+export * from "./executor-protocol.js";
+export * from "./integration-protocol.js";
 export * from "./json-schema.js";
 export * from "./mention.js";
 export * from "./presentation.js";

--- a/packages/core/src/integration-protocol.ts
+++ b/packages/core/src/integration-protocol.ts
@@ -1,0 +1,248 @@
+import { z } from "zod";
+
+const ProviderDataSchema = z.record(z.unknown());
+
+export const OpenTagIntegrationProtocolVersionSchema = z.literal("opentag.integration.v1");
+export const OpenTagExecutorRoleProtocolVersionSchema = z.literal("opentag.executor.v1");
+export const OpenTagStdioJsonlBindingKindSchema = z.literal("stdio-jsonl");
+export const OpenTagExecutorProfileSchema = z.literal("stdio-jsonl-basic");
+
+export const OpenTagExecutorWorkspaceIsolationSchema = z.enum(["branch", "worktree"]);
+export const OpenTagExecutorProgressEventModeSchema = z.enum(["none", "audit", "human"]);
+export const OpenTagExecutorConversationAccessSchema = z.enum(["none", "request", "thread_transcript"]);
+
+export const OpenTagExecutorProtocolCapabilitiesSchema = z
+  .object({
+    workspaceIsolation: OpenTagExecutorWorkspaceIsolationSchema.default("worktree"),
+    conversationAccess: OpenTagExecutorConversationAccessSchema.default("request"),
+    progressEvents: OpenTagExecutorProgressEventModeSchema.default("audit"),
+    supportsCancel: z.boolean().default(false),
+    supportsStreaming: z.boolean().default(false)
+  })
+  .strict();
+
+export const OpenTagStdioJsonlBindingSchema = z
+  .object({
+    kind: OpenTagStdioJsonlBindingKindSchema,
+    command: z.string().trim().min(1),
+    args: z.array(z.string()).default([]),
+    cwd: z.string().trim().min(1).optional(),
+    env: z.record(z.string()).default({})
+  })
+  .strict();
+
+export const OpenTagIntegrationBindingSchema = OpenTagStdioJsonlBindingSchema;
+
+export const OpenTagExecutorIntegrationRoleSchema = z
+  .object({
+    protocol: OpenTagExecutorRoleProtocolVersionSchema,
+    profile: OpenTagExecutorProfileSchema,
+    binding: z.string().trim().min(1),
+    capabilities: OpenTagExecutorProtocolCapabilitiesSchema.default({})
+  })
+  .strict();
+
+export const OpenTagIntegrationRolesSchema = z
+  .object({
+    executor: OpenTagExecutorIntegrationRoleSchema.optional()
+  })
+  .strict();
+
+export const OpenTagResourceCapabilitySchema = z
+  .object({
+    refs: z.boolean().default(true),
+    read: z.boolean().default(false),
+    write: z.boolean().default(false),
+    comments: z.boolean().optional(),
+    status: z.boolean().optional()
+  })
+  .strict();
+
+export const OpenTagIntegrationResourcesSchema = z
+  .object({
+    repo: OpenTagResourceCapabilitySchema.optional(),
+    changeRequest: OpenTagResourceCapabilitySchema.optional(),
+    workItem: OpenTagResourceCapabilitySchema.optional(),
+    context: OpenTagResourceCapabilitySchema.optional(),
+    identity: OpenTagResourceCapabilitySchema.optional()
+  })
+  .strict()
+  .default({});
+
+export const OpenTagIntegrationManifestSchema = z
+  .object({
+    protocol: OpenTagIntegrationProtocolVersionSchema,
+    id: z.string().trim().min(1),
+    label: z.string().trim().min(1),
+    bindings: z.record(OpenTagIntegrationBindingSchema),
+    roles: OpenTagIntegrationRolesSchema,
+    resources: OpenTagIntegrationResourcesSchema
+  })
+  .strict()
+  .superRefine((manifest, ctx) => {
+    if (Object.keys(manifest.bindings).length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["bindings"],
+        message: "Integration manifest must declare at least one binding."
+      });
+    }
+    const executor = manifest.roles.executor;
+    if (!executor) return;
+    const binding = manifest.bindings[executor.binding];
+    if (!binding) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["roles", "executor", "binding"],
+        message: `Executor role references missing binding '${executor.binding}'.`
+      });
+      return;
+    }
+    if (executor.profile === "stdio-jsonl-basic" && binding.kind !== "stdio-jsonl") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["roles", "executor", "binding"],
+        message: "Executor profile stdio-jsonl-basic requires a stdio-jsonl binding."
+      });
+    }
+  });
+
+export const OpenTagActorRefSchema = z
+  .object({
+    provider: z.string().trim().min(1),
+    id: z.string().trim().min(1),
+    displayName: z.string().trim().min(1).optional(),
+    url: z.string().trim().min(1).optional(),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export const OpenTagChannelRefSchema = z
+  .object({
+    provider: z.string().trim().min(1),
+    id: z.string().trim().min(1).optional(),
+    workspace: z.string().trim().min(1).optional(),
+    name: z.string().trim().min(1).optional(),
+    url: z.string().trim().min(1).optional(),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export const OpenTagThreadRefSchema = z
+  .object({
+    provider: z.string().trim().min(1),
+    id: z.string().trim().min(1),
+    parentMessageId: z.string().trim().min(1).optional(),
+    url: z.string().trim().min(1).optional(),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export const OpenTagRepoRefSchema = z
+  .object({
+    provider: z.string().trim().min(1),
+    owner: z.string().trim().min(1),
+    name: z.string().trim().min(1),
+    url: z.string().trim().min(1).optional(),
+    defaultBranch: z.string().trim().min(1).optional(),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export const OpenTagChangeRequestRefSchema = z
+  .object({
+    provider: z.string().trim().min(1),
+    repo: OpenTagRepoRefSchema.optional(),
+    id: z.string().trim().min(1),
+    number: z.number().int().positive().optional(),
+    title: z.string().trim().min(1).optional(),
+    url: z.string().trim().min(1).optional(),
+    sourceBranch: z.string().trim().min(1).optional(),
+    targetBranch: z.string().trim().min(1).optional(),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export const OpenTagWorkItemRefSchema = z
+  .object({
+    provider: z.string().trim().min(1),
+    id: z.string().trim().min(1),
+    title: z.string().trim().min(1).optional(),
+    url: z.string().trim().min(1).optional(),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export const OpenTagContextRefKindSchema = z.enum(["doc", "wiki", "file", "search", "memory", "thread", "issue", "change_request", "url"]);
+
+export const OpenTagContextRefSchema = z
+  .object({
+    provider: z.string().trim().min(1),
+    kind: OpenTagContextRefKindSchema,
+    id: z.string().trim().min(1),
+    title: z.string().trim().min(1).optional(),
+    url: z.string().trim().min(1).optional(),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export const OpenTagRunSourceKindSchema = z.enum(["channel_message", "automation", "api", "webhook"]);
+
+export const OpenTagRunSourceRefSchema = z
+  .object({
+    kind: OpenTagRunSourceKindSchema,
+    channel: OpenTagChannelRefSchema.optional(),
+    thread: OpenTagThreadRefSchema.optional(),
+    actor: OpenTagActorRefSchema.optional(),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export const OpenTagRunTargetsSchema = z
+  .object({
+    repo: OpenTagRepoRefSchema.optional(),
+    changeRequest: OpenTagChangeRequestRefSchema.optional(),
+    workItem: OpenTagWorkItemRefSchema.optional(),
+    context: z.array(OpenTagContextRefSchema).default([])
+  })
+  .strict();
+
+export const OpenTagReplyPurposeSchema = z.enum(["all", "progress", "final", "error", "approval"]);
+
+export const OpenTagReplyTargetRefSchema = z
+  .object({
+    channel: OpenTagChannelRefSchema,
+    thread: OpenTagThreadRefSchema.optional(),
+    purpose: OpenTagReplyPurposeSchema.default("all"),
+    providerData: ProviderDataSchema.optional()
+  })
+  .strict();
+
+export type OpenTagIntegrationProtocolVersion = z.infer<typeof OpenTagIntegrationProtocolVersionSchema>;
+export type OpenTagExecutorRoleProtocolVersion = z.infer<typeof OpenTagExecutorRoleProtocolVersionSchema>;
+export type OpenTagStdioJsonlBindingKind = z.infer<typeof OpenTagStdioJsonlBindingKindSchema>;
+export type OpenTagExecutorProfile = z.infer<typeof OpenTagExecutorProfileSchema>;
+export type OpenTagExecutorWorkspaceIsolation = z.infer<typeof OpenTagExecutorWorkspaceIsolationSchema>;
+export type OpenTagExecutorProgressEventMode = z.infer<typeof OpenTagExecutorProgressEventModeSchema>;
+export type OpenTagExecutorConversationAccess = z.infer<typeof OpenTagExecutorConversationAccessSchema>;
+export type OpenTagExecutorProtocolCapabilities = z.infer<typeof OpenTagExecutorProtocolCapabilitiesSchema>;
+export type OpenTagStdioJsonlBinding = z.infer<typeof OpenTagStdioJsonlBindingSchema>;
+export type OpenTagIntegrationBinding = z.infer<typeof OpenTagIntegrationBindingSchema>;
+export type OpenTagExecutorIntegrationRole = z.infer<typeof OpenTagExecutorIntegrationRoleSchema>;
+export type OpenTagIntegrationRoles = z.infer<typeof OpenTagIntegrationRolesSchema>;
+export type OpenTagResourceCapability = z.infer<typeof OpenTagResourceCapabilitySchema>;
+export type OpenTagIntegrationResources = z.infer<typeof OpenTagIntegrationResourcesSchema>;
+export type OpenTagIntegrationManifest = z.infer<typeof OpenTagIntegrationManifestSchema>;
+export type OpenTagActorRef = z.infer<typeof OpenTagActorRefSchema>;
+export type OpenTagChannelRef = z.infer<typeof OpenTagChannelRefSchema>;
+export type OpenTagThreadRef = z.infer<typeof OpenTagThreadRefSchema>;
+export type OpenTagRepoRef = z.infer<typeof OpenTagRepoRefSchema>;
+export type OpenTagChangeRequestRef = z.infer<typeof OpenTagChangeRequestRefSchema>;
+export type OpenTagWorkItemRef = z.infer<typeof OpenTagWorkItemRefSchema>;
+export type OpenTagContextRefKind = z.infer<typeof OpenTagContextRefKindSchema>;
+export type OpenTagContextRef = z.infer<typeof OpenTagContextRefSchema>;
+export type OpenTagRunSourceKind = z.infer<typeof OpenTagRunSourceKindSchema>;
+export type OpenTagRunSourceRef = z.infer<typeof OpenTagRunSourceRefSchema>;
+export type OpenTagRunTargets = z.infer<typeof OpenTagRunTargetsSchema>;
+export type OpenTagReplyPurpose = z.infer<typeof OpenTagReplyPurposeSchema>;
+export type OpenTagReplyTargetRef = z.infer<typeof OpenTagReplyTargetRefSchema>;

--- a/packages/core/src/integration-protocol.ts
+++ b/packages/core/src/integration-protocol.ts
@@ -208,6 +208,7 @@ export const OpenTagRunTargetsSchema = z
   .strict();
 
 export const OpenTagReplyPurposeSchema = z.enum(["all", "progress", "final", "error", "approval"]);
+export const OpenTagReplyDeliveryPurposeSchema = OpenTagReplyPurposeSchema.exclude(["all"]);
 
 export const OpenTagReplyTargetRefSchema = z
   .object({
@@ -248,4 +249,12 @@ export type OpenTagRunSourceKind = z.infer<typeof OpenTagRunSourceKindSchema>;
 export type OpenTagRunSourceRef = z.infer<typeof OpenTagRunSourceRefSchema>;
 export type OpenTagRunTargets = z.infer<typeof OpenTagRunTargetsSchema>;
 export type OpenTagReplyPurpose = z.infer<typeof OpenTagReplyPurposeSchema>;
+export type OpenTagReplyDeliveryPurpose = z.infer<typeof OpenTagReplyDeliveryPurposeSchema>;
 export type OpenTagReplyTargetRef = z.infer<typeof OpenTagReplyTargetRefSchema>;
+
+export function selectReplyTargetsForPurpose(
+  replyTo: readonly OpenTagReplyTargetRef[],
+  purpose: OpenTagReplyDeliveryPurpose
+): OpenTagReplyTargetRef[] {
+  return replyTo.filter((target) => target.purpose === "all" || target.purpose === purpose);
+}

--- a/packages/core/src/integration-protocol.ts
+++ b/packages/core/src/integration-protocol.ts
@@ -7,17 +7,17 @@ export const OpenTagExecutorRoleProtocolVersionSchema = z.literal("opentag.execu
 export const OpenTagStdioJsonlBindingKindSchema = z.literal("stdio-jsonl");
 export const OpenTagExecutorProfileSchema = z.literal("stdio-jsonl-basic");
 
-export const OpenTagExecutorWorkspaceIsolationSchema = z.enum(["branch", "worktree"]);
-export const OpenTagExecutorProgressEventModeSchema = z.enum(["none", "audit", "human"]);
-export const OpenTagExecutorConversationAccessSchema = z.enum(["none", "request", "thread_transcript"]);
+export const OpenTagExecutorWorkspaceIsolationSchema = z.literal("worktree");
+export const OpenTagExecutorProgressEventModeSchema = z.literal("audit");
+export const OpenTagExecutorConversationAccessSchema = z.literal("request");
 
 export const OpenTagExecutorProtocolCapabilitiesSchema = z
   .object({
     workspaceIsolation: OpenTagExecutorWorkspaceIsolationSchema.default("worktree"),
     conversationAccess: OpenTagExecutorConversationAccessSchema.default("request"),
     progressEvents: OpenTagExecutorProgressEventModeSchema.default("audit"),
-    supportsCancel: z.boolean().default(false),
-    supportsStreaming: z.boolean().default(false)
+    supportsCancel: z.literal(false).default(false),
+    supportsStreaming: z.literal(false).default(false)
   })
   .strict();
 
@@ -226,12 +226,15 @@ export type OpenTagExecutorWorkspaceIsolation = z.infer<typeof OpenTagExecutorWo
 export type OpenTagExecutorProgressEventMode = z.infer<typeof OpenTagExecutorProgressEventModeSchema>;
 export type OpenTagExecutorConversationAccess = z.infer<typeof OpenTagExecutorConversationAccessSchema>;
 export type OpenTagExecutorProtocolCapabilities = z.infer<typeof OpenTagExecutorProtocolCapabilitiesSchema>;
+export type OpenTagStdioJsonlBindingInput = z.input<typeof OpenTagStdioJsonlBindingSchema>;
 export type OpenTagStdioJsonlBinding = z.infer<typeof OpenTagStdioJsonlBindingSchema>;
 export type OpenTagIntegrationBinding = z.infer<typeof OpenTagIntegrationBindingSchema>;
+export type OpenTagExecutorIntegrationRoleInput = z.input<typeof OpenTagExecutorIntegrationRoleSchema>;
 export type OpenTagExecutorIntegrationRole = z.infer<typeof OpenTagExecutorIntegrationRoleSchema>;
 export type OpenTagIntegrationRoles = z.infer<typeof OpenTagIntegrationRolesSchema>;
 export type OpenTagResourceCapability = z.infer<typeof OpenTagResourceCapabilitySchema>;
 export type OpenTagIntegrationResources = z.infer<typeof OpenTagIntegrationResourcesSchema>;
+export type OpenTagIntegrationManifestInput = z.input<typeof OpenTagIntegrationManifestSchema>;
 export type OpenTagIntegrationManifest = z.infer<typeof OpenTagIntegrationManifestSchema>;
 export type OpenTagActorRef = z.infer<typeof OpenTagActorRefSchema>;
 export type OpenTagChannelRef = z.infer<typeof OpenTagChannelRefSchema>;

--- a/packages/core/src/json-schema.ts
+++ b/packages/core/src/json-schema.ts
@@ -27,6 +27,23 @@ import {
   WorkItemReferenceSchema,
   WorkThreadSchema
 } from "./schema.js";
+import {
+  OpenTagExecutorProtocolEventSchema,
+  OpenTagExecutorRunRequestSchema
+} from "./executor-protocol.js";
+import {
+  OpenTagActorRefSchema,
+  OpenTagChannelRefSchema,
+  OpenTagChangeRequestRefSchema,
+  OpenTagContextRefSchema,
+  OpenTagIntegrationManifestSchema,
+  OpenTagReplyTargetRefSchema,
+  OpenTagRepoRefSchema,
+  OpenTagRunSourceRefSchema,
+  OpenTagRunTargetsSchema,
+  OpenTagThreadRefSchema,
+  OpenTagWorkItemRefSchema
+} from "./integration-protocol.js";
 
 export const OpenTagJsonSchemas = {
   OpenTagEvent: zodToJsonSchema(OpenTagEventSchema, "OpenTagEvent"),
@@ -38,6 +55,19 @@ export const OpenTagJsonSchemas = {
   ConversationAnchor: zodToJsonSchema(ConversationAnchorSchema, "ConversationAnchor"),
   WorkThread: zodToJsonSchema(WorkThreadSchema, "WorkThread"),
   ContextPacket: zodToJsonSchema(ContextPacketSchema, "ContextPacket"),
+  OpenTagIntegrationManifest: zodToJsonSchema(OpenTagIntegrationManifestSchema, "OpenTagIntegrationManifest"),
+  OpenTagActorRef: zodToJsonSchema(OpenTagActorRefSchema, "OpenTagActorRef"),
+  OpenTagChannelRef: zodToJsonSchema(OpenTagChannelRefSchema, "OpenTagChannelRef"),
+  OpenTagThreadRef: zodToJsonSchema(OpenTagThreadRefSchema, "OpenTagThreadRef"),
+  OpenTagRepoRef: zodToJsonSchema(OpenTagRepoRefSchema, "OpenTagRepoRef"),
+  OpenTagChangeRequestRef: zodToJsonSchema(OpenTagChangeRequestRefSchema, "OpenTagChangeRequestRef"),
+  OpenTagWorkItemRef: zodToJsonSchema(OpenTagWorkItemRefSchema, "OpenTagWorkItemRef"),
+  OpenTagContextRef: zodToJsonSchema(OpenTagContextRefSchema, "OpenTagContextRef"),
+  OpenTagRunSourceRef: zodToJsonSchema(OpenTagRunSourceRefSchema, "OpenTagRunSourceRef"),
+  OpenTagRunTargets: zodToJsonSchema(OpenTagRunTargetsSchema, "OpenTagRunTargets"),
+  OpenTagReplyTargetRef: zodToJsonSchema(OpenTagReplyTargetRefSchema, "OpenTagReplyTargetRef"),
+  OpenTagExecutorRunRequest: zodToJsonSchema(OpenTagExecutorRunRequestSchema, "OpenTagExecutorRunRequest"),
+  OpenTagExecutorProtocolEvent: zodToJsonSchema(OpenTagExecutorProtocolEventSchema, "OpenTagExecutorProtocolEvent"),
   RunEventVisibility: zodToJsonSchema(RunEventVisibilitySchema, "RunEventVisibility"),
   RunEventImportance: zodToJsonSchema(RunEventImportanceSchema, "RunEventImportance"),
   RunEvent: zodToJsonSchema(RunEventSchema, "RunEvent"),

--- a/packages/core/test/executor-protocol.test.ts
+++ b/packages/core/test/executor-protocol.test.ts
@@ -127,4 +127,17 @@ describe("OpenTag executor protocol schemas", () => {
       })
     ).toThrow();
   });
+
+  it("accepts RFC 3339 event timestamps with explicit timezone offsets", () => {
+    expect(
+      OpenTagExecutorProtocolEventSchema.parse({
+        type: "started",
+        message: "started outside UTC",
+        at: "2026-07-07T19:00:00+02:00"
+      })
+    ).toMatchObject({
+      type: "started",
+      at: "2026-07-07T19:00:00+02:00"
+    });
+  });
 });

--- a/packages/core/test/executor-protocol.test.ts
+++ b/packages/core/test/executor-protocol.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  OpenTagExecutorProtocolEventSchema,
+  OpenTagExecutorRunRequestSchema
+} from "../src/executor-protocol.js";
+import { OpenTagIntegrationManifestSchema } from "../src/integration-protocol.js";
+
+describe("OpenTag executor protocol schemas", () => {
+  it("models integration manifests with an executor role and stdio-jsonl binding", () => {
+    const manifest = OpenTagIntegrationManifestSchema.parse({
+      protocol: "opentag.integration.v1",
+      id: "fake",
+      label: "Fake",
+      bindings: {
+        executorStdio: {
+          kind: "stdio-jsonl",
+          command: "fake-agent"
+        }
+      },
+      roles: {
+        executor: {
+          protocol: "opentag.executor.v1",
+          profile: "stdio-jsonl-basic",
+          binding: "executorStdio"
+        }
+      }
+    });
+
+    expect(manifest.bindings.executorStdio.args).toEqual([]);
+    expect(manifest.roles.executor?.capabilities).toEqual({
+      workspaceIsolation: "worktree",
+      conversationAccess: "request",
+      progressEvents: "audit",
+      supportsCancel: false,
+      supportsStreaming: false
+    });
+  });
+
+  it("rejects executor roles that reference missing bindings", () => {
+    expect(() =>
+      OpenTagIntegrationManifestSchema.parse({
+        protocol: "opentag.integration.v1",
+        id: "fake",
+        label: "Fake",
+        bindings: {
+          other: {
+            kind: "stdio-jsonl",
+            command: "fake-agent"
+          }
+        },
+        roles: {
+          executor: {
+            protocol: "opentag.executor.v1",
+            profile: "stdio-jsonl-basic",
+            binding: "missing"
+          }
+        }
+      })
+    ).toThrow("missing binding");
+  });
+
+  it("models run requests with explicit workspace and per-run session fields", () => {
+    const request = OpenTagExecutorRunRequestSchema.parse({
+      protocol: "opentag.executor.v1",
+      runId: "run_1",
+      workspace: {
+        path: "/tmp/opentag/run_1",
+        baseBranch: "main",
+        branchName: "opentag/run_1",
+        isolation: "worktree"
+      },
+      session: {
+        scope: "run",
+        key: "opentag:fake:run_1"
+      },
+      command: { rawText: "fix this", intent: "fix", args: {} },
+      source: {
+        kind: "channel_message",
+        channel: { provider: "slack", id: "C123" },
+        thread: { provider: "slack", id: "171234.5678" },
+        actor: { provider: "slack", id: "U123", displayName: "Ada" }
+      },
+      targets: {
+        repo: { provider: "github", owner: "amplifthq", name: "opentag", defaultBranch: "main" },
+        changeRequest: { provider: "github", id: "79", number: 79, title: "Add protocol executor" },
+        context: [{ provider: "github", kind: "thread", id: "issue-comment-1", url: "https://example.test/comment" }]
+      },
+      replyTo: [{ channel: { provider: "slack", id: "C123" }, thread: { provider: "slack", id: "171234.5678" } }],
+      context: [],
+      sourceControl: {
+        owner: "opentag",
+        forbiddenCommands: ["git add", "git commit", "git push", "gh pr create"]
+      }
+    });
+
+    expect(request.workspace.path).toBe("/tmp/opentag/run_1");
+    expect(request.session.key).toContain("run_1");
+    expect(request.permissions).toEqual([]);
+    expect(request.metadata).toEqual({});
+    expect(request.source?.channel?.provider).toBe("slack");
+    expect(request.targets?.repo?.name).toBe("opentag");
+    expect(request.replyTo[0]?.purpose).toBe("all");
+  });
+
+  it("requires completed events to acknowledge the actual workspace", () => {
+    expect(
+      OpenTagExecutorProtocolEventSchema.parse({
+        type: "completed",
+        message: "done",
+        actualWorkspacePath: "/tmp/opentag/run_1",
+        summary: "Finished.",
+        verification: [{ outcome: "passed", command: "test", summary: "Tests passed." }],
+        artifacts: [],
+        risks: []
+      })
+    ).toMatchObject({
+      type: "completed",
+      actualWorkspacePath: "/tmp/opentag/run_1",
+      verification: [{ outcome: "passed" }]
+    });
+
+    expect(() =>
+      OpenTagExecutorProtocolEventSchema.parse({
+        type: "completed",
+        message: "done",
+        summary: "Finished."
+      })
+    ).toThrow();
+  });
+});

--- a/packages/core/test/executor-protocol.test.ts
+++ b/packages/core/test/executor-protocol.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   OpenTagExecutorProtocolEventSchema,
-  OpenTagExecutorRunRequestSchema
+  OpenTagExecutorRunRequestSchema,
+  replyDeliveryPurposeForExecutorEventType,
+  selectReplyTargetsForExecutorEventType
 } from "../src/executor-protocol.js";
-import { OpenTagIntegrationManifestSchema } from "../src/integration-protocol.js";
+import {
+  OpenTagIntegrationManifestSchema,
+  selectReplyTargetsForPurpose,
+  type OpenTagReplyTargetRef
+} from "../src/integration-protocol.js";
 
 describe("OpenTag executor protocol schemas", () => {
   it("models integration manifests with an executor role and stdio-jsonl binding", () => {
@@ -100,6 +106,64 @@ describe("OpenTag executor protocol schemas", () => {
     expect(request.source?.channel?.provider).toBe("slack");
     expect(request.targets?.repo?.name).toBe("opentag");
     expect(request.replyTo[0]?.purpose).toBe("all");
+  });
+
+  it("selects every reply target whose purpose matches the delivery", () => {
+    const replyTo: OpenTagReplyTargetRef[] = [
+      { channel: { provider: "slack", id: "all-1" }, purpose: "all" },
+      { channel: { provider: "slack", id: "progress-1" }, purpose: "progress" },
+      { channel: { provider: "github", id: "final" }, purpose: "final" },
+      { channel: { provider: "github", id: "all-2" }, purpose: "all" },
+      { channel: { provider: "github", id: "error" }, purpose: "error" },
+      { channel: { provider: "slack", id: "progress-2" }, purpose: "progress" },
+      { channel: { provider: "slack", id: "approval" }, purpose: "approval" },
+      { channel: { provider: "slack", id: "progress-3" }, purpose: "progress" }
+    ];
+
+    expect(selectReplyTargetsForPurpose(replyTo, "progress").map((target) => target.channel.id)).toEqual([
+      "all-1",
+      "progress-1",
+      "all-2",
+      "progress-2",
+      "progress-3"
+    ]);
+    expect(selectReplyTargetsForPurpose(replyTo, "final").map((target) => target.channel.id)).toEqual([
+      "all-1",
+      "final",
+      "all-2"
+    ]);
+    expect(selectReplyTargetsForPurpose(replyTo, "error").map((target) => target.channel.id)).toEqual([
+      "all-1",
+      "all-2",
+      "error"
+    ]);
+    expect(selectReplyTargetsForPurpose(replyTo, "approval").map((target) => target.channel.id)).toEqual([
+      "all-1",
+      "all-2",
+      "approval"
+    ]);
+  });
+
+  it("maps executor events to canonical reply delivery purposes", () => {
+    expect(replyDeliveryPurposeForExecutorEventType("started")).toBe("progress");
+    expect(replyDeliveryPurposeForExecutorEventType("progress")).toBe("progress");
+    expect(replyDeliveryPurposeForExecutorEventType("completed")).toBe("final");
+    expect(replyDeliveryPurposeForExecutorEventType("failed")).toBe("error");
+
+    const replyTo: OpenTagReplyTargetRef[] = [
+      { channel: { provider: "slack", id: "all-1" }, purpose: "all" },
+      { channel: { provider: "slack", id: "progress" }, purpose: "progress" },
+      { channel: { provider: "github", id: "final-1" }, purpose: "final" },
+      { channel: { provider: "slack", id: "all-2" }, purpose: "all" },
+      { channel: { provider: "github", id: "error" }, purpose: "error" },
+      { channel: { provider: "github", id: "final-2" }, purpose: "final" }
+    ];
+    expect(selectReplyTargetsForExecutorEventType(replyTo, "completed").map((target) => target.channel.id)).toEqual([
+      "all-1",
+      "final-1",
+      "all-2",
+      "final-2"
+    ]);
   });
 
   it("requires completed events to acknowledge the actual workspace", () => {

--- a/packages/runner/src/executor.ts
+++ b/packages/runner/src/executor.ts
@@ -1,4 +1,14 @@
-import { contextPointerLabel, type ContextPacket, type ContextPointer, type OpenTagCommand, type OpenTagRunResult, type PermissionGrant } from "@opentag/core";
+import {
+  contextPointerLabel,
+  type ContextPacket,
+  type ContextPointer,
+  type OpenTagCommand,
+  type OpenTagReplyTargetRef,
+  type OpenTagRunResult,
+  type OpenTagRunSourceRef,
+  type OpenTagRunTargets,
+  type PermissionGrant
+} from "@opentag/core";
 import type { AgentSessionProfile } from "./session-profile.js";
 
 export type ExecutorEvent = {
@@ -15,6 +25,9 @@ export type ExecutorRunInput = {
   runId: string;
   workspacePath: string;
   command: OpenTagCommand;
+  source?: OpenTagRunSourceRef;
+  targets?: OpenTagRunTargets;
+  replyTo?: OpenTagReplyTargetRef[];
   context: ContextPointer[];
   contextPacket?: ContextPacket;
   permissions?: PermissionGrant[];

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -4,6 +4,7 @@ export * from "./command.js";
 export * from "./echo.js";
 export * from "./executor.js";
 export * from "./git.js";
+export * from "./protocol-executor.js";
 export * from "./result.js";
 export * from "./security.js";
 export * from "./session-profile.js";

--- a/packages/runner/src/protocol-executor.ts
+++ b/packages/runner/src/protocol-executor.ts
@@ -1,13 +1,20 @@
 import { resolve } from "node:path";
 import type {
-  ContextPacket,
-  ContextPointer,
-  OpenTagCommand,
-  OpenTagReplyTargetRef,
-  OpenTagRunSourceRef,
-  OpenTagRunTargets,
-  PermissionGrant,
-  ResultArtifact
+  OpenTagExecutorCompletedEvent,
+  OpenTagExecutorFailedEvent,
+  OpenTagExecutorIntegrationRoleInput,
+  OpenTagExecutorProtocolCapabilities,
+  OpenTagExecutorProtocolEvent,
+  OpenTagExecutorProtocolVerification,
+  OpenTagExecutorRunRequest,
+  OpenTagIntegrationManifestInput,
+  OpenTagStdioJsonlBindingInput,
+  OpenTagStdioJsonlBinding
+} from "@opentag/core";
+import {
+  OpenTagExecutorProtocolEventSchema,
+  OpenTagExecutorRunRequestSchema,
+  OpenTagIntegrationManifestSchema
 } from "@opentag/core";
 import { nodeCommandRunner, type CommandEnvironment, type CommandResult, type CommandRunner } from "./command.js";
 import { type ExecutorAdapter, type ExecutorEventSink, type ExecutorRunInput } from "./executor.js";
@@ -17,57 +24,21 @@ import {
   changedFiles,
   cleanupInternalArtifacts,
   commitRunChanges,
-  createRunBranch,
   createRunWorktree,
   deleteRunBranch,
   removeRunWorktree,
   worktreePathForRun
 } from "./git.js";
 import { createExecutorRunResult } from "./result.js";
+import { scrubEnvironment } from "./security.js";
 
 const SOURCE_CONTROL_FORBIDDEN_COMMANDS = ["git add", "git commit", "git push", "gh pr create"];
 
-export type ProtocolExecutorCapabilities = {
-  workspaceIsolation: "branch" | "worktree";
-  conversationAccess: "none" | "request" | "thread_transcript";
-  progressEvents: "none" | "audit" | "human";
-  supportsCancel: boolean;
-  supportsStreaming: boolean;
-};
-
-export type ProtocolExecutorStdioJsonlBindingInput = {
-  kind: "stdio-jsonl";
-  command: string;
-  args?: string[];
-  cwd?: string;
-  env?: Record<string, string>;
-};
-
-export type ProtocolExecutorRoleInput = {
-  protocol: "opentag.executor.v1";
-  profile: "stdio-jsonl-basic";
-  binding: string;
-  capabilities?: Partial<ProtocolExecutorCapabilities>;
-};
-
-export type ProtocolExecutorManifestInput = {
-  protocol: "opentag.integration.v1";
-  id: string;
-  label: string;
-  bindings: Record<string, ProtocolExecutorStdioJsonlBindingInput>;
-  roles: {
-    executor?: ProtocolExecutorRoleInput;
-  };
-  resources?: Record<string, unknown>;
-};
-
-export type ProtocolExecutorStdioJsonlBinding = {
-  kind: "stdio-jsonl";
-  command: string;
-  args: string[];
-  cwd?: string;
-  env: Record<string, string>;
-};
+export type ProtocolExecutorStdioJsonlBindingInput = OpenTagStdioJsonlBindingInput;
+export type ProtocolExecutorRoleInput = OpenTagExecutorIntegrationRoleInput;
+export type ProtocolExecutorManifestInput = OpenTagIntegrationManifestInput;
+export type ProtocolExecutorCapabilities = OpenTagExecutorProtocolCapabilities;
+export type ProtocolExecutorStdioJsonlBinding = OpenTagStdioJsonlBinding;
 
 export type ProtocolExecutorManifest = {
   protocol: "opentag.integration.v1";
@@ -79,72 +50,11 @@ export type ProtocolExecutorManifest = {
   capabilities: ProtocolExecutorCapabilities;
 };
 
-export type ProtocolExecutorRunRequest = {
-  protocol: "opentag.executor.v1";
-  runId: string;
-  workspace: {
-    path: string;
-    baseBranch: string;
-    branchName: string;
-    isolation: "branch" | "worktree";
-  };
-  session: {
-    scope: "run";
-    key: string;
-  };
-  command: OpenTagCommand;
-  source?: OpenTagRunSourceRef;
-  targets?: OpenTagRunTargets;
-  replyTo: OpenTagReplyTargetRef[];
-  context: ContextPointer[];
-  contextPacket?: ContextPacket;
-  permissions: PermissionGrant[];
-  metadata: Record<string, unknown>;
-  sourceControl: {
-    owner: "opentag";
-    forbiddenCommands: string[];
-  };
-};
-
-export type ProtocolExecutorVerification = {
-  command?: string;
-  outcome: "passed" | "failed" | "not_run";
-  summary?: string;
-};
-
-type ProtocolBaseEvent = {
-  message: string;
-  at?: string;
-};
-
-export type ProtocolExecutorStartedEvent = ProtocolBaseEvent & {
-  type: "started";
-};
-
-export type ProtocolExecutorProgressEvent = ProtocolBaseEvent & {
-  type: "progress";
-};
-
-export type ProtocolExecutorCompletedEvent = ProtocolBaseEvent & {
-  type: "completed";
-  actualWorkspacePath: string;
-  summary: string;
-  verification: ProtocolExecutorVerification[];
-  artifacts: ResultArtifact[];
-  notes: string[];
-  risks: string[];
-};
-
-export type ProtocolExecutorFailedEvent = ProtocolBaseEvent & {
-  type: "failed";
-  actualWorkspacePath?: string;
-};
-
-export type ProtocolExecutorEvent =
-  | ProtocolExecutorStartedEvent
-  | ProtocolExecutorProgressEvent
-  | ProtocolExecutorCompletedEvent
-  | ProtocolExecutorFailedEvent;
+export type ProtocolExecutorRunRequest = OpenTagExecutorRunRequest;
+export type ProtocolExecutorVerification = OpenTagExecutorProtocolVerification;
+export type ProtocolExecutorCompletedEvent = OpenTagExecutorCompletedEvent;
+export type ProtocolExecutorFailedEvent = OpenTagExecutorFailedEvent;
+export type ProtocolExecutorEvent = OpenTagExecutorProtocolEvent;
 
 export type ProtocolExecutorOptions = {
   manifest: ProtocolExecutorManifestInput;
@@ -161,141 +71,34 @@ function eventAt(event: ProtocolExecutorEvent): string {
   return event.at ?? new Date().toISOString();
 }
 
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
-}
-
-function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
-}
-
-function stringArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
-}
-
 function normalizeManifest(input: ProtocolExecutorManifestInput): ProtocolExecutorManifest {
-  if (input.protocol !== "opentag.integration.v1") {
-    throw new Error("Protocol executor manifest must use opentag.integration.v1.");
-  }
-  const executor = input.roles?.executor;
+  const parsed = OpenTagIntegrationManifestSchema.parse(input);
+  const executor = parsed.roles.executor;
   if (!executor) {
     throw new Error("Protocol executor manifest must declare roles.executor.");
   }
-  if (executor.protocol !== "opentag.executor.v1") {
-    throw new Error("Protocol executor role must use opentag.executor.v1.");
-  }
-  if (executor.profile !== "stdio-jsonl-basic") {
-    throw new Error("Protocol executor prototype only supports the stdio-jsonl-basic profile.");
-  }
-  const bindingName = executor.binding.trim();
-  if (!bindingName) {
-    throw new Error("Protocol executor role binding must not be empty.");
-  }
-  const binding = input.bindings?.[bindingName];
-  if (!binding) {
-    throw new Error(`Protocol executor role references missing binding '${bindingName}'.`);
-  }
-  if (binding.kind !== "stdio-jsonl") {
-    throw new Error("Protocol executor prototype only supports stdio-jsonl bindings.");
-  }
-  const capabilities = executor.capabilities ?? {};
-  const cwd = binding.cwd?.trim();
+  const bindingName = executor.binding;
+  const binding = parsed.bindings[bindingName];
+  if (!binding) throw new Error(`Protocol executor role references missing binding '${bindingName}'.`);
   return {
-    protocol: input.protocol,
-    id: input.id.trim(),
-    label: input.label.trim(),
+    protocol: parsed.protocol,
+    id: parsed.id,
+    label: parsed.label,
     profile: executor.profile,
     bindingName,
-    binding: {
-      kind: binding.kind,
-      command: binding.command.trim(),
-      args: binding.args ?? [],
-      ...(cwd ? { cwd } : {}),
-      env: binding.env ?? {}
-    },
-    capabilities: {
-      workspaceIsolation: capabilities.workspaceIsolation ?? "worktree",
-      conversationAccess: capabilities.conversationAccess ?? "request",
-      progressEvents: capabilities.progressEvents ?? "audit",
-      supportsCancel: capabilities.supportsCancel ?? false,
-      supportsStreaming: capabilities.supportsStreaming ?? false
-    }
+    binding,
+    capabilities: executor.capabilities
   };
 }
 
-function assertValidManifest(manifest: ProtocolExecutorManifest): void {
-  if (manifest.protocol !== "opentag.integration.v1") throw new Error("Protocol executor manifest must use opentag.integration.v1.");
-  if (!manifest.id) throw new Error("Protocol executor manifest id must not be empty.");
-  if (!manifest.label) throw new Error("Protocol executor manifest label must not be empty.");
-  if (!manifest.binding.command) throw new Error("Protocol executor stdio-jsonl binding command must not be empty.");
-}
-
-function parseVerification(value: unknown): ProtocolExecutorVerification[] {
-  if (!Array.isArray(value)) return [];
-  const allowedOutcomes = new Set(["passed", "failed", "not_run"]);
-  return value.flatMap((item) => {
-    const record = asRecord(item);
-    const outcome = record ? nonEmptyString(record["outcome"]) : undefined;
-    if (!record || !outcome || !allowedOutcomes.has(outcome)) return [];
-    const command = nonEmptyString(record["command"]);
-    const summary = nonEmptyString(record["summary"]);
-    return [
-      {
-        outcome: outcome as "passed" | "failed" | "not_run",
-        ...(command ? { command } : {}),
-        ...(summary ? { summary } : {})
-      }
-    ];
-  });
-}
-
-function parseProtocolArtifacts(value: unknown): ResultArtifact[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((item) => {
-    const record = asRecord(item);
-    const title = record ? nonEmptyString(record["title"]) : undefined;
-    const uri = record ? nonEmptyString(record["uri"]) : undefined;
-    if (!record || !title || !uri) return [];
-    return [record as ResultArtifact];
-  });
-}
-
 function parseProtocolEventValue(value: unknown, lineNumber: number): ProtocolExecutorEvent {
-  const record = asRecord(value);
-  const type = record ? nonEmptyString(record["type"]) : undefined;
-  const message = record ? nonEmptyString(record["message"]) : undefined;
-  if (!record || !type || !message) {
-    throw new Error(`Protocol executor emitted invalid event at line ${lineNumber}: missing type or message.`);
+  try {
+    return OpenTagExecutorProtocolEventSchema.parse(value);
+  } catch (error) {
+    throw new Error(
+      `Protocol executor emitted invalid event at line ${lineNumber}: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
-  const at = nonEmptyString(record["at"]);
-  const base = { message, ...(at ? { at } : {}) };
-
-  if (type === "started" || type === "progress") {
-    return { type, ...base };
-  }
-  if (type === "failed") {
-    const actualWorkspacePath = nonEmptyString(record["actualWorkspacePath"]);
-    return { type, ...base, ...(actualWorkspacePath ? { actualWorkspacePath } : {}) };
-  }
-  if (type === "completed") {
-    const actualWorkspacePath = nonEmptyString(record["actualWorkspacePath"]);
-    const summary = nonEmptyString(record["summary"]);
-    if (!actualWorkspacePath || !summary) {
-      throw new Error(`Protocol executor emitted invalid completed event at line ${lineNumber}: missing actualWorkspacePath or summary.`);
-    }
-    return {
-      type,
-      ...base,
-      actualWorkspacePath,
-      summary,
-      verification: parseVerification(record["verification"]),
-      artifacts: parseProtocolArtifacts(record["artifacts"]),
-      notes: stringArray(record["notes"]),
-      risks: stringArray(record["risks"])
-    };
-  }
-
-  throw new Error(`Protocol executor emitted invalid event at line ${lineNumber}: unknown type ${type}.`);
 }
 
 async function emitProtocolEvent(sink: ExecutorEventSink, event: ProtocolExecutorEvent): Promise<void> {
@@ -355,7 +158,7 @@ function requestForRun(input: {
   branchName: string;
   baseBranch: string;
 }): ProtocolExecutorRunRequest {
-  return {
+  return OpenTagExecutorRunRequestSchema.parse({
     protocol: "opentag.executor.v1",
     runId: input.run.runId,
     workspace: {
@@ -380,7 +183,7 @@ function requestForRun(input: {
       owner: "opentag",
       forbiddenCommands: SOURCE_CONTROL_FORBIDDEN_COMMANDS
     }
-  };
+  });
 }
 
 function outputForCompletedEvent(input: { completed: ProtocolExecutorCompletedEvent; changedFiles: string[] }): string {
@@ -410,7 +213,6 @@ async function cleanupAfterChild(input: {
   runner: CommandRunner;
   workspacePath: string;
   sink: ExecutorEventSink;
-  primaryError?: unknown;
 }): Promise<void> {
   try {
     const cleanedArtifacts = await cleanupInternalArtifacts({ runner: input.runner, workspacePath: input.workspacePath });
@@ -422,7 +224,6 @@ async function cleanupAfterChild(input: {
       });
     }
   } catch (cleanupError) {
-    if (!input.primaryError) throw cleanupError;
     await input.sink.emit({
       type: "executor.progress",
       message: `Failed to clean internal artifacts: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
@@ -434,20 +235,9 @@ async function cleanupAfterChild(input: {
 async function createIsolation(input: {
   runner: CommandRunner;
   run: ExecutorRunInput;
-  manifest: ProtocolExecutorManifest;
   branchName: string;
   baseBranch: string;
 }): Promise<string> {
-  if (input.manifest.capabilities.workspaceIsolation === "branch") {
-    await createRunBranch({
-      runner: input.runner,
-      workspacePath: input.run.workspacePath,
-      branchName: input.branchName,
-      startPoint: input.baseBranch
-    });
-    return input.run.workspacePath;
-  }
-
   const worktreePath = worktreePathForRun({
     workspacePath: input.run.workspacePath,
     runId: input.run.runId,
@@ -466,14 +256,12 @@ async function createIsolation(input: {
 async function maybeRemoveIsolation(input: {
   runner: CommandRunner;
   run: ExecutorRunInput;
-  manifest: ProtocolExecutorManifest;
   workspacePath: string;
   branchName: string;
   completed: boolean;
   changedFileCount: number | undefined;
   sink: ExecutorEventSink;
 }): Promise<void> {
-  if (input.manifest.capabilities.workspaceIsolation !== "worktree") return;
   const keepWorktree = input.run.keepWorktree ?? "on_failure";
   const shouldRemove = keepWorktree === "never" || (keepWorktree === "on_failure" && input.completed);
   if (!shouldRemove) return;
@@ -497,14 +285,12 @@ function childFailure(input: { manifest: ProtocolExecutorManifest; result: Comma
   return new Error(`protocol executor ${input.manifest.id} failed with exit code ${input.result.exitCode}: ${input.result.stderr || input.result.stdout}`);
 }
 
-function envForBinding(binding: ProtocolExecutorStdioJsonlBinding): CommandEnvironment | undefined {
-  if (Object.keys(binding.env).length === 0) return undefined;
-  return { ...process.env, ...binding.env };
+function envForBinding(binding: ProtocolExecutorStdioJsonlBinding): CommandEnvironment {
+  return { ...scrubEnvironment(), ...binding.env };
 }
 
 export function createProtocolExecutor(options: ProtocolExecutorOptions): ExecutorAdapter {
   const manifest = normalizeManifest(options.manifest);
-  assertValidManifest(manifest);
   const runner = options.runner ?? nodeCommandRunner;
 
   return {
@@ -564,29 +350,29 @@ export function createProtocolExecutor(options: ProtocolExecutorOptions): Execut
       });
 
       try {
-        workspacePath = await createIsolation({ runner, run: input, manifest, branchName, baseBranch });
+        workspacePath = await createIsolation({ runner, run: input, branchName, baseBranch });
         const request = requestForRun({ run: input, manifest, workspacePath, branchName, baseBranch });
-        const bindingEnv = envForBinding(manifest.binding);
         const childResult = await runner.run(manifest.binding.command, manifest.binding.args, {
           cwd: manifest.binding.cwd ?? workspacePath,
           input: `${JSON.stringify(request)}\n`,
-          ...(bindingEnv ? { env: bindingEnv } : {})
+          env: envForBinding(manifest.binding)
         });
 
         let primaryError: unknown = childFailure({ manifest, result: childResult });
         let events: ProtocolExecutorEvent[] = [];
-        if (!primaryError) {
-          try {
-            events = parseProtocolEvents(childResult.stdout);
-          } catch (error) {
-            primaryError = error;
-          }
+        let eventParseError: unknown;
+        try {
+          events = parseProtocolEvents(childResult.stdout);
+        } catch (error) {
+          eventParseError = error;
         }
 
+        for (const event of events) {
+          await emitProtocolEvent(sink, event);
+        }
+        primaryError ??= eventParseError;
+
         if (!primaryError) {
-          for (const event of events) {
-            await emitProtocolEvent(sink, event);
-          }
           const final = finalEvent(events);
           if (!final) {
             primaryError = new Error(`Protocol executor ${manifest.id} exited without a completed or failed event.`);
@@ -601,7 +387,7 @@ export function createProtocolExecutor(options: ProtocolExecutorOptions): Execut
           }
         }
 
-        await cleanupAfterChild({ runner, workspacePath, sink, ...(primaryError ? { primaryError } : {}) });
+        await cleanupAfterChild({ runner, workspacePath, sink });
         if (primaryError) throw primaryError;
 
         const completedEvent = finalEvent(events);
@@ -643,7 +429,6 @@ export function createProtocolExecutor(options: ProtocolExecutorOptions): Execut
         await maybeRemoveIsolation({
           runner,
           run: input,
-          manifest,
           workspacePath,
           branchName,
           completed,

--- a/packages/runner/src/protocol-executor.ts
+++ b/packages/runner/src/protocol-executor.ts
@@ -1,0 +1,659 @@
+import { resolve } from "node:path";
+import type {
+  ContextPacket,
+  ContextPointer,
+  OpenTagCommand,
+  OpenTagReplyTargetRef,
+  OpenTagRunSourceRef,
+  OpenTagRunTargets,
+  PermissionGrant,
+  ResultArtifact
+} from "@opentag/core";
+import { nodeCommandRunner, type CommandEnvironment, type CommandResult, type CommandRunner } from "./command.js";
+import { type ExecutorAdapter, type ExecutorEventSink, type ExecutorRunInput } from "./executor.js";
+import { EXECUTOR_REPORT_END, EXECUTOR_REPORT_START } from "./executor-report.js";
+import {
+  branchNameForRun,
+  changedFiles,
+  cleanupInternalArtifacts,
+  commitRunChanges,
+  createRunBranch,
+  createRunWorktree,
+  deleteRunBranch,
+  removeRunWorktree,
+  worktreePathForRun
+} from "./git.js";
+import { createExecutorRunResult } from "./result.js";
+
+const SOURCE_CONTROL_FORBIDDEN_COMMANDS = ["git add", "git commit", "git push", "gh pr create"];
+
+export type ProtocolExecutorCapabilities = {
+  workspaceIsolation: "branch" | "worktree";
+  conversationAccess: "none" | "request" | "thread_transcript";
+  progressEvents: "none" | "audit" | "human";
+  supportsCancel: boolean;
+  supportsStreaming: boolean;
+};
+
+export type ProtocolExecutorStdioJsonlBindingInput = {
+  kind: "stdio-jsonl";
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+};
+
+export type ProtocolExecutorRoleInput = {
+  protocol: "opentag.executor.v1";
+  profile: "stdio-jsonl-basic";
+  binding: string;
+  capabilities?: Partial<ProtocolExecutorCapabilities>;
+};
+
+export type ProtocolExecutorManifestInput = {
+  protocol: "opentag.integration.v1";
+  id: string;
+  label: string;
+  bindings: Record<string, ProtocolExecutorStdioJsonlBindingInput>;
+  roles: {
+    executor?: ProtocolExecutorRoleInput;
+  };
+  resources?: Record<string, unknown>;
+};
+
+export type ProtocolExecutorStdioJsonlBinding = {
+  kind: "stdio-jsonl";
+  command: string;
+  args: string[];
+  cwd?: string;
+  env: Record<string, string>;
+};
+
+export type ProtocolExecutorManifest = {
+  protocol: "opentag.integration.v1";
+  id: string;
+  label: string;
+  profile: "stdio-jsonl-basic";
+  bindingName: string;
+  binding: ProtocolExecutorStdioJsonlBinding;
+  capabilities: ProtocolExecutorCapabilities;
+};
+
+export type ProtocolExecutorRunRequest = {
+  protocol: "opentag.executor.v1";
+  runId: string;
+  workspace: {
+    path: string;
+    baseBranch: string;
+    branchName: string;
+    isolation: "branch" | "worktree";
+  };
+  session: {
+    scope: "run";
+    key: string;
+  };
+  command: OpenTagCommand;
+  source?: OpenTagRunSourceRef;
+  targets?: OpenTagRunTargets;
+  replyTo: OpenTagReplyTargetRef[];
+  context: ContextPointer[];
+  contextPacket?: ContextPacket;
+  permissions: PermissionGrant[];
+  metadata: Record<string, unknown>;
+  sourceControl: {
+    owner: "opentag";
+    forbiddenCommands: string[];
+  };
+};
+
+export type ProtocolExecutorVerification = {
+  command?: string;
+  outcome: "passed" | "failed" | "not_run";
+  summary?: string;
+};
+
+type ProtocolBaseEvent = {
+  message: string;
+  at?: string;
+};
+
+export type ProtocolExecutorStartedEvent = ProtocolBaseEvent & {
+  type: "started";
+};
+
+export type ProtocolExecutorProgressEvent = ProtocolBaseEvent & {
+  type: "progress";
+};
+
+export type ProtocolExecutorCompletedEvent = ProtocolBaseEvent & {
+  type: "completed";
+  actualWorkspacePath: string;
+  summary: string;
+  verification: ProtocolExecutorVerification[];
+  artifacts: ResultArtifact[];
+  notes: string[];
+  risks: string[];
+};
+
+export type ProtocolExecutorFailedEvent = ProtocolBaseEvent & {
+  type: "failed";
+  actualWorkspacePath?: string;
+};
+
+export type ProtocolExecutorEvent =
+  | ProtocolExecutorStartedEvent
+  | ProtocolExecutorProgressEvent
+  | ProtocolExecutorCompletedEvent
+  | ProtocolExecutorFailedEvent;
+
+export type ProtocolExecutorOptions = {
+  manifest: ProtocolExecutorManifestInput;
+  runner?: CommandRunner;
+};
+
+export function defaultProtocolSessionKey(input: { executorId: string; runId: string }): string {
+  const safeExecutorId = input.executorId.replace(/[^a-zA-Z0-9._-]/g, "-");
+  const safeRunId = input.runId.replace(/[^a-zA-Z0-9._-]/g, "-");
+  return `opentag:${safeExecutorId}:${safeRunId}`;
+}
+
+function eventAt(event: ProtocolExecutorEvent): string {
+  return event.at ?? new Date().toISOString();
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function normalizeManifest(input: ProtocolExecutorManifestInput): ProtocolExecutorManifest {
+  if (input.protocol !== "opentag.integration.v1") {
+    throw new Error("Protocol executor manifest must use opentag.integration.v1.");
+  }
+  const executor = input.roles?.executor;
+  if (!executor) {
+    throw new Error("Protocol executor manifest must declare roles.executor.");
+  }
+  if (executor.protocol !== "opentag.executor.v1") {
+    throw new Error("Protocol executor role must use opentag.executor.v1.");
+  }
+  if (executor.profile !== "stdio-jsonl-basic") {
+    throw new Error("Protocol executor prototype only supports the stdio-jsonl-basic profile.");
+  }
+  const bindingName = executor.binding.trim();
+  if (!bindingName) {
+    throw new Error("Protocol executor role binding must not be empty.");
+  }
+  const binding = input.bindings?.[bindingName];
+  if (!binding) {
+    throw new Error(`Protocol executor role references missing binding '${bindingName}'.`);
+  }
+  if (binding.kind !== "stdio-jsonl") {
+    throw new Error("Protocol executor prototype only supports stdio-jsonl bindings.");
+  }
+  const capabilities = executor.capabilities ?? {};
+  const cwd = binding.cwd?.trim();
+  return {
+    protocol: input.protocol,
+    id: input.id.trim(),
+    label: input.label.trim(),
+    profile: executor.profile,
+    bindingName,
+    binding: {
+      kind: binding.kind,
+      command: binding.command.trim(),
+      args: binding.args ?? [],
+      ...(cwd ? { cwd } : {}),
+      env: binding.env ?? {}
+    },
+    capabilities: {
+      workspaceIsolation: capabilities.workspaceIsolation ?? "worktree",
+      conversationAccess: capabilities.conversationAccess ?? "request",
+      progressEvents: capabilities.progressEvents ?? "audit",
+      supportsCancel: capabilities.supportsCancel ?? false,
+      supportsStreaming: capabilities.supportsStreaming ?? false
+    }
+  };
+}
+
+function assertValidManifest(manifest: ProtocolExecutorManifest): void {
+  if (manifest.protocol !== "opentag.integration.v1") throw new Error("Protocol executor manifest must use opentag.integration.v1.");
+  if (!manifest.id) throw new Error("Protocol executor manifest id must not be empty.");
+  if (!manifest.label) throw new Error("Protocol executor manifest label must not be empty.");
+  if (!manifest.binding.command) throw new Error("Protocol executor stdio-jsonl binding command must not be empty.");
+}
+
+function parseVerification(value: unknown): ProtocolExecutorVerification[] {
+  if (!Array.isArray(value)) return [];
+  const allowedOutcomes = new Set(["passed", "failed", "not_run"]);
+  return value.flatMap((item) => {
+    const record = asRecord(item);
+    const outcome = record ? nonEmptyString(record["outcome"]) : undefined;
+    if (!record || !outcome || !allowedOutcomes.has(outcome)) return [];
+    const command = nonEmptyString(record["command"]);
+    const summary = nonEmptyString(record["summary"]);
+    return [
+      {
+        outcome: outcome as "passed" | "failed" | "not_run",
+        ...(command ? { command } : {}),
+        ...(summary ? { summary } : {})
+      }
+    ];
+  });
+}
+
+function parseProtocolArtifacts(value: unknown): ResultArtifact[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    const record = asRecord(item);
+    const title = record ? nonEmptyString(record["title"]) : undefined;
+    const uri = record ? nonEmptyString(record["uri"]) : undefined;
+    if (!record || !title || !uri) return [];
+    return [record as ResultArtifact];
+  });
+}
+
+function parseProtocolEventValue(value: unknown, lineNumber: number): ProtocolExecutorEvent {
+  const record = asRecord(value);
+  const type = record ? nonEmptyString(record["type"]) : undefined;
+  const message = record ? nonEmptyString(record["message"]) : undefined;
+  if (!record || !type || !message) {
+    throw new Error(`Protocol executor emitted invalid event at line ${lineNumber}: missing type or message.`);
+  }
+  const at = nonEmptyString(record["at"]);
+  const base = { message, ...(at ? { at } : {}) };
+
+  if (type === "started" || type === "progress") {
+    return { type, ...base };
+  }
+  if (type === "failed") {
+    const actualWorkspacePath = nonEmptyString(record["actualWorkspacePath"]);
+    return { type, ...base, ...(actualWorkspacePath ? { actualWorkspacePath } : {}) };
+  }
+  if (type === "completed") {
+    const actualWorkspacePath = nonEmptyString(record["actualWorkspacePath"]);
+    const summary = nonEmptyString(record["summary"]);
+    if (!actualWorkspacePath || !summary) {
+      throw new Error(`Protocol executor emitted invalid completed event at line ${lineNumber}: missing actualWorkspacePath or summary.`);
+    }
+    return {
+      type,
+      ...base,
+      actualWorkspacePath,
+      summary,
+      verification: parseVerification(record["verification"]),
+      artifacts: parseProtocolArtifacts(record["artifacts"]),
+      notes: stringArray(record["notes"]),
+      risks: stringArray(record["risks"])
+    };
+  }
+
+  throw new Error(`Protocol executor emitted invalid event at line ${lineNumber}: unknown type ${type}.`);
+}
+
+async function emitProtocolEvent(sink: ExecutorEventSink, event: ProtocolExecutorEvent): Promise<void> {
+  if (event.type === "started") {
+    await sink.emit({ type: "executor.started", message: event.message, at: eventAt(event) });
+  }
+  if (event.type === "progress") {
+    await sink.emit({ type: "executor.progress", message: event.message, at: eventAt(event) });
+  }
+  if (event.type === "failed") {
+    await sink.emit({ type: "executor.failed", message: event.message, at: eventAt(event) });
+  }
+}
+
+function parseProtocolEvents(stdout: string): ProtocolExecutorEvent[] {
+  const events: ProtocolExecutorEvent[] = [];
+  const lines = stdout.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+
+  for (const [index, line] of lines.entries()) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        `Protocol executor emitted malformed JSONL on stdout at line ${index + 1}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    events.push(parseProtocolEventValue(parsed, index + 1));
+  }
+
+  return events;
+}
+
+function finalEvent(events: ProtocolExecutorEvent[]): ProtocolExecutorCompletedEvent | ProtocolExecutorFailedEvent | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.type === "completed" || event?.type === "failed") return event;
+  }
+  return undefined;
+}
+
+function assertActualWorkspace(input: { expected: string; actual: string; executorId: string }): void {
+  const expected = resolve(input.expected);
+  const actual = resolve(input.actual);
+  if (actual !== expected) {
+    throw new Error(
+      `Protocol executor ${input.executorId} reported actual workspace ${actual}, expected ${expected}. Refusing to accept changes from an unbound workspace.`
+    );
+  }
+}
+
+function requestForRun(input: {
+  run: ExecutorRunInput;
+  manifest: ProtocolExecutorManifest;
+  workspacePath: string;
+  branchName: string;
+  baseBranch: string;
+}): ProtocolExecutorRunRequest {
+  return {
+    protocol: "opentag.executor.v1",
+    runId: input.run.runId,
+    workspace: {
+      path: input.workspacePath,
+      baseBranch: input.baseBranch,
+      branchName: input.branchName,
+      isolation: input.manifest.capabilities.workspaceIsolation
+    },
+    session: {
+      scope: "run",
+      key: defaultProtocolSessionKey({ executorId: input.manifest.id, runId: input.run.runId })
+    },
+    command: input.run.command,
+    ...(input.run.source ? { source: input.run.source } : {}),
+    ...(input.run.targets ? { targets: input.run.targets } : {}),
+    replyTo: input.run.replyTo ?? [],
+    context: input.run.context,
+    ...(input.run.contextPacket ? { contextPacket: input.run.contextPacket } : {}),
+    permissions: input.run.permissions ?? [],
+    metadata: input.run.metadata ?? {},
+    sourceControl: {
+      owner: "opentag",
+      forbiddenCommands: SOURCE_CONTROL_FORBIDDEN_COMMANDS
+    }
+  };
+}
+
+function outputForCompletedEvent(input: { completed: ProtocolExecutorCompletedEvent; changedFiles: string[] }): string {
+  return [
+    input.completed.summary,
+    "",
+    EXECUTOR_REPORT_START,
+    JSON.stringify(
+      {
+        changes: [
+          { summary: input.completed.summary },
+          ...input.changedFiles.map((file) => ({ file, summary: "Changed by protocol executor." }))
+        ],
+        verification: input.completed.verification,
+        artifacts: input.completed.artifacts,
+        risks: input.completed.risks,
+        notes: input.completed.notes
+      },
+      null,
+      2
+    ),
+    EXECUTOR_REPORT_END
+  ].join("\n");
+}
+
+async function cleanupAfterChild(input: {
+  runner: CommandRunner;
+  workspacePath: string;
+  sink: ExecutorEventSink;
+  primaryError?: unknown;
+}): Promise<void> {
+  try {
+    const cleanedArtifacts = await cleanupInternalArtifacts({ runner: input.runner, workspacePath: input.workspacePath });
+    if (cleanedArtifacts.length > 0) {
+      await input.sink.emit({
+        type: "executor.progress",
+        message: `Cleaned internal artifacts: ${cleanedArtifacts.join(", ")}`,
+        at: new Date().toISOString()
+      });
+    }
+  } catch (cleanupError) {
+    if (!input.primaryError) throw cleanupError;
+    await input.sink.emit({
+      type: "executor.progress",
+      message: `Failed to clean internal artifacts: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+      at: new Date().toISOString()
+    });
+  }
+}
+
+async function createIsolation(input: {
+  runner: CommandRunner;
+  run: ExecutorRunInput;
+  manifest: ProtocolExecutorManifest;
+  branchName: string;
+  baseBranch: string;
+}): Promise<string> {
+  if (input.manifest.capabilities.workspaceIsolation === "branch") {
+    await createRunBranch({
+      runner: input.runner,
+      workspacePath: input.run.workspacePath,
+      branchName: input.branchName,
+      startPoint: input.baseBranch
+    });
+    return input.run.workspacePath;
+  }
+
+  const worktreePath = worktreePathForRun({
+    workspacePath: input.run.workspacePath,
+    runId: input.run.runId,
+    ...(input.run.worktreeRoot ? { worktreeRoot: input.run.worktreeRoot } : {})
+  });
+  await createRunWorktree({
+    runner: input.runner,
+    workspacePath: input.run.workspacePath,
+    worktreePath,
+    branchName: input.branchName,
+    baseBranch: input.baseBranch
+  });
+  return worktreePath;
+}
+
+async function maybeRemoveIsolation(input: {
+  runner: CommandRunner;
+  run: ExecutorRunInput;
+  manifest: ProtocolExecutorManifest;
+  workspacePath: string;
+  branchName: string;
+  completed: boolean;
+  changedFileCount: number | undefined;
+  sink: ExecutorEventSink;
+}): Promise<void> {
+  if (input.manifest.capabilities.workspaceIsolation !== "worktree") return;
+  const keepWorktree = input.run.keepWorktree ?? "on_failure";
+  const shouldRemove = keepWorktree === "never" || (keepWorktree === "on_failure" && input.completed);
+  if (!shouldRemove) return;
+
+  try {
+    await removeRunWorktree({ runner: input.runner, workspacePath: input.run.workspacePath, worktreePath: input.workspacePath });
+    if (input.completed && input.changedFileCount === 0) {
+      await deleteRunBranch({ runner: input.runner, workspacePath: input.run.workspacePath, branchName: input.branchName });
+    }
+  } catch (error) {
+    await input.sink.emit({
+      type: "executor.progress",
+      message: `Could not clean up protocol executor worktree or branch for ${input.workspacePath}: ${error instanceof Error ? error.message : String(error)}`,
+      at: new Date().toISOString()
+    });
+  }
+}
+
+function childFailure(input: { manifest: ProtocolExecutorManifest; result: CommandResult }): Error | undefined {
+  if (input.result.exitCode === 0) return undefined;
+  return new Error(`protocol executor ${input.manifest.id} failed with exit code ${input.result.exitCode}: ${input.result.stderr || input.result.stdout}`);
+}
+
+function envForBinding(binding: ProtocolExecutorStdioJsonlBinding): CommandEnvironment | undefined {
+  if (Object.keys(binding.env).length === 0) return undefined;
+  return { ...process.env, ...binding.env };
+}
+
+export function createProtocolExecutor(options: ProtocolExecutorOptions): ExecutorAdapter {
+  const manifest = normalizeManifest(options.manifest);
+  assertValidManifest(manifest);
+  const runner = options.runner ?? nodeCommandRunner;
+
+  return {
+    id: manifest.id,
+    displayName: manifest.label,
+    capability: {
+      id: manifest.id,
+      invocation: "spawn",
+      supportsProfile: false,
+      supportsStreaming: manifest.capabilities.supportsStreaming,
+      supportsCancel: manifest.capabilities.supportsCancel,
+      supportsHookCompletion: false,
+      progressEvents: manifest.capabilities.progressEvents,
+      approvalMode: "opentag_policy",
+      contextAccess: ["context_packet", "context_pointers", "workspace"],
+      promptAssembly: "opentag",
+      writeAccess: "workspace",
+      conversationAccess: manifest.capabilities.conversationAccess,
+      promptMutation: "none",
+      rawContextAccess: false,
+      writeActionAccess: "none",
+      workspaceIsolation: manifest.capabilities.workspaceIsolation,
+      requiredSecrets: [],
+      completionSignals: [
+        {
+          type: "process_exit",
+          required: true,
+          description: "OpenTag treats the stdio-jsonl child process exit and a final protocol event as the completion signal."
+        }
+      ]
+    },
+    async canRun(input) {
+      const gitRepo = await runner.run("git", ["rev-parse", "--show-toplevel"], { cwd: input.workspacePath });
+      if (gitRepo.exitCode !== 0) {
+        return { ready: false, reason: `Workspace is not a git checkout: ${gitRepo.stderr || gitRepo.stdout}` };
+      }
+      const baseBranch = input.baseBranch ?? "main";
+      const baseRef = await runner.run("git", ["rev-parse", "--verify", `${baseBranch}^{commit}`], {
+        cwd: input.workspacePath
+      });
+      if (baseRef.exitCode !== 0) {
+        return { ready: false, reason: `Base branch '${baseBranch}' is not available: ${baseRef.stderr || baseRef.stdout}` };
+      }
+      return { ready: true };
+    },
+    async run(input, sink) {
+      const branchName = branchNameForRun(input.runId);
+      const baseBranch = input.baseBranch ?? "main";
+      let completed = false;
+      let changedFileCount: number | undefined;
+      let workspacePath = input.workspacePath;
+
+      await sink.emit({
+        type: "executor.started",
+        message: `Creating protocol executor ${manifest.capabilities.workspaceIsolation} isolation ${branchName}`,
+        at: new Date().toISOString()
+      });
+
+      try {
+        workspacePath = await createIsolation({ runner, run: input, manifest, branchName, baseBranch });
+        const request = requestForRun({ run: input, manifest, workspacePath, branchName, baseBranch });
+        const bindingEnv = envForBinding(manifest.binding);
+        const childResult = await runner.run(manifest.binding.command, manifest.binding.args, {
+          cwd: manifest.binding.cwd ?? workspacePath,
+          input: `${JSON.stringify(request)}\n`,
+          ...(bindingEnv ? { env: bindingEnv } : {})
+        });
+
+        let primaryError: unknown = childFailure({ manifest, result: childResult });
+        let events: ProtocolExecutorEvent[] = [];
+        if (!primaryError) {
+          try {
+            events = parseProtocolEvents(childResult.stdout);
+          } catch (error) {
+            primaryError = error;
+          }
+        }
+
+        if (!primaryError) {
+          for (const event of events) {
+            await emitProtocolEvent(sink, event);
+          }
+          const final = finalEvent(events);
+          if (!final) {
+            primaryError = new Error(`Protocol executor ${manifest.id} exited without a completed or failed event.`);
+          } else if (final.type === "failed") {
+            primaryError = new Error(`Protocol executor ${manifest.id} failed: ${final.message}`);
+          } else {
+            try {
+              assertActualWorkspace({ expected: workspacePath, actual: final.actualWorkspacePath, executorId: manifest.id });
+            } catch (error) {
+              primaryError = error;
+            }
+          }
+        }
+
+        await cleanupAfterChild({ runner, workspacePath, sink, ...(primaryError ? { primaryError } : {}) });
+        if (primaryError) throw primaryError;
+
+        const completedEvent = finalEvent(events);
+        if (!completedEvent || completedEvent.type !== "completed") {
+          throw new Error(`Protocol executor ${manifest.id} exited without a completed event.`);
+        }
+
+        const files = await changedFiles({ runner, workspacePath });
+        changedFileCount = files.length;
+        if (files.length > 0) {
+          await sink.emit({
+            type: "executor.progress",
+            message: `Committing ${files.length} changed file(s) to ${branchName}`,
+            at: new Date().toISOString()
+          });
+          await commitRunChanges({
+            runner,
+            workspacePath,
+            message: `OpenTag run ${input.runId}`
+          });
+        }
+        completed = true;
+
+        await sink.emit({
+          type: "executor.completed",
+          message: `Protocol executor ${manifest.id} completed with ${files.length} changed file(s)`,
+          at: new Date().toISOString()
+        });
+
+        return createExecutorRunResult({
+          executorName: manifest.label,
+          runId: input.runId,
+          branchName,
+          baseBranch,
+          output: outputForCompletedEvent({ completed: completedEvent, changedFiles: files }),
+          changedFiles: files
+        });
+      } finally {
+        await maybeRemoveIsolation({
+          runner,
+          run: input,
+          manifest,
+          workspacePath,
+          branchName,
+          completed,
+          changedFileCount,
+          sink
+        });
+      }
+    },
+    async cancel() {
+      return;
+    }
+  };
+}

--- a/packages/runner/test/fixtures/protocol-shim-bad-workspace.mjs
+++ b/packages/runner/test/fixtures/protocol-shim-bad-workspace.mjs
@@ -1,0 +1,22 @@
+const input = await new Promise((resolve) => {
+  let data = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    data += chunk;
+  });
+  process.stdin.on("end", () => resolve(data.trim()));
+});
+
+const request = JSON.parse(input);
+console.log(JSON.stringify({ type: "started", message: "Bad workspace shim started" }));
+console.log(
+  JSON.stringify({
+    type: "completed",
+    message: "Bad workspace shim completed",
+    actualWorkspacePath: `${request.workspace.path}-wrong`,
+    summary: "This should be rejected.",
+    verification: [],
+    artifacts: [],
+    risks: []
+  })
+);

--- a/packages/runner/test/fixtures/protocol-shim-env.mjs
+++ b/packages/runner/test/fixtures/protocol-shim-env.mjs
@@ -1,0 +1,35 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const input = await new Promise((resolve) => {
+  let data = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    data += chunk;
+  });
+  process.stdin.on("end", () => resolve(data.trim()));
+});
+
+const request = JSON.parse(input);
+mkdirSync(request.workspace.path, { recursive: true });
+writeFileSync(
+  join(request.workspace.path, "protocol-env.json"),
+  JSON.stringify({
+    inheritedSecret: process.env.OPENTAG_TEST_HOST_SECRET ?? null,
+    inheritedMarker: process.env.OPENTAG_TEST_HOST_MARKER ?? null,
+    explicitValue: process.env.OPENTAG_TEST_EXPLICIT_VALUE ?? null
+  })
+);
+
+console.log(
+  JSON.stringify({
+    type: "completed",
+    message: "Protocol environment recorded",
+    actualWorkspacePath: request.workspace.path,
+    summary: "Recorded the protocol shim environment.",
+    verification: [],
+    artifacts: [],
+    notes: [],
+    risks: []
+  })
+);

--- a/packages/runner/test/fixtures/protocol-shim-failed.mjs
+++ b/packages/runner/test/fixtures/protocol-shim-failed.mjs
@@ -1,0 +1,19 @@
+const input = await new Promise((resolve) => {
+  let data = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    data += chunk;
+  });
+  process.stdin.on("end", () => resolve(data.trim()));
+});
+
+const request = JSON.parse(input);
+console.log(JSON.stringify({ type: "progress", message: "Captured child diagnostic before failure" }));
+console.log(
+  JSON.stringify({
+    type: "failed",
+    message: "Structured child failure",
+    actualWorkspacePath: request.workspace.path
+  })
+);
+process.exitCode = 17;

--- a/packages/runner/test/fixtures/protocol-shim-invalid-event.mjs
+++ b/packages/runner/test/fixtures/protocol-shim-invalid-event.mjs
@@ -1,0 +1,22 @@
+const input = await new Promise((resolve) => {
+  let data = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    data += chunk;
+  });
+  process.stdin.on("end", () => resolve(data.trim()));
+});
+
+const request = JSON.parse(input);
+console.log(
+  JSON.stringify({
+    type: "completed",
+    message: "Invalid event shim completed",
+    actualWorkspacePath: request.workspace.path,
+    summary: "The invalid verification entry must not be ignored.",
+    verification: [{ outcome: "unknown" }],
+    artifacts: [],
+    notes: [],
+    risks: []
+  })
+);

--- a/packages/runner/test/fixtures/protocol-shim-malformed.mjs
+++ b/packages/runner/test/fixtures/protocol-shim-malformed.mjs
@@ -1,0 +1,1 @@
+console.log("not-json");

--- a/packages/runner/test/fixtures/protocol-shim-missing-final.mjs
+++ b/packages/runner/test/fixtures/protocol-shim-missing-final.mjs
@@ -1,0 +1,2 @@
+console.log(JSON.stringify({ type: "started", message: "Missing final shim started" }));
+console.log(JSON.stringify({ type: "progress", message: "No final event will be emitted" }));

--- a/packages/runner/test/fixtures/protocol-shim.mjs
+++ b/packages/runner/test/fixtures/protocol-shim.mjs
@@ -1,0 +1,37 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const input = await new Promise((resolve) => {
+  let data = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    data += chunk;
+  });
+  process.stdin.on("end", () => resolve(data.trim()));
+});
+
+const request = JSON.parse(input);
+if (request.protocol !== "opentag.executor.v1") {
+  throw new Error(`Unexpected protocol ${request.protocol}`);
+}
+if (!request.session.key.includes(request.runId)) {
+  throw new Error("Session key must include run id.");
+}
+
+mkdirSync(request.workspace.path, { recursive: true });
+writeFileSync(join(request.workspace.path, "protocol-output.txt"), `run=${request.runId}\nsession=${request.session.key}\n`);
+writeFileSync(join(request.workspace.path, "protocol-request.json"), JSON.stringify(request, null, 2));
+
+console.log(JSON.stringify({ type: "started", message: "Protocol shim started" }));
+console.log(JSON.stringify({ type: "progress", message: "Protocol shim wrote files" }));
+console.log(
+  JSON.stringify({
+    type: "completed",
+    message: "Protocol shim completed",
+    actualWorkspacePath: request.workspace.path,
+    summary: "Protocol shim completed the run.",
+    verification: [{ command: "protocol-shim self-check", outcome: "passed", summary: "Workspace and session were validated." }],
+    artifacts: [],
+    risks: []
+  })
+);

--- a/packages/runner/test/protocol-executor.test.ts
+++ b/packages/runner/test/protocol-executor.test.ts
@@ -5,7 +5,11 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CommandRunner } from "../src/command.js";
-import { createProtocolExecutor, defaultProtocolSessionKey } from "../src/protocol-executor.js";
+import {
+  createProtocolExecutor,
+  defaultProtocolSessionKey,
+  type ProtocolExecutorManifestInput
+} from "../src/protocol-executor.js";
 
 const fixturesDir = fileURLToPath(new URL("./fixtures/", import.meta.url));
 
@@ -67,6 +71,19 @@ function manifestForFixture(fixture: string) {
   };
 }
 
+function manifestWithCapabilityOverride(capabilities: Record<string, unknown>): ProtocolExecutorManifestInput {
+  const manifest = manifestForFixture("protocol-shim.mjs");
+  return {
+    ...manifest,
+    roles: {
+      executor: {
+        ...manifest.roles.executor,
+        capabilities: { ...manifest.roles.executor.capabilities, ...capabilities }
+      }
+    }
+  } as unknown as ProtocolExecutorManifestInput;
+}
+
 describe("protocol executor", () => {
   it("runs a stdio-jsonl shim in an isolated worktree and reports changed files", async () => {
     const repo = initGitRepo();
@@ -115,6 +132,66 @@ describe("protocol executor", () => {
     expect(request.targets.repo.name).toBe("opentag");
     expect(request.targets.changeRequest.number).toBe(79);
     expect(request.replyTo[0].purpose).toBe("all");
+  }, 15_000);
+
+  it("does not expose the complete inherited host environment to a protocol shim", async () => {
+    const previousSecret = process.env.OPENTAG_TEST_HOST_SECRET;
+    const previousMarker = process.env.OPENTAG_TEST_HOST_MARKER;
+    process.env.OPENTAG_TEST_HOST_SECRET = "must-not-reach-shim";
+    process.env.OPENTAG_TEST_HOST_MARKER = "ordinary-host-value";
+
+    try {
+      const repo = initGitRepo();
+      const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim-env.mjs") });
+
+      await executor.run(
+        {
+          runId: "run_env_scrubbed",
+          workspacePath: repo,
+          command: { rawText: "record environment", intent: "fix", args: {} },
+          context: [],
+          baseBranch: "main"
+        },
+        { emit: async () => undefined }
+      );
+
+      const observedEnv = JSON.parse(runGit(repo, ["show", "opentag/run_env_scrubbed:protocol-env.json"]));
+      expect(observedEnv).toEqual({ inheritedSecret: null, inheritedMarker: null, explicitValue: null });
+    } finally {
+      if (previousSecret === undefined) delete process.env.OPENTAG_TEST_HOST_SECRET;
+      else process.env.OPENTAG_TEST_HOST_SECRET = previousSecret;
+      if (previousMarker === undefined) delete process.env.OPENTAG_TEST_HOST_MARKER;
+      else process.env.OPENTAG_TEST_HOST_MARKER = previousMarker;
+    }
+  }, 15_000);
+
+  it("passes only explicitly configured binding values on top of the scrubbed environment", async () => {
+    const previousSecret = process.env.OPENTAG_TEST_HOST_SECRET;
+    process.env.OPENTAG_TEST_HOST_SECRET = "must-not-reach-shim";
+
+    try {
+      const repo = initGitRepo();
+      const manifest = manifestForFixture("protocol-shim-env.mjs");
+      manifest.bindings.executorStdio.env = { OPENTAG_TEST_EXPLICIT_VALUE: "explicit-value" };
+      const executor = createProtocolExecutor({ manifest });
+
+      await executor.run(
+        {
+          runId: "run_env_explicit",
+          workspacePath: repo,
+          command: { rawText: "record explicit environment", intent: "fix", args: {} },
+          context: [],
+          baseBranch: "main"
+        },
+        { emit: async () => undefined }
+      );
+
+      const observedEnv = JSON.parse(runGit(repo, ["show", "opentag/run_env_explicit:protocol-env.json"]));
+      expect(observedEnv).toEqual({ inheritedSecret: null, inheritedMarker: null, explicitValue: "explicit-value" });
+    } finally {
+      if (previousSecret === undefined) delete process.env.OPENTAG_TEST_HOST_SECRET;
+      else process.env.OPENTAG_TEST_HOST_SECRET = previousSecret;
+    }
   }, 15_000);
 
   it("rejects a shim that acknowledges a different actual workspace", async () => {
@@ -189,6 +266,97 @@ describe("protocol executor", () => {
     expect(calls.some((call) => call.command === "git" && call.args[0] === "worktree" && call.args[1] === "remove")).toBe(true);
   });
 
+  it("reports cleanup failure without replacing a successful child result", async () => {
+    const runner: CommandRunner = {
+      async run(command, args, options) {
+        if (command === "git" && args[0] === "worktree" && args[1] === "add") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "fake-shim") {
+          const request = JSON.parse(options?.input?.trim() ?? "{}");
+          return {
+            exitCode: 0,
+            stdout: `${JSON.stringify({
+              type: "completed",
+              message: "done",
+              actualWorkspacePath: request.workspace.path,
+              summary: "successful child",
+              verification: [],
+              artifacts: [],
+              notes: [],
+              risks: []
+            })}\n`,
+            stderr: ""
+          };
+        }
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
+          return { exitCode: 0, stdout: "?? .omx/\0", stderr: "" };
+        }
+        if (command === "git" && args[0] === "clean") {
+          return { exitCode: 1, stdout: "", stderr: "cleanup exploded" };
+        }
+        if (command === "git" && args[0] === "worktree" && args[1] === "remove") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "git" && args[0] === "branch" && args[1] === "-D") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+    const manifest = manifestForFixture("protocol-shim.mjs");
+    manifest.bindings.executorStdio = { ...manifest.bindings.executorStdio, command: "fake-shim", args: [] };
+    const executor = createProtocolExecutor({ manifest, runner });
+    const events: string[] = [];
+    const repo = tempDir("protocol-cleanup-success");
+
+    const result = await executor.run(
+      {
+        runId: "run_cleanup_success",
+        workspacePath: repo,
+        command: { rawText: "succeed", intent: "fix", args: {} },
+        context: [],
+        baseBranch: "main",
+        keepWorktree: "never"
+      },
+      {
+        emit: async (event) => {
+          events.push(event.message);
+        }
+      }
+    );
+
+    expect(result.changedFiles).toEqual([]);
+    expect(events.some((event) => event.includes("cleanup exploded"))).toBe(true);
+  });
+
+  it("emits structured diagnostics before rejecting a non-zero child exit", async () => {
+    const repo = initGitRepo();
+    const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim-failed.mjs") });
+    const events: string[] = [];
+
+    await expect(
+      executor.run(
+        {
+          runId: "run_nonzero_diagnostics",
+          workspacePath: repo,
+          command: { rawText: "fail with diagnostics", intent: "fix", args: {} },
+          context: [],
+          baseBranch: "main",
+          keepWorktree: "never"
+        },
+        {
+          emit: async (event) => {
+            events.push(`${event.type}:${event.message}`);
+          }
+        }
+      )
+    ).rejects.toThrow("exit code 17");
+
+    expect(events).toContain("executor.progress:Captured child diagnostic before failure");
+    expect(events).toContain("executor.failed:Structured child failure");
+  }, 15_000);
+
   it("rejects malformed JSONL output", async () => {
     const repo = initGitRepo();
     const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim-malformed.mjs") });
@@ -206,6 +374,25 @@ describe("protocol executor", () => {
         { emit: async () => undefined }
       )
     ).rejects.toThrow("malformed JSONL");
+  }, 15_000);
+
+  it("rejects events that do not satisfy the canonical event schema", async () => {
+    const repo = initGitRepo();
+    const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim-invalid-event.mjs") });
+
+    await expect(
+      executor.run(
+        {
+          runId: "run_invalid_event",
+          workspacePath: repo,
+          command: { rawText: "emit invalid event", intent: "fix", args: {} },
+          context: [],
+          baseBranch: "main",
+          keepWorktree: "never"
+        },
+        { emit: async () => undefined }
+      )
+    ).rejects.toThrow("invalid event");
   }, 15_000);
 
   it("rejects shim output without a final event", async () => {
@@ -238,6 +425,36 @@ describe("protocol executor", () => {
       conversationAccess: "request",
       workspaceIsolation: "worktree"
     });
+  });
+
+  it("rejects branch isolation for the worktree-only stdio-jsonl-basic profile", () => {
+    const manifest = manifestWithCapabilityOverride({ workspaceIsolation: "branch" });
+
+    expect(() => createProtocolExecutor({ manifest })).toThrow("workspaceIsolation");
+  });
+
+  it("rejects cancellation claims that stdio-jsonl-basic cannot honor", () => {
+    const manifest = manifestWithCapabilityOverride({ supportsCancel: true });
+
+    expect(() => createProtocolExecutor({ manifest })).toThrow("supportsCancel");
+  });
+
+  it("rejects streaming claims while stdio-jsonl-basic buffers child output", () => {
+    const manifest = manifestWithCapabilityOverride({ supportsStreaming: true });
+
+    expect(() => createProtocolExecutor({ manifest })).toThrow("supportsStreaming");
+  });
+
+  it("rejects conversation modes that stdio-jsonl-basic does not implement", () => {
+    const manifest = manifestWithCapabilityOverride({ conversationAccess: "thread_transcript" });
+
+    expect(() => createProtocolExecutor({ manifest })).toThrow("conversationAccess");
+  });
+
+  it("rejects progress modes that stdio-jsonl-basic does not implement", () => {
+    const manifest = manifestWithCapabilityOverride({ progressEvents: "human" });
+
+    expect(() => createProtocolExecutor({ manifest })).toThrow("progressEvents");
   });
 
   it("requires an executor role in the integration manifest", () => {

--- a/packages/runner/test/protocol-executor.test.ts
+++ b/packages/runner/test/protocol-executor.test.ts
@@ -1,0 +1,248 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CommandRunner } from "../src/command.js";
+import { createProtocolExecutor, defaultProtocolSessionKey } from "../src/protocol-executor.js";
+
+const fixturesDir = fileURLToPath(new URL("./fixtures/", import.meta.url));
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function tempDir(name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `opentag-${name}-`));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function runGit(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+function initGitRepo(): string {
+  const repo = tempDir("protocol-repo");
+  runGit(repo, ["init", "-b", "main"]);
+  runGit(repo, ["config", "user.email", "opentag@example.test"]);
+  runGit(repo, ["config", "user.name", "OpenTag Test"]);
+  writeFileSync(join(repo, "README.md"), "# demo\n");
+  runGit(repo, ["add", "README.md"]);
+  runGit(repo, ["commit", "-m", "initial"]);
+  return repo;
+}
+
+function manifestForFixture(fixture: string) {
+  return {
+    protocol: "opentag.integration.v1" as const,
+    id: "fake-protocol",
+    label: "Fake Protocol",
+    bindings: {
+      executorStdio: {
+        kind: "stdio-jsonl" as const,
+        command: process.execPath,
+        args: [join(fixturesDir, fixture)]
+      }
+    },
+    roles: {
+      executor: {
+        protocol: "opentag.executor.v1" as const,
+        profile: "stdio-jsonl-basic" as const,
+        binding: "executorStdio",
+        capabilities: {
+          workspaceIsolation: "worktree" as const,
+          conversationAccess: "request" as const,
+          progressEvents: "audit" as const,
+          supportsCancel: false,
+          supportsStreaming: false
+        }
+      }
+    }
+  };
+}
+
+describe("protocol executor", () => {
+  it("runs a stdio-jsonl shim in an isolated worktree and reports changed files", async () => {
+    const repo = initGitRepo();
+    const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim.mjs") });
+    const events: string[] = [];
+
+    const result = await executor.run(
+      {
+        runId: "run_protocol",
+        workspacePath: repo,
+        command: { rawText: "write protocol output", intent: "fix", args: {} },
+        source: {
+          kind: "channel_message",
+          channel: { provider: "slack", id: "C123" },
+          thread: { provider: "slack", id: "171234.5678" },
+          actor: { provider: "slack", id: "U123", displayName: "Ada" }
+        },
+        targets: {
+          repo: { provider: "github", owner: "amplifthq", name: "opentag", defaultBranch: "main" },
+          changeRequest: { provider: "github", id: "79", number: 79, title: "Add protocol executor" },
+          context: [{ provider: "github", kind: "thread", id: "issue-comment-1" }]
+        },
+        replyTo: [{ channel: { provider: "slack", id: "C123" }, thread: { provider: "slack", id: "171234.5678" }, purpose: "all" }],
+        context: [],
+        baseBranch: "main"
+      },
+      {
+        emit: async (event) => {
+          events.push(`${event.type}:${event.message}`);
+        }
+      }
+    );
+
+    expect(events).toContain("executor.started:Protocol shim started");
+    expect(events).toContain("executor.progress:Protocol shim wrote files");
+    expect(result.changedFiles).toEqual(["protocol-output.txt", "protocol-request.json"]);
+    expect(result.summary).toContain("Protocol shim completed the run.");
+    expect(result.summary).toContain("protocol-shim self-check");
+
+    const branchFile = runGit(repo, ["show", "opentag/run_protocol:protocol-output.txt"]);
+    expect(branchFile).toContain("run=run_protocol");
+    expect(branchFile).toContain(defaultProtocolSessionKey({ executorId: "fake-protocol", runId: "run_protocol" }));
+
+    const request = JSON.parse(runGit(repo, ["show", "opentag/run_protocol:protocol-request.json"]));
+    expect(request.source.channel.provider).toBe("slack");
+    expect(request.targets.repo.name).toBe("opentag");
+    expect(request.targets.changeRequest.number).toBe(79);
+    expect(request.replyTo[0].purpose).toBe("all");
+  }, 15_000);
+
+  it("rejects a shim that acknowledges a different actual workspace", async () => {
+    const repo = initGitRepo();
+    const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim-bad-workspace.mjs") });
+
+    await expect(
+      executor.run(
+        {
+          runId: "run_bad_workspace",
+          workspacePath: repo,
+          command: { rawText: "write elsewhere", intent: "fix", args: {} },
+          context: [],
+          baseBranch: "main",
+          keepWorktree: "never"
+        },
+        { emit: async () => undefined }
+      )
+    ).rejects.toThrow("Refusing to accept changes from an unbound workspace");
+  }, 15_000);
+
+  it("uses a per-run default protocol session key", () => {
+    expect(defaultProtocolSessionKey({ executorId: "fake protocol", runId: "run/one" })).toBe("opentag:fake-protocol:run-one");
+    expect(defaultProtocolSessionKey({ executorId: "fake protocol", runId: "run/two" })).toBe("opentag:fake-protocol:run-two");
+  });
+
+  it("preserves a primary child failure when cleanup also fails", async () => {
+    const calls: { command: string; args: string[]; cwd?: string }[] = [];
+    const runner: CommandRunner = {
+      async run(command, args, options) {
+        calls.push({ command, args, cwd: options?.cwd });
+        if (command === "git" && args[0] === "worktree" && args[1] === "add") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        if (command === "fake-shim") {
+          return { exitCode: 1, stdout: "", stderr: "child failed" };
+        }
+        if (command === "git" && args.join(" ") === "-c core.quotePath=false status --porcelain -z") {
+          return { exitCode: 1, stdout: "", stderr: "cleanup exploded" };
+        }
+        if (command === "git" && args[0] === "worktree" && args[1] === "remove") {
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${command} ${args.join(" ")}` };
+      }
+    };
+    const manifest = manifestForFixture("protocol-shim.mjs");
+    manifest.bindings.executorStdio = { ...manifest.bindings.executorStdio, command: "fake-shim", args: [] };
+    const executor = createProtocolExecutor({ manifest, runner });
+    const events: string[] = [];
+    const repo = tempDir("protocol-mock-repo");
+
+    await expect(
+      executor.run(
+        {
+          runId: "run_cleanup",
+          workspacePath: repo,
+          command: { rawText: "fail", intent: "fix", args: {} },
+          context: [],
+          baseBranch: "main",
+          keepWorktree: "never"
+        },
+        {
+          emit: async (event) => {
+            events.push(event.message);
+          }
+        }
+      )
+    ).rejects.toThrow("protocol executor fake-protocol failed with exit code 1: child failed");
+
+    expect(events.some((event) => event.includes("cleanup exploded"))).toBe(true);
+    expect(calls.some((call) => call.command === "git" && call.args[0] === "worktree" && call.args[1] === "remove")).toBe(true);
+  });
+
+  it("rejects malformed JSONL output", async () => {
+    const repo = initGitRepo();
+    const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim-malformed.mjs") });
+
+    await expect(
+      executor.run(
+        {
+          runId: "run_malformed",
+          workspacePath: repo,
+          command: { rawText: "bad json", intent: "fix", args: {} },
+          context: [],
+          baseBranch: "main",
+          keepWorktree: "never"
+        },
+        { emit: async () => undefined }
+      )
+    ).rejects.toThrow("malformed JSONL");
+  }, 15_000);
+
+  it("rejects shim output without a final event", async () => {
+    const repo = initGitRepo();
+    const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim-missing-final.mjs") });
+
+    await expect(
+      executor.run(
+        {
+          runId: "run_missing_final",
+          workspacePath: repo,
+          command: { rawText: "no final", intent: "fix", args: {} },
+          context: [],
+          baseBranch: "main",
+          keepWorktree: "never"
+        },
+        { emit: async () => undefined }
+      )
+    ).rejects.toThrow("without a completed or failed event");
+  }, 15_000);
+
+  it("exposes manifest capabilities through the executor contract", () => {
+    const executor = createProtocolExecutor({ manifest: manifestForFixture("protocol-shim.mjs") });
+
+    expect(executor.capability).toMatchObject({
+      id: "fake-protocol",
+      invocation: "spawn",
+      progressEvents: "audit",
+      promptAssembly: "opentag",
+      conversationAccess: "request",
+      workspaceIsolation: "worktree"
+    });
+  });
+
+  it("requires an executor role in the integration manifest", () => {
+    const manifest = { ...manifestForFixture("protocol-shim.mjs"), roles: {} };
+
+    expect(() => createProtocolExecutor({ manifest })).toThrow("roles.executor");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `opentag.integration.v1` as the manifest envelope for role-based integrations.
- Keeps `opentag.executor.v1` as the executor runtime role protocol with a conformance-backed `stdio-jsonl-basic` profile.
- Adds shared semantic refs for sanitized `source`, `targets`, and `replyTo` run context without connection credentials or raw provider payloads.
- Documents the role/resource/binding split and keeps hosted connection-instance state out of the prototype schema.

## Split Context
This PR separates the executor/integration protocol prototype from the Linear adapter work that was previously mixed into #81.

## Verification
- `corepack pnpm test -- packages/core/test/executor-protocol.test.ts packages/runner/test/protocol-executor.test.ts`
- `corepack pnpm test -- packages/core/test`
- `corepack pnpm test -- packages/runner/test`
- `corepack pnpm --filter @opentag/core lint`
- `corepack pnpm --filter @opentag/core build`
- `corepack pnpm --filter @opentag/runner lint`
- `corepack pnpm typecheck`
- `git diff --check`

## Remaining Risks
- This does not migrate Codex, Claude Code, Hermes, or OpenClaw to the new protocol path.
- Connection-instance and credential lifecycle modeling stays out of code until there is a hosted or managed control-plane runtime consumer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized executor and integration manifest protocols with validated run requests and structured lifecycle events.
  * Introduced a protocol-based executor that runs in isolated workspaces, emits progress/completion events, and reports changed files.
* **Bug Fixes**
  * Enforced stronger contract validation (missing/invalid final events, malformed event streams, workspace mismatch rejection) and safer shim behavior.
  * Improved cleanup and failure handling, preserving the primary child failure and reporting cleanup errors.
* **Documentation**
  * Added executor role run protocol and integration manifest taxonomy reference docs.
* **Tests**
  * Expanded end-to-end protocol coverage, schema conformance checks, and protocol shim fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->