### PR TITLE
fix(slack): preserve complete executor summaries safely

### DIFF
--- a/packages/dispatcher/src/callbacks.ts
+++ b/packages/dispatcher/src/callbacks.ts
@@ -459,12 +459,14 @@ export function createSlackCallbackSink(input: {
             ? createSlackUpdateMessagePayload({
                 channelId: thread.channelId,
                 text: message.body,
+                textFormat: "mrkdwn",
                 messageTs: existingStatusTs,
                 ...(message.blocks?.length ? { blocks: message.blocks } : {})
               })
             : createSlackPostMessagePayload({
                 channelId: thread.channelId,
                 text: message.body,
+                textFormat: "mrkdwn",
                 threadTs: thread.threadTs,
                 ...(message.blocks?.length ? { blocks: message.blocks } : {})
               })

--- a/packages/dispatcher/src/presentation.ts
+++ b/packages/dispatcher/src/presentation.ts
@@ -45,6 +45,7 @@ import {
   createSlackFinalSummaryBlocks,
   createSlackRunStatusBlocks,
   createSlackSourceThreadStatusBlocks,
+  markdownToSlackMrkdwn,
   renderSlackActionReceiptPresentation,
   renderSlackApprovalPrompt,
   renderSlackAcknowledgement,
@@ -213,7 +214,7 @@ function renderDoctorSummary(provider: CallbackProvider, presentation: OpenTagDo
   const canRenderRich = supportsRichPresentation(provider);
   if (canRenderRich && provider === "slack") {
     return {
-      body,
+      body: markdownToSlackMrkdwn(body),
       blocks: createSlackDoctorSummaryBlocks(presentation)
     };
   }
@@ -234,7 +235,7 @@ function renderSourceThreadStatus(provider: CallbackProvider, presentation: Open
   const canRenderRich = supportsRichPresentation(provider);
   if (canRenderRich && provider === "slack") {
     return {
-      body,
+      body: markdownToSlackMrkdwn(body),
       blocks: createSlackSourceThreadStatusBlocks(presentation)
     };
   }

--- a/packages/dispatcher/test/callbacks.test.ts
+++ b/packages/dispatcher/test/callbacks.test.ts
@@ -18,6 +18,7 @@ import {
   createSlackSourceReceiptSink,
   createTelegramCallbackSink
 } from "../src/callbacks.js";
+import { createDefaultCallbackPresentation } from "../src/presentation.js";
 import { processPendingCallbacks } from "../src/server.js";
 
 describe("createGitHubCallbackSink", () => {
@@ -736,6 +737,74 @@ describe("createGitHubCallbackSink", () => {
     ]);
   });
 
+  it("posts and updates rendered Slack final summaries without encoding mrkdwn twice", async () => {
+    const requests: unknown[] = [];
+    const sink = createSlackCallbackSink({
+      botToken: "xoxb-test",
+      fetchImpl: (async (_url, init) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return Response.json({ ok: true, ts: "1710000000.000200" });
+      }) as typeof fetch
+    });
+    const rendered = createDefaultCallbackPresentation().final({
+      provider: "slack",
+      result: {
+        conclusion: "success",
+        summary: "Use <tag> & [docs](https://example.com?a=1&b=2)"
+      }
+    });
+    await sink.deliver({
+      runId: "run_rendered_slack",
+      kind: "final",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      body: rendered.body,
+      ...(rendered.blocks ? { blocks: rendered.blocks } : {})
+    });
+    await sink.deliver({
+      runId: "run_rendered_slack_update",
+      kind: "final",
+      provider: "slack",
+      uri: "https://slack.com/api/chat.postMessage",
+      threadKey: "T123|C123|1710000000.000100",
+      externalMessageId: "1710000000.000200",
+      body: rendered.body,
+      ...(rendered.blocks ? { blocks: rendered.blocks } : {})
+    });
+
+    expect(requests).toEqual([
+      {
+        channel: "C123",
+        text: "*Finished: success.*\nUse &lt;tag&gt; &amp; <https://example.com?a=1&b=2|docs>",
+        thread_ts: "1710000000.000100",
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "*Finished: success.*\nUse &lt;tag&gt; &amp; <https://example.com?a=1&b=2|docs>"
+            }
+          }
+        ]
+      },
+      {
+        channel: "C123",
+        text: "*Finished: success.*\nUse &lt;tag&gt; &amp; <https://example.com?a=1&b=2|docs>",
+        ts: "1710000000.000200",
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "*Finished: success.*\nUse &lt;tag&gt; &amp; <https://example.com?a=1&b=2|docs>"
+            }
+          }
+        ]
+      }
+    ]);
+  });
+
   it("sanitizes credential-like Slack text and blocks before provider rendering", async () => {
     const payloads: unknown[] = [];
     const raw = "xoxb\x2d1234567890-abcdefghijklmnopqrstuvwxyz";
@@ -1169,7 +1238,7 @@ describe("createGitHubCallbackSink", () => {
       provider: "slack",
       uri: "https://slack.com/api/chat.postMessage",
       threadKey: "T123|C123|1710000000.000100",
-      body: "**done**",
+      body: "*done*",
       blocks: [
         {
           type: "section",

--- a/packages/dispatcher/test/presentation.test.ts
+++ b/packages/dispatcher/test/presentation.test.ts
@@ -307,6 +307,36 @@ describe("default callback presentation", () => {
     expect(JSON.stringify(presentation.render({ provider: "lark", presentation: status }).rich)).toContain("label this bug");
   });
 
+  it("escapes Slack fallbacks for plain doctor and source-thread presentations", () => {
+    const presentation = createDefaultCallbackPresentation();
+    const doctor = createDoctorSummaryPresentation({
+      title: "OpenTag doctor <redacted> & ready",
+      checks: [{ status: "ok", name: "dispatcher <local>", message: "reachable & healthy" }]
+    });
+    const status = createSourceThreadStatusPresentation({
+      sourceContainer: "slack:T123/C456",
+      projectTarget: "github:acme/demo",
+      bindingState: "bound",
+      queuedFollowUps: [],
+      queuedFollowUpsTotal: 0,
+      currentCommand: "fix <tag> & [docs](https://example.com)",
+      nextAction: "wait & review <output>"
+    });
+
+    const slackDoctor = presentation.render({ provider: "slack", presentation: doctor });
+    expect(slackDoctor.body).toContain("OpenTag doctor &lt;redacted&gt; &amp; ready");
+    expect(slackDoctor.body).toContain("dispatcher &lt;local&gt;: reachable &amp; healthy");
+    expect(slackDoctor.blocks).toBeDefined();
+
+    const slackStatus = presentation.render({ provider: "slack", presentation: status });
+    expect(slackStatus.body).toContain("Command: fix &lt;tag&gt; &amp; <https://example.com|docs>");
+    expect(slackStatus.body).toContain("Next action: wait &amp; review &lt;output&gt;");
+    expect(slackStatus.blocks).toBeDefined();
+
+    expect(presentation.render({ provider: "github", presentation: doctor }).body).toContain("OpenTag doctor <redacted> & ready");
+    expect(presentation.render({ provider: "custom", presentation: status }).body).toContain("Command: fix <tag> & [docs](https://example.com)");
+  });
+
   it("renders standalone action receipts as Slack and Lark native UI with plain-text fallback", () => {
     const presentation = createDefaultCallbackPresentation();
     const receipt = createActionReceiptPresentation({

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -226,7 +226,7 @@ export function createSlackReactionPayload(input: { channelId: string; messageTs
 }
 
 function truncateSlackText(text: string, maxLength: number): string {
-  const normalized = text.replace(/\s+/g, " ").trim();
+  const normalized = text.replace(/\r\n/g, "\n").trim();
   if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
 }
@@ -239,12 +239,8 @@ function firstMarkdownSection(text: string, heading: string): string | undefined
 
 function compactSlackSummary(summary: string): string {
   const whatChanged = firstMarkdownSection(summary, "What changed");
-  const firstParagraph = summary
-    .split(/\n\s*\n/)
-    .map((part) => part.trim())
-    .find(Boolean);
-  const selected = whatChanged ?? firstParagraph ?? summary;
-  return truncateSlackText(selected.replace(/^\*\*[^*]+:\*\*\s*/i, ""), 360);
+  const selected = whatChanged ?? summary;
+  return truncateSlackText(selected.replace(/^\*\*[^*]+:\*\*\s*/i, ""), 2800);
 }
 
 function compactNextAction(nextAction: string): string {

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -82,6 +82,8 @@ export type SlackSourceReceiptState = "received" | "running";
 
 const MAX_SLACK_SUGGESTED_ACTION_CANDIDATES = 20;
 const MAX_SLACK_COMPACT_FINAL_ACTIONS = 3;
+// Slack section text is capped at 3000 characters; reserve space for the final-summary prefix.
+const MAX_SLACK_FINAL_SUMMARY_LENGTH = 2500;
 
 export type SlackRenderOptions = {
   receiptContext?: ActionReceiptContext;
@@ -237,10 +239,39 @@ function firstMarkdownSection(text: string, heading: string): string | undefined
   return match?.[1]?.trim();
 }
 
+// Apply the limit after mrkdwn conversion because Slack escaping can expand the source text.
+function truncateSlackMrkdwn(text: string, maxLength: number): string {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  const rendered = markdownToSlackMrkdwn(normalized);
+  if (rendered.length <= maxLength) return rendered;
+
+  const characters = Array.from(normalized);
+  let low = 0;
+  let high = Math.min(characters.length, Math.max(0, maxLength - 1));
+  let best = "…";
+
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = markdownToSlackMrkdwn(`${characters.slice(0, midpoint).join("").trimEnd()}…`);
+    if (candidate.length <= maxLength) {
+      best = candidate;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+
+  return best;
+}
+
 function compactSlackSummary(summary: string): string {
   const whatChanged = firstMarkdownSection(summary, "What changed");
   const selected = whatChanged ?? summary;
-  return truncateSlackText(selected.replace(/^\*\*[^*]+:\*\*\s*/i, ""), 2800);
+  return truncateSlackText(selected.replace(/^\*\*[^*]+:\*\*\s*/i, ""), MAX_SLACK_FINAL_SUMMARY_LENGTH);
+}
+
+function renderCompactSlackSummary(summary: string): string {
+  return truncateSlackMrkdwn(compactSlackSummary(summary), MAX_SLACK_FINAL_SUMMARY_LENGTH);
 }
 
 function compactNextAction(nextAction: string): string {
@@ -614,7 +645,7 @@ export function renderSlackFinalResult(result: OpenTagRunResult, options: SlackR
 }
 
 export function renderSlackFinalSummaryPresentation(presentation: OpenTagFinalSummaryPresentation): string {
-  const lines = [`*Finished: ${presentation.outcome}.*`, markdownToSlackMrkdwn(compactSlackSummary(presentation.summary))];
+  const lines = [`*Finished: ${presentation.outcome}.*`, renderCompactSlackSummary(presentation.summary)];
 
   if (presentation.verification?.length) {
     lines.push(
@@ -664,7 +695,7 @@ export function createSlackFinalSummaryBlocks(presentation: OpenTagFinalSummaryP
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Finished: ${presentation.outcome}.*\n${markdownToSlackMrkdwn(compactSlackSummary(presentation.summary))}`
+        text: `*Finished: ${presentation.outcome}.*\n${renderCompactSlackSummary(presentation.summary)}`
       }
     }
   ];

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -228,9 +228,13 @@ export function createSlackReactionPayload(input: { channelId: string; messageTs
 }
 
 function truncateSlackText(text: string, maxLength: number): string {
-  const normalized = text.replace(/\r\n/g, "\n").trim();
+  const normalized = text.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function normalizeSlackMultilineText(text: string): string {
+  return text.replace(/\r\n?/g, "\n").trim();
 }
 
 function firstMarkdownSection(text: string, heading: string): string | undefined {
@@ -241,7 +245,7 @@ function firstMarkdownSection(text: string, heading: string): string | undefined
 
 // Apply the limit after mrkdwn conversion because Slack escaping can expand the source text.
 function truncateSlackMrkdwn(text: string, maxLength: number): string {
-  const normalized = text.replace(/\r\n/g, "\n").trim();
+  const normalized = normalizeSlackMultilineText(text);
   const rendered = markdownToSlackMrkdwn(normalized);
   if (rendered.length <= maxLength) return rendered;
 
@@ -267,7 +271,7 @@ function truncateSlackMrkdwn(text: string, maxLength: number): string {
 function compactSlackSummary(summary: string): string {
   const whatChanged = firstMarkdownSection(summary, "What changed");
   const selected = whatChanged ?? summary;
-  return truncateSlackText(selected.replace(/^\*\*[^*]+:\*\*\s*/i, ""), MAX_SLACK_FINAL_SUMMARY_LENGTH);
+  return normalizeSlackMultilineText(selected.replace(/^\*\*[^*]+:\*\*\s*/i, ""));
 }
 
 function renderCompactSlackSummary(summary: string): string {
@@ -821,19 +825,31 @@ export function createSlackSourceThreadStatusBlocks(presentation: OpenTagSourceT
   return blocks;
 }
 
-export function createSlackPostMessagePayload(input: { channelId: string; text: string; threadTs: string; blocks?: SlackBlock[] }): SlackMessagePayload {
+export function createSlackPostMessagePayload(input: {
+  channelId: string;
+  text: string;
+  textFormat?: "markdown" | "mrkdwn";
+  threadTs: string;
+  blocks?: SlackBlock[];
+}): SlackMessagePayload {
   return {
     channel: input.channelId,
-    text: markdownToSlackMrkdwn(input.text),
+    text: input.textFormat === "mrkdwn" ? input.text : markdownToSlackMrkdwn(input.text),
     thread_ts: input.threadTs,
     ...(input.blocks?.length ? { blocks: input.blocks } : {})
   };
 }
 
-export function createSlackUpdateMessagePayload(input: { channelId: string; text: string; messageTs: string; blocks?: SlackBlock[] }): SlackMessagePayload {
+export function createSlackUpdateMessagePayload(input: {
+  channelId: string;
+  text: string;
+  textFormat?: "markdown" | "mrkdwn";
+  messageTs: string;
+  blocks?: SlackBlock[];
+}): SlackMessagePayload {
   return {
     channel: input.channelId,
-    text: markdownToSlackMrkdwn(input.text),
+    text: input.textFormat === "mrkdwn" ? input.text : markdownToSlackMrkdwn(input.text),
     ts: input.messageTs,
     ...(input.blocks?.length ? { blocks: input.blocks } : {})
   };

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -170,6 +170,20 @@ describe("Slack callback rendering", () => {
     ]);
   });
 
+  it("keeps escaped final summaries within Slack section text limits", () => {
+    const blocks = createSlackFinalResultBlocks({
+      conclusion: "success",
+      summary: "&<>".repeat(1000)
+    });
+
+    const summaryBlock = blocks[0];
+    if (summaryBlock?.type !== "section") throw new Error("expected summary section");
+    expect(summaryBlock.text.text).toContain("&amp;&lt;&gt;");
+    expect(summaryBlock.text.text.length).toBeLessThanOrEqual(3000);
+    expect(summaryBlock.text.text.split("\n", 2)[1]?.length).toBeLessThanOrEqual(2500);
+    expect(summaryBlock.text.text.endsWith("…")).toBe(true);
+  });
+
   it("builds Block Kit sections for source-thread status", () => {
     const blocks = createSlackSourceThreadStatusBlocks(
       createSourceThreadStatusPresentation({

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -184,6 +184,42 @@ describe("Slack callback rendering", () => {
     expect(summaryBlock.text.text.endsWith("…")).toBe(true);
   });
 
+  it("preserves final-summary paragraphs while normalizing CRLF and lone CR", () => {
+    const blocks = createSlackFinalResultBlocks({
+      conclusion: "success",
+      summary: "first paragraph\r\n\r\nsecond paragraph\rthird line"
+    });
+
+    const summaryBlock = blocks[0];
+    if (summaryBlock?.type !== "section") throw new Error("expected summary section");
+    expect(summaryBlock.text.text).toBe("*Finished: success.*\nfirst paragraph\n\nsecond paragraph\nthird line");
+  });
+
+  it("keeps truncated final summaries as well-formed Unicode", () => {
+    const blocks = createSlackFinalResultBlocks({
+      conclusion: "success",
+      summary: "😀".repeat(1300)
+    });
+
+    const summaryBlock = blocks[0];
+    if (summaryBlock?.type !== "section") throw new Error("expected summary section");
+    const summaryText = summaryBlock.text.text.split("\n", 2)[1] ?? "";
+    expect(summaryText.isWellFormed()).toBe(true);
+    expect(summaryText.length).toBeLessThanOrEqual(2500);
+    expect(summaryText.endsWith("…")).toBe(true);
+  });
+
+  it("keeps compact one-line fields collapsed", () => {
+    const text = renderSlackFinalResult({
+      conclusion: "success",
+      summary: "Done.",
+      nextAction: "open the thread\r\nthen\tfollow up"
+    });
+
+    expect(text).toContain("Next: open the thread then follow up");
+    expect(text).not.toContain("open the thread\nthen");
+  });
+
   it("builds Block Kit sections for source-thread status", () => {
     const blocks = createSlackSourceThreadStatusBlocks(
       createSourceThreadStatusPresentation({


### PR DESCRIPTION
## Problem

Slack final replies could silently discard most executor output: only the first paragraph was selected, the remaining text was capped at 360 characters, and shared whitespace normalization collapsed line breaks.

## Fix

- Preserve the complete final summary, including paragraph breaks.
- Prefer the dedicated `What changed` section when the executor returns a structured summary.
- Normalize CRLF and lone CR without flattening multiline output.
- Convert Markdown to Slack mrkdwn before applying a 2500-character summary cap, leaving room under Slack's 3000-character section limit.
- Truncate on Unicode code-point boundaries so emoji cannot leave lone surrogate characters.
- Keep shared compact fields such as next actions on one line.
- Mark provider-rendered callback bodies as Slack mrkdwn so `chat.postMessage` and `chat.update` do not encode entities and links twice.
- Escape plain Slack fallbacks for doctor summaries and source-thread status without changing their blocks.

## Regression coverage

- Multi-paragraph summaries and blank lines are preserved.
- Escaping expansion remains within the Slack section limit.
- Emoji boundary truncation produces well-formed Unicode.
- Compact one-line fields still collapse whitespace.
- The complete presentation-to-callback path preserves entities and Slack links for both post and update payloads.
- Doctor and source-thread Slack fallbacks escape entities and convert Markdown links while other providers stay plain.

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 119 test files, 1517 tests passed
- Focused Slack renderer and dispatcher callback suites — 82 tests passed
- `git diff --check`

## Files changed

- `packages/slack/src/render.ts`
- `packages/slack/test/render.test.ts`
- `packages/dispatcher/src/callbacks.ts`
- `packages/dispatcher/test/callbacks.test.ts`
- `packages/dispatcher/src/presentation.ts`
- `packages/dispatcher/test/presentation.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack “Finished”/final summary rendering: consistent newline normalization, better selection of the “What changed” section, cleaner header handling, and safer mrkdwn truncation within Slack limits.
  * Prevented double-encoding by introducing an explicit `textFormat` option for Slack message payloads (and setting it to `mrkdwn` in the callback flow).
  * Updated Slack doctor/source-thread presentations to render bodies as Slack-compatible MRKDWN when supported.
* **Tests**
  * Added/expanded Vitest coverage for Slack Block Kit compliance, CRLF/CR newline behavior, Unicode-safe ellipsis truncation, compact “next action” formatting, and mrkdwn escaping in both top-level text and blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
