### PR TITLE
Require ACP workspace conformance before execution

### DIFF
--- a/docs/acp-agent-integration.md
+++ b/docs/acp-agent-integration.md
@@ -52,7 +52,8 @@ Add a named `opentag.integration.v1` manifest under `agents`:
         "agent": {
           "protocol": "agent-client-protocol",
           "protocolVersion": 1,
-          "binding": "agent"
+          "binding": "agent",
+          "workspace": { "sessionCwd": "required" }
         }
       },
       "resources": {}
@@ -69,6 +70,14 @@ Connection or secret-reference resolver, not in a reusable manifest.
 
 The map key, manifest `id`, and executor selection name must match. Selecting
 `example-acp` causes the Generic ACP Host to launch the declared binding.
+
+`workspace.sessionCwd: "required"` is the integration author's attestation
+that the agent's real file tools honor the absolute `cwd` supplied to ACP
+`session/new`. ACP transports that value but does not prove how an agent or an
+external gateway uses it. The field is required: OpenTag rejects an ACP Agent
+manifest without it during schema parsing, before constructing an executor.
+Declare it only after testing the real tools in both an isolated repository
+worktree and a scratch directory; it is not runtime proof or a sandbox claim.
 
 ## ACP session lifecycle
 
@@ -211,7 +220,8 @@ runtime identities:
         "agent": {
           "protocol": "agent-client-protocol",
           "protocolVersion": 1,
-          "binding": "agent"
+          "binding": "agent",
+          "workspace": { "sessionCwd": "required" }
         }
       },
       "resources": {}
@@ -245,6 +255,8 @@ Before describing an ACP integration as ready, verify that it:
 
 - completes ACP initialization and a fresh session over stdio;
 - honors the absolute Attempt `cwd` for its real tools;
+- declares `roles.agent.workspace.sessionCwd: "required"` only after that
+  real-tool check passes;
 - works in both repository worktrees and repository-free scratch directories;
 - supports cancellation without changing a cancelled Run to success;
 - routes permission requests through OpenTag instead of prompting separately;

--- a/docs/acp-first-agent-runtime-design.md
+++ b/docs/acp-first-agent-runtime-design.md
@@ -157,11 +157,19 @@ Agent declaration:
     "agent": {
       "protocol": "agent-client-protocol",
       "protocolVersion": 1,
-      "binding": "hermesAcp"
+      "binding": "hermesAcp",
+      "workspace": { "sessionCwd": "required" }
     }
   }
 }
 ```
+
+`workspace.sessionCwd: "required"` is a manifest attestation that the Agent's
+real file tools honor the ACP session `cwd`. It is not negotiated runtime proof
+and does not turn `cwd` into a sandbox. The integration schema rejects an ACP
+Agent role when this required attestation is absent, before the Generic ACP Host
+is constructed. Integrators make it only after worktree and scratch conformance
+tests pass.
 
 A Hermes integration may also declare a Channel role, but the two roles use isolated runtime profiles and processes.
 
@@ -707,7 +715,7 @@ When the system cannot determine whether a material effect occurred, it records 
 5. Executor capabilities never enter a Channel runtime.
 6. Raw connection credentials never enter durable Run content or prompts.
 7. ACP permission interaction is not the authority boundary; OpenTag policy and the execution envelope are.
-8. The ACP `cwd` is a working directory, not a sandbox. Worker isolation and grants enforce the boundary.
+8. The ACP `cwd` is a working directory, not a sandbox. A manifest declaration attests that real Agent tools honor it; Worker isolation and grants enforce the boundary.
 9. Material external mutations require stable action identity and an observable receipt or reconciliation path.
 10. A stale Worker cannot update a reassigned Attempt.
 11. Agent completion cannot bypass Output Contract verification.
@@ -768,7 +776,7 @@ The former `opentag.executor.v1` and `stdio-jsonl-basic` implementation was remo
 
 The completed replacement:
 
-1. uses `agent-client-protocol`, `protocolVersion: 1`, and a separate `stdio` binding in Agent manifests;
+1. uses `agent-client-protocol`, `protocolVersion: 1`, a required session-cwd attestation, and a separate `stdio` binding in Agent manifests;
 2. hosts ACP through the Generic ACP Host;
 3. maps ACP session updates into internal Attempt events instead of Core domain or channel events;
 4. supplies execution context through the Input Snapshot, prompt, absolute `cwd`, and optional run-scoped MCP;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,8 @@ ordinary ACP agent in this example; selecting `hermes-acp` starts `hermes acp`:
         "agent": {
           "protocol": "agent-client-protocol",
           "protocolVersion": 1,
-          "binding": "agent"
+          "binding": "agent",
+          "workspace": { "sessionCwd": "required" }
         }
       },
       "resources": {}
@@ -83,6 +84,12 @@ ordinary ACP agent in this example; selecting `hermes-acp` starts `hermes acp`:
   "keepScratch": "on_failure"
 }
 ```
+
+The workspace declaration is a manifest attestation, not runtime proof. ACP
+transports the session `cwd`, but the agent's real file tools must be tested in
+repository worktrees and scratch directories before the declaration is added.
+An ACP Agent manifest without it is invalid configuration and is rejected while
+loading the config, before an executor can start.
 
 ### ACP-first setup choices
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -365,10 +365,17 @@ type ExecutorCapability = {
   rawContextAccess: boolean;
   writeActionAccess: "none" | "propose" | "execute";
   workspaceIsolation: "none" | "branch" | "worktree" | "external";
+  workspaceCwdConformance?: "declared" | "unverified";
   requiredSecrets: SecretRefRequirement[];
   completionSignals: CompletionSignalDescriptor[];
 };
 ```
+
+`workspaceCwdConformance` is a shared audit surface for executor adapters.
+Generic ACP manifests require the explicit `declared` attestation and fail
+schema parsing without it; `unverified` remains available for other adapters
+that must report they cannot attest session-cwd behavior. Transport of the path
+alone is not evidence that an agent's real file tools honor it.
 
 Spawn-based executors remain the simplest path: OpenTag creates an isolated
 branch or worktree, starts the command with bounded context, captures output,

--- a/docs/integration-taxonomy.md
+++ b/docs/integration-taxonomy.md
@@ -32,12 +32,19 @@ The manifest is not a runtime event stream and must not contain credentials.
     "agent": {
       "protocol": "agent-client-protocol",
       "protocolVersion": 1,
-      "binding": "agent"
+      "binding": "agent",
+      "workspace": { "sessionCwd": "required" }
     }
   },
   "resources": {}
 }
 ```
+
+The Agent workspace declaration attests that the integration's real file tools
+honor the ACP session `cwd`; ACP transport alone does not prove this. OpenTag
+rejects an ACP Agent role during manifest parsing when the declaration is
+absent. Integrators must verify real-tool behavior in worktree and scratch
+Attempts before making the attestation.
 
 ## Active roles
 

--- a/docs/superpowers/plans/2026-07-12-acp-first-agent-runtime.md
+++ b/docs/superpowers/plans/2026-07-12-acp-first-agent-runtime.md
@@ -54,8 +54,12 @@
     protocol: "agent-client-protocol";
     protocolVersion: 1;
     binding: string;
+    workspace: { sessionCwd: "required" };
   }
   ```
+
+  The workspace attestation is required; manifests that omit it fail schema
+  parsing rather than entering a compatibility or deferred-readiness path.
 
 - Add an optional `roles.channel` declaration using `opentag.channel.v1`. The manifest role only declares its binding and managed/exclusive ownership metadata; it does not execute agent work.
 - Keep resources extensible with `z.record(OpenTagResourceCapabilitySchema)` so OpenTag is not repository-bound.

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -115,7 +115,8 @@ describe("OpenTag CLI config", () => {
               agent: {
                 protocol: "agent-client-protocol",
                 protocolVersion: 1,
-                binding: "agent"
+                binding: "agent",
+                workspace: { sessionCwd: "required" }
               }
             },
             resources: {}

--- a/packages/core/src/integration-protocol.ts
+++ b/packages/core/src/integration-protocol.ts
@@ -31,11 +31,18 @@ export const OpenTagStdioBindingSchema = z
 
 export const OpenTagIntegrationBindingSchema = OpenTagStdioBindingSchema;
 
+export const OpenTagAgentWorkspaceConformanceSchema = z
+  .object({
+    sessionCwd: z.literal("required")
+  })
+  .strict();
+
 export const OpenTagAgentIntegrationRoleSchema = z
   .object({
     protocol: OpenTagAgentProtocolSchema,
     protocolVersion: OpenTagAgentProtocolVersionSchema,
-    binding: z.string().trim().min(1)
+    binding: z.string().trim().min(1),
+    workspace: OpenTagAgentWorkspaceConformanceSchema
   })
   .strict();
 
@@ -223,6 +230,7 @@ export type OpenTagStdioBindingKind = z.infer<typeof OpenTagStdioBindingKindSche
 export type OpenTagStdioBindingInput = z.input<typeof OpenTagStdioBindingSchema>;
 export type OpenTagStdioBinding = z.infer<typeof OpenTagStdioBindingSchema>;
 export type OpenTagIntegrationBinding = z.infer<typeof OpenTagIntegrationBindingSchema>;
+export type OpenTagAgentWorkspaceConformance = z.infer<typeof OpenTagAgentWorkspaceConformanceSchema>;
 export type OpenTagAgentIntegrationRoleInput = z.input<typeof OpenTagAgentIntegrationRoleSchema>;
 export type OpenTagAgentIntegrationRole = z.infer<typeof OpenTagAgentIntegrationRoleSchema>;
 export type OpenTagManagedChannelOwnership = z.infer<typeof OpenTagManagedChannelOwnershipSchema>;

--- a/packages/core/test/integration-protocol.test.ts
+++ b/packages/core/test/integration-protocol.test.ts
@@ -25,7 +25,8 @@ function acpManifest() {
       agent: {
         protocol: "agent-client-protocol",
         protocolVersion: 1,
-        binding: "hermesAcp"
+        binding: "hermesAcp",
+        workspace: { sessionCwd: "required" }
       },
       channel: {
         protocol: "opentag.channel.v1",
@@ -56,10 +57,49 @@ describe("OpenTag integration manifest", () => {
     expect(manifest.roles.agent).toEqual({
       protocol: "agent-client-protocol",
       protocolVersion: 1,
-      binding: "hermesAcp"
+      binding: "hermesAcp",
+      workspace: { sessionCwd: "required" }
     });
     expect(manifest.roles.channel?.ownership).toEqual({ mode: "managed", exclusive: true });
     expect(manifest.resources["custom.report"]).toEqual({ refs: false, read: true, write: false });
+  });
+
+  it("requires a strict ACP session cwd conformance declaration", () => {
+    const parsed = OpenTagIntegrationManifestSchema.parse(acpManifest());
+
+    expect(parsed.roles.agent?.workspace).toEqual({ sessionCwd: "required" });
+  });
+
+  it("rejects an ACP agent role without the session cwd conformance declaration", () => {
+    const manifest = acpManifest();
+    const { workspace: _workspace, ...agentWithoutWorkspace } = manifest.roles.agent;
+
+    expect(() =>
+      OpenTagIntegrationManifestSchema.parse({
+        ...manifest,
+        roles: {
+          ...manifest.roles,
+          agent: agentWithoutWorkspace
+        }
+      })
+    ).toThrow();
+  });
+
+  it.each([
+    { sessionCwd: "optional" },
+    { sessionCwd: "required", extra: true }
+  ])("rejects an invalid ACP workspace conformance declaration: %j", (workspace) => {
+    const manifest = acpManifest();
+
+    expect(() =>
+      OpenTagIntegrationManifestSchema.parse({
+        ...manifest,
+        roles: {
+          ...manifest.roles,
+          agent: { ...manifest.roles.agent, workspace }
+        }
+      })
+    ).toThrow();
   });
 
   it("rejects an empty binding map", () => {

--- a/packages/local-runtime/src/daemon.ts
+++ b/packages/local-runtime/src/daemon.ts
@@ -367,6 +367,20 @@ export async function runOneDaemonIteration(input: {
     scratchAttemptCreated = false;
   }
 
+  const runId = claimed.run.id;
+  const activeExecutor = executor;
+  const runTimeoutMs = input.runTimeoutMs;
+  try {
+    await input.client.markRunning(runId, activeExecutor.id, lease, {
+      ...(activeExecutor.capability ? { executorCapability: activeExecutor.capability as unknown as Record<string, unknown> } : {}),
+      idempotencyKey: `${input.runnerId}:${runId}:running`,
+      ...(runTimeoutMs ? { runTimeoutMs } : {})
+    });
+  } catch (error) {
+    await cleanupUnexecutedScratch();
+    throw error;
+  }
+
   let readiness: Awaited<ReturnType<ExecutorAdapter["canRun"]>>;
   try {
     readiness = await executor.canRun({
@@ -398,21 +412,8 @@ export async function runOneDaemonIteration(input: {
     return true;
   }
 
-  const runId = claimed.run.id;
   const attemptId = claimed.attemptId;
-  const activeExecutor = executor;
   const heartbeatIntervalMs = input.heartbeatIntervalMs ?? 15_000;
-  const runTimeoutMs = input.runTimeoutMs;
-  try {
-    await input.client.markRunning(runId, activeExecutor.id, lease, {
-      ...(activeExecutor.capability ? { executorCapability: activeExecutor.capability as unknown as Record<string, unknown> } : {}),
-      idempotencyKey: `${input.runnerId}:${runId}:running`,
-      ...(runTimeoutMs ? { runTimeoutMs } : {})
-    });
-  } catch (error) {
-    await cleanupUnexecutedScratch();
-    throw error;
-  }
   let heartbeatHandle: ReturnType<typeof setInterval> | undefined;
   let heartbeatInFlight: Promise<void> | undefined;
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;

--- a/packages/local-runtime/src/doctor.ts
+++ b/packages/local-runtime/src/doctor.ts
@@ -45,9 +45,18 @@ function formatExecutorCapability(capability: ExecutorCapabilityContract): strin
     `raw_context=${yesNo(capability.rawContextAccess)}`,
     `write_actions=${capability.writeActionAccess}`,
     `isolation=${capability.workspaceIsolation}`,
+    `cwd_conformance=${capability.workspaceCwdConformance ?? "not_applicable"}`,
     `secrets=${secrets}`,
     `completion=${completion}`
   ].join(", ");
+}
+
+function checkExecutorCapability(name: string, capability: ExecutorCapabilityContract): DoctorCheck {
+  return check(
+    capability.workspaceCwdConformance === "unverified" ? "fail" : "ok",
+    `${name} capability`,
+    formatExecutorCapability(capability)
+  );
 }
 
 function envSecretConfigured(env: Record<string, string | undefined>, name: string): boolean {
@@ -305,7 +314,7 @@ async function checkGitCheckout(input: {
   }
   checks.push(
     executor.capability
-      ? check("ok", `${input.repository.defaultExecutor} capability`, formatExecutorCapability(executor.capability))
+      ? checkExecutorCapability(input.repository.defaultExecutor, executor.capability)
       : check(
           "warn",
           `${input.repository.defaultExecutor} capability`,
@@ -391,7 +400,16 @@ export async function runDoctor(input: {
   checks.push(...checkRunnerTokenRotation(input.config));
 
   if (!input.config.repositories.length) {
-    checks.push(check("fail", "repository config", "No repositories are configured."));
+    const configuredAgentCount = Object.keys(input.config.agents ?? {}).length;
+    checks.push(
+      configuredAgentCount > 0
+        ? check(
+            "ok",
+            "repository config",
+            `${configuredAgentCount} configured agent${configuredAgentCount === 1 ? "" : "s"} support${configuredAgentCount === 1 ? "s" : ""} repository-free Runs.`
+          )
+        : check("fail", "repository config", "No repositories or agents are configured.")
+    );
   }
 
   if (shouldCheckCodexConfig(input.config)) {
@@ -422,6 +440,29 @@ export async function runDoctor(input: {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       checks.push(check(message.includes("repo_binding_not_found") ? "warn" : "fail", `${repository.owner}/${repository.repo} binding`, message));
+    }
+  }
+
+  const repositoryExecutorIds = new Set(input.config.repositories.map((repository) => repository.defaultExecutor));
+  for (const agentId of Object.keys(input.config.agents ?? {})) {
+    if (repositoryExecutorIds.has(agentId)) continue;
+    const executor = input.executors[agentId];
+    if (!executor) {
+      checks.push(check("fail", `${agentId} configured agent`, "No local executor is configured with this id."));
+      continue;
+    }
+    checks.push(check("ok", `${agentId} configured agent`, `${executor.displayName} (${executor.id})`));
+    checks.push(
+      executor.capability
+        ? checkExecutorCapability(agentId, executor.capability)
+        : check(
+            "warn",
+            `${agentId} capability`,
+            "Executor does not declare a capability contract; readiness may be incomplete."
+          )
+    );
+    if (executor.capability) {
+      checks.push(...checkExecutorSecretRequirements({ capability: executor.capability, env }));
     }
   }
 

--- a/packages/local-runtime/test/acp-daemon.test.ts
+++ b/packages/local-runtime/test/acp-daemon.test.ts
@@ -214,7 +214,7 @@ describe("ACP daemon workspaces", () => {
             args: [acpFixture, "permission"]
           }
         },
-        roles: { agent: { protocol: "agent-client-protocol", protocolVersion: 1, binding: "agent" } },
+        roles: { agent: { protocol: "agent-client-protocol", protocolVersion: 1, binding: "agent", workspace: { sessionCwd: "required" } } },
         resources: {}
       }
     });
@@ -365,7 +365,7 @@ describe("ACP daemon workspaces", () => {
         id: "fixture-agent",
         label: "Fixture ACP Agent",
         bindings: { agent: { kind: "stdio", command: process.execPath, args: [acpFixture] } },
-        roles: { agent: { protocol: "agent-client-protocol", protocolVersion: 1, binding: "agent" } },
+        roles: { agent: { protocol: "agent-client-protocol", protocolVersion: 1, binding: "agent", workspace: { sessionCwd: "required" } } },
         resources: {}
       }
     });
@@ -403,7 +403,7 @@ describe("ACP daemon workspaces", () => {
         id: "fixture-agent",
         label: "Fixture ACP Agent",
         bindings: { agent: { kind: "stdio", command: process.execPath, args: [acpFixture] } },
-        roles: { agent: { protocol: "agent-client-protocol", protocolVersion: 1, binding: "agent" } },
+        roles: { agent: { protocol: "agent-client-protocol", protocolVersion: 1, binding: "agent", workspace: { sessionCwd: "required" } } },
         resources: {}
       }
     });
@@ -473,6 +473,91 @@ describe("ACP daemon workspaces", () => {
     expect(existsSync(scratchRoot)).toBe(true);
     expect(readdirSync(scratchRoot)).toEqual([]);
     expect(completed[0]).toMatchObject({ conclusion: "needs_human", summary: "not configured" });
+  });
+
+  it("snapshots an unverified custom capability before readiness rejects without running the executor", async () => {
+    const scratchRoot = join(mkdtempSync(join(tmpdir(), "opentag-scratch-parent-")), "scratch");
+    const completed: OpenTagRunResult[] = [];
+    const order: string[] = [];
+    const markRunningCalls: Array<{
+      executor: string;
+      options: Parameters<DaemonClient["markRunning"]>[3];
+    }> = [];
+    const acpExecutor = createAcpExecutor({
+      manifest: {
+        protocol: "opentag.integration.v1",
+        id: "reviewer",
+        label: "Unverified ACP Agent",
+        bindings: { agent: { kind: "stdio", command: process.execPath, args: [acpFixture] } },
+        roles: {
+          agent: {
+            protocol: "agent-client-protocol",
+            protocolVersion: 1,
+            binding: "agent",
+            workspace: { sessionCwd: "required" }
+          }
+        },
+        resources: {}
+      }
+    });
+    if (!acpExecutor.capability) throw new Error("Expected ACP capability in daemon test fixture.");
+    const run = vi.fn(async () => ({ conclusion: "success" as const, summary: "unexpected execution" }));
+    const executor: ExecutorAdapter = {
+      ...acpExecutor,
+      capability: {
+        ...acpExecutor.capability,
+        writeAccess: "external",
+        workspaceIsolation: "external",
+        workspaceCwdConformance: "unverified"
+      },
+      async canRun() {
+        order.push("canRun:start");
+        order.push("canRun:end");
+        return { ready: false, reason: "Executor workspace conformance is unverified." };
+      },
+      run
+    };
+    const client = clientFor({
+      claimed: claimed({ event: event({ id: "evt_unverified_snapshot" }) }),
+      completed
+    });
+    client.markRunning = async (_runId, selectedExecutor, _lease, options) => {
+      order.push("markRunning");
+      markRunningCalls.push({ executor: selectedExecutor, options });
+    };
+    client.complete = async (_runId, _lease, result) => {
+      order.push("complete");
+      completed.push(result);
+    };
+
+    await runOneDaemonIteration({
+      runnerId: "runner_local",
+      repositories: [],
+      executors: { reviewer: executor },
+      scratchRoot,
+      heartbeatIntervalMs: 0,
+      client
+    });
+
+    expect(order).toEqual(["markRunning", "canRun:start", "canRun:end", "complete"]);
+    expect(markRunningCalls).toEqual([
+      expect.objectContaining({
+        executor: "reviewer",
+        options: expect.objectContaining({
+          executorCapability: expect.objectContaining({
+            writeAccess: "external",
+            workspaceIsolation: "external",
+            workspaceCwdConformance: "unverified"
+          })
+        })
+      })
+    ]);
+    expect(run).not.toHaveBeenCalled();
+    expect(completed[0]).toMatchObject({
+      conclusion: "needs_human",
+      summary: "Executor workspace conformance is unverified."
+    });
+    expect(readdirSync(scratchRoot)).toEqual([]);
   });
 
   it("never removes a sibling attempt while cleaning a readiness failure", async () => {
@@ -743,7 +828,7 @@ describe("ACP daemon workspaces", () => {
             args: [acpFixture, "success", fixtureConfigPath]
           }
         },
-        roles: { agent: { protocol: "agent-client-protocol", protocolVersion: 1, binding: "agent" } },
+        roles: { agent: { protocol: "agent-client-protocol", protocolVersion: 1, binding: "agent", workspace: { sessionCwd: "required" } } },
         resources: {}
       }
     });

--- a/packages/local-runtime/test/config.test.ts
+++ b/packages/local-runtime/test/config.test.ts
@@ -20,7 +20,12 @@ function acpManifest(input: { id: string; label: string; command: string; args?:
       agent: { kind: "stdio" as const, command: input.command, args: input.args ?? [] }
     },
     roles: {
-      agent: { protocol: "agent-client-protocol" as const, protocolVersion: 1 as const, binding: "agent" }
+      agent: {
+        protocol: "agent-client-protocol" as const,
+        protocolVersion: 1 as const,
+        binding: "agent",
+        workspace: { sessionCwd: "required" as const }
+      }
     },
     resources: {}
   };
@@ -39,6 +44,7 @@ describe("parseDaemonConfig ACP agents", () => {
     const executors = executorsFromConfig(config);
     expect(executors["hermes-acp"]).toMatchObject({ id: "hermes-acp", displayName: "Hermes ACP" });
     expect(executors.reviewer).toMatchObject({ id: "reviewer", displayName: "Review Agent" });
+    expect(executors.reviewer?.capability).toMatchObject({ workspaceCwdConformance: "declared" });
     expect(executors["hermes-acp"]?.capability?.completionSignals).toEqual(
       executors.reviewer?.capability?.completionSignals
     );
@@ -52,6 +58,22 @@ describe("parseDaemonConfig ACP agents", () => {
         }
       })
     ).toThrow(/reviewer|different-id/u);
+  });
+
+  it("rejects an ACP agent manifest without the required session cwd conformance", () => {
+    const manifest = acpManifest({ id: "reviewer", label: "Review Agent", command: "review-agent" });
+    const { workspace: _workspace, ...agentWithoutWorkspace } = manifest.roles.agent;
+
+    expect(() =>
+      parseDaemonConfig({
+        agents: {
+          reviewer: {
+            ...manifest,
+            roles: { agent: agentWithoutWorkspace }
+          }
+        }
+      })
+    ).toThrow(/workspace/u);
   });
 
   it.each(["echo", "codex", "claude-code", "hermes"])(

--- a/packages/local-runtime/test/doctor.test.ts
+++ b/packages/local-runtime/test/doctor.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { createHermesExecutor, type CommandRunner, type ExecutorAdapter } from "@opentag/runner";
+import { createAcpExecutor, createHermesExecutor, type CommandRunner, type ExecutorAdapter } from "@opentag/runner";
 import type { OpenTagDaemonConfig } from "../src/config.js";
 import { doctorHasFailures, formatDoctorChecks, runDoctor } from "../src/doctor.js";
 
@@ -54,6 +54,19 @@ const codexExecutor: ExecutorAdapter = {
   async cancel() {}
 };
 
+function withUnverifiedWorkspaceCapability(executor: ExecutorAdapter): ExecutorAdapter {
+  if (!executor.capability) throw new Error("Expected executor capability in doctor test fixture.");
+  return {
+    ...executor,
+    capability: {
+      ...executor.capability,
+      writeAccess: "external",
+      workspaceIsolation: "external",
+      workspaceCwdConformance: "unverified"
+    }
+  };
+}
+
 function tokenFingerprint(token: string): string {
   return createHash("sha256").update(token).digest("hex");
 }
@@ -61,7 +74,11 @@ function tokenFingerprint(token: string): string {
 async function runCodexDoctor(
   codexConfig: string,
   configOverrides: Partial<OpenTagDaemonConfig> = {},
-  options: { executors?: Record<string, ExecutorAdapter>; env?: Record<string, string | undefined> } = {}
+  options: {
+    executors?: Record<string, ExecutorAdapter>;
+    env?: Record<string, string | undefined>;
+    repositoryDefaultExecutor?: string;
+  } = {}
 ) {
   const root = mkdtempSync(join(tmpdir(), "opentag-local-runtime-doctor-"));
   const checkoutPath = join(root, "demo");
@@ -81,7 +98,7 @@ async function runCodexDoctor(
             owner: "acme",
             repo: "demo",
             checkoutPath,
-            defaultExecutor: "codex",
+            defaultExecutor: options.repositoryDefaultExecutor ?? "codex",
             baseBranch: "main",
             pushRemote: "origin",
             keepWorktree: "on_failure"
@@ -138,8 +155,171 @@ describe("local-runtime doctor", () => {
     expect(formatDoctorChecks(checks)).toContain("context=context_packet,context_pointers,workspace");
     expect(formatDoctorChecks(checks)).toContain("prompt=executor_adapter, write=workspace");
     expect(formatDoctorChecks(checks)).toContain("conversation=request, prompt_mutation=none, raw_context=no, write_actions=none");
+    expect(formatDoctorChecks(checks)).toContain("isolation=worktree, cwd_conformance=not_applicable");
     expect(formatDoctorChecks(checks)).toContain("OK   github:acme/demo checkout: Workspace path configured (hasWorkspacePath=yes).");
     expect(formatDoctorChecks(checks)).not.toContain("opentag-local-runtime-doctor-");
+  });
+
+  it("reports a repository-free executor's unverified workspace capability", async () => {
+    const manifest = {
+      protocol: "opentag.integration.v1" as const,
+      id: "scratch-agent",
+      label: "Scratch ACP Agent",
+      bindings: {
+        agent: { kind: "stdio" as const, command: "scratch-agent", args: ["acp"] }
+      },
+      roles: {
+        agent: {
+          protocol: "agent-client-protocol" as const,
+          protocolVersion: 1 as const,
+          binding: "agent",
+          workspace: { sessionCwd: "required" as const }
+        }
+      },
+      resources: {}
+    };
+    const executor = withUnverifiedWorkspaceCapability(createAcpExecutor({ manifest }));
+    const checks = await runCodexDoctor(
+      'service_tier = "fast"\n',
+      { repositories: [], agents: { "scratch-agent": manifest } },
+      { executors: { "scratch-agent": executor } }
+    );
+    const output = formatDoctorChecks(checks);
+
+    expect(output).toContain("OK   scratch-agent configured agent: Scratch ACP Agent (scratch-agent)");
+    expect(output).toContain("FAIL scratch-agent capability:");
+    expect(output).toContain("isolation=external, cwd_conformance=unverified");
+    expect(doctorHasFailures(checks)).toBe(true);
+  });
+
+  it("passes repository-free doctor checks for a declared scratch-only ACP agent", async () => {
+    const manifest = {
+      protocol: "opentag.integration.v1" as const,
+      id: "declared-agent",
+      label: "Declared ACP Agent",
+      bindings: { agent: { kind: "stdio" as const, command: "declared-agent" } },
+      roles: {
+        agent: {
+          protocol: "agent-client-protocol" as const,
+          protocolVersion: 1 as const,
+          binding: "agent",
+          workspace: { sessionCwd: "required" as const }
+        }
+      },
+      resources: {}
+    };
+    const executor = createAcpExecutor({ manifest });
+    const checks = await runCodexDoctor(
+      'service_tier = "fast"\n',
+      { repositories: [], agents: { "declared-agent": manifest } },
+      { executors: { "declared-agent": executor } }
+    );
+    const output = formatDoctorChecks(checks);
+
+    expect(output).toContain("OK   repository config: 1 configured agent supports repository-free Runs.");
+    expect(output).toContain("OK   declared-agent capability:");
+    expect(doctorHasFailures(checks)).toBe(false);
+  });
+
+  it("fails repository configuration when neither repositories nor agents are configured", async () => {
+    const checks = await runCodexDoctor(
+      'service_tier = "fast"\n',
+      { repositories: [], agents: {} },
+      { executors: {} }
+    );
+
+    expect(formatDoctorChecks(checks)).toContain(
+      "FAIL repository config: No repositories or agents are configured."
+    );
+    expect(doctorHasFailures(checks)).toBe(true);
+  });
+
+  it("fails when a repository-free configured ACP agent has no local executor", async () => {
+    const manifest = {
+      protocol: "opentag.integration.v1" as const,
+      id: "missing-agent",
+      label: "Missing ACP Agent",
+      bindings: { agent: { kind: "stdio" as const, command: "missing-agent" } },
+      roles: {
+        agent: {
+          protocol: "agent-client-protocol" as const,
+          protocolVersion: 1 as const,
+          binding: "agent",
+          workspace: { sessionCwd: "required" as const }
+        }
+      },
+      resources: {}
+    };
+    const checks = await runCodexDoctor(
+      'service_tier = "fast"\n',
+      { repositories: [], agents: { "missing-agent": manifest } },
+      { executors: {} }
+    );
+
+    expect(formatDoctorChecks(checks)).toContain(
+      "FAIL missing-agent configured agent: No local executor is configured with this id."
+    );
+  });
+
+  it("does not duplicate an unverified executor capability already covered by a repository default", async () => {
+    const manifest = {
+      protocol: "opentag.integration.v1" as const,
+      id: "repo-agent",
+      label: "Repository ACP Agent",
+      bindings: { agent: { kind: "stdio" as const, command: "repo-agent" } },
+      roles: {
+        agent: {
+          protocol: "agent-client-protocol" as const,
+          protocolVersion: 1 as const,
+          binding: "agent",
+          workspace: { sessionCwd: "required" as const }
+        }
+      },
+      resources: {}
+    };
+    const acpExecutor = withUnverifiedWorkspaceCapability(createAcpExecutor({ manifest }));
+    const executor: ExecutorAdapter = { ...acpExecutor, canRun: async () => ({ ready: true }) };
+    const checks = await runCodexDoctor(
+      'service_tier = "fast"\n',
+      { agents: { "repo-agent": manifest } },
+      { executors: { "repo-agent": executor }, repositoryDefaultExecutor: "repo-agent" }
+    );
+    const output = formatDoctorChecks(checks);
+
+    expect(output.match(/repo-agent capability:/gu)).toHaveLength(1);
+    expect(output).toContain("FAIL repo-agent capability:");
+    expect(output).not.toContain("repo-agent configured agent:");
+    expect(doctorHasFailures(checks)).toBe(true);
+  });
+
+  it("fails a healthy repository doctor when a secondary configured ACP agent is unverified", async () => {
+    const manifest = {
+      protocol: "opentag.integration.v1" as const,
+      id: "secondary-agent",
+      label: "Secondary ACP Agent",
+      bindings: { agent: { kind: "stdio" as const, command: "secondary-agent" } },
+      roles: {
+        agent: {
+          protocol: "agent-client-protocol" as const,
+          protocolVersion: 1 as const,
+          binding: "agent",
+          workspace: { sessionCwd: "required" as const }
+        }
+      },
+      resources: {}
+    };
+    const secondaryExecutor = withUnverifiedWorkspaceCapability(createAcpExecutor({ manifest }));
+    const checks = await runCodexDoctor(
+      'service_tier = "fast"\n',
+      { agents: { "secondary-agent": manifest } },
+      { executors: { codex: codexExecutor, "secondary-agent": secondaryExecutor } }
+    );
+    const output = formatDoctorChecks(checks);
+
+    expect(output).toContain("OK   github:acme/demo git repo: Git checkout detected");
+    expect(output).toContain("FAIL secondary-agent capability:");
+    expect(output).toContain("cwd_conformance=unverified");
+    expect(doctorHasFailures(checks)).toBe(true);
   });
 
   it("fails Hermes readiness when the configured fixed profile is unavailable", async () => {

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -17,7 +17,7 @@ pnpm add @opentag/runner
 - `createCodexExecutor`: executor that runs `codex exec` in a mapped local checkout.
 - Git helpers such as `createRunBranch`, `changedFiles`, and `branchNameForRun`.
 - Command helpers such as `nodeCommandRunner` and `assertCommandSucceeded`.
-- Built-in executors expose an optional `capability` contract so setup, doctor, status, and service surfaces can report profile, cancellation, hook-completion, progress-event, approval-boundary, prompt/context trust gates, workspace-isolation, secret, and completion-signal support honestly.
+- Built-in and generic ACP executors expose an optional `capability` contract so setup, doctor, status, and service surfaces can report profile, cancellation, hook-completion, progress-event, approval-boundary, prompt/context trust gates, workspace isolation, ACP session-cwd conformance, secret, and completion-signal support honestly.
 
 ## Example
 

--- a/packages/runner/src/acp-executor.ts
+++ b/packages/runner/src/acp-executor.ts
@@ -302,7 +302,11 @@ function normalizeManifest(input: OpenTagIntegrationManifestInput): NormalizedAc
   if (!role) throw new Error("ACP executor manifest must declare roles.agent.");
   const binding = manifest.bindings[role.binding];
   if (!binding) throw new Error(`ACP agent role references missing binding '${role.binding}'.`);
-  return { id: manifest.id, label: manifest.label, binding };
+  return {
+    id: manifest.id,
+    label: manifest.label,
+    binding
+  };
 }
 
 function assertExplicitWorkspace(input: ExecutorRunInput): ExecutorWorkspace {
@@ -552,6 +556,7 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
       rawContextAccess: false,
       writeActionAccess: "propose",
       workspaceIsolation: "worktree",
+      workspaceCwdConformance: "declared",
       sourceControl: "self_committing",
       requiredSecrets: [],
       completionSignals: [{ type: "stream_event", required: true, description: "ACP session/prompt stop response." }]

--- a/packages/runner/src/executor.ts
+++ b/packages/runner/src/executor.ts
@@ -143,6 +143,7 @@ export type ExecutorWriteAccess = "none" | "workspace" | "external";
 export type ExecutorConversationAccess = "none" | "request" | "thread_transcript";
 export type ExecutorPromptMutation = "none" | "append" | "replace";
 export type ExecutorWriteActionAccess = "none" | "propose" | "execute";
+export type ExecutorWorkspaceCwdConformance = "declared" | "unverified";
 
 export type ExecutorCapabilityContract = {
   id: string;
@@ -161,6 +162,7 @@ export type ExecutorCapabilityContract = {
   rawContextAccess: boolean;
   writeActionAccess: ExecutorWriteActionAccess;
   workspaceIsolation: "none" | "branch" | "worktree" | "external";
+  workspaceCwdConformance?: ExecutorWorkspaceCwdConformance;
   sourceControl?: "none" | "daemon_managed" | "self_committing";
   requiredSecrets: ExecutorSecretRequirement[];
   completionSignals: ExecutorCompletionSignal[];

--- a/packages/runner/test/acp-executor.test.ts
+++ b/packages/runner/test/acp-executor.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync,
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAcpExecutor, type AcpPermissionResolver } from "../src/acp-executor.js";
 
 const fixture = fileURLToPath(new URL("./fixtures/acp-agent.mjs", import.meta.url));
@@ -50,10 +50,25 @@ function manifest(mode = "success") {
       agent: {
         protocol: "agent-client-protocol" as const,
         protocolVersion: 1 as const,
-        binding: "agent"
+        binding: "agent",
+        workspace: { sessionCwd: "required" as const }
       }
     },
     resources: {}
+  };
+}
+
+function unverifiedManifest(mode = "success") {
+  const configured = manifest(mode);
+  return {
+    ...configured,
+    roles: {
+      agent: {
+        protocol: configured.roles.agent.protocol,
+        protocolVersion: configured.roles.agent.protocolVersion,
+        binding: configured.roles.agent.binding
+      }
+    }
   };
 }
 
@@ -112,6 +127,24 @@ async function waitForFile(path: string): Promise<void> {
 }
 
 describe("ACP executor", () => {
+  it("derives workspace capability from the required manifest conformance declaration", () => {
+    expect(createAcpExecutor({ manifest: manifest() }).capability).toMatchObject({
+      writeAccess: "workspace",
+      workspaceIsolation: "worktree",
+      workspaceCwdConformance: "declared"
+    });
+  });
+
+  it("rejects an ACP manifest before executor construction when session cwd conformance is undeclared", () => {
+    const run = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+
+    expect(() =>
+      createAcpExecutor({ manifest: unverifiedManifest() as never, runner: { run } })
+    ).toThrow(/workspace/u);
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("streams normalized plan, tool, and message updates and commits repository changes", async () => {
     const repo = initRepo();
     const executor = createAcpExecutor({ manifest: manifest() });

--- a/scripts/release/check-cli-package.mjs
+++ b/scripts/release/check-cli-package.mjs
@@ -88,7 +88,7 @@ function checkInstalledDoctorCommand(installDir) {
   if (doctor.status !== 1) {
     throw new Error(`Expected the intentionally incomplete doctor config to exit 1, received ${doctor.status ?? "no status"}.`);
   }
-  for (const expected of ["OpenTag doctor", "FAIL repository config: No repositories are configured."]) {
+  for (const expected of ["OpenTag doctor", "FAIL repository config: No repositories or agents are configured."]) {
     if (!doctorOutput.includes(expected)) {
       throw new Error(`Installed opentag doctor output did not contain ${JSON.stringify(expected)}.`);
     }


### PR DESCRIPTION
## Summary

- require the strict `roles.agent.workspace.sessionCwd: "required"` attestation for every ACP Agent manifest
- reject omission during manifest/config parsing and executor construction instead of deferring failure to readiness
- expose workspace conformance in doctor and Attempt capability snapshots, including repository-free and custom executors
- document that the declaration is an integration attestation, not runtime proof or sandboxing

## Validation

- `corepack pnpm build`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test` — 119 files, 1531 tests passed
- `corepack pnpm release:check` — packed-install CLI check passed
- `corepack pnpm smoke:governance -- --all` — 7 cases passed
- `corepack pnpm smoke:privacy`
- `git diff --check`

## Notes

- ACP Agent manifests that omit the session-cwd contract are invalid; no compatibility or deferred-readiness path is retained.
- Integrators must test real file tools in both repository worktrees and repository-free scratch directories before declaring conformance.
- Readiness preflight remains part of the durable running Attempt so custom executor capability evidence is recorded even when readiness rejects.
- Live third-party ACP agent real-tool conformance is intentionally not claimed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit workspace session-directory conformance requirements for ACP agent configurations.
  * Executor capability and diagnostic output now report session working-directory conformance.
  * Doctor checks now validate configured agents, including repository-free setups and executor readiness.

* **Bug Fixes**
  * Daemon runs are marked active before readiness checks, improving status reporting for early failures.

* **Documentation**
  * Updated configuration, integration, security, and conformance guidance for session-directory handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->