### PR TITLE
Harden live release validation after the 0.5.0 rollout

### DIFF
--- a/docs/npm-release.md
+++ b/docs/npm-release.md
@@ -14,6 +14,14 @@ The release is first published on the npm `next` dist-tag, tested from the
 registry, then promoted to `latest`. The exact commit that produced the npm
 artifacts must also receive the matching `v0.5.0` git tag and GitHub Release.
 
+npm also creates `latest` when a package name receives its first version, even
+when that version is published with `--tag next`. For 0.5.0, this applies to the
+new Discord, Linear, and Teams packages. Treat those unavoidable initial
+`latest` pointers as a registry constraint, not as completion of the promotion
+gate: run every registry and live-platform check before the explicit,
+idempotent all-package promotion below. The other packages must remain on their
+previous `latest` version until that gate passes.
+
 ## Public package discovery and order
 
 The release helpers discover packages from `packages/*/package.json`. A package
@@ -142,7 +150,9 @@ done
 ## Promote the same artifacts to `latest`
 
 Promotion changes dist-tags only; it must not rebuild or republish. After all
-registry and live-platform checks pass:
+registry and live-platform checks pass, run the same command for every package.
+It is intentionally idempotent for first-release packages whose `latest` tag
+was created by npm:
 
 ```bash
 for manifest in packages/*/package.json; do
@@ -178,13 +188,17 @@ identify version `0.5.0`.
 
 Do not unpublish immutable package versions during rollback.
 
-- If canary validation fails before promotion, leave `latest` untouched. After
-  preserving diagnostics, remove the failed canary tag from every package with
-  `npm dist-tag rm <package> next`, or move `next` to a corrected version.
+- If canary validation fails before promotion, leave the existing packages'
+  previous `latest` tags untouched and stop the rollout. npm has already
+  created `latest` for any first-release package and rejects removing that tag;
+  if the new package is unsafe, deprecate the bad version and publish a fixed
+  version rather than trying to erase immutable history. Preserve `next` for
+  diagnosis or move it to the corrected version.
 - If `latest` promotion fails partway, first finish or retry the idempotent
   promotion loop. If 0.5.0 itself must be withdrawn, restore `0.4.0` where it
-  exists. The Discord, Linear, and Teams adapters are first published in 0.5.0,
-  so remove their `latest` tags instead. Leave 0.5.0 on `next` for diagnosis:
+  exists. The Discord, Linear, and Teams adapters have no previous version to
+  restore, so flag them for an incident decision instead. Leave 0.5.0 on
+  `next` for diagnosis:
 
 ```bash
 for manifest in packages/*/package.json; do
@@ -193,7 +207,7 @@ for manifest in packages/*/package.json; do
   if npm view "$package@0.4.0" version >/dev/null 2>&1; then
     npm dist-tag add "$package@0.4.0" latest
   else
-    npm dist-tag rm "$package" latest || true
+    echo "$package has no pre-0.5.0 version; latest cannot be rolled back" >&2
   fi
   npm dist-tag add "$package@0.5.0" next
 done

--- a/scripts/dev/run-github-webhook-live-test.sh
+++ b/scripts/dev/run-github-webhook-live-test.sh
@@ -303,14 +303,13 @@ PY
 
 issue_comments_contain() {
   local pattern="$1"
-  gh issue view "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --json comments --jq '[
-    .comments[].body
-  ] | join("\n--- opentag-comment-boundary ---\n")' | grep -F "$pattern" >/dev/null
+  gh api --paginate "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+    --jq '.[].body' | grep -F "$pattern" >/dev/null
 }
 
 applied_receipt_has_double_period() {
-  gh issue view "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --json comments --jq '
-    .comments[].body
+  gh api --paginate "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '
+    .[].body
     | split("\n")[]
     | select(startswith("Applied:"))
   ' | grep -E '\.\.$' >/dev/null
@@ -510,15 +509,29 @@ if [[ -z "${status:-}" || "$status" == "queued" || "$status" == "assigned" || "$
   echo "Timed out waiting for run completion. Last status: ${status:-unknown}" >&2
   exit 1
 fi
+if [[ "$status" != "succeeded" ]]; then
+  echo "GitHub webhook run did not succeed. Final status: $status" >&2
+  exit 1
+fi
 print_metrics "$RUN_ID"
 
 echo "Recent issue comments after final receipt:"
-gh issue view "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --json comments --jq '.comments[-4:][] | {author: .author.login, body: (.body | split("\n")[0:8] | join("\n"))}'
+gh api "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments?sort=created&direction=desc&per_page=4" \
+  --jq 'reverse[] | {author: .user.login, body: (.body | split("\n")[0:8] | join("\n"))}'
 EXPECTED_HEADING="<summary>Ready to apply</summary>"
 if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN"; then
   EXPECTED_HEADING="<summary>Needs setup</summary>"
 fi
-if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN"; then
+if [[ "$OPENTAG_GH_LIVE_EXECUTOR" == "echo" ]]; then
+  if ! issue_comments_contain "OpenTag finished with **success**."; then
+    echo "Expected the Echo smoke to post a successful final receipt." >&2
+    exit 1
+  fi
+  if issue_comments_contain '`apply 1`'; then
+    echo "Expected the Echo smoke not to advertise apply actions." >&2
+    exit 1
+  fi
+elif bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN"; then
   if ! issue_comments_contain "$EXPECTED_HEADING"; then
     echo "Expected the final GitHub receipt to render '$EXPECTED_HEADING'." >&2
     exit 1
@@ -599,7 +612,8 @@ PY
   gh pr view "$PR_URL" --json number,state,headRefName,baseRefName,url --jq '{number,state,headRefName,baseRefName,url}'
   print_metrics "$RUN_ID"
   echo "Recent issue comments after apply receipt:"
-  gh issue view "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --json comments --jq '.comments[-5:][] | {author: .author.login, body: (.body | split("\n")[0:8] | join("\n"))}'
+  gh api "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments?sort=created&direction=desc&per_page=5" \
+    --jq 'reverse[] | {author: .user.login, body: (.body | split("\n")[0:8] | join("\n"))}'
   if ! issue_comments_contain "Applied:"; then
     echo "Expected the GitHub thread to contain an applied receipt." >&2
     exit 1

--- a/scripts/dev/run-lark-message-patch-live-test.ts
+++ b/scripts/dev/run-lark-message-patch-live-test.ts
@@ -19,6 +19,7 @@ type DeliveryProbe = {
 
 const LARK_CLI = process.env.OPENTAG_LARK_CLI ?? "lark-cli";
 const DEFAULT_REPO = "amplifthq/opentag-test";
+const LIVE_TENANT_KEY = "lark-live-e2e";
 
 let idempotencySequence = 0;
 
@@ -31,11 +32,20 @@ async function main(): Promise<void> {
   const source = getOrCreateSourceMessage(authStatus);
   const runnerId = `lark-live-patch-${Date.now().toString(36)}`;
   const runId = `run_lark_patch_${Date.now()}`;
+  const channelApplicationId = getString(authStatus, ["appId"]);
+  const channelPrincipalCredential = `lark-live-principal-${runId}`;
 
   const deliveryLog: DeliveryProbe[] = [];
   const liveLarkSink = createLarkCallbackSink({ client: createLiveLarkClient(source.messageId) });
   const app = createDispatcherApp({
     databasePath: ":memory:",
+    channelPrincipals: [
+      {
+        provider: "lark",
+        applicationId: channelApplicationId,
+        credential: channelPrincipalCredential,
+      },
+    ],
     callbackSink: {
       async deliver(message) {
         const probe: DeliveryProbe = {
@@ -79,11 +89,35 @@ async function main(): Promise<void> {
     201,
   );
 
+  await requestJson(
+    app,
+    "/v1/channel-bindings",
+    {
+      method: "POST",
+      headers: { "x-opentag-channel-principal": channelPrincipalCredential },
+      body: {
+        provider: "lark",
+        accountId: LIVE_TENANT_KEY,
+        conversationId: source.chatId,
+        repoProvider: "github",
+        owner: repoRef.owner,
+        repo: repoRef.repo,
+        ownership: {
+          mode: "managed",
+          exclusive: true,
+          applicationId: channelApplicationId,
+        },
+      },
+    },
+    201,
+  );
+
   const createRunResponse = await requestJson(
     app,
     "/v1/runs",
     {
       method: "POST",
+      headers: { "x-opentag-channel-principal": channelPrincipalCredential },
       body: {
         runId,
         event: createLarkEvent({
@@ -255,7 +289,6 @@ function createLarkEvent(args: {
   chatId: string;
   messageId: string;
 }): JsonObject {
-  const tenantKey = "lark-live-e2e";
   return {
     id: `evt_${args.runId}`,
     source: "lark",
@@ -272,7 +305,7 @@ function createLarkEvent(args: {
       {
         provider: "lark",
         kind: "message",
-        uri: `lark://tenant/${tenantKey}/chat/${args.chatId}/message/${args.messageId}`,
+        uri: `lark://tenant/${LIVE_TENANT_KEY}/chat/${args.chatId}/message/${args.messageId}`,
         visibility: "organization",
         title: "Lark message",
       },
@@ -281,10 +314,10 @@ function createLarkEvent(args: {
     callback: {
       provider: "lark",
       uri: "lark://im/v1/messages",
-      threadKey: `${tenantKey}|${args.chatId}|${args.messageId}`,
+      threadKey: `${LIVE_TENANT_KEY}|${args.chatId}|${args.messageId}`,
     },
     metadata: {
-      tenantKey,
+      tenantKey: LIVE_TENANT_KEY,
       chatId: args.chatId,
       messageId: args.messageId,
       repoProvider: "github",
@@ -297,12 +330,15 @@ function createLarkEvent(args: {
 async function requestJson(
   app: ReturnType<typeof createDispatcherApp>,
   path: string,
-  options: { method: string; body?: JsonObject },
+  options: { method: string; body?: JsonObject; headers?: Record<string, string> },
   expectedStatus: number,
 ): Promise<JsonObject> {
   const response = await app.request(path, {
     method: options.method,
-    headers: options.body ? { "content-type": "application/json" } : undefined,
+    headers: {
+      ...(options.body ? { "content-type": "application/json" } : {}),
+      ...options.headers,
+    },
     body: options.body ? JSON.stringify(options.body) : undefined,
   });
   const bodyText = await response.text();


### PR DESCRIPTION
## Summary

- document npm first-publish `latest` behavior and make rollback guidance reflect immutable first versions
- authenticate the Lark live harness with the same managed channel-principal and ownership boundary used in production
- make the GitHub webhook harness validate successful Echo receipts without expecting a nonexistent apply proposal, and use REST for issue-comment reads

## Why this follows the release commit

`v0.5.0` intentionally remains anchored to `79ce5d48e842fa53d1e1c306c1fdd4d743c17581`, the exact commit that produced the npm artifacts. These are validation-harness and operational-documentation corrections discovered while testing those registry artifacts.

## Verification

- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test` — 119 files, 1511 tests
- `bash -n scripts/dev/run-github-webhook-live-test.sh`
- `git diff --check`
- real GitHub webhook smoke against `amplifthq/opentag-test` — run succeeded and posted the final success receipt
- npm registry — all 15 packages report `0.5.0` for both `next` and `latest`

## External limitation

The Lark harness now crosses managed admission correctly, but Lark rejected the outbound seed-message call because the account monthly API quota is exhausted. The commit records that gap honestly instead of weakening the ownership check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified npm release and promotion procedures, including handling of automatically created `latest` tags.
  * Added detailed rollback guidance for failed canary validation, partial promotions, and packages without a previous version.
  * Documented warnings and recovery steps for packages that cannot have `latest` removed.

* **Tests**
  * Improved live webhook and Lark integration checks with stronger status, receipt, comment, and channel-binding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->