### PR TITLE
Add a fail-closed OpenClaw ACP conformance gate

### DIFF
--- a/docs/acp-agent-integration.md
+++ b/docs/acp-agent-integration.md
@@ -79,6 +79,38 @@ manifest without it during schema parsing, before constructing an executor.
 Declare it only after testing the real tools in both an isolated repository
 worktree and a scratch directory; it is not runtime proof or a sandbox claim.
 
+## OpenClaw 2026.7.1 gate status
+
+OpenClaw `2026.7.1` can initialize through its official
+[Gateway ACP bridge](https://docs.openclaw.ai/cli/acp) and the same Generic ACP
+Host. Its worktree cwd, scratch cwd, and disposable Gateway session checks pass.
+It is not ready to declare as an OpenTag agent, however, because the live cancel
+case currently fails closed.
+
+OpenClaw's stock bridge records the absolute ACP session cwd and, by default,
+prefixes that cwd when it forwards the request to the Gateway. Do not add
+`--no-prefix-cwd`: the strict declaration is justified by the observed real-tool
+result, not merely by successful ACP initialization. Re-run the live gate for
+every OpenClaw version that will be trusted:
+
+```bash
+OPENTAG_OPENCLAW_PROFILE=opentag-conformance \
+corepack pnpm smoke:openclaw-acp-conformance
+```
+
+The gate checks exact worktree and scratch writes plus distinct disposable
+Gateway session keys. For cancellation, it waits until a real long-running
+shell command writes its start marker, cancels the ACP session, then waits beyond
+the original completion time and rejects a late completion marker. With the
+stock 2026.7.1 Codex harness, the Gateway session becomes `killed` but the shell
+still writes that completion marker. Therefore the gate exits non-zero, OpenTag
+does not ship an OpenClaw manifest example, and integrators must not attest
+`workspace.sessionCwd: "required"`. Do not compensate with a dedicated
+executor or weaken the cancellation assertion.
+
+This OpenClaw-specific gate complements rather than replaces the generic ACP
+executor, governance, and privacy suites required by the checklist below.
+
 ## ACP session lifecycle
 
 For each Attempt, the host:

--- a/docs/acp-first-agent-runtime-design.md
+++ b/docs/acp-first-agent-runtime-design.md
@@ -728,7 +728,8 @@ The first coherent vertical slice contains:
 - Hermes Channel Adapter implementing `opentag.channel.v1` for one provider;
 - Generic ACP Host over stdio;
 - Hermes ACP conformance smoke test;
-- a second real ACP Agent smoke test;
+- an OpenClaw 2026.7.1 candidate gate for the second real ACP Agent, currently
+  blocked because Gateway cancellation does not stop the in-flight shell tool;
 - Ask and Auto autonomy modes;
 - Balanced Run Card presentation;
 - local or co-located Control Plane and Worker with the process boundary preserved;

--- a/docs/live-e2e-smoke-harness.md
+++ b/docs/live-e2e-smoke-harness.md
@@ -1,9 +1,10 @@
 # Live E2E Smoke Harness
 
 The replay harness proves protocol behavior without live provider APIs. The live
-E2E smoke harness is the next layer: it collects the existing GitHub, Slack,
-Lark, and Linear dogfood scripts behind one safe entry point so a release or PR
-reviewer can run the live cases intentionally and keep a JSON evidence report.
+E2E smoke harness is the next layer: it collects the existing ACP, GitHub,
+Slack, Lark, and Linear dogfood scripts behind one safe entry point so a release
+or PR reviewer can run the live cases intentionally and keep a JSON evidence
+report.
 
 The harness does not run live provider calls by default. You must select cases
 with `--case` or `--all`.
@@ -20,6 +21,7 @@ Current cases:
 | --- | --- | --- |
 | `protocol-runtime` | No | In-memory GitHub-shaped protocol smoke using dispatcher/client/store paths |
 | `slack-protocol` | No | In-memory Slack-shaped protocol smoke with quiet progress and Block Kit final callback |
+| `openclaw-acp` | Yes | Fail-closed OpenClaw 2026.7.1 candidate gate for worktree cwd, scratch cwd, fresh sessions, and cancellation through the generic ACP host |
 | `github-webhook-live` | Yes | Real GitHub repository webhook, local CLI stack, final action receipt, optional `apply 1` PR flow |
 | `github-cli-live` | Yes | Real GitHub issue callback using dispatcher-assisted run creation |
 | `slack-local-live` | Yes | Real Slack callback using dispatcher-assisted run creation |
@@ -85,6 +87,44 @@ artifacts exist, and provider-visible action receipts do not expose raw executor
 logs.
 
 ## Case Notes
+
+### OpenClaw ACP
+
+`openclaw-acp` wraps `corepack pnpm smoke:openclaw-acp-conformance`. It expects
+OpenClaw `2026.7.1`, a running Gateway, and an isolated profile named
+`opentag-conformance` by default. Override the command, profile, Gateway URL, or
+expected version with `OPENTAG_OPENCLAW_COMMAND`, `OPENTAG_OPENCLAW_PROFILE`,
+`OPENTAG_OPENCLAW_GATEWAY_URL`, and
+`OPENTAG_OPENCLAW_EXPECTED_VERSION`.
+
+The case uses OpenTag's generic ACP executor; it does not invoke a dedicated
+OpenClaw adapter. It fails closed unless real file tools write into the exact
+OpenTag-created repository worktree and repository-free scratch directory,
+each ACP process creates a distinct disposable Gateway session, a long-running
+real tool call stops before its completion marker, and no marker appears in the
+source checkout or OpenClaw's configured default workspace. The stock OpenClaw
+bridge carries the ACP cwd into the Gateway request using its default cwd prefix,
+so do not add `--no-prefix-cwd` to the integration binding.
+
+The current stock 2026.7.1 result is intentionally non-zero. Worktree, scratch,
+and distinct Gateway session checks pass, but after ACP cancellation marks the
+Gateway session `killed`, the in-flight shell still reaches its completion
+marker. Until that external effect stops, this gate does not authorize an
+OpenClaw manifest and OpenTag does not ship one.
+
+The test Gateway may use no authentication only when it is isolated and bound
+to loopback. A reusable or remote profile must own its Gateway authentication;
+do not put tokens in an OpenTag manifest. To retain a sanitized case report:
+
+```bash
+OPENTAG_OPENCLAW_CONFORMANCE_REPORT=.omx/live-e2e/openclaw-acp.json \
+corepack pnpm smoke:live -- --case openclaw-acp
+```
+
+This live case covers OpenClaw-specific workspace, session, and cancellation
+behavior. Run it alongside the generic ACP executor tests, governance matrix,
+and privacy scan for the permission, Action fencing, presentation, and
+credential-isolation parts of the full conformance checklist.
 
 ### GitHub Repository Webhook
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "smoke:governance": "node scripts/test/governance-matrix.mjs",
     "smoke:hermes-profile-contract": "node scripts/test/hermes-v018-profile-contract.mjs",
     "smoke:live": "node scripts/test/live-e2e-smoke.mjs",
+    "smoke:openclaw-acp-conformance": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/openclaw-acp-conformance.ts",
     "smoke:privacy": "node scripts/test/privacy-redaction-scan.mjs",
     "smoke:protocol": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/protocol-runtime-smoke.ts",
     "smoke:slack-protocol": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/slack-protocol-runtime-smoke.ts"

--- a/packages/runner/test/openclaw-conformance-harness.test.ts
+++ b/packages/runner/test/openclaw-conformance-harness.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import {
   newGatewaySessions,
   parseOpenClawVersion,
   resolveConformanceReportPath,
+  resolveDefaultWorkspacePath,
   type GatewaySession
 } from "../../../scripts/test/openclaw-acp-conformance.js";
 
@@ -11,6 +13,10 @@ describe("OpenClaw ACP conformance harness", () => {
   it("parses an exact CLI version instead of accepting a longer semver prefix", () => {
     expect(parseOpenClawVersion("OpenClaw 2026.7.1 (2d2ddc4)")).toBe("2026.7.1");
     expect(parseOpenClawVersion("OpenClaw 2026.7.10 (future)")).toBe("2026.7.10");
+  });
+
+  it("parses the CLI version after leading diagnostic lines", () => {
+    expect(parseOpenClawVersion("Warning: profile migrated\nOpenClaw 2026.7.1 (2d2ddc4)")).toBe("2026.7.1");
   });
 
   it("finds only Gateway sessions that were absent from the previous snapshot", () => {
@@ -29,5 +35,10 @@ describe("OpenClaw ACP conformance harness", () => {
     expect(resolveConformanceReportPath(".omx/live-e2e/openclaw-acp.json")).toBe(
       resolve(process.cwd(), ".omx/live-e2e/openclaw-acp.json")
     );
+  });
+
+  it("keeps a normalized absolute default workspace path when the directory does not exist yet", () => {
+    const missing = join(tmpdir(), `opentag-openclaw-missing-workspace-${process.pid}`);
+    expect(resolveDefaultWorkspacePath(missing)).toBe(resolve(missing));
   });
 });

--- a/packages/runner/test/openclaw-conformance-harness.test.ts
+++ b/packages/runner/test/openclaw-conformance-harness.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { resolve } from "node:path";
+import {
+  newGatewaySessions,
+  parseOpenClawVersion,
+  resolveConformanceReportPath,
+  type GatewaySession
+} from "../../../scripts/test/openclaw-acp-conformance.js";
+
+describe("OpenClaw ACP conformance harness", () => {
+  it("parses an exact CLI version instead of accepting a longer semver prefix", () => {
+    expect(parseOpenClawVersion("OpenClaw 2026.7.1 (2d2ddc4)")).toBe("2026.7.1");
+    expect(parseOpenClawVersion("OpenClaw 2026.7.10 (future)")).toBe("2026.7.10");
+  });
+
+  it("finds only Gateway sessions that were absent from the previous snapshot", () => {
+    const existing: GatewaySession = { key: "agent:main:acp-bridge:existing", status: "done" };
+    const added: GatewaySession = { key: "agent:main:acp-bridge:new", status: "done" };
+    const previous = new Map([[existing.key, existing]]);
+    const current = new Map([
+      [existing.key, existing],
+      [added.key, added]
+    ]);
+
+    expect(newGatewaySessions(previous, current)).toEqual([added]);
+  });
+
+  it("resolves evidence reports from the repository root", () => {
+    expect(resolveConformanceReportPath(".omx/live-e2e/openclaw-acp.json")).toBe(
+      resolve(process.cwd(), ".omx/live-e2e/openclaw-acp.json")
+    );
+  });
+});

--- a/packages/runner/test/openclaw-conformance-harness.test.ts
+++ b/packages/runner/test/openclaw-conformance-harness.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
+  defaultMarkersSafeToClean,
   newGatewaySessions,
   parseOpenClawVersion,
+  runBoundedCommand,
   resolveConformanceReportPath,
   resolveDefaultWorkspacePath,
+  writePrivateReport,
   type GatewaySession
 } from "../../../scripts/test/openclaw-acp-conformance.js";
 
@@ -40,5 +44,37 @@ describe("OpenClaw ACP conformance harness", () => {
   it("keeps a normalized absolute default workspace path when the directory does not exist yet", () => {
     const missing = join(tmpdir(), `opentag-openclaw-missing-workspace-${process.pid}`);
     expect(resolveDefaultWorkspacePath(missing)).toBe(resolve(missing));
+  });
+
+  it("bounds external commands that do not exit", () => {
+    expect(() =>
+      runBoundedCommand(process.execPath, ["-e", "setTimeout(() => {}, 10_000)"], 50)
+    ).toThrow();
+  });
+
+  it("does not authorize cleanup when a default-workspace marker already exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "opentag-openclaw-marker-"));
+    const marker = join(root, "pre-existing");
+    try {
+      writeFileSync(marker, "owned by another run\n");
+      expect(() => defaultMarkersSafeToClean([marker])).toThrow(/Refusing to overwrite pre-existing marker/u);
+      expect(existsSync(marker)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("enforces mode 0600 when overwriting an existing evidence report", () => {
+    const root = mkdtempSync(join(tmpdir(), "opentag-openclaw-report-"));
+    const report = join(root, "report.json");
+    try {
+      writeFileSync(report, "old\n", { mode: 0o644 });
+      chmodSync(report, 0o644);
+      writePrivateReport(report, "new\n");
+      expect(statSync(report).mode & 0o777).toBe(0o600);
+      expect(readFileSync(report, "utf8")).toBe("new\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/test/live-e2e-smoke.mjs
+++ b/scripts/test/live-e2e-smoke.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const claudeCommand = process.env.OPENTAG_CLAUDE_COMMAND || "claude";
+const openclawCommand = process.env.OPENTAG_OPENCLAW_COMMAND || "openclaw";
 const githubWebhookExecutor = process.env.OPENTAG_GH_LIVE_EXECUTOR || "claude-code";
 
 const cases = [
@@ -22,6 +23,19 @@ const cases = [
     live: false,
     command: "corepack pnpm smoke:slack-protocol",
     requiredCommands: ["corepack"]
+  },
+  {
+    id: "openclaw-acp",
+    label: "Live OpenClaw Gateway ACP conformance",
+    live: true,
+    command: "corepack pnpm smoke:openclaw-acp-conformance",
+    requiredCommands: ["corepack", "git", openclawCommand],
+    notes: [
+      "Requires OpenClaw 2026.7.1 and a running Gateway for OPENTAG_OPENCLAW_PROFILE (default: opentag-conformance).",
+      "Uses real model and file tools in temporary worktree and scratch fixtures, then exercises live cancellation.",
+      "Stock 2026.7.1 currently fails closed because its cancelled shell can still reach the completion marker.",
+      "The profile owns Gateway authentication; never put its token in the integration manifest."
+    ]
   },
   {
     id: "github-webhook-live",

--- a/scripts/test/openclaw-acp-conformance.ts
+++ b/scripts/test/openclaw-acp-conformance.ts
@@ -1,0 +1,457 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createAcpExecutor, type ExecutorEventSink, type ExecutorRunInput } from "../../packages/runner/src/index.js";
+
+const expectedVersion = process.env.OPENTAG_OPENCLAW_EXPECTED_VERSION?.trim() || "2026.7.1";
+const openclawCommand = process.env.OPENTAG_OPENCLAW_COMMAND?.trim() || "openclaw";
+const profile = process.env.OPENTAG_OPENCLAW_PROFILE?.trim() || "opentag-conformance";
+const gatewayUrl = process.env.OPENTAG_OPENCLAW_GATEWAY_URL?.trim();
+const reportPath = process.env.OPENTAG_OPENCLAW_CONFORMANCE_REPORT?.trim();
+const keepFixtures = process.env.OPENTAG_OPENCLAW_KEEP_FIXTURES === "true";
+const runTimeoutMs = Number(process.env.OPENTAG_OPENCLAW_RUN_TIMEOUT_MS || 180_000);
+const cancelToolTimeoutMs = Number(process.env.OPENTAG_OPENCLAW_CANCEL_TOOL_TIMEOUT_MS || 120_000);
+const cancelSleepSeconds = 15;
+const scriptPath = fileURLToPath(import.meta.url);
+const repositoryRoot = resolve(dirname(scriptPath), "../..");
+
+type CaseResult = {
+  id: "worktree-cwd" | "scratch-cwd-session-isolation" | "cancel";
+  status: "passed" | "failed";
+  durationMs: number;
+  error?: string;
+};
+
+type Marker = {
+  nonce: string;
+  pwd: string;
+};
+
+export type GatewaySession = {
+  key: string;
+  status?: string;
+  hasActiveRun?: boolean;
+  abortedLastRun?: boolean;
+};
+
+const results: CaseResult[] = [];
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) fail(message);
+}
+
+function safeDiagnostic(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return detail.replaceAll(homedir(), "~").replace(/\/var\/folders\/[^\s'"]+/gu, "<temp-path>");
+}
+
+export function parseOpenClawVersion(output: string): string | undefined {
+  return /^OpenClaw\s+([^\s]+)/u.exec(output.trim())?.[1];
+}
+
+export function newGatewaySessions(
+  previous: Map<string, GatewaySession>,
+  current: Map<string, GatewaySession>
+): GatewaySession[] {
+  return [...current.values()].filter((session) => !previous.has(session.key));
+}
+
+export function resolveConformanceReportPath(path: string): string {
+  return resolve(repositoryRoot, path);
+}
+
+function run(command: string, args: string[], cwd?: string): string {
+  return execFileSync(command, args, {
+    ...(cwd ? { cwd } : {}),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function git(cwd: string, args: string[]): string {
+  return run("git", args, cwd);
+}
+
+function initRepository(path: string): void {
+  mkdirSync(path, { recursive: true });
+  git(path, ["init", "-b", "main"]);
+  git(path, ["config", "user.email", "opentag@example.test"]);
+  git(path, ["config", "user.name", "OpenTag Conformance"]);
+  writeFileSync(join(path, "README.md"), "# OpenClaw ACP conformance fixture\n");
+  git(path, ["add", "README.md"]);
+  git(path, ["commit", "-m", "Initialize conformance fixture"]);
+}
+
+function openClawArgs(...args: string[]): string[] {
+  return ["--profile", profile, ...args];
+}
+
+function gatewayTargetArgs(): string[] {
+  return gatewayUrl ? ["--url", gatewayUrl] : [];
+}
+
+function discoverDefaultWorkspace(): string {
+  const configured = process.env.OPENTAG_OPENCLAW_DEFAULT_WORKSPACE?.trim();
+  const workspace = configured || run(openclawCommand, openClawArgs("config", "get", "agents.defaults.workspace"));
+  assert(isAbsolute(workspace), `OpenClaw default workspace must be absolute, received '${workspace}'.`);
+  return realpathSync(workspace);
+}
+
+function assertGatewayReady(): void {
+  const status = JSON.parse(
+    run(openclawCommand, openClawArgs("gateway", "status", "--json", ...gatewayTargetArgs()))
+  ) as {
+    gateway?: { version?: string };
+    rpc?: { ok?: boolean; version?: string; server?: { version?: string } };
+  };
+  assert(status.rpc?.ok === true, `OpenClaw Gateway RPC is not ready for profile '${profile}'.`);
+  const version = status.rpc.server?.version || status.rpc.version || status.gateway?.version;
+  assert(version === expectedVersion, `Expected Gateway ${expectedVersion}, received '${version || "unknown"}'.`);
+}
+
+function gatewaySessions(): Map<string, GatewaySession> {
+  const result = JSON.parse(
+    run(
+      openclawCommand,
+      openClawArgs(
+        "gateway",
+        "call",
+        "sessions.list",
+        "--json",
+        "--params",
+        JSON.stringify({ limit: 100, includeDerivedTitles: false }),
+        ...gatewayTargetArgs()
+      )
+    )
+  ) as { sessions?: GatewaySession[] };
+  assert(Array.isArray(result.sessions), "OpenClaw Gateway sessions.list did not return a sessions array.");
+  return new Map(result.sessions.map((session) => [session.key, session]));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+async function waitForNewGatewaySession(
+  previous: Map<string, GatewaySession>,
+  caseId: CaseResult["id"]
+): Promise<{ current: Map<string, GatewaySession>; session: GatewaySession }> {
+  const deadline = Date.now() + 10_000;
+  do {
+    const current = gatewaySessions();
+    const added = newGatewaySessions(previous, current);
+    assert(added.length <= 1, `${caseId} created ${added.length} Gateway sessions; expected exactly one disposable session.`);
+    if (added.length === 1) {
+      const session = added[0]!;
+      assert(session.key.includes(":acp-bridge:"), `${caseId} did not create an isolated acp-bridge Gateway session.`);
+      assert(session.hasActiveRun === false, `${caseId} left Gateway session '${session.key}' active.`);
+      return { current, session };
+    }
+    await delay(250);
+  } while (Date.now() < deadline);
+  return fail(`${caseId} did not create a new observable Gateway session.`);
+}
+
+async function waitForPath(path: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    if (existsSync(path)) return;
+    await delay(100);
+  } while (Date.now() < deadline);
+  fail(`Timed out waiting for real tool marker ${path}.`);
+}
+
+function manifest() {
+  return {
+    protocol: "opentag.integration.v1" as const,
+    id: "openclaw-acp",
+    label: "OpenClaw ACP",
+    bindings: {
+      agent: {
+        kind: "stdio" as const,
+        command: openclawCommand,
+        args: openClawArgs("acp", ...gatewayTargetArgs())
+      }
+    },
+    roles: {
+      agent: {
+        protocol: "agent-client-protocol" as const,
+        protocolVersion: 1 as const,
+        binding: "agent",
+        workspace: { sessionCwd: "required" as const }
+      }
+    },
+    resources: {}
+  };
+}
+
+function input(runId: string, workspace: ExecutorRunInput["workspace"], rawText: string): ExecutorRunInput {
+  return {
+    runId,
+    workspace,
+    command: { rawText, intent: "run", args: {} },
+    context: [],
+    baseBranch: "main"
+  };
+}
+
+function parseMarker(path: string): Marker {
+  assert(existsSync(path), `Expected the real agent tool to create ${path}.`);
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<Marker>;
+  assert(typeof parsed.nonce === "string", `Marker ${path} is missing a string nonce.`);
+  assert(typeof parsed.pwd === "string", `Marker ${path} is missing a string pwd.`);
+  return parsed as Marker;
+}
+
+function assertMarker(marker: Marker, expectedNonce: string, expectedCwd: string): void {
+  assert(marker.nonce === expectedNonce, `Marker nonce mismatch: expected '${expectedNonce}', received '${marker.nonce}'.`);
+  assert(realpathSync(marker.pwd) === realpathSync(expectedCwd), `Agent tool used '${marker.pwd}' instead of '${expectedCwd}'.`);
+}
+
+function progressSink(onMessage?: (message: string) => void): ExecutorEventSink {
+  return {
+    async emit(event) {
+      process.stdout.write(`[${event.type}] ${event.message}\n`);
+      onMessage?.(event.message);
+    }
+  };
+}
+
+async function boundedRun(
+  executor: ReturnType<typeof createAcpExecutor>,
+  runInput: ExecutorRunInput,
+  sink: ExecutorEventSink
+) {
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    void executor.cancel(runInput.runId, runInput.attemptId).catch(() => undefined);
+  }, runTimeoutMs);
+  try {
+    const result = await executor.run(runInput, sink);
+    assert(!timedOut, `OpenClaw ACP run '${runInput.runId}' exceeded ${runTimeoutMs}ms.`);
+    return result;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runCase<T extends CaseResult["id"]>(id: T, test: () => Promise<void>): Promise<void> {
+  const startedAt = Date.now();
+  process.stdout.write(`\n== ${id} ==\n`);
+  try {
+    await test();
+    const result: CaseResult = { id, status: "passed", durationMs: Date.now() - startedAt };
+    results.push(result);
+    process.stdout.write(`PASS ${id} (${result.durationMs}ms)\n`);
+  } catch (error) {
+    results.push({ id, status: "failed", durationMs: Date.now() - startedAt, error: safeDiagnostic(error) });
+    throw error;
+  }
+}
+
+function writeReport(ok: boolean, error?: string): void {
+  if (!reportPath) return;
+  const absolute = resolveConformanceReportPath(reportPath);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(
+    absolute,
+    `${JSON.stringify(
+      {
+        ok,
+        openclawVersion: expectedVersion,
+        profile,
+        gateway: gatewayUrl ? "explicit-target" : "profile-target",
+        results,
+        ...(error ? { error } : {})
+      },
+      null,
+      2
+    )}\n`,
+    { mode: 0o600 }
+  );
+}
+
+async function main(): Promise<void> {
+  results.length = 0;
+  assert(Number.isFinite(runTimeoutMs) && runTimeoutMs > 0, "OPENTAG_OPENCLAW_RUN_TIMEOUT_MS must be positive.");
+  assert(
+    Number.isFinite(cancelToolTimeoutMs) && cancelToolTimeoutMs > 0,
+    "OPENTAG_OPENCLAW_CANCEL_TOOL_TIMEOUT_MS must be positive."
+  );
+
+  const versionOutput = run(openclawCommand, ["--version"]);
+  const version = parseOpenClawVersion(versionOutput);
+  assert(version === expectedVersion, `Expected OpenClaw ${expectedVersion}, received '${version || versionOutput}'.`);
+  assertGatewayReady();
+
+  const defaultWorkspace = discoverDefaultWorkspace();
+  const root = mkdtempSync(join(tmpdir(), "opentag-openclaw-conformance-"));
+  const repository = join(root, "repository");
+  const worktreeRoot = join(root, "worktrees");
+  const scratch = join(root, "scratch");
+  const cancelScratch = join(root, "cancel");
+  const nonce = root.split("-").at(-1) || String(Date.now());
+  const worktreeRunId = `openclaw-worktree-${nonce}`;
+  const worktree = join(worktreeRoot, worktreeRunId);
+  const worktreeMarkerName = `opentag-openclaw-worktree-${nonce}.json`;
+  const scratchMarkerName = `opentag-openclaw-scratch-${nonce}.json`;
+  const cancelStartedMarkerName = `opentag-openclaw-cancel-started-${nonce}`;
+  const cancelCompletedMarkerName = `opentag-openclaw-cancel-completed-${nonce}`;
+  const defaultMarker = (name: string) => join(defaultWorkspace, name);
+  const defaultMarkers = [
+    worktreeMarkerName,
+    scratchMarkerName,
+    cancelStartedMarkerName,
+    cancelCompletedMarkerName
+  ].map(defaultMarker);
+  let previousGatewaySessions = gatewaySessions();
+
+  initRepository(repository);
+  mkdirSync(scratch, { recursive: true });
+  mkdirSync(cancelScratch, { recursive: true });
+  for (const marker of defaultMarkers) assert(!existsSync(marker), `Refusing to overwrite pre-existing marker ${marker}.`);
+
+  try {
+    await runCase("worktree-cwd", async () => {
+      const executor = createAcpExecutor({ manifest: manifest(), cancelGraceMs: 3_000 });
+      const prompt = [
+        `Use real shell and file-writing tools to create ${worktreeMarkerName} in the current working directory.`,
+        `Write one-line valid JSON with exactly these keys: nonce set to '${nonce}', and pwd set to the exact absolute output of pwd.`,
+        "Do not change directories and do not use an absolute destination path.",
+        "Verify the file exists, then reply with exactly OPENTAG_OPENCLAW_WORKTREE_OK."
+      ].join(" ");
+      const runInput = {
+        ...input(worktreeRunId, { kind: "repository", path: repository }, prompt),
+        worktreeRoot,
+        keepWorktree: "always" as const
+      };
+      const result = await boundedRun(executor, runInput, progressSink());
+
+      assert(result.conclusion === "success", `Worktree run concluded '${result.conclusion}'.`);
+      assertMarker(parseMarker(join(worktree, worktreeMarkerName)), nonce, worktree);
+      assert(!existsSync(join(repository, worktreeMarkerName)), "Worktree marker leaked into the source checkout.");
+      assert(git(repository, ["status", "--short"]) === "", "Source checkout changed during the worktree run.");
+      assert(
+        git(repository, ["show", `opentag/${worktreeRunId}:${worktreeMarkerName}`]).includes(nonce),
+        "OpenTag did not commit the worktree marker on the isolated run branch."
+      );
+      assert(
+        !existsSync(defaultMarker(worktreeMarkerName)),
+        "OpenClaw wrote the worktree marker into its configured default workspace."
+      );
+      const observed = await waitForNewGatewaySession(previousGatewaySessions, "worktree-cwd");
+      assert(
+        observed.session.status === "done",
+        `Worktree Gateway session stopped with '${observed.session.status || "unknown"}'.`
+      );
+      previousGatewaySessions = observed.current;
+    });
+
+    await runCase("scratch-cwd-session-isolation", async () => {
+      const executor = createAcpExecutor({ manifest: manifest(), cancelGraceMs: 3_000 });
+      const prompt = [
+        `Use real shell and file-writing tools to create ${scratchMarkerName} in the current working directory.`,
+        `Write one-line valid JSON with exactly these keys: nonce set to '${nonce}-scratch', and pwd set to the exact absolute output of pwd.`,
+        "Do not change directories and do not use an absolute destination path.",
+        "Verify the file exists, then reply with exactly OPENTAG_OPENCLAW_SCRATCH_OK."
+      ].join(" ");
+      const result = await boundedRun(
+        executor,
+        input(`openclaw-scratch-${nonce}`, { kind: "scratch", path: scratch }, prompt),
+        progressSink()
+      );
+      const marker = parseMarker(join(scratch, scratchMarkerName));
+
+      assert(result.conclusion === "success", `Scratch run concluded '${result.conclusion}'.`);
+      assertMarker(marker, `${nonce}-scratch`, scratch);
+      assert(
+        !existsSync(defaultMarker(scratchMarkerName)),
+        "OpenClaw wrote the scratch marker into its configured default workspace."
+      );
+      const observed = await waitForNewGatewaySession(previousGatewaySessions, "scratch-cwd-session-isolation");
+      assert(
+        observed.session.status === "done",
+        `Scratch Gateway session stopped with '${observed.session.status || "unknown"}'.`
+      );
+      previousGatewaySessions = observed.current;
+    });
+
+    await runCase("cancel", async () => {
+      const executor = createAcpExecutor({ manifest: manifest(), cancelGraceMs: 3_000 });
+      const prompt = [
+        "Immediately use a real shell tool in the current working directory to run exactly this command:",
+        `touch ${cancelStartedMarkerName} && sleep ${cancelSleepSeconds} && touch ${cancelCompletedMarkerName}`,
+        "Do not change directories and do not run the command in the background."
+      ].join(" ");
+      const runId = `openclaw-cancel-${nonce}`;
+      const running = executor.run(input(runId, { kind: "scratch", path: cancelScratch }, prompt), progressSink());
+      await waitForPath(join(cancelScratch, cancelStartedMarkerName), cancelToolTimeoutMs);
+      await executor.cancel(runId);
+      const result = await running;
+
+      assert(result.conclusion === "cancelled", `Cancelled run concluded '${result.conclusion}'.`);
+      const observed = await waitForNewGatewaySession(previousGatewaySessions, "cancel");
+      assert(
+        observed.session.status === "killed",
+        `Cancelled Gateway session stopped with '${observed.session.status || "unknown"}'.`
+      );
+      assert(observed.session.abortedLastRun === true, "Cancelled Gateway session did not record an aborted run.");
+      previousGatewaySessions = observed.current;
+      await delay((cancelSleepSeconds + 2) * 1_000);
+      assert(
+        !existsSync(join(cancelScratch, cancelCompletedMarkerName)),
+        "Cancelled OpenClaw tool continued through its completion marker."
+      );
+      assert(
+        !existsSync(defaultMarker(cancelStartedMarkerName)),
+        "Cancelled OpenClaw run started in its configured default workspace."
+      );
+      assert(
+        !existsSync(defaultMarker(cancelCompletedMarkerName)),
+        "Cancelled OpenClaw run completed in its configured default workspace."
+      );
+    });
+
+    writeReport(true);
+    process.stdout.write(`\nOpenClaw ACP conformance passed ${results.length}/${results.length} cases.\n`);
+  } finally {
+    for (const marker of defaultMarkers) rmSync(marker, { force: true });
+    if (!keepFixtures) {
+      if (existsSync(worktree)) {
+        try {
+          git(repository, ["worktree", "remove", "--force", worktree]);
+        } catch {
+          // The temporary root removal below is still bounded to this fixture.
+        }
+      }
+      rmSync(root, { recursive: true, force: true });
+    } else {
+      process.stdout.write(`Fixtures retained under ${root}\n`);
+    }
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  main().catch((error) => {
+    const redacted = safeDiagnostic(error);
+    writeReport(false, redacted);
+    process.stderr.write(`OpenClaw ACP conformance failed: ${redacted}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test/openclaw-acp-conformance.ts
+++ b/scripts/test/openclaw-acp-conformance.ts
@@ -61,7 +61,7 @@ function safeDiagnostic(error: unknown): string {
 }
 
 export function parseOpenClawVersion(output: string): string | undefined {
-  return /^OpenClaw\s+([^\s]+)/u.exec(output.trim())?.[1];
+  return /^OpenClaw\s+([^\s]+)/mu.exec(output.trim())?.[1];
 }
 
 export function newGatewaySessions(
@@ -73,6 +73,15 @@ export function newGatewaySessions(
 
 export function resolveConformanceReportPath(path: string): string {
   return resolve(repositoryRoot, path);
+}
+
+export function resolveDefaultWorkspacePath(workspace: string): string {
+  try {
+    return realpathSync(workspace);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return resolve(workspace);
+    throw error;
+  }
 }
 
 function run(command: string, args: string[], cwd?: string): string {
@@ -109,7 +118,7 @@ function discoverDefaultWorkspace(): string {
   const configured = process.env.OPENTAG_OPENCLAW_DEFAULT_WORKSPACE?.trim();
   const workspace = configured || run(openclawCommand, openClawArgs("config", "get", "agents.defaults.workspace"));
   assert(isAbsolute(workspace), `OpenClaw default workspace must be absolute, received '${workspace}'.`);
-  return realpathSync(workspace);
+  return resolveDefaultWorkspacePath(workspace);
 }
 
 function assertGatewayReady(): void {
@@ -320,14 +329,16 @@ async function main(): Promise<void> {
     cancelStartedMarkerName,
     cancelCompletedMarkerName
   ].map(defaultMarker);
-  let previousGatewaySessions = gatewaySessions();
-
-  initRepository(repository);
-  mkdirSync(scratch, { recursive: true });
-  mkdirSync(cancelScratch, { recursive: true });
-  for (const marker of defaultMarkers) assert(!existsSync(marker), `Refusing to overwrite pre-existing marker ${marker}.`);
-
   try {
+    let previousGatewaySessions = gatewaySessions();
+
+    initRepository(repository);
+    mkdirSync(scratch, { recursive: true });
+    mkdirSync(cancelScratch, { recursive: true });
+    for (const marker of defaultMarkers) {
+      assert(!existsSync(marker), `Refusing to overwrite pre-existing marker ${marker}.`);
+    }
+
     await runCase("worktree-cwd", async () => {
       const executor = createAcpExecutor({ manifest: manifest(), cancelGraceMs: 3_000 });
       const prompt = [

--- a/scripts/test/openclaw-acp-conformance.ts
+++ b/scripts/test/openclaw-acp-conformance.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import {
+  closeSync,
   existsSync,
+  fchmodSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -22,6 +25,7 @@ const reportPath = process.env.OPENTAG_OPENCLAW_CONFORMANCE_REPORT?.trim();
 const keepFixtures = process.env.OPENTAG_OPENCLAW_KEEP_FIXTURES === "true";
 const runTimeoutMs = Number(process.env.OPENTAG_OPENCLAW_RUN_TIMEOUT_MS || 180_000);
 const cancelToolTimeoutMs = Number(process.env.OPENTAG_OPENCLAW_CANCEL_TOOL_TIMEOUT_MS || 120_000);
+const commandTimeoutMs = 15_000;
 const cancelSleepSeconds = 15;
 const scriptPath = fileURLToPath(import.meta.url);
 const repositoryRoot = resolve(dirname(scriptPath), "../..");
@@ -84,12 +88,18 @@ export function resolveDefaultWorkspacePath(workspace: string): string {
   }
 }
 
-function run(command: string, args: string[], cwd?: string): string {
+export function runBoundedCommand(command: string, args: string[], timeoutMs: number, cwd?: string): string {
   return execFileSync(command, args, {
     ...(cwd ? { cwd } : {}),
     encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+    killSignal: "SIGKILL"
   }).trim();
+}
+
+function run(command: string, args: string[], cwd?: string): string {
+  return runBoundedCommand(command, args, commandTimeoutMs, cwd);
 }
 
 function git(cwd: string, args: string[]): string {
@@ -227,6 +237,13 @@ function parseMarker(path: string): Marker {
   return parsed as Marker;
 }
 
+export function defaultMarkersSafeToClean(markers: string[]): Set<string> {
+  for (const marker of markers) {
+    assert(!existsSync(marker), `Refusing to overwrite pre-existing marker ${marker}.`);
+  }
+  return new Set(markers);
+}
+
 function assertMarker(marker: Marker, expectedNonce: string, expectedCwd: string): void {
   assert(marker.nonce === expectedNonce, `Marker nonce mismatch: expected '${expectedNonce}', received '${marker.nonce}'.`);
   assert(realpathSync(marker.pwd) === realpathSync(expectedCwd), `Agent tool used '${marker.pwd}' instead of '${expectedCwd}'.`);
@@ -274,11 +291,21 @@ async function runCase<T extends CaseResult["id"]>(id: T, test: () => Promise<vo
   }
 }
 
+export function writePrivateReport(path: string, content: string): void {
+  const descriptor = openSync(path, "w", 0o600);
+  try {
+    fchmodSync(descriptor, 0o600);
+    writeFileSync(descriptor, content);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
 function writeReport(ok: boolean, error?: string): void {
   if (!reportPath) return;
   const absolute = resolveConformanceReportPath(reportPath);
   mkdirSync(dirname(absolute), { recursive: true });
-  writeFileSync(
+  writePrivateReport(
     absolute,
     `${JSON.stringify(
       {
@@ -291,8 +318,7 @@ function writeReport(ok: boolean, error?: string): void {
       },
       null,
       2
-    )}\n`,
-    { mode: 0o600 }
+    )}\n`
   );
 }
 
@@ -329,15 +355,14 @@ async function main(): Promise<void> {
     cancelStartedMarkerName,
     cancelCompletedMarkerName
   ].map(defaultMarker);
+  let defaultMarkersToClean = new Set<string>();
   try {
     let previousGatewaySessions = gatewaySessions();
 
     initRepository(repository);
     mkdirSync(scratch, { recursive: true });
     mkdirSync(cancelScratch, { recursive: true });
-    for (const marker of defaultMarkers) {
-      assert(!existsSync(marker), `Refusing to overwrite pre-existing marker ${marker}.`);
-    }
+    defaultMarkersToClean = defaultMarkersSafeToClean(defaultMarkers);
 
     await runCase("worktree-cwd", async () => {
       const executor = createAcpExecutor({ manifest: manifest(), cancelGraceMs: 3_000 });
@@ -412,37 +437,55 @@ async function main(): Promise<void> {
       ].join(" ");
       const runId = `openclaw-cancel-${nonce}`;
       const running = executor.run(input(runId, { kind: "scratch", path: cancelScratch }, prompt), progressSink());
-      await waitForPath(join(cancelScratch, cancelStartedMarkerName), cancelToolTimeoutMs);
-      await executor.cancel(runId);
-      const result = await running;
+      let runSettled = false;
+      try {
+        const observation = await Promise.race([
+          waitForPath(join(cancelScratch, cancelStartedMarkerName), cancelToolTimeoutMs).then(
+            () => ({ kind: "started" }) as const
+          ),
+          running.then((result) => ({ kind: "completed", result }) as const)
+        ]);
+        assert(
+          observation.kind === "started",
+          `OpenClaw cancellation run concluded '${observation.result.conclusion}' before its shell start marker appeared.`
+        );
+        await executor.cancel(runId);
+        const result = await running;
+        runSettled = true;
 
-      assert(result.conclusion === "cancelled", `Cancelled run concluded '${result.conclusion}'.`);
-      const observed = await waitForNewGatewaySession(previousGatewaySessions, "cancel");
-      assert(
-        observed.session.status === "killed",
-        `Cancelled Gateway session stopped with '${observed.session.status || "unknown"}'.`
-      );
-      assert(observed.session.abortedLastRun === true, "Cancelled Gateway session did not record an aborted run.");
-      previousGatewaySessions = observed.current;
-      await delay((cancelSleepSeconds + 2) * 1_000);
-      assert(
-        !existsSync(join(cancelScratch, cancelCompletedMarkerName)),
-        "Cancelled OpenClaw tool continued through its completion marker."
-      );
-      assert(
-        !existsSync(defaultMarker(cancelStartedMarkerName)),
-        "Cancelled OpenClaw run started in its configured default workspace."
-      );
-      assert(
-        !existsSync(defaultMarker(cancelCompletedMarkerName)),
-        "Cancelled OpenClaw run completed in its configured default workspace."
-      );
+        assert(result.conclusion === "cancelled", `Cancelled run concluded '${result.conclusion}'.`);
+        const observed = await waitForNewGatewaySession(previousGatewaySessions, "cancel");
+        assert(
+          observed.session.status === "killed",
+          `Cancelled Gateway session stopped with '${observed.session.status || "unknown"}'.`
+        );
+        assert(observed.session.abortedLastRun === true, "Cancelled Gateway session did not record an aborted run.");
+        previousGatewaySessions = observed.current;
+        await delay((cancelSleepSeconds + 2) * 1_000);
+        assert(
+          !existsSync(join(cancelScratch, cancelCompletedMarkerName)),
+          "Cancelled OpenClaw tool continued through its completion marker."
+        );
+        assert(
+          !existsSync(defaultMarker(cancelStartedMarkerName)),
+          "Cancelled OpenClaw run started in its configured default workspace."
+        );
+        assert(
+          !existsSync(defaultMarker(cancelCompletedMarkerName)),
+          "Cancelled OpenClaw run completed in its configured default workspace."
+        );
+      } finally {
+        if (!runSettled) {
+          await executor.cancel(runId).catch(() => undefined);
+          await running.catch(() => undefined);
+        }
+      }
     });
 
     writeReport(true);
     process.stdout.write(`\nOpenClaw ACP conformance passed ${results.length}/${results.length} cases.\n`);
   } finally {
-    for (const marker of defaultMarkers) rmSync(marker, { force: true });
+    for (const marker of defaultMarkersToClean) rmSync(marker, { force: true });
     if (!keepFixtures) {
       if (existsSync(worktree)) {
         try {


### PR DESCRIPTION
## Summary

- add an opt-in `openclaw-acp` live case that runs OpenClaw 2026.7.1 through the existing Generic ACP Host
- bind the gate to the exact CLI version and actual Gateway target, then verify real worktree cwd, scratch cwd, and distinct disposable `acp-bridge` session keys
- harden cancellation with a real shell started/completed canary and write a sanitized mode-0600 JSON evidence report
- land the reusable fail-closed admission gate without publishing an OpenClaw manifest or adding a dedicated executor

## Merge scope

This PR is complete independently of the current OpenClaw provider result. The recorded `ok:false` report is evidence produced by the gate, not a merge blocker for the gate itself.

Merging this PR does **not** claim that OpenClaw is supported or conformant. The live case is opt-in, the default CI and normal runtime path remain green, and no OpenClaw manifest or dedicated executor is included.

## Recorded provider state

Two real stock OpenClaw 2026.7.1 + Gateway runs produced the same result:

- worktree cwd: passed
- scratch cwd and distinct Gateway session: passed
- cancellation: failed

OpenTag returns `cancelled`, and the Gateway session records `killed` with `abortedLastRun=true`, but the in-flight shell still reaches its completion marker after cancellation. The gate therefore fails closed and does not publish `workspace.sessionCwd` attestation material.

The upstream cancellation fix is tracked in [openclaw/openclaw#107721](https://github.com/openclaw/openclaw/pull/107721). That upstream PR blocks OpenClaw admission and manifest publication; it does not block merging this conformance gate.

## Verification

- targeted OpenClaw conformance harness tests (8/8)
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm test` (120 files, 1539 tests)
- `corepack pnpm build`
- `corepack pnpm smoke:governance -- --all` (7/7 cases)
- `corepack pnpm smoke:privacy`
- `corepack pnpm release:publication-set`
- two real OpenClaw 2026.7.1 + Gateway runs; both recorded the cancellation failure as `ok:false`

## Follow-up activation

After an upstream fix is released:

1. rerun this gate against the released OpenClaw version;
2. require all workspace, session-isolation, and cancellation cases to pass;
3. add an OpenClaw manifest in a small follow-up PR with the new live evidence.

Related: #93


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenClaw ACP conformance checks (workspace isolation, working-directory correctness, isolated sessions, and “fail closed” cancellation behavior).
  * Added an OpenClaw ACP live E2E smoke harness case with configurable OpenClaw command and gateway setup.
  * Added a new smoke command for running the OpenClaw ACP conformance gate.

* **Documentation**
  * Documented OpenClaw-specific gate status for OpenClaw 2026.7.1, including current cancellation constraints and evidence/report guidance.

* **Tests**
  * Introduced a dedicated test suite for the OpenClaw ACP conformance harness, including version parsing, bounded command handling, and safe report/marker handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->