### PR TITLE
fix(hermes): remove unsupported per-invocation profiles

### DIFF
--- a/apps/opentagd/src/index.ts
+++ b/apps/opentagd/src/index.ts
@@ -6,7 +6,7 @@ import { Command } from "commander";
 import { createInitialConfig, formatConfigError, loadConfigFromEnv, normalizeChannelBindings } from "./config.js";
 import { runOneDaemonIteration, serveDaemon } from "./daemon.js";
 import { doctorHasFailures, formatDoctorChecks, runDoctor } from "./doctor.js";
-import { createDaemonRuntimeInput, executorsFromConfig } from "./runtime.js";
+import { createDaemonRuntimeInput, executorsFromConfig, hermesProfileMigrationWarning } from "./runtime.js";
 
 const program = new Command();
 
@@ -227,6 +227,8 @@ program
   .description("Claim and execute one run if available")
   .action(async () => {
     const config = loadConfigOrExit();
+    const hermesWarning = hermesProfileMigrationWarning(config);
+    if (hermesWarning) console.warn(hermesWarning);
     const didWork = await runOneDaemonIteration(createDaemonRuntimeInput(config));
     console.log(didWork ? "OpenTag run completed" : "No OpenTag run available");
   });
@@ -236,6 +238,8 @@ program
   .description("Continuously poll for and execute OpenTag runs")
   .action(async () => {
     const config = loadConfigOrExit();
+    const hermesWarning = hermesProfileMigrationWarning(config);
+    if (hermesWarning) console.warn(hermesWarning);
     await serveDaemon(createDaemonRuntimeInput(config));
   });
 

--- a/apps/opentagd/test/runtime.test.ts
+++ b/apps/opentagd/test/runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenTagDaemonConfig } from "../src/config.js";
-import { createDaemonRuntimeInput, pullRequestOptionsFromConfig, securityFromConfig } from "../src/runtime.js";
+import { createDaemonRuntimeInput, hermesProfileMigrationWarning, pullRequestOptionsFromConfig, securityFromConfig } from "../src/runtime.js";
 
 const config: OpenTagDaemonConfig = {
   runnerId: "runner_local",
@@ -40,6 +40,16 @@ describe("opentagd runtime helpers", () => {
       allowUnsafePrompts: false,
       extraSafeEnv: ["OPENTAG_DEBUG"]
     });
+  });
+
+  it("explains how to migrate legacy Hermes profile configuration", () => {
+    expect(
+      hermesProfileMigrationWarning({
+        ...config,
+        hermes: { profile: "legacy-fixed" }
+      })
+    ).toContain("hermes profile use <name>");
+    expect(hermesProfileMigrationWarning(config)).toBeUndefined();
   });
 
   it("omits pull request options when GitHub PR creation is not configured", () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,7 +168,7 @@ use `--permission-mode plan`.
 | `slackChannels` | none | Slack compatibility bindings that map `teamId/channelId` into the generic channel binding table |
 | `larkChannels` | none | Lark bindings that map `tenantKey/chatId` into the generic channel binding table |
 | `claudeCode` | none | Claude Code executor settings |
-| `hermes` | none | Hermes executor command/profile settings; `profile` and `profileTemplate` still override the Hermes CLI `-p` argument |
+| `hermes` | none | Hermes executor command settings. Legacy `profile` and `profileTemplate` fields remain accepted for compatibility but are not forwarded because Hermes CLI 0.18 removed per-invocation `-p`; select the sticky default with `hermes profile use`. |
 | `agentSessionProfile` | derived per run | Executor-neutral session identity. Use `profile` for a fixed local agent identity or `profileTemplate` for a stable identity derived from provider, source thread, Project Target, and actor metadata. The `opentag status` session-profile section shows the active rule without embedding local checkout paths or secret values in the session identity. |
 | `security` | none | Runner security policy |
 | `githubToken` | none | GitHub token for callback comments, dispatcher GitHub apply helpers, and optional legacy PR creation |
@@ -178,6 +178,8 @@ use `--permission-mode plan`.
 | `pollIntervalMs` | `5000` | Poll interval for `serve` |
 | `heartbeatIntervalMs` | `15000` | Heartbeat interval for claimed runs |
 | `runTimeoutMs` | none | Optional hard timeout for one executor run. When it fires, OpenTag requests cancellation and records the run as `timed_out`. |
+
+For Hermes, new `opentag setup` runs only write the optional `command` setting and no longer expose or generate per-run profile settings. Existing `daemon.hermes.profile` and `daemon.hermes.profileTemplate` values still parse so upgrades do not fail, but startup warns that they are ignored. Select the long-lived Hermes default before starting OpenTag with `hermes profile use <name>`.
 
 `opentag status --run <run_id>` shows the timeout policy for that run. Once the
 runner has marked the run as running, the command prefers the run-specific

--- a/packages/cli/src/catalogs/capabilities.ts
+++ b/packages/cli/src/catalogs/capabilities.ts
@@ -69,7 +69,7 @@ export const EXECUTOR_CAPABILITIES: Record<ExecutorId, ExecutorCapabilityDescrip
   hermes: {
     id: "hermes",
     invocation: "spawn",
-    supportsProfile: true,
+    supportsProfile: false,
     supportsStreaming: false,
     supportsCancel: false,
     supportsHookCompletion: false,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -59,8 +59,6 @@ program
   .option("--language <language>", "Setup language: en or zh-CN")
   .option("--executor <executor>", "Default executor: echo, codex, claude-code, or hermes")
   .option("--hermes-command <command>", "Hermes CLI command")
-  .option("--hermes-profile <profile>", "Hermes profile")
-  .option("--hermes-profile-template <template>", "Hermes profile template")
   .option("--agent-profile <profile>", "Executor-neutral agent session profile")
   .option("--agent-profile-template <template>", "Executor-neutral agent session profile template")
   .option("--lark-setup <method>", "Lark setup method: saved, scan, or manual")

--- a/packages/cli/src/setup/builders.ts
+++ b/packages/cli/src/setup/builders.ts
@@ -171,9 +171,7 @@ export function createSetupConfig(input: OpenTagSetupInput, env: PathEnvironment
       ...(input.hermes
         ? {
             hermes: {
-              ...(input.hermes.command ? { command: input.hermes.command } : {}),
-              ...(input.hermes.profile ? { profile: input.hermes.profile } : {}),
-              ...(input.hermes.profileTemplate ? { profileTemplate: input.hermes.profileTemplate } : {})
+              ...(input.hermes.command ? { command: input.hermes.command } : {})
             }
           }
         : {}),

--- a/packages/cli/src/setup/defaults.ts
+++ b/packages/cli/src/setup/defaults.ts
@@ -50,8 +50,6 @@ export function setupDefaultsFromConfig(config: OpenTagCliConfig): SetupDefaults
     ...(repository?.checkoutPath ? { projectPath: repository.checkoutPath } : {}),
     ...(repository?.defaultExecutor ? { executor: repository.defaultExecutor } : {}),
     ...(hermes?.command ? { hermesCommand: hermes.command } : {}),
-    ...(hermes?.profile ? { hermesProfile: hermes.profile } : {}),
-    ...(hermes?.profileTemplate ? { hermesProfileTemplate: hermes.profileTemplate } : {}),
     ...(agentSessionProfile?.profile ? { agentProfile: agentSessionProfile.profile } : {}),
     ...(agentSessionProfile?.profileTemplate ? { agentProfileTemplate: agentSessionProfile.profileTemplate } : {}),
     ...(lastSetup?.larkSetupMethod ? { larkSetupMethod: lastSetup.larkSetupMethod } : {}),

--- a/packages/cli/src/setup/flow.ts
+++ b/packages/cli/src/setup/flow.ts
@@ -46,8 +46,6 @@ import type {
   TelegramSetupMode
 } from "./types.js";
 
-const DEFAULT_HERMES_PROFILE_TEMPLATE =
-  "opentag-{provider}-{accountId}-{conversationId}-{owner}-{repo}-i{issueNumber}-pr{pullRequestNumber}";
 const DEFAULT_TELEGRAM_AGENT_ID = "opentag";
 const DEFAULT_DISCORD_WEBHOOK_PATH = "/discord/interactions";
 
@@ -120,8 +118,6 @@ export type SetupCommandOptions = {
   discordBotToken?: string;
   discordWebhookPath?: string;
   hermesCommand?: string;
-  hermesProfile?: string;
-  hermesProfileTemplate?: string;
   agentProfile?: string;
   agentProfileTemplate?: string;
   binding?: string;
@@ -322,32 +318,16 @@ function optionalTrimmed(value: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
-function hasHermesOptions(options: SetupCommandOptions): boolean {
-  return Boolean(options.hermesCommand || options.hermesProfile || options.hermesProfileTemplate);
-}
-
 function collectHermesSetup(options: SetupCommandOptions, defaults: SetupDefaults, executor: string): HermesSetupInput | undefined {
   if (executor !== "hermes") {
-    if (hasHermesOptions(options)) {
-      throw new Error("--hermes-command, --hermes-profile, and --hermes-profile-template can only be used with --executor hermes.");
+    if (options.hermesCommand) {
+      throw new Error("--hermes-command can only be used with --executor hermes.");
     }
     return undefined;
   }
 
-  const explicitProfile = optionalTrimmed(options.hermesProfile);
-  const explicitProfileTemplate = optionalTrimmed(options.hermesProfileTemplate);
   const command = optionalTrimmed(options.hermesCommand) ?? defaults.hermesCommand;
-  const profile = explicitProfileTemplate ? explicitProfile : explicitProfile ?? defaults.hermesProfile;
-  const profileTemplate =
-    explicitProfileTemplate ??
-    (explicitProfile ? undefined : defaults.hermesProfileTemplate) ??
-    (profile ? undefined : DEFAULT_HERMES_PROFILE_TEMPLATE);
-
-  return {
-    ...(command ? { command } : {}),
-    ...(profile ? { profile } : {}),
-    ...(profileTemplate ? { profileTemplate } : {})
-  };
+  return command ? { command } : undefined;
 }
 
 function collectAgentSessionProfileSetup(options: SetupCommandOptions, defaults: SetupDefaults) {

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -103,8 +103,6 @@ export type DiscordSetupInput = {
 
 export type HermesSetupInput = {
   command?: string;
-  profile?: string;
-  profileTemplate?: string;
 };
 
 export type AgentSessionProfileSetupInput = {
@@ -168,8 +166,6 @@ export type SetupDefaults = Partial<{
   discordMode: DiscordSetupMode;
   discordWebhookPath: string;
   hermesCommand: string;
-  hermesProfile: string;
-  hermesProfileTemplate: string;
   agentProfile: string;
   agentProfileTemplate: string;
   savedLarkCredentials: SavedLarkCredentials;

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -22,6 +22,7 @@ import {
 import {
   createDaemonRuntimeInput,
   dispatcherRuntimeHardeningInputFromEnv,
+  hermesProfileMigrationWarning,
   normalizeChannelBindings,
   serveDaemon,
   startDispatcher,
@@ -1085,6 +1086,8 @@ export async function startFromConfig(input: StartFromConfigInput): Promise<void
   ensurePrivateDirectory(input.config.state.worktreeRoot);
 
   const dependencies = defaultStartDependencies(input.dependencies);
+  const hermesWarning = hermesProfileMigrationWarning(input.config.daemon);
+  if (hermesWarning) dependencies.logger.log(hermesWarning);
   if (runtimeModeFromConfig(input.config) === "local") {
     await dependencies.assertStartPortsAvailable(input.config);
   }

--- a/packages/cli/test/executors.test.ts
+++ b/packages/cli/test/executors.test.ts
@@ -30,7 +30,7 @@ describe("executor catalog", () => {
     expect(output).toContain("raw_context=no");
     expect(output).toContain("write_actions=none");
     expect(output).toContain("secrets=openai_api_key");
-    expect(output).toContain("Hermes: invocation=spawn, profile=yes");
+    expect(output).toContain("Hermes: invocation=spawn, profile=no");
     expect(output).toContain("completion=process_exit");
   });
 

--- a/packages/cli/test/setup.test.ts
+++ b/packages/cli/test/setup.test.ts
@@ -1279,7 +1279,7 @@ describe("OpenTag CLI setup", () => {
     ).rejects.toThrow("Discord application public key is only used with --discord-mode webhook.");
   });
 
-  it("writes Hermes setup options into daemon config", async () => {
+  it("writes only the supported Hermes command into daemon config", async () => {
     const configPath = join(tempDir(), "config.json");
 
     await runSetupCommand(
@@ -1291,8 +1291,6 @@ describe("OpenTag CLI setup", () => {
         githubRepository: "acme/demo",
         githubToken: "ghp_test",
         hermesCommand: "custom-hermes",
-        hermesProfile: "opentag-fixed",
-        hermesProfileTemplate: "opentag-{provider}-{owner}-{repo}",
         force: true,
         yes: true
       },
@@ -1301,11 +1299,7 @@ describe("OpenTag CLI setup", () => {
 
     const config = readCliConfig(configPath);
     expect(config.daemon.repositories[0]?.defaultExecutor).toBe("hermes");
-    expect(config.daemon.hermes).toEqual({
-      command: "custom-hermes",
-      profile: "opentag-fixed",
-      profileTemplate: "opentag-{provider}-{owner}-{repo}"
-    });
+    expect(config.daemon.hermes).toEqual({ command: "custom-hermes" });
   });
 
   it("writes generic agent session profile options into daemon config", async () => {
@@ -1371,7 +1365,7 @@ describe("OpenTag CLI setup", () => {
     });
   });
 
-  it("defaults Hermes profileTemplate when no fixed profile is provided", async () => {
+  it("does not generate removed Hermes profile settings", async () => {
     const configPath = join(tempDir(), "config.json");
 
     await runSetupCommand(
@@ -1388,48 +1382,7 @@ describe("OpenTag CLI setup", () => {
       { prompts: testPrompts() }
     );
 
-    expect(readCliConfig(configPath).daemon.hermes).toEqual({
-      profileTemplate:
-        "opentag-{provider}-{accountId}-{conversationId}-{owner}-{repo}-i{issueNumber}-pr{pullRequestNumber}"
-    });
-  });
-
-  it("does not keep an inherited Hermes fixed profile when a profileTemplate is explicitly provided", async () => {
-    const configPath = join(tempDir(), "config.json");
-    const projectPath = tempDir();
-
-    await runSetupCommand(
-      {
-        config: configPath,
-        project: projectPath,
-        platform: "github",
-        executor: "hermes",
-        githubRepository: "acme/demo",
-        githubToken: "ghp_test",
-        hermesProfile: "opentag-fixed",
-        force: true,
-        yes: true
-      },
-      { prompts: testPrompts() }
-    );
-    await runSetupCommand(
-      {
-        config: configPath,
-        project: projectPath,
-        platform: "github",
-        executor: "hermes",
-        githubRepository: "acme/demo",
-        githubToken: "ghp_test",
-        hermesProfileTemplate: "opentag-{provider}-{owner}-{repo}",
-        force: true,
-        yes: true
-      },
-      { prompts: testPrompts() }
-    );
-
-    expect(readCliConfig(configPath).daemon.hermes).toEqual({
-      profileTemplate: "opentag-{provider}-{owner}-{repo}"
-    });
+    expect(readCliConfig(configPath).daemon.hermes).toBeUndefined();
   });
 
   it("rejects Slack setup without an initial channel binding", async () => {

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -847,6 +847,10 @@ describe("OpenTag CLI start wiring", () => {
       relayProvider: "custom"
     };
     built.daemon.dispatcherUrl = "https://relay.example";
+    built.daemon.hermes = {
+      profile: "legacy-fixed",
+      profileTemplate: "legacy-{provider}-{owner}-{repo}"
+    };
     const calls: string[] = [];
     const logs: string[] = [];
     const dispatcherHandle = {
@@ -893,6 +897,8 @@ describe("OpenTag CLI start wiring", () => {
 
     expect(calls).toEqual(["wait", "bootstrap", "daemon"]);
     expect(logs.join("\n")).toContain("OpenTag is running in relay mode.");
+    expect(logs.join("\n")).toContain("daemon.hermes.profile and daemon.hermes.profileTemplate are deprecated and ignored");
+    expect(logs.join("\n")).toContain("hermes profile use <name>");
     expect(logs.join("\n")).toContain("Local dispatcher: disabled");
     expect(logs.join("\n")).toContain("Security: only pair with a relay you operate or trust");
     expect(logs.join("\n")).toContain("GitHub webhook URL: https://relay.example/github/webhooks");

--- a/packages/local-runtime/src/runtime.ts
+++ b/packages/local-runtime/src/runtime.ts
@@ -17,6 +17,11 @@ export function securityFromConfig(config: OpenTagDaemonConfig): RunnerSecurityP
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
+export function hermesProfileMigrationWarning(config: OpenTagDaemonConfig): string | undefined {
+  if (!config.hermes?.profile && !config.hermes?.profileTemplate) return undefined;
+  return "Hermes configuration warning: daemon.hermes.profile and daemon.hermes.profileTemplate are deprecated and ignored because Hermes CLI 0.18 removed per-invocation profiles. Run `hermes profile use <name>` before starting OpenTag.";
+}
+
 export function executorsFromConfig(config: OpenTagDaemonConfig) {
   const security = securityFromConfig(config);
 
@@ -35,9 +40,7 @@ export function executorsFromConfig(config: OpenTagDaemonConfig) {
       ...(security ? { security } : {})
     }),
     hermes: createHermesExecutor({
-      ...(config.hermes?.command ? { hermesCommand: config.hermes.command } : {}),
-      ...(config.hermes?.profile ? { profile: config.hermes.profile } : {}),
-      ...(config.hermes?.profileTemplate ? { profileTemplate: config.hermes.profileTemplate } : {})
+      ...(config.hermes?.command ? { hermesCommand: config.hermes.command } : {})
     })
   };
 }

--- a/packages/local-runtime/test/hermes-daemon.test.ts
+++ b/packages/local-runtime/test/hermes-daemon.test.ts
@@ -107,7 +107,7 @@ describe("Hermes daemon integration", () => {
       profileTemplate: "opentag-{provider}-{accountId}-{conversationId}",
       expectedProfile: "opentag-telegram-bot_123-456"
     }
-  ])("selects an isolated Hermes profile for $source events", async ({ source, metadata, profileTemplate, expectedProfile }) => {
+  ])("does not pass the removed Hermes profile flag for $source events", async ({ source, metadata, profileTemplate, expectedProfile }) => {
     const { calls, completed } = await runForEvent({
       event: eventWithMetadata(source, metadata),
       profileTemplate
@@ -115,8 +115,8 @@ describe("Hermes daemon integration", () => {
 
     const hermesCall = calls.find((call) => call.command === "hermes" && call.args.includes("-z"));
     expect(hermesCall, JSON.stringify({ calls, completed })).toBeDefined();
-    expect(hermesCall?.args).toContain("-p");
-    expect(hermesCall?.args).toContain(expectedProfile);
+    expect(hermesCall?.args).not.toContain("-p");
+    expect(hermesCall?.args).not.toContain(expectedProfile);
     expect(completed?.conclusion).toBe("success");
   });
 });

--- a/packages/runner/src/hermes.ts
+++ b/packages/runner/src/hermes.ts
@@ -4,12 +4,13 @@ import { executorPolicyPromptLines } from "./executor-report.js";
 import { renderContextPacketForPrompt, type ExecutorAdapter } from "./executor.js";
 import { branchNameForRun, changedFiles, cleanupInternalArtifacts, createRunBranch } from "./git.js";
 import { createExecutorRunResult } from "./result.js";
-import { resolveAgentSessionProfile } from "./session-profile.js";
 
 export type HermesExecutorOptions = {
   runner?: CommandRunner;
   hermesCommand?: string;
+  /** @deprecated Hermes CLI >= 0.18 manages profiles outside one-shot invocations. */
   profile?: string;
+  /** @deprecated Hermes CLI >= 0.18 manages profiles outside one-shot invocations. */
   profileTemplate?: string;
 };
 
@@ -36,7 +37,6 @@ function buildPrompt(input: {
     "Context pointers:",
     contextLines(input.context),
     "",
-    "Use only the selected Hermes profile for tools, skills, memory, and session behavior.",
     ...executorPolicyPromptLines()
   ].join("\n");
 }
@@ -51,7 +51,7 @@ export function createHermesExecutor(options: HermesExecutorOptions = {}): Execu
     capability: {
       id: "hermes",
       invocation: "spawn",
-      supportsProfile: true,
+      supportsProfile: false,
       supportsStreaming: false,
       supportsCancel: false,
       supportsHookCompletion: false,
@@ -127,17 +127,11 @@ export function createHermesExecutor(options: HermesExecutorOptions = {}): Execu
         contextPacket: input.contextPacket
       });
 
-      const profile = resolveAgentSessionProfile({
-        ...(options.profile ? { profile: options.profile } : {}),
-        ...(options.profileTemplate ? { profileTemplate: options.profileTemplate } : {}),
-        metadata: {
-          ...(input.metadata ?? {}),
-          runId: input.runId
-        },
-        ...(input.sessionProfile ? { fallback: input.sessionProfile } : {})
-      });
-
-      const args = [...(profile ? ["-p", profile.id] : []), "-z", prompt];
+      // Hermes CLI (>= 0.18) has no `-p`/`--profile` flag; profiles are managed
+      // through the `hermes profile` subcommand, not per-invocation selection.
+      // OpenTag already isolates each run at the workspace/branch level, so a
+      // plain one-shot invocation is sufficient.
+      const args = ["-z", prompt];
 
       let hermesResult: CommandResult | undefined;
       try {

--- a/packages/runner/test/executor-capability.test.ts
+++ b/packages/runner/test/executor-capability.test.ts
@@ -38,7 +38,7 @@ describe("executor capability contracts", () => {
     expect(createCodexExecutor().capability?.workspaceIsolation).toBe("worktree");
     expect(createClaudeCodeExecutor().capability?.workspaceIsolation).toBe("worktree");
     expect(createHermesExecutor().capability).toMatchObject({
-      supportsProfile: true,
+      supportsProfile: false,
       workspaceIsolation: "branch"
     });
     expect(createEchoExecutor().capability?.workspaceIsolation).toBe("none");

--- a/packages/runner/test/hermes.test.ts
+++ b/packages/runner/test/hermes.test.ts
@@ -4,7 +4,7 @@ import type { CommandRunner } from "../src/command.js";
 import { EXECUTOR_REPORT_END, EXECUTOR_REPORT_START } from "../src/executor-report.js";
 
 describe("Hermes executor", () => {
-  it("creates an isolated branch, runs Hermes with an isolated profile and context, and reports changed files", async () => {
+  it("creates an isolated branch, runs Hermes without the removed profile flag, and reports changed files", async () => {
     const calls: { command: string; args: string[] }[] = [];
     const runner: CommandRunner = {
       async run(command, args) {
@@ -86,8 +86,8 @@ describe("Hermes executor", () => {
     const prompt = hermesCall?.args[hermesCall.args.indexOf("-z") + 1];
 
     expect(calls.some((call) => call.command === "git" && call.args.join(" ") === "checkout -B opentag/run_1 main")).toBe(true);
-    expect(hermesCall?.args).toContain("-p");
-    expect(hermesCall?.args).toContain("opentag-slack-T123-456");
+    expect(hermesCall?.args).not.toContain("-p");
+    expect(hermesCall?.args).not.toContain("opentag-slack-T123-456");
     expect(hermesCall?.args).not.toContain("--provider");
     expect(hermesCall?.args).not.toContain("--model");
     expect(hermesCall?.args).not.toContain("-s");
@@ -131,7 +131,7 @@ describe("Hermes executor", () => {
     ).resolves.toEqual({ ready: false, reason: "Workspace is not a git checkout: bad cwd" });
   });
 
-  it("inherits a generic agent session profile when no Hermes-specific profile is configured", async () => {
+  it("does not forward a generic session profile through the removed Hermes profile flag", async () => {
     const calls: { command: string; args: string[] }[] = [];
     const runner: CommandRunner = {
       async run(command, args) {
@@ -168,8 +168,8 @@ describe("Hermes executor", () => {
     });
 
     const hermesCall = calls.find((call) => call.command === "hermes" && call.args.includes("-z"));
-    expect(hermesCall?.args).toContain("-p");
-    expect(hermesCall?.args).toContain("opentag-slack-T123-C456-acme-demo-U123");
+    expect(hermesCall?.args).not.toContain("-p");
+    expect(hermesCall?.args).not.toContain("opentag-slack-T123-C456-acme-demo-U123");
   });
 
   it("cleans internal artifacts when Hermes exits unsuccessfully", async () => {


### PR DESCRIPTION
## Summary

Hermes 0.18 no longer accepts the per-invocation `-p`/`--profile` flag. Invoke Hermes with the prompt only and report profile support consistently across the runner and CLI capability catalogs.

Stop exposing or generating Hermes profile settings during setup while continuing to parse legacy configuration for upgrade compatibility. Ignore those legacy values at runtime and warn operators to select the sticky profile with `hermes profile use <name>`.

Add regression coverage for invocation arguments, setup output, capability display, legacy configuration migration warnings, and Slack, GitHub, and Telegram daemon event paths.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @opentag/cli lint`
- `pnpm --filter @opentag/local-runtime lint`
- `pnpm --filter @opentag/opentagd lint`
- `pnpm --filter @opentag/runner lint`
- Targeted Vitest suite: 8 test files, 120 tests passed
- Full Vitest suite: 102 test files, 1,133 tests passed
- Verified built `opentag setup --help` exposes `--hermes-command` but no longer exposes `--hermes-profile` or `--hermes-profile-template`
- `git diff --check`

## Notes

- Legacy `daemon.hermes.profile` and `daemon.hermes.profileTemplate` fields remain accepted so existing configurations continue to parse, but they are intentionally ignored and produce a migration warning at startup.
- Operators who need a long-lived Hermes profile should select it before starting OpenTag with `hermes profile use <name>`.
- The installed Hermes 0.18.2 CLI help and profile commands were inspected to confirm the current interface.
- A real Hermes coding task was not executed; invocation and daemon behavior are covered by mocked runner and integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes now runs without per-invocation profile selection.
  * Added migration guidance for existing Hermes profile settings.

* **Changes**
  * CLI setup now configures only the Hermes command; profile options are no longer generated or accepted.
  * Existing profile settings remain readable but are ignored during execution.
  * Hermes setup and runtime documentation has been updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->