### PR TITLE
AMP-153 Slack: query unfinished Linear issues via /linear

### DIFF
--- a/apps/slack-events/test/app.test.ts
+++ b/apps/slack-events/test/app.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { computeSlackSignature, createSlackEventsApp, verifySlackTimestamp } from "../src/app.js";
 
+// The Events API ingress acks event_callback/block_actions requests with
+// {ok:true} immediately and processes them in a detached background task
+// (see packages/slack/src/ingress.ts). Tests that assert on side effects of
+// that processing (created runs, replies, etc.) need to let the background
+// task run before asserting.
+function flushAsyncEvents(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("Slack events app", () => {
   const now = "2024-06-24T00:00:00.000Z";
   const currentTimestamp = "1719187200";
@@ -141,7 +150,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "status" });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
       channelId: "C123",
@@ -205,7 +215,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind" });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(canManageBinding).toHaveBeenCalledWith({
       action: "bind",
@@ -277,7 +288,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", unauthorized: true });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(bindChannel).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
@@ -334,7 +346,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", usage: true });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(bindChannel).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
@@ -389,7 +402,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", unavailable: true });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
       channelId: "C123",
@@ -445,12 +459,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      ok: true,
-      selfService: "stop",
-      outcome: "cancelled",
-      runId: "run_active"
-    });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(stopRun).toHaveBeenCalledWith({
       teamId: "T123",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -654,6 +654,7 @@ webhook path for hosted Linear OAuth App installs.
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `OPENTAG_LINEAR_API_KEY` / `OPENTAG_LINEAR_TOKEN` | none | Linear OAuth access token or raw `lin_api_...` API key used for callbacks and direct issue apply; OAuth tokens may include or omit the `Bearer ` prefix |
+| `OPENTAG_LINEAR_PROJECT_ID` | none | Linear project id used by the read-only Slack `/linear` backlog command; prefer `platforms.linear.projectId` in the OpenTag config |
 | `OPENTAG_LINEAR_GRAPHQL_URL` | `https://api.linear.app/graphql` | Optional Linear GraphQL endpoint override |
 | `OPENTAG_LINEAR_WEBHOOK_SECRET` | none | Enables dispatcher-mounted Linear webhook ingress and verifies `Linear-Signature` |
 | `OPENTAG_LINEAR_WEBHOOK_PATH` | `/linear/webhooks` | Public Linear webhook path |
@@ -836,6 +837,16 @@ before the daemon can claim and execute runs for it. Binding changes require
 the sender's Slack user id to be listed in
 `OPENTAG_SLACK_BINDING_ADMIN_USER_IDS`, or the channel binding must be updated
 from local config or the dispatcher API.
+
+Slack source-thread queries can also list the configured Linear project's
+unfinished issues with `/linear` (or the bare mention `@OpenTag linear`). The
+command is deterministic and read-only: it does not create an Agent Run, does
+not modify Linear, and replies in the original thread with issue identifiers,
+titles, states, the query timestamp, and an explicit truncation notice above
+20 results. Configure `platforms.linear.token` and `platforms.linear.projectId`
+(or the `OPENTAG_LINEAR_API_KEY` / `OPENTAG_LINEAR_PROJECT_ID` environment
+fallback). A query-only Linear config needs no `webhookSecret`; the Linear
+webhook ingress is only mounted when `webhookSecret` is present.
 
 ## Lark Ingress Environment
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -330,6 +330,7 @@ const LinearPlatformSchema = z
     webhookSecret: SecretStringSchema.optional(),
     teamId: z.string().min(1).optional(),
     teamKey: z.string().min(1).optional(),
+    projectId: z.string().min(1).optional(),
     graphqlUrl: z.string().url().optional(),
     webhookPath: z.string().min(1).optional(),
     port: OptionalPortSchema,
@@ -353,11 +354,12 @@ const LinearPlatformSchema = z
         message: "Linear token is required unless auth.method is hosted_oauth_app."
       });
     }
-    if (!value.webhookSecret) {
+    if (!value.webhookSecret && !value.projectId) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["webhookSecret"],
-        message: "Linear webhookSecret is required unless auth.method is hosted_oauth_app."
+        message:
+          "Linear webhookSecret is required unless auth.method is hosted_oauth_app or the config is query-only (projectId set)."
       });
     }
   });

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -71,7 +71,10 @@ export function createSlackLinearBacklogHandler(input: {
         fetchImpl: input.fetchImpl ?? fetch,
         timeoutMs: SLACK_LINEAR_BACKLOG_TIMEOUT_MS
       });
-      return renderSlackLinearBacklogReply({ backlog, limit: SLACK_LINEAR_BACKLOG_LIMIT, queriedAt: now() });
+      return {
+        text: renderSlackLinearBacklogReply({ backlog, limit: SLACK_LINEAR_BACKLOG_LIMIT, queriedAt: now() }),
+        textFormat: "mrkdwn" as const
+      };
     } catch (error) {
       // linearGraphql error messages contain the HTTP status and GraphQL error
       // text only — never the token — so the message is safe for local logs.

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -10,7 +10,7 @@ const NOT_CONFIGURED_TEXT =
 const UNAVAILABLE_TEXT = "Linear API is unavailable right now; try again later.";
 
 export function resolveSlackLinearBacklogSettings(input: {
-  linear?: { token?: string; projectId?: string; graphqlUrl?: string } | undefined;
+  linear?: { token?: string | undefined; projectId?: string | undefined; graphqlUrl?: string | undefined } | undefined;
   env?: NodeJS.ProcessEnv;
 }): { token: string; projectId: string; graphqlUrl?: string } | null {
   const env = input.env ?? {};

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -1,5 +1,5 @@
 import { fetchLinearProjectBacklog, type LinearProjectBacklog } from "@opentag/linear";
-import type { SlackEventProcessorInput } from "@opentag/slack";
+import { escapeSlackText, type SlackEventProcessorInput } from "@opentag/slack";
 import type { OpenTagCliConfig } from "./config.js";
 
 export const SLACK_LINEAR_BACKLOG_LIMIT = 20;
@@ -40,7 +40,7 @@ export function renderSlackLinearBacklogReply(input: {
     lines.push("No unfinished issues in the configured Linear project.");
   }
   for (const issue of shown) {
-    lines.push(`• <${issue.url}|${issue.identifier}> — ${issue.title}  [${issue.stateName}]`);
+    lines.push(`• <${issue.url}|${issue.identifier}> — ${escapeSlackText(issue.title)}  [${escapeSlackText(issue.stateName)}]`);
   }
   if (input.backlog.issues.length > shown.length || input.backlog.hasMore) {
     lines.push(`Showing ${shown.length} of ${totalLabel} open issues.`);

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -1,4 +1,4 @@
-import { fetchLinearProjectBacklog, type LinearProjectBacklog } from "@opentag/linear";
+import { fetchLinearProjectBacklog, type LinearBacklogIssue, type LinearProjectBacklog } from "@opentag/linear";
 import { escapeSlackText, type SlackEventProcessorInput } from "@opentag/slack";
 import type { OpenTagCliConfig } from "./config.js";
 
@@ -8,6 +8,15 @@ export const SLACK_LINEAR_BACKLOG_TIMEOUT_MS = 10_000;
 const NOT_CONFIGURED_TEXT =
   "Linear backlog is not configured. Set platforms.linear.projectId and a Linear token in the OpenTag config, or export OPENTAG_LINEAR_API_KEY and OPENTAG_LINEAR_PROJECT_ID.";
 const UNAVAILABLE_TEXT = "Linear API is unavailable right now; try again later.";
+
+// Emoji shown before each state-type group heading; anything not in this map
+// (unknown/future Linear state types) falls back to a neutral marker.
+const STATE_TYPE_EMOJI: Record<string, string> = {
+  started: "🔵",
+  unstarted: "⚪",
+  backlog: "⚫",
+  triage: "🟣"
+};
 
 export function resolveSlackLinearBacklogSettings(input: {
   linear?: { token?: string | undefined; projectId?: string | undefined; graphqlUrl?: string | undefined } | undefined;
@@ -21,10 +30,34 @@ export function resolveSlackLinearBacklogSettings(input: {
   return { token: token.trim(), projectId: projectId.trim(), ...(graphqlUrl ? { graphqlUrl } : {}) };
 }
 
-// "2026-07-16T21:30:45.123Z" -> "2026-07-16T21:30Z": minute precision keeps the
-// reply short while still time-stamping the data source.
-function formatQueriedAt(iso: string): string {
-  return iso.replace(/:\d{2}\.\d{3}Z$/u, "Z");
+function priorityMarker(priority: number): string {
+  if (priority === 1) return " [urgent]";
+  if (priority === 2) return " [high]";
+  return "";
+}
+
+function renderIssueLine(issue: LinearBacklogIssue): string {
+  const marker = priorityMarker(issue.priority);
+  return `• <${encodeURI(issue.url)}|${escapeSlackText(issue.identifier)}>${marker} ${escapeSlackText(issue.title)}`;
+}
+
+type IssueGroup = { stateName: string; stateType: string; issues: LinearBacklogIssue[] };
+
+// Groups the already-limited "shown" issues by stateName, preserving the
+// order in which each stateName is first encountered in the sorted list.
+function groupShownIssues(shown: LinearBacklogIssue[]): IssueGroup[] {
+  const groups: IssueGroup[] = [];
+  const byStateName = new Map<string, IssueGroup>();
+  for (const issue of shown) {
+    let group = byStateName.get(issue.stateName);
+    if (!group) {
+      group = { stateName: issue.stateName, stateType: issue.stateType, issues: [] };
+      byStateName.set(issue.stateName, group);
+      groups.push(group);
+    }
+    group.issues.push(issue);
+  }
+  return groups;
 }
 
 export function renderSlackLinearBacklogReply(input: {
@@ -32,18 +65,41 @@ export function renderSlackLinearBacklogReply(input: {
   limit: number;
   queriedAt: string;
 }): string {
-  const shown = input.backlog.issues.slice(0, input.limit);
-  const totalLabel = input.backlog.hasMore ? `${input.backlog.fetched}+` : String(input.backlog.fetched);
-  const noun = input.backlog.fetched === 1 && !input.backlog.hasMore ? "open issue" : "open issues";
-  const lines = [`OpenTag project backlog — ${totalLabel} ${noun} (source: Linear, queried ${formatQueriedAt(input.queriedAt)}):`];
-  if (shown.length === 0) {
-    lines.push("No unfinished issues in the configured Linear project.");
+  const { backlog, limit, queriedAt } = input;
+  const shown = backlog.issues.slice(0, limit);
+  const name = escapeSlackText(backlog.projectName ?? "Backlog");
+  const truncated = backlog.fetched > limit || backlog.hasMore;
+  const queriedHhMm = queriedAt.slice(11, 16);
+
+  const lines: string[] = [];
+  if (backlog.fetched === 0) {
+    lines.push(`*${name} · 0 open* 🎉`);
+    lines.push("No unfinished issues in this Linear project.");
+  } else {
+    const totalLabel = backlog.hasMore ? `${backlog.fetched}+` : String(backlog.fetched);
+    const showingSuffix = truncated ? ` · showing ${shown.length}` : "";
+    lines.push(`*${name} · ${totalLabel} open*${showingSuffix}`);
+
+    for (const group of groupShownIssues(shown)) {
+      const totalInGroup = backlog.issues.filter((issue) => issue.stateName === group.stateName).length;
+      const shownInGroup = group.issues.length;
+      const countLabel = shownInGroup < totalInGroup ? `${shownInGroup} of ${totalInGroup}` : String(totalInGroup);
+      const emoji = STATE_TYPE_EMOJI[group.stateType] ?? "▫️";
+      lines.push("");
+      lines.push(`${emoji} *${escapeSlackText(group.stateName)} (${countLabel})*`);
+      for (const issue of group.issues) {
+        lines.push(renderIssueLine(issue));
+      }
+    }
   }
-  for (const issue of shown) {
-    lines.push(`• <${encodeURI(issue.url)}|${issue.identifier}> — ${escapeSlackText(issue.title)}  [${escapeSlackText(issue.stateName)}]`);
-  }
-  if (input.backlog.issues.length > shown.length || input.backlog.hasMore) {
-    lines.push(`Showing ${shown.length} of ${totalLabel} open issues.`);
+
+  lines.push("");
+  if (truncated) {
+    const hiddenCount = backlog.fetched - shown.length;
+    const hiddenLabel = backlog.hasMore ? `${hiddenCount}+` : String(hiddenCount);
+    lines.push(`_Linear · queried ${queriedHhMm} UTC · ${hiddenLabel} more not shown_`);
+  } else {
+    lines.push(`_Linear · queried ${queriedHhMm} UTC_`);
   }
   return lines.join("\n");
 }

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -40,7 +40,7 @@ export function renderSlackLinearBacklogReply(input: {
     lines.push("No unfinished issues in the configured Linear project.");
   }
   for (const issue of shown) {
-    lines.push(`• <${issue.url}|${issue.identifier}> — ${escapeSlackText(issue.title)}  [${escapeSlackText(issue.stateName)}]`);
+    lines.push(`• <${encodeURI(issue.url)}|${issue.identifier}> — ${escapeSlackText(issue.title)}  [${escapeSlackText(issue.stateName)}]`);
   }
   if (input.backlog.issues.length > shown.length || input.backlog.hasMore) {
     lines.push(`Showing ${shown.length} of ${totalLabel} open issues.`);

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -110,6 +110,7 @@ export function createSlackLinearBacklogHandler(input: {
   fetchImpl?: typeof fetch;
   now?: () => string;
   logError?: (message: string) => void;
+  getToken?: () => Promise<string | undefined> | string | undefined;
 }): NonNullable<SlackEventProcessorInput["linear"]> {
   const now = input.now ?? (() => new Date().toISOString());
   const logError = input.logError ?? ((message: string) => console.error(message));
@@ -119,9 +120,11 @@ export function createSlackLinearBacklogHandler(input: {
       env: input.env ?? process.env
     });
     if (!settings) return NOT_CONFIGURED_TEXT;
+    const freshToken = input.getToken ? await input.getToken() : undefined;
+    const token = freshToken?.trim() ? freshToken : settings.token;
     try {
       const backlog = await fetchLinearProjectBacklog({
-        token: settings.token,
+        token,
         projectId: settings.projectId,
         ...(settings.graphqlUrl ? { graphqlUrl: settings.graphqlUrl } : {}),
         fetchImpl: input.fetchImpl ?? fetch,

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -1,0 +1,82 @@
+import { fetchLinearProjectBacklog, type LinearProjectBacklog } from "@opentag/linear";
+import type { SlackEventProcessorInput } from "@opentag/slack";
+import type { OpenTagCliConfig } from "./config.js";
+
+export const SLACK_LINEAR_BACKLOG_LIMIT = 20;
+export const SLACK_LINEAR_BACKLOG_TIMEOUT_MS = 10_000;
+
+const NOT_CONFIGURED_TEXT =
+  "Linear backlog is not configured. Set platforms.linear.projectId and a Linear token in the OpenTag config, or export OPENTAG_LINEAR_API_KEY and OPENTAG_LINEAR_PROJECT_ID.";
+const UNAVAILABLE_TEXT = "Linear API is unavailable right now; try again later.";
+
+export function resolveSlackLinearBacklogSettings(input: {
+  linear?: { token?: string; projectId?: string; graphqlUrl?: string } | undefined;
+  env?: NodeJS.ProcessEnv;
+}): { token: string; projectId: string; graphqlUrl?: string } | null {
+  const env = input.env ?? {};
+  const token = input.linear?.token ?? env.OPENTAG_LINEAR_API_KEY ?? env.OPENTAG_LINEAR_TOKEN;
+  const projectId = input.linear?.projectId ?? env.OPENTAG_LINEAR_PROJECT_ID;
+  if (!token?.trim() || !projectId?.trim()) return null;
+  const graphqlUrl = input.linear?.graphqlUrl ?? env.OPENTAG_LINEAR_GRAPHQL_URL;
+  return { token: token.trim(), projectId: projectId.trim(), ...(graphqlUrl ? { graphqlUrl } : {}) };
+}
+
+// "2026-07-16T21:30:45.123Z" -> "2026-07-16T21:30Z": minute precision keeps the
+// reply short while still time-stamping the data source.
+function formatQueriedAt(iso: string): string {
+  return iso.replace(/:\d{2}\.\d{3}Z$/u, "Z");
+}
+
+export function renderSlackLinearBacklogReply(input: {
+  backlog: LinearProjectBacklog;
+  limit: number;
+  queriedAt: string;
+}): string {
+  const shown = input.backlog.issues.slice(0, input.limit);
+  const totalLabel = input.backlog.hasMore ? `${input.backlog.fetched}+` : String(input.backlog.fetched);
+  const noun = input.backlog.fetched === 1 && !input.backlog.hasMore ? "open issue" : "open issues";
+  const lines = [`OpenTag project backlog — ${totalLabel} ${noun} (source: Linear, queried ${formatQueriedAt(input.queriedAt)}):`];
+  if (shown.length === 0) {
+    lines.push("No unfinished issues in the configured Linear project.");
+  }
+  for (const issue of shown) {
+    lines.push(`• <${issue.url}|${issue.identifier}> — ${issue.title}  [${issue.stateName}]`);
+  }
+  if (input.backlog.issues.length > shown.length || input.backlog.hasMore) {
+    lines.push(`Showing ${shown.length} of ${totalLabel} open issues.`);
+  }
+  return lines.join("\n");
+}
+
+export function createSlackLinearBacklogHandler(input: {
+  linear?: OpenTagCliConfig["platforms"]["linear"];
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  now?: () => string;
+  logError?: (message: string) => void;
+}): NonNullable<SlackEventProcessorInput["linear"]> {
+  const now = input.now ?? (() => new Date().toISOString());
+  const logError = input.logError ?? ((message: string) => console.error(message));
+  return async () => {
+    const settings = resolveSlackLinearBacklogSettings({
+      ...(input.linear ? { linear: input.linear } : {}),
+      env: input.env ?? process.env
+    });
+    if (!settings) return NOT_CONFIGURED_TEXT;
+    try {
+      const backlog = await fetchLinearProjectBacklog({
+        token: settings.token,
+        projectId: settings.projectId,
+        ...(settings.graphqlUrl ? { graphqlUrl: settings.graphqlUrl } : {}),
+        fetchImpl: input.fetchImpl ?? fetch,
+        timeoutMs: SLACK_LINEAR_BACKLOG_TIMEOUT_MS
+      });
+      return renderSlackLinearBacklogReply({ backlog, limit: SLACK_LINEAR_BACKLOG_LIMIT, queriedAt: now() });
+    } catch (error) {
+      // linearGraphql error messages contain the HTTP status and GraphQL error
+      // text only — never the token — so the message is safe for local logs.
+      logError(`[slack] linear backlog query failed: ${error instanceof Error ? error.message : String(error)}`);
+      return UNAVAILABLE_TEXT;
+    }
+  };
+}

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -511,7 +511,7 @@ function slackModeFromCliConfig(config: OpenTagCliConfig): "socket_mode" | "even
 export function slackIngressConfigFromCliConfig(
   config: OpenTagCliConfig,
   input: { env?: NodeJS.ProcessEnv } = {}
-): SlackEventsApiIngressConfig & { linear: ReturnType<typeof createSlackLinearBacklogHandler> } {
+): SlackEventsApiIngressConfig {
   const slack = requireSlackConfig(config);
   if (!slack.signingSecret) {
     throw new Error("Slack Events API mode requires platforms.slack.signingSecret.");

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -168,6 +168,15 @@ function requireLinearConfig(config: OpenTagCliConfig): NonNullable<OpenTagCliCo
   return linear;
 }
 
+// A query-only Linear config (token + projectId, no webhookSecret) powers the
+// read-only Slack /linear backlog command and must not mount webhook ingress.
+function linearIngressEnabled(
+  linear: OpenTagCliConfig["platforms"]["linear"]
+): linear is NonNullable<OpenTagCliConfig["platforms"]["linear"]> {
+  if (!linear) return false;
+  return Boolean(linear.webhookSecret) || linear.auth?.method === "hosted_oauth_app";
+}
+
 function hasStartablePlatform(config: OpenTagCliConfig): boolean {
   return Boolean(
     config.platforms.lark ||
@@ -239,7 +248,7 @@ function localStartPortChecks(config: OpenTagCliConfig): LocalPortCheck[] {
     });
   }
   const linear = config.platforms.linear;
-  if (linear) {
+  if (linearIngressEnabled(linear)) {
     checks.push({
       label: "Linear local webhook",
       port: linear.port ?? DEFAULT_LINEAR_WEBHOOK_PORT,
@@ -1007,7 +1016,7 @@ async function startLocalMode(input: StartFromConfigInput, abortController: Abor
       const handle = dependencies.startGitLabIngress(gitlabIngressConfigFromCliConfig(config));
       ingresses.push({ platform: "gitlab", url: handle.url, webhookPath: handle.webhookPath, handle });
     }
-    if (config.platforms.linear) {
+    if (linearIngressEnabled(config.platforms.linear)) {
       const linearIngressConfig = linearIngressConfigFromCliConfig(config);
       if (linearTokenProvider) {
         linearIngressConfig.getLinearToken = linearTokenProvider;

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -414,7 +414,7 @@ export function dispatcherRuntimeInputFromCliConfig(
         ? { githubApplyToken: config.daemon.githubToken }
         : {}),
     ...(gitlab ? { gitlabToken: gitlab.token, gitlabBaseUrl: gitlab.baseUrl } : {}),
-    ...(linear && linear.token
+    ...(linearIngressEnabled(linear) && linear.token
       ? {
           linearToken: linear.token,
           ...(linear.graphqlUrl ? { linearGraphqlUrl: linear.graphqlUrl } : {}),

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -55,6 +55,7 @@ import { DEFAULT_GITHUB_WEBHOOK_PORT, DEFAULT_GITLAB_WEBHOOK_PORT, DEFAULT_LINEA
 import { teamsLocalWebhookUrl, teamsPublicWebhookUrlPlaceholder } from "./platforms/teams/display.js";
 import { telegramLocalWebhookUrl, telegramPublicWebhookUrlPlaceholder } from "./platforms/telegram/display.js";
 import { assertRelayTransportAllowed, relayTrustWarning } from "./relay-security.js";
+import { createSlackLinearBacklogHandler } from "./slack-linear-backlog.js";
 
 export type StartCommandOptions = {
   config?: string;
@@ -510,7 +511,7 @@ function slackModeFromCliConfig(config: OpenTagCliConfig): "socket_mode" | "even
 export function slackIngressConfigFromCliConfig(
   config: OpenTagCliConfig,
   input: { env?: NodeJS.ProcessEnv } = {}
-): SlackEventsApiIngressConfig {
+): SlackEventsApiIngressConfig & { linear: ReturnType<typeof createSlackLinearBacklogHandler> } {
   const slack = requireSlackConfig(config);
   if (!slack.signingSecret) {
     throw new Error("Slack Events API mode requires platforms.slack.signingSecret.");
@@ -533,11 +534,18 @@ export function slackIngressConfigFromCliConfig(
     ...(slack.appId ? { appId: slack.appId } : {}),
     ...(config.daemon.runTimeoutMs ? { runTimeoutMs: config.daemon.runTimeoutMs } : {}),
     ...(maxRequestBodyBytes ? { maxRequestBodyBytes } : {}),
-    ...(slack.port ? { port: slack.port } : {})
+    ...(slack.port ? { port: slack.port } : {}),
+    linear: createSlackLinearBacklogHandler({
+      ...(config.platforms.linear ? { linear: config.platforms.linear } : {}),
+      env: input.env ?? process.env
+    })
   };
 }
 
-export function slackSocketModeIngressConfigFromCliConfig(config: OpenTagCliConfig): SlackSocketModeIngressConfig {
+export function slackSocketModeIngressConfigFromCliConfig(
+  config: OpenTagCliConfig,
+  input: { env?: NodeJS.ProcessEnv } = {}
+): SlackSocketModeIngressConfig {
   const slack = requireSlackConfig(config);
   if (!slack.appToken) {
     throw new Error("Slack Socket Mode requires platforms.slack.appToken.");
@@ -557,7 +565,11 @@ export function slackSocketModeIngressConfigFromCliConfig(config: OpenTagCliConf
         }
       : {}),
     ...(config.daemon.runTimeoutMs ? { runTimeoutMs: config.daemon.runTimeoutMs } : {}),
-    ...(slack.appId ? { appId: slack.appId } : {})
+    ...(slack.appId ? { appId: slack.appId } : {}),
+    linear: createSlackLinearBacklogHandler({
+      ...(config.platforms.linear ? { linear: config.platforms.linear } : {}),
+      env: input.env ?? process.env
+    })
   };
 }
 
@@ -1000,7 +1012,7 @@ async function startLocalMode(input: StartFromConfigInput, abortController: Abor
     }
     if (config.platforms.slack) {
       if (slackModeFromCliConfig(config) === "socket_mode") {
-        const handle = dependencies.startSlackSocketModeIngress(slackSocketModeIngressConfigFromCliConfig(config));
+        const handle = dependencies.startSlackSocketModeIngress(slackSocketModeIngressConfigFromCliConfig(config, { env }));
         ingresses.push({ platform: "slack", mode: "socket_mode", handle });
         abortOnSubsystemFailure(handle.startPromise, abortController);
       } else {

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -62,6 +62,8 @@ export type StartCommandOptions = {
   background?: boolean;
 };
 
+type LinearTokenProvider = NonNullable<LocalDispatcherRuntimeInput["linearTokenProvider"]>;
+
 type Logger = Pick<Console, "log">;
 
 export type StartRuntimeDependencies = {
@@ -510,7 +512,7 @@ function slackModeFromCliConfig(config: OpenTagCliConfig): "socket_mode" | "even
 
 export function slackIngressConfigFromCliConfig(
   config: OpenTagCliConfig,
-  input: { env?: NodeJS.ProcessEnv } = {}
+  input: { env?: NodeJS.ProcessEnv; linearTokenProvider?: LinearTokenProvider } = {}
 ): SlackEventsApiIngressConfig {
   const slack = requireSlackConfig(config);
   if (!slack.signingSecret) {
@@ -537,14 +539,15 @@ export function slackIngressConfigFromCliConfig(
     ...(slack.port ? { port: slack.port } : {}),
     linear: createSlackLinearBacklogHandler({
       ...(config.platforms.linear ? { linear: config.platforms.linear } : {}),
-      env: input.env ?? process.env
+      env: input.env ?? process.env,
+      ...(input.linearTokenProvider ? { getToken: input.linearTokenProvider } : {})
     })
   };
 }
 
 export function slackSocketModeIngressConfigFromCliConfig(
   config: OpenTagCliConfig,
-  input: { env?: NodeJS.ProcessEnv } = {}
+  input: { env?: NodeJS.ProcessEnv; linearTokenProvider?: LinearTokenProvider } = {}
 ): SlackSocketModeIngressConfig {
   const slack = requireSlackConfig(config);
   if (!slack.appToken) {
@@ -568,7 +571,8 @@ export function slackSocketModeIngressConfigFromCliConfig(
     ...(slack.appId ? { appId: slack.appId } : {}),
     linear: createSlackLinearBacklogHandler({
       ...(config.platforms.linear ? { linear: config.platforms.linear } : {}),
-      env: input.env ?? process.env
+      env: input.env ?? process.env,
+      ...(input.linearTokenProvider ? { getToken: input.linearTokenProvider } : {})
     })
   };
 }
@@ -1012,11 +1016,15 @@ async function startLocalMode(input: StartFromConfigInput, abortController: Abor
     }
     if (config.platforms.slack) {
       if (slackModeFromCliConfig(config) === "socket_mode") {
-        const handle = dependencies.startSlackSocketModeIngress(slackSocketModeIngressConfigFromCliConfig(config, { env }));
+        const handle = dependencies.startSlackSocketModeIngress(
+          slackSocketModeIngressConfigFromCliConfig(config, { env, ...(linearTokenProvider ? { linearTokenProvider } : {}) })
+        );
         ingresses.push({ platform: "slack", mode: "socket_mode", handle });
         abortOnSubsystemFailure(handle.startPromise, abortController);
       } else {
-        const handle = dependencies.startSlackIngress(slackIngressConfigFromCliConfig(config, { env }));
+        const handle = dependencies.startSlackIngress(
+          slackIngressConfigFromCliConfig(config, { env, ...(linearTokenProvider ? { linearTokenProvider } : {}) })
+        );
         ingresses.push({ platform: "slack", mode: "events_api", url: handle.url, handle });
       }
     }

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -634,3 +634,25 @@ describe("OpenTag CLI config", () => {
     });
   });
 });
+
+describe("query-only Linear platform config (AMP-153)", () => {
+  it("accepts token + projectId without webhookSecret", () => {
+    const source = config();
+    source.platforms.linear = { token: "lin_api_secret", projectId: "proj_123" } as never;
+    const parsed = parseCliConfig(JSON.parse(JSON.stringify(source)));
+    expect(parsed.platforms.linear?.projectId).toBe("proj_123");
+    expect(parsed.platforms.linear?.webhookSecret).toBeUndefined();
+  });
+
+  it("still rejects a Linear config with neither webhookSecret nor projectId", () => {
+    const source = config();
+    source.platforms.linear = { token: "lin_api_secret" } as never;
+    expect(() => parseCliConfig(JSON.parse(JSON.stringify(source)))).toThrow(/webhookSecret/);
+  });
+
+  it("still rejects a Linear config without a token", () => {
+    const source = config();
+    source.platforms.linear = { projectId: "proj_123" } as never;
+    expect(() => parseCliConfig(JSON.parse(JSON.stringify(source)))).toThrow(/token/);
+  });
+});

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -263,4 +263,54 @@ describe("createSlackLinearBacklogHandler", () => {
     expect(logged.join("\n")).not.toContain("supersecret");
     expect(String(reply)).not.toContain("supersecret");
   });
+
+  it("uses the live token from getToken instead of the stale static config token", async () => {
+    let capturedAuthorization: string | undefined;
+    const capturingFetch = (async (_url: unknown, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      capturedAuthorization = headers?.authorization;
+      return new Response(
+        JSON.stringify({
+          data: {
+            project: { name: "opentag" },
+            issues: { nodes: [], pageInfo: { hasNextPage: false } }
+          }
+        }),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+    const handler = createSlackLinearBacklogHandler({
+      linear: { token: "stale_token", projectId: "proj_1" } as never,
+      env: {},
+      fetchImpl: capturingFetch,
+      getToken: async () => "fresh_token"
+    });
+    await handler(CONTEXT);
+    expect(capturedAuthorization).toBe("Bearer fresh_token");
+  });
+
+  it("falls back to the static configured token when getToken resolves undefined", async () => {
+    let capturedAuthorization: string | undefined;
+    const capturingFetch = (async (_url: unknown, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      capturedAuthorization = headers?.authorization;
+      return new Response(
+        JSON.stringify({
+          data: {
+            project: { name: "opentag" },
+            issues: { nodes: [], pageInfo: { hasNextPage: false } }
+          }
+        }),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+    const handler = createSlackLinearBacklogHandler({
+      linear: { token: "static_token", projectId: "proj_1" } as never,
+      env: {},
+      fetchImpl: capturingFetch,
+      getToken: async () => undefined
+    });
+    await handler(CONTEXT);
+    expect(capturedAuthorization).toBe("Bearer static_token");
+  });
 });

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSlackLinearBacklogHandler,
+  renderSlackLinearBacklogReply,
+  resolveSlackLinearBacklogSettings,
+  SLACK_LINEAR_BACKLOG_LIMIT
+} from "../src/slack-linear-backlog.js";
+
+const CONTEXT = { teamId: "T123", channelId: "C123", threadTs: "1.0", userId: "U1", binding: null };
+
+function issue(n: number, stateName = "Todo", stateType = "unstarted") {
+  return { identifier: `AMP-${n}`, title: `Task ${n}`, url: `https://linear.app/a/issue/AMP-${n}`, stateName, stateType };
+}
+
+function backlogFetch(nodes: ReturnType<typeof issue>[], hasNextPage = false): typeof fetch {
+  return (async () =>
+    new Response(
+      JSON.stringify({
+        data: {
+          issues: {
+            nodes: nodes.map((entry) => ({
+              identifier: entry.identifier,
+              title: entry.title,
+              url: entry.url,
+              state: { name: entry.stateName, type: entry.stateType }
+            })),
+            pageInfo: { hasNextPage }
+          }
+        }
+      }),
+      { status: 200 }
+    )) as typeof fetch;
+}
+
+describe("resolveSlackLinearBacklogSettings", () => {
+  it("prefers platforms.linear over env fallback", () => {
+    const settings = resolveSlackLinearBacklogSettings({
+      linear: { token: "cfg_token", projectId: "cfg_proj" },
+      env: { OPENTAG_LINEAR_API_KEY: "env_token", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
+    });
+    expect(settings).toEqual({ token: "cfg_token", projectId: "cfg_proj" });
+  });
+
+  it("falls back to OPENTAG_LINEAR_API_KEY / OPENTAG_LINEAR_PROJECT_ID", () => {
+    const settings = resolveSlackLinearBacklogSettings({
+      env: { OPENTAG_LINEAR_API_KEY: "env_token", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
+    });
+    expect(settings).toEqual({ token: "env_token", projectId: "env_proj" });
+  });
+
+  it("accepts OPENTAG_LINEAR_TOKEN as the secondary token fallback", () => {
+    const settings = resolveSlackLinearBacklogSettings({
+      env: { OPENTAG_LINEAR_TOKEN: "env_token2", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
+    });
+    expect(settings?.token).toBe("env_token2");
+  });
+
+  it("returns null when token or projectId is missing", () => {
+    expect(resolveSlackLinearBacklogSettings({ env: { OPENTAG_LINEAR_API_KEY: "t" } })).toBeNull();
+    expect(resolveSlackLinearBacklogSettings({ env: { OPENTAG_LINEAR_PROJECT_ID: "p" } })).toBeNull();
+    expect(resolveSlackLinearBacklogSettings({})).toBeNull();
+  });
+});
+
+describe("renderSlackLinearBacklogReply", () => {
+  it("renders header with count, source, query time, and one line per issue", () => {
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [issue(131, "In Progress", "started"), issue(153)], fetched: 2, hasMore: false },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T21:30:45.123Z"
+    });
+    expect(text).toContain("OpenTag project backlog — 2 open issues (source: Linear, queried 2026-07-16T21:30Z):");
+    expect(text).toContain("• <https://linear.app/a/issue/AMP-131|AMP-131> — Task 131  [In Progress]");
+    expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153> — Task 153  [Todo]");
+    expect(text).not.toContain("Showing");
+  });
+
+  it("truncates at the limit and reports shown/total", () => {
+    const issues = Array.from({ length: 25 }, (_, index) => issue(index + 1));
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues, fetched: 25, hasMore: false },
+      limit: 20,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain("25 open issues");
+    expect(text.match(/^• /gmu)).toHaveLength(20);
+    expect(text).toContain("Showing 20 of 25 open issues.");
+  });
+
+  it("marks totals as N+ when the Linear page reports more results", () => {
+    const issues = Array.from({ length: 100 }, (_, index) => issue(index + 1));
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues, fetched: 100, hasMore: true },
+      limit: 20,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain("100+ open issues");
+    expect(text).toContain("Showing 20 of 100+ open issues.");
+  });
+
+  it("renders an explicit empty-backlog line", () => {
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [], fetched: 0, hasMore: false },
+      limit: 20,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain("0 open issues");
+    expect(text).toContain("No unfinished issues in the configured Linear project.");
+  });
+});
+
+describe("createSlackLinearBacklogHandler", () => {
+  it("replies not-configured when settings are missing", async () => {
+    const handler = createSlackLinearBacklogHandler({ env: {} });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("Linear backlog is not configured");
+  });
+
+  it("queries Linear and renders the backlog reply", async () => {
+    const handler = createSlackLinearBacklogHandler({
+      linear: { token: "lin_api_test", projectId: "proj_1" } as never,
+      env: {},
+      fetchImpl: backlogFetch([issue(153)]),
+      now: () => "2026-07-16T21:30:00.000Z"
+    });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("1 open issue");
+    expect(reply).toContain("AMP-153");
+  });
+
+  it("replies a safe unavailable message on API failure and logs without the token", async () => {
+    const logged: string[] = [];
+    const failingFetch = (async () => new Response(JSON.stringify({ errors: [{ message: "boom" }] }), { status: 500 })) as typeof fetch;
+    const handler = createSlackLinearBacklogHandler({
+      linear: { token: "lin_api_supersecret", projectId: "proj_1" } as never,
+      env: {},
+      fetchImpl: failingFetch,
+      logError: (message) => logged.push(message)
+    });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("Linear API is unavailable");
+    expect(logged.join("\n")).toContain("boom");
+    expect(logged.join("\n")).not.toContain("supersecret");
+    expect(String(reply)).not.toContain("supersecret");
+  });
+});

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -107,6 +107,26 @@ describe("renderSlackLinearBacklogReply", () => {
     expect(text).toContain("0 open issues");
     expect(text).toContain("No unfinished issues in the configured Linear project.");
   });
+
+  it("escapes Linear-controlled title and state text so hostile content cannot inject Slack mrkdwn links", () => {
+    const hostileIssue = {
+      identifier: "AMP-999",
+      title: "<https://evil.example|click here> & more",
+      url: "https://linear.app/a/issue/AMP-999",
+      stateName: "<b>Weird</b> & State",
+      stateType: "started"
+    };
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [hostileIssue], fetched: 1, hasMore: false },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain(
+      "• <https://linear.app/a/issue/AMP-999|AMP-999> — &lt;https://evil.example|click here&gt; &amp; more  [&lt;b&gt;Weird&lt;/b&gt; &amp; State]"
+    );
+    // The identifier link itself must stay unescaped so Slack still renders it as a clickable link.
+    expect(text).toContain("<https://linear.app/a/issue/AMP-999|AMP-999>");
+  });
 });
 
 describe("createSlackLinearBacklogHandler", () => {

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -127,6 +127,33 @@ describe("renderSlackLinearBacklogReply", () => {
     // The identifier link itself must stay unescaped so Slack still renders it as a clickable link.
     expect(text).toContain("<https://linear.app/a/issue/AMP-999|AMP-999>");
   });
+
+  it("percent-encodes non-ASCII characters in the Linear issue URL so Slack renders a valid link", () => {
+    const nonAsciiIssue = {
+      identifier: "AMP-153",
+      title: "Task",
+      url: "https://linear.app/amplift/issue/AMP-153/slack通过-opentag-linear-查询未完成的-linear-任务",
+      stateName: "Todo",
+      stateType: "unstarted"
+    };
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [nonAsciiIssue], fetched: 1, hasMore: false },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain(
+      "• <https://linear.app/amplift/issue/AMP-153/slack%E9%80%9A%E8%BF%87-opentag-linear-%E6%9F%A5%E8%AF%A2%E6%9C%AA%E5%AE%8C%E6%88%90%E7%9A%84-linear-%E4%BB%BB%E5%8A%A1|AMP-153>"
+    );
+  });
+
+  it("leaves an already-ASCII issue URL byte-identical", () => {
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [issue(153)], fetched: 1, hasMore: false },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153>");
+  });
 });
 
 describe("createSlackLinearBacklogHandler", () => {

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -171,8 +171,13 @@ describe("createSlackLinearBacklogHandler", () => {
       now: () => "2026-07-16T21:30:00.000Z"
     });
     const reply = await handler(CONTEXT);
-    expect(reply).toContain("1 open issue");
-    expect(reply).toContain("AMP-153");
+    expect(reply).toEqual(
+      expect.objectContaining({
+        textFormat: "mrkdwn",
+        text: expect.stringContaining("1 open issue")
+      })
+    );
+    expect(typeof reply === "string" ? reply : reply.text).toContain("AMP-153");
   });
 
   it("replies a safe unavailable message on API failure and logs without the token", async () => {

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -8,23 +8,37 @@ import {
 
 const CONTEXT = { teamId: "T123", channelId: "C123", threadTs: "1.0", userId: "U1", binding: null };
 
-function issue(n: number, stateName = "Todo", stateType = "unstarted") {
-  return { identifier: `AMP-${n}`, title: `Task ${n}`, url: `https://linear.app/a/issue/AMP-${n}`, stateName, stateType };
+function issue(n: number, overrides: Partial<{ stateName: string; stateType: string; priority: number; title: string }> = {}) {
+  const stateName = overrides.stateName ?? "Todo";
+  const stateType = overrides.stateType ?? "unstarted";
+  return {
+    identifier: `AMP-${n}`,
+    title: overrides.title ?? `Task ${n}`,
+    url: `https://linear.app/a/issue/AMP-${n}`,
+    stateName,
+    stateType,
+    priority: overrides.priority ?? 0
+  };
 }
 
-function backlogFetch(nodes: ReturnType<typeof issue>[], hasNextPage = false): typeof fetch {
+function backlogFetch(
+  nodes: ReturnType<typeof issue>[],
+  options: { hasNextPage?: boolean; projectName?: string | null } = {}
+): typeof fetch {
   return (async () =>
     new Response(
       JSON.stringify({
         data: {
+          project: options.projectName === undefined ? { name: "opentag" } : options.projectName ? { name: options.projectName } : null,
           issues: {
             nodes: nodes.map((entry) => ({
               identifier: entry.identifier,
               title: entry.title,
               url: entry.url,
+              priority: entry.priority,
               state: { name: entry.stateName, type: entry.stateType }
             })),
-            pageInfo: { hasNextPage }
+            pageInfo: { hasNextPage: options.hasNextPage ?? false }
           }
         }
       }),
@@ -63,66 +77,119 @@ describe("resolveSlackLinearBacklogSettings", () => {
 });
 
 describe("renderSlackLinearBacklogReply", () => {
-  it("renders header with count, source, query time, and one line per issue", () => {
+  it("renders the header with project name and total, grouped headings, and issue lines", () => {
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [issue(131, "In Progress", "started"), issue(153)], fetched: 2, hasMore: false },
+      backlog: {
+        issues: [
+          issue(140, { stateName: "In Progress", stateType: "started", priority: 1, title: "显示生成失败重试机制" }),
+          issue(131, { stateName: "In Progress", stateType: "started", title: "这个ocr把他主人的名字都搞错了；代办 ocr 优化" }),
+          issue(153, { priority: 2, title: "Slack：通过 @opentag linear 查询未完成的 Linear 任务" }),
+          issue(132, { title: "显示生成失败，the provider returned an empty draft" })
+        ],
+        fetched: 4,
+        hasMore: false,
+        projectName: "opentag"
+      },
       limit: SLACK_LINEAR_BACKLOG_LIMIT,
-      queriedAt: "2026-07-16T21:30:45.123Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
-    expect(text).toContain("OpenTag project backlog — 2 open issues (source: Linear, queried 2026-07-16T21:30Z):");
-    expect(text).toContain("• <https://linear.app/a/issue/AMP-131|AMP-131> — Task 131  [In Progress]");
-    expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153> — Task 153  [Todo]");
-    expect(text).not.toContain("Showing");
+
+    const lines = text.split("\n");
+    expect(lines).toEqual([
+      "*opentag · 4 open*",
+      "",
+      "🔵 *In Progress (2)*",
+      "• <https://linear.app/a/issue/AMP-140|AMP-140> [urgent] 显示生成失败重试机制",
+      "• <https://linear.app/a/issue/AMP-131|AMP-131> 这个ocr把他主人的名字都搞错了；代办 ocr 优化",
+      "",
+      "⚪ *Todo (2)*",
+      "• <https://linear.app/a/issue/AMP-153|AMP-153> [high] Slack：通过 @opentag linear 查询未完成的 Linear 任务",
+      "• <https://linear.app/a/issue/AMP-132|AMP-132> 显示生成失败，the provider returned an empty draft",
+      "",
+      "_Linear · queried 22:48 UTC_"
+    ]);
   });
 
-  it("truncates at the limit and reports shown/total", () => {
-    const issues = Array.from({ length: 25 }, (_, index) => issue(index + 1));
+  it("falls back to 'Backlog' as the header name when no project name is available", () => {
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues, fetched: 25, hasMore: false },
-      limit: 20,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      backlog: { issues: [issue(1)], fetched: 1, hasMore: false, projectName: null },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
-    expect(text).toContain("25 open issues");
-    expect(text.match(/^• /gmu)).toHaveLength(20);
-    expect(text).toContain("Showing 20 of 25 open issues.");
+    expect(text).toContain("*Backlog · 1 open*");
   });
 
-  it("marks totals as N+ when the Linear page reports more results", () => {
+  it("uses no priority marker and a single space before the title when priority has no urgent/high marker", () => {
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [issue(1, { priority: 3 })], fetched: 1, hasMore: false, projectName: "opentag" },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T22:48:00.000Z"
+    });
+    expect(text).toContain("• <https://linear.app/a/issue/AMP-1|AMP-1> Task 1");
+  });
+
+  it("truncates at the limit, marks a partially-shown group heading, and reports the hidden count in the footer", () => {
+    const inProgress = Array.from({ length: 2 }, (_, index) => issue(index + 1, { stateName: "In Progress", stateType: "started" }));
+    const todo = Array.from({ length: 30 }, (_, index) => issue(1000 + index));
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [...inProgress, ...todo], fetched: 32, hasMore: false, projectName: "opentag" },
+      limit: 20,
+      queriedAt: "2026-07-16T22:48:00.000Z"
+    });
+
+    expect(text).toContain("*opentag · 32 open* · showing 20");
+    expect(text).toContain("🔵 *In Progress (2)*");
+    expect(text).toContain("⚪ *Todo (18 of 30)*");
+    expect(text.match(/^• /gmu)).toHaveLength(20);
+    expect(text).toContain("_Linear · queried 22:48 UTC · 12 more not shown_");
+  });
+
+  it("renders N+ totals and hidden counts when Linear reports more pages via hasMore", () => {
     const issues = Array.from({ length: 100 }, (_, index) => issue(index + 1));
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues, fetched: 100, hasMore: true },
+      backlog: { issues, fetched: 100, hasMore: true, projectName: "opentag" },
       limit: 20,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
-    expect(text).toContain("100+ open issues");
-    expect(text).toContain("Showing 20 of 100+ open issues.");
+
+    expect(text).toContain("*opentag · 100+ open* · showing 20");
+    expect(text).toContain("_Linear · queried 22:48 UTC · 80+ more not shown_");
   });
 
-  it("renders an explicit empty-backlog line", () => {
+  it("renders the empty-backlog layout", () => {
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [], fetched: 0, hasMore: false },
+      backlog: { issues: [], fetched: 0, hasMore: false, projectName: "opentag" },
       limit: 20,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
-    expect(text).toContain("0 open issues");
-    expect(text).toContain("No unfinished issues in the configured Linear project.");
+
+    expect(text.split("\n")).toEqual([
+      "*opentag · 0 open* 🎉",
+      "No unfinished issues in this Linear project.",
+      "",
+      "_Linear · queried 22:48 UTC_"
+    ]);
   });
 
-  it("escapes Linear-controlled title and state text so hostile content cannot inject Slack mrkdwn links", () => {
+  it("escapes Linear-controlled title, state, and project name so hostile content cannot inject Slack mrkdwn", () => {
     const hostileIssue = {
       identifier: "AMP-999",
       title: "<https://evil.example|click here> & more",
       url: "https://linear.app/a/issue/AMP-999",
       stateName: "<b>Weird</b> & State",
-      stateType: "started"
+      stateType: "started",
+      priority: 0
     };
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [hostileIssue], fetched: 1, hasMore: false },
+      backlog: { issues: [hostileIssue], fetched: 1, hasMore: false, projectName: "<script>evil</script>" },
       limit: SLACK_LINEAR_BACKLOG_LIMIT,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
+
+    expect(text).toContain("*&lt;script&gt;evil&lt;/script&gt; · 1 open*");
+    expect(text).toContain("🔵 *&lt;b&gt;Weird&lt;/b&gt; &amp; State (1)*");
     expect(text).toContain(
-      "• <https://linear.app/a/issue/AMP-999|AMP-999> — &lt;https://evil.example|click here&gt; &amp; more  [&lt;b&gt;Weird&lt;/b&gt; &amp; State]"
+      "• <https://linear.app/a/issue/AMP-999|AMP-999> &lt;https://evil.example|click here&gt; &amp; more"
     );
     // The identifier link itself must stay unescaped so Slack still renders it as a clickable link.
     expect(text).toContain("<https://linear.app/a/issue/AMP-999|AMP-999>");
@@ -134,23 +201,24 @@ describe("renderSlackLinearBacklogReply", () => {
       title: "Task",
       url: "https://linear.app/amplift/issue/AMP-153/slack通过-opentag-linear-查询未完成的-linear-任务",
       stateName: "Todo",
-      stateType: "unstarted"
+      stateType: "unstarted",
+      priority: 0
     };
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [nonAsciiIssue], fetched: 1, hasMore: false },
+      backlog: { issues: [nonAsciiIssue], fetched: 1, hasMore: false, projectName: "opentag" },
       limit: SLACK_LINEAR_BACKLOG_LIMIT,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
     expect(text).toContain(
-      "• <https://linear.app/amplift/issue/AMP-153/slack%E9%80%9A%E8%BF%87-opentag-linear-%E6%9F%A5%E8%AF%A2%E6%9C%AA%E5%AE%8C%E6%88%90%E7%9A%84-linear-%E4%BB%BB%E5%8A%A1|AMP-153>"
+      "<https://linear.app/amplift/issue/AMP-153/slack%E9%80%9A%E8%BF%87-opentag-linear-%E6%9F%A5%E8%AF%A2%E6%9C%AA%E5%AE%8C%E6%88%90%E7%9A%84-linear-%E4%BB%BB%E5%8A%A1|AMP-153>"
     );
   });
 
   it("leaves an already-ASCII issue URL byte-identical", () => {
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [issue(153)], fetched: 1, hasMore: false },
+      backlog: { issues: [issue(153)], fetched: 1, hasMore: false, projectName: "opentag" },
       limit: SLACK_LINEAR_BACKLOG_LIMIT,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
     expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153>");
   });
@@ -168,13 +236,13 @@ describe("createSlackLinearBacklogHandler", () => {
       linear: { token: "lin_api_test", projectId: "proj_1" } as never,
       env: {},
       fetchImpl: backlogFetch([issue(153)]),
-      now: () => "2026-07-16T21:30:00.000Z"
+      now: () => "2026-07-16T22:48:00.000Z"
     });
     const reply = await handler(CONTEXT);
     expect(reply).toEqual(
       expect.objectContaining({
         textFormat: "mrkdwn",
-        text: expect.stringContaining("1 open issue")
+        text: expect.stringContaining("opentag · 1 open")
       })
     );
     expect(typeof reply === "string" ? reply : reply.text).toContain("AMP-153");

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -407,6 +407,13 @@ describe("OpenTag CLI start wiring", () => {
     });
   });
 
+  it("does not forward the Linear token to the dispatcher for a query-only Linear config", () => {
+    const built = linearConfig();
+    built.platforms.linear = { token: "lin_api_qo", projectId: "proj_qo" } as never;
+
+    expect(dispatcherRuntimeInputFromCliConfig(built)).not.toHaveProperty("linearToken");
+  });
+
   it("refreshes and persists Linear OAuth app tokens before they expire", async () => {
     const built = linearOAuthConfig();
     const configPath = join(tempDir(), "config.json");

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -1307,3 +1307,17 @@ describe("OpenTag CLI start wiring", () => {
     expect(shouldRethrowAbortReason({ shutdownRequested: false, reason: "stopped" })).toBe(false);
   });
 });
+
+describe("slack linear backlog wiring (AMP-153)", () => {
+  it("attaches a linear handler to the Socket Mode ingress config", () => {
+    const built = slackSocketModeConfig();
+    const ingressConfig = slackSocketModeIngressConfigFromCliConfig(built, { env: {} });
+    expect(typeof ingressConfig.linear).toBe("function");
+  });
+
+  it("attaches a linear handler to the Events API ingress config", () => {
+    const built = slackConfig();
+    const ingressConfig = slackIngressConfigFromCliConfig(built, { env: {} });
+    expect(typeof ingressConfig.linear).toBe("function");
+  });
+});

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -1327,4 +1327,22 @@ describe("slack linear backlog wiring (AMP-153)", () => {
     const ingressConfig = slackIngressConfigFromCliConfig(built, { env: {} });
     expect(typeof ingressConfig.linear).toBe("function");
   });
+
+  it("still attaches a linear handler when a linearTokenProvider is threaded through Socket Mode config", () => {
+    const built = slackSocketModeConfig();
+    const ingressConfig = slackSocketModeIngressConfigFromCliConfig(built, {
+      env: {},
+      linearTokenProvider: async () => "fresh_token"
+    });
+    expect(typeof ingressConfig.linear).toBe("function");
+  });
+
+  it("still attaches a linear handler when a linearTokenProvider is threaded through Events API config", () => {
+    const built = slackConfig();
+    const ingressConfig = slackIngressConfigFromCliConfig(built, {
+      env: {},
+      linearTokenProvider: async () => "fresh_token"
+    });
+    expect(typeof ingressConfig.linear).toBe("function");
+  });
 });

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -1,0 +1,74 @@
+import { linearGraphql, type FetchLike } from "./graphql.js";
+
+export const LINEAR_BACKLOG_PAGE_SIZE = 100;
+export const DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS = 10_000;
+
+export type LinearBacklogIssue = {
+  identifier: string;
+  title: string;
+  url: string;
+  stateName: string;
+  stateType: string;
+};
+
+export type LinearProjectBacklog = {
+  issues: LinearBacklogIssue[];
+  fetched: number;
+  hasMore: boolean;
+};
+
+const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $first: Int!) {
+  issues(
+    filter: {
+      project: { id: { eq: $projectId } }
+      state: { type: { nin: ["completed", "canceled"] } }
+    }
+    first: $first
+  ) {
+    nodes { identifier title url state { name type } }
+    pageInfo { hasNextPage }
+  }
+}`;
+
+const STATE_TYPE_ORDER: Record<string, number> = { started: 0, unstarted: 1, backlog: 2, triage: 3 };
+
+function issueNumber(identifier: string): number {
+  const value = Number(identifier.split("-")[1]);
+  return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+}
+
+export async function fetchLinearProjectBacklog(input: {
+  token: string;
+  projectId: string;
+  graphqlUrl?: string;
+  fetchImpl: FetchLike;
+  timeoutMs?: number;
+}): Promise<LinearProjectBacklog> {
+  const data = await linearGraphql<{
+    issues: {
+      nodes: Array<{ identifier: string; title: string; url: string; state: { name: string; type: string } }>;
+      pageInfo: { hasNextPage: boolean };
+    };
+  }>({
+    token: input.token,
+    ...(input.graphqlUrl ? { graphqlUrl: input.graphqlUrl } : {}),
+    query: BACKLOG_QUERY,
+    variables: { projectId: input.projectId, first: LINEAR_BACKLOG_PAGE_SIZE },
+    fetchImpl: input.fetchImpl,
+    timeoutMs: input.timeoutMs ?? DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS
+  });
+  const issues = data.issues.nodes
+    .map((node) => ({
+      identifier: node.identifier,
+      title: node.title,
+      url: node.url,
+      stateName: node.state.name,
+      stateType: node.state.type
+    }))
+    .sort(
+      (a, b) =>
+        (STATE_TYPE_ORDER[a.stateType] ?? 9) - (STATE_TYPE_ORDER[b.stateType] ?? 9) ||
+        issueNumber(a.identifier) - issueNumber(b.identifier)
+    );
+  return { issues, fetched: issues.length, hasMore: data.issues.pageInfo.hasNextPage };
+}

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -9,15 +9,18 @@ export type LinearBacklogIssue = {
   url: string;
   stateName: string;
   stateType: string;
+  priority: number;
 };
 
 export type LinearProjectBacklog = {
   issues: LinearBacklogIssue[];
   fetched: number;
   hasMore: boolean;
+  projectName: string | null;
 };
 
 const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $first: Int!) {
+  project(id: $projectId) { name }
   issues(
     filter: {
       project: { id: { eq: $projectId } }
@@ -25,7 +28,7 @@ const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $first: Int!
     }
     first: $first
   ) {
-    nodes { identifier title url state { name type } }
+    nodes { identifier title url priority state { name type } }
     pageInfo { hasNextPage }
   }
 }`;
@@ -37,6 +40,13 @@ function issueNumber(identifier: string): number {
   return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
 }
 
+// Linear priority semantics: 0 none, 1 urgent, 2 high, 3 medium, 4 low.
+// Rank "none" after every set priority so unprioritized issues sort last
+// within their state type.
+function priorityRank(priority: number): number {
+  return priority === 0 ? 5 : priority;
+}
+
 export async function fetchLinearProjectBacklog(input: {
   token: string;
   projectId: string;
@@ -45,8 +55,15 @@ export async function fetchLinearProjectBacklog(input: {
   timeoutMs?: number;
 }): Promise<LinearProjectBacklog> {
   const data = await linearGraphql<{
+    project: { name: string } | null;
     issues: {
-      nodes: Array<{ identifier: string; title: string; url: string; state: { name: string; type: string } }>;
+      nodes: Array<{
+        identifier: string;
+        title: string;
+        url: string;
+        priority: number | null;
+        state: { name: string; type: string };
+      }>;
       pageInfo: { hasNextPage: boolean };
     };
   }>({
@@ -63,12 +80,19 @@ export async function fetchLinearProjectBacklog(input: {
       title: node.title,
       url: node.url,
       stateName: node.state.name,
-      stateType: node.state.type
+      stateType: node.state.type,
+      priority: node.priority ?? 0
     }))
     .sort(
       (a, b) =>
         (STATE_TYPE_ORDER[a.stateType] ?? 9) - (STATE_TYPE_ORDER[b.stateType] ?? 9) ||
+        priorityRank(a.priority) - priorityRank(b.priority) ||
         issueNumber(a.identifier) - issueNumber(b.identifier)
     );
-  return { issues, fetched: issues.length, hasMore: data.issues.pageInfo.hasNextPage };
+  return {
+    issues,
+    fetched: issues.length,
+    hasMore: data.issues.pageInfo.hasNextPage,
+    projectName: data.project?.name ?? null
+  };
 }

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -19,8 +19,8 @@ export type LinearProjectBacklog = {
   projectName: string | null;
 };
 
-const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $first: Int!) {
-  project(id: $projectId) { name }
+const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey: String!, $first: Int!) {
+  project(id: $projectKey) { name }
   issues(
     filter: {
       project: { id: { eq: $projectId } }
@@ -70,7 +70,7 @@ export async function fetchLinearProjectBacklog(input: {
     token: input.token,
     ...(input.graphqlUrl ? { graphqlUrl: input.graphqlUrl } : {}),
     query: BACKLOG_QUERY,
-    variables: { projectId: input.projectId, first: LINEAR_BACKLOG_PAGE_SIZE },
+    variables: { projectId: input.projectId, projectKey: input.projectId, first: LINEAR_BACKLOG_PAGE_SIZE },
     fetchImpl: input.fetchImpl,
     timeoutMs: input.timeoutMs ?? DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS
   });

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -74,6 +74,9 @@ export async function fetchLinearProjectBacklog(input: {
     fetchImpl: input.fetchImpl,
     timeoutMs: input.timeoutMs ?? DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS
   });
+  if (data.project == null) {
+    throw new Error("Linear project not found or inaccessible; check platforms.linear.projectId and the token's access.");
+  }
   const issues = data.issues.nodes
     .map((node) => ({
       identifier: node.identifier,
@@ -93,6 +96,6 @@ export async function fetchLinearProjectBacklog(input: {
     issues,
     fetched: issues.length,
     hasMore: data.issues.pageInfo.hasNextPage,
-    projectName: data.project?.name ?? null
+    projectName: data.project.name
   };
 }

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -19,6 +19,12 @@ export type LinearProjectBacklog = {
   projectName: string | null;
 };
 
+// Server-side priority ordering (Descending: Urgent -> High -> ... -> No priority
+// last) so the first $first rows returned are the globally highest-priority
+// issues, not just the $first most-recently-created ones. Without this, a
+// project with >100 unfinished issues could have higher-priority issues on
+// later pages silently dropped before the local sort below ever sees them,
+// making the "top 20 by priority" wrong. This keeps the request count at 1.
 const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey: String!, $first: Int!) {
   project(id: $projectKey) { name }
   issues(
@@ -26,6 +32,7 @@ const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey:
       project: { id: { eq: $projectId } }
       state: { type: { nin: ["completed", "canceled"] } }
     }
+    sort: [{ priority: { order: Descending } }]
     first: $first
   ) {
     nodes { identifier title url priority state { name type } }

--- a/packages/linear/src/index.ts
+++ b/packages/linear/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./agent.js";
 export * from "./apply.js";
+export * from "./backlog.js";
 export * from "./discovery.js";
 export * from "./graphql.js";
 export * from "./ingress.js";

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -63,10 +63,10 @@ describe("fetchLinearProjectBacklog", () => {
     expect(calls).toHaveLength(1);
     const query = String(calls[0]!.body.query);
     expect(query).toContain('nin: ["completed", "canceled"]');
-    expect(query).toContain("project(id: $projectId)");
+    expect(query).toContain("project(id: $projectKey)");
     expect(query).toContain("priority");
     expect(query).not.toContain("mutation");
-    expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", first: 100 });
+    expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", projectKey: "proj_1", first: 100 });
   });
 
   it("sorts by state type (started, unstarted, backlog) then priority then issue number", async () => {

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -5,52 +5,178 @@ type FetchCall = { url: string; body: Record<string, unknown> };
 
 function fetchStub(input: {
   calls: FetchCall[];
-  nodes: Array<{ identifier: string; title: string; url: string; state: { name: string; type: string } }>;
+  project?: { name: string } | null;
+  nodes: Array<{
+    identifier: string;
+    title: string;
+    url: string;
+    priority?: number | null;
+    state: { name: string; type: string };
+  }>;
   hasNextPage?: boolean;
 }): typeof fetch {
   return (async (url: RequestInfo | URL, init?: RequestInit) => {
     input.calls.push({ url: String(url), body: JSON.parse(String(init?.body)) as Record<string, unknown> });
     return new Response(
-      JSON.stringify({ data: { issues: { nodes: input.nodes, pageInfo: { hasNextPage: input.hasNextPage ?? false } } } }),
+      JSON.stringify({
+        data: {
+          project: input.project ?? null,
+          issues: { nodes: input.nodes, pageInfo: { hasNextPage: input.hasNextPage ?? false } }
+        }
+      }),
       { status: 200 }
     );
   }) as typeof fetch;
 }
 
-const AMP_153 = { identifier: "AMP-153", title: "Slack linear command", url: "https://linear.app/a/issue/AMP-153", state: { name: "Todo", type: "unstarted" } };
-const AMP_131 = { identifier: "AMP-131", title: "OCR fix", url: "https://linear.app/a/issue/AMP-131", state: { name: "In Progress", type: "started" } };
-const AMP_9 = { identifier: "AMP-9", title: "Old backlog item", url: "https://linear.app/a/issue/AMP-9", state: { name: "Backlog", type: "backlog" } };
+const AMP_153 = {
+  identifier: "AMP-153",
+  title: "Slack linear command",
+  url: "https://linear.app/a/issue/AMP-153",
+  priority: 2,
+  state: { name: "Todo", type: "unstarted" }
+};
+const AMP_131 = {
+  identifier: "AMP-131",
+  title: "OCR fix",
+  url: "https://linear.app/a/issue/AMP-131",
+  priority: 0,
+  state: { name: "In Progress", type: "started" }
+};
+const AMP_9 = {
+  identifier: "AMP-9",
+  title: "Old backlog item",
+  url: "https://linear.app/a/issue/AMP-9",
+  priority: 4,
+  state: { name: "Backlog", type: "backlog" }
+};
 
 describe("fetchLinearProjectBacklog", () => {
-  it("queries unfinished project issues and excludes completed/canceled state types", async () => {
+  it("queries unfinished project issues, the project name, and excludes completed/canceled state types", async () => {
     const calls: FetchCall[] = [];
-    await fetchLinearProjectBacklog({ token: "lin_api_test", projectId: "proj_1", fetchImpl: fetchStub({ calls, nodes: [] }) });
+    await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls, project: null, nodes: [] })
+    });
 
     expect(calls).toHaveLength(1);
     const query = String(calls[0]!.body.query);
     expect(query).toContain('nin: ["completed", "canceled"]');
+    expect(query).toContain("project(id: $projectId)");
+    expect(query).toContain("priority");
     expect(query).not.toContain("mutation");
     expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", first: 100 });
   });
 
-  it("sorts by state type (started, unstarted, backlog) then issue number", async () => {
+  it("sorts by state type (started, unstarted, backlog) then priority then issue number", async () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], nodes: [AMP_9, AMP_153, AMP_131] })
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [AMP_9, AMP_153, AMP_131] })
     });
 
     expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-131", "AMP-153", "AMP-9"]);
-    expect(backlog.issues[0]).toEqual({ identifier: "AMP-131", title: "OCR fix", url: "https://linear.app/a/issue/AMP-131", stateName: "In Progress", stateType: "started" });
+    expect(backlog.issues[0]).toEqual({
+      identifier: "AMP-131",
+      title: "OCR fix",
+      url: "https://linear.app/a/issue/AMP-131",
+      stateName: "In Progress",
+      stateType: "started",
+      priority: 0
+    });
     expect(backlog.fetched).toBe(3);
     expect(backlog.hasMore).toBe(false);
+  });
+
+  it("sorts by priority within a single state type: urgent, then high, then medium, then none", async () => {
+    const none = {
+      identifier: "AMP-4",
+      title: "None",
+      url: "https://linear.app/a/issue/AMP-4",
+      priority: 0,
+      state: { name: "Todo", type: "unstarted" }
+    };
+    const medium = {
+      identifier: "AMP-3",
+      title: "Medium",
+      url: "https://linear.app/a/issue/AMP-3",
+      priority: 3,
+      state: { name: "Todo", type: "unstarted" }
+    };
+    const urgent = {
+      identifier: "AMP-1",
+      title: "Urgent",
+      url: "https://linear.app/a/issue/AMP-1",
+      priority: 1,
+      state: { name: "Todo", type: "unstarted" }
+    };
+    const high = {
+      identifier: "AMP-2",
+      title: "High",
+      url: "https://linear.app/a/issue/AMP-2",
+      priority: 2,
+      state: { name: "Todo", type: "unstarted" }
+    };
+
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [none, medium, urgent, high] })
+    });
+
+    expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-1", "AMP-2", "AMP-3", "AMP-4"]);
+  });
+
+  it("maps the project name from the GraphQL response", async () => {
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [] })
+    });
+
+    expect(backlog.projectName).toBe("opentag");
+  });
+
+  it("maps a missing project to a null project name", async () => {
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [] })
+    });
+
+    expect(backlog.projectName).toBeNull();
+  });
+
+  it("maps missing or null priority to 0", async () => {
+    const missingPriorityField = {
+      identifier: "AMP-5",
+      title: "No priority field",
+      url: "https://linear.app/a/issue/AMP-5",
+      state: { name: "Todo", type: "unstarted" }
+    };
+    const nullPriority = {
+      identifier: "AMP-6",
+      title: "Null priority",
+      url: "https://linear.app/a/issue/AMP-6",
+      priority: null,
+      state: { name: "Todo", type: "unstarted" }
+    };
+
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [missingPriorityField, nullPriority] })
+    });
+
+    expect(backlog.issues.every((issue) => issue.priority === 0)).toBe(true);
   });
 
   it("reports hasMore from pageInfo.hasNextPage", async () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], nodes: [AMP_153], hasNextPage: true })
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [AMP_153], hasNextPage: true })
     });
 
     expect(backlog.hasMore).toBe(true);

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { fetchLinearProjectBacklog } from "../src/backlog.js";
+
+type FetchCall = { url: string; body: Record<string, unknown> };
+
+function fetchStub(input: {
+  calls: FetchCall[];
+  nodes: Array<{ identifier: string; title: string; url: string; state: { name: string; type: string } }>;
+  hasNextPage?: boolean;
+}): typeof fetch {
+  return (async (url: RequestInfo | URL, init?: RequestInit) => {
+    input.calls.push({ url: String(url), body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+    return new Response(
+      JSON.stringify({ data: { issues: { nodes: input.nodes, pageInfo: { hasNextPage: input.hasNextPage ?? false } } } }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+}
+
+const AMP_153 = { identifier: "AMP-153", title: "Slack linear command", url: "https://linear.app/a/issue/AMP-153", state: { name: "Todo", type: "unstarted" } };
+const AMP_131 = { identifier: "AMP-131", title: "OCR fix", url: "https://linear.app/a/issue/AMP-131", state: { name: "In Progress", type: "started" } };
+const AMP_9 = { identifier: "AMP-9", title: "Old backlog item", url: "https://linear.app/a/issue/AMP-9", state: { name: "Backlog", type: "backlog" } };
+
+describe("fetchLinearProjectBacklog", () => {
+  it("queries unfinished project issues and excludes completed/canceled state types", async () => {
+    const calls: FetchCall[] = [];
+    await fetchLinearProjectBacklog({ token: "lin_api_test", projectId: "proj_1", fetchImpl: fetchStub({ calls, nodes: [] }) });
+
+    expect(calls).toHaveLength(1);
+    const query = String(calls[0]!.body.query);
+    expect(query).toContain('nin: ["completed", "canceled"]');
+    expect(query).not.toContain("mutation");
+    expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", first: 100 });
+  });
+
+  it("sorts by state type (started, unstarted, backlog) then issue number", async () => {
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], nodes: [AMP_9, AMP_153, AMP_131] })
+    });
+
+    expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-131", "AMP-153", "AMP-9"]);
+    expect(backlog.issues[0]).toEqual({ identifier: "AMP-131", title: "OCR fix", url: "https://linear.app/a/issue/AMP-131", stateName: "In Progress", stateType: "started" });
+    expect(backlog.fetched).toBe(3);
+    expect(backlog.hasMore).toBe(false);
+  });
+
+  it("reports hasMore from pageInfo.hasNextPage", async () => {
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], nodes: [AMP_153], hasNextPage: true })
+    });
+
+    expect(backlog.hasMore).toBe(true);
+  });
+
+  it("propagates GraphQL failures without embedding the token", async () => {
+    const failingFetch = (async () =>
+      new Response(JSON.stringify({ errors: [{ message: "rate limited" }] }), { status: 429 })) as typeof fetch;
+
+    await expect(
+      fetchLinearProjectBacklog({ token: "lin_api_supersecret", projectId: "proj_1", fetchImpl: failingFetch })
+    ).rejects.toThrow(/rate limited/);
+    await expect(
+      fetchLinearProjectBacklog({ token: "lin_api_supersecret", projectId: "proj_1", fetchImpl: failingFetch })
+    ).rejects.not.toThrow(/supersecret/);
+  });
+});

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -65,6 +65,7 @@ describe("fetchLinearProjectBacklog", () => {
     expect(query).toContain('nin: ["completed", "canceled"]');
     expect(query).toContain("project(id: $projectKey)");
     expect(query).toContain("priority");
+    expect(query).toContain("sort: [{ priority: { order: Descending } }]");
     expect(query).not.toContain("mutation");
     expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", projectKey: "proj_1", first: 100 });
   });

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -57,7 +57,7 @@ describe("fetchLinearProjectBacklog", () => {
     await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls, project: null, nodes: [] })
+      fetchImpl: fetchStub({ calls, project: { name: "opentag" }, nodes: [] })
     });
 
     expect(calls).toHaveLength(1);
@@ -73,7 +73,7 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [AMP_9, AMP_153, AMP_131] })
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [AMP_9, AMP_153, AMP_131] })
     });
 
     expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-131", "AMP-153", "AMP-9"]);
@@ -122,7 +122,7 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [none, medium, urgent, high] })
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [none, medium, urgent, high] })
     });
 
     expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-1", "AMP-2", "AMP-3", "AMP-4"]);
@@ -138,14 +138,14 @@ describe("fetchLinearProjectBacklog", () => {
     expect(backlog.projectName).toBe("opentag");
   });
 
-  it("maps a missing project to a null project name", async () => {
-    const backlog = await fetchLinearProjectBacklog({
+  it("rejects when the Linear project is missing or inaccessible instead of resolving an empty backlog", async () => {
+    const resultPromise = fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
       fetchImpl: fetchStub({ calls: [], project: null, nodes: [] })
     });
 
-    expect(backlog.projectName).toBeNull();
+    await expect(resultPromise).rejects.toThrow(/not found or inaccessible/i);
   });
 
   it("maps missing or null priority to 0", async () => {
@@ -166,7 +166,7 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [missingPriorityField, nullPriority] })
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [missingPriorityField, nullPriority] })
     });
 
     expect(backlog.issues.every((issue) => issue.priority === 0)).toBe(true);
@@ -176,7 +176,7 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [AMP_153], hasNextPage: true })
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [AMP_153], hasNextPage: true })
     });
 
     expect(backlog.hasMore).toBe(true);

--- a/packages/slack/src/dispatcher-events.ts
+++ b/packages/slack/src/dispatcher-events.ts
@@ -289,6 +289,7 @@ export function createSlackDispatcherEventProcessorInput(config: SlackDispatcher
             channelId: input.channelId,
             threadTs: input.threadTs,
             text: input.text,
+            ...(input.textFormat ? { textFormat: input.textFormat } : {}),
             ...(input.blocks?.length ? { blocks: input.blocks } : {})
           })
         )

--- a/packages/slack/src/dispatcher-events.ts
+++ b/packages/slack/src/dispatcher-events.ts
@@ -16,6 +16,7 @@ export type SlackDispatcherEventConfig = {
   bindingAdminUserIds?: string[];
   runTimeoutMs?: number;
   fetchImpl?: typeof fetch;
+  linear?: SlackEventProcessorInput["linear"];
 } & SlackChannelPrincipalConfig;
 
 function assertSlackChannelPrincipalConfig(config: {
@@ -272,6 +273,7 @@ export function createSlackDispatcherEventProcessorInput(config: SlackDispatcher
         return doctorUnavailable({ teamId: input.teamId, channelId: input.channelId, binding: input.binding, error });
       }
     },
+    ...(config.linear ? { linear: config.linear } : {}),
     now: () => new Date().toISOString()
   };
   if (config.botToken) {

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -329,6 +329,19 @@ function doctorReply(input: SlackSelfServiceContext): SlackSelfServiceReply {
 }
 
 export function createSlackEventProcessor(input: SlackEventProcessorInput) {
+  const MAX_SEEN_EVENT_IDS = 1000;
+  const seenEventIds = new Set<string>();
+  function markEventSeen(eventId: string): "new" | "duplicate" {
+    if (seenEventIds.has(eventId)) return "duplicate";
+    seenEventIds.add(eventId);
+    // Bounded: evict oldest insertion when over cap (Set preserves insertion order).
+    if (seenEventIds.size > MAX_SEEN_EVENT_IDS) {
+      const oldest = seenEventIds.values().next().value;
+      if (oldest !== undefined) seenEventIds.delete(oldest);
+    }
+    return "new";
+  }
+
   async function processBlockActions(payload: SlackInteractivePayload, slackApp: SlackAppRuntimeConfig): Promise<SlackEventProcessorResult> {
     const action = payload.actions?.find((candidate) => {
       if (candidate.action_id?.startsWith("opentag:")) return true;
@@ -424,6 +437,9 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
       }
       if (!payload.team_id || !payload.event.channel || !payload.event.user || !payload.event.text || !payload.event.ts || !payload.event_id) {
         return json({ error: "invalid_event_payload" }, 400);
+      }
+      if (markEventSeen(payload.event_id) === "duplicate") {
+        return json({ ok: true, ignored: "duplicate_event" });
       }
 
       const rawThreadActionText =

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -88,6 +88,7 @@ export type SlackAppRuntimeConfig = {
 
 export type SlackSelfServiceReply = {
   text: string;
+  textFormat?: "mrkdwn";
   blocks?: SlackBlock[];
 };
 
@@ -120,7 +121,7 @@ export type SlackEventProcessorInput = {
   submitThreadAction?(action: SlackThreadActionInput): Promise<unknown>;
   bindChannel?(input: { teamId: string; channelId: string; repoProvider: string; owner: string; repo: string }): Promise<void>;
   unbindChannel?(input: { teamId: string; channelId: string }): Promise<void>;
-  reply?(input: { channelId: string; threadTs: string; text: string; blocks?: SlackBlock[] }): Promise<void>;
+  reply?(input: { channelId: string; threadTs: string; text: string; textFormat?: "mrkdwn"; blocks?: SlackBlock[] }): Promise<void>;
   status?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
   doctor?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
   linear?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
@@ -600,6 +601,7 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
           channelId: payload.event.channel,
           threadTs,
           text: reply.text,
+          ...(reply.textFormat ? { textFormat: reply.textFormat } : {}),
           ...(reply.blocks?.length ? { blocks: reply.blocks } : {})
         });
         return json({ ok: true, selfService: "linear" });

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -123,6 +123,7 @@ export type SlackEventProcessorInput = {
   reply?(input: { channelId: string; threadTs: string; text: string; blocks?: SlackBlock[] }): Promise<void>;
   status?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
   doctor?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
+  linear?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
   stopRun?(input: { teamId: string; channelId: string; runId?: string; requestedBy: string }): Promise<SlackStopRunResult>;
   canManageBinding?(input: SlackBindingManagementContext): Promise<boolean> | boolean;
   now(): string;
@@ -155,6 +156,7 @@ const HELP_TEXT = [
   "- @mention the app with `/bind <owner>/<repo>` or `/bind <provider>:<owner>/<repo>` to connect this Slack channel to a Project Target.",
   "- @mention the app with `/status` to see the Project Target, active run, queued follow-ups, and next safe action.",
   "- @mention the app with `/doctor` to see a redacted readiness summary for this Slack channel.",
+  "- @mention the app with `/linear` to list unfinished Linear issues for the configured Linear project (read-only).",
   "- @mention the app with `/stop [run_id]` to request cancellation for the active channel run or a specific run; OpenTag will not treat stop as successful completion.",
   "- @mention the app with `/unbind confirm` to disconnect this Slack channel from its Project Target; this does not delete local checkout config.",
   "- Reply in a source thread with `apply 1`, `approve 1`, `reject 1`, or `continue 1` when OpenTag posts source-thread actions.",
@@ -170,6 +172,10 @@ const STOP_UNAVAILABLE_TEXT = [
   "Run cancellation from this Slack ingress is not configured.",
   "OpenTag will not treat a stop request as a successful completion. Use `opentag status --run <run_id>` for audit detail, or `opentag service stop` if you need to stop the local background service."
 ].join("\n");
+const LINEAR_UNAVAILABLE_TEXT =
+  "Linear backlog is not available on this OpenTag runtime. Start OpenTag with `opentag start` after configuring platforms.linear, or update the ingress deployment.";
+const LINEAR_USAGE =
+  "Usage: @mention the app with `/linear` to list unfinished Linear issues for the configured Linear project (read-only).";
 const BINDING_AUTH_DENIED_TEXT =
   "Only an authorized Slack binding manager can change this channel's Project Target. Ask an admin to run the command or update local OpenTag channel bindings.";
 
@@ -183,6 +189,16 @@ function parseSelfServiceCommand(command: string | null): "help" | "status" | "d
   if (/^\/help(\s|$)/.test(trimmed)) return "help";
   if (/^\/status(\s|$)/.test(trimmed)) return "status";
   if (/^\/doctor(\s|$)/.test(trimmed)) return "doctor";
+  return null;
+}
+
+function parseLinearCommand(command: string | null): { ok: true } | { ok: false } | null {
+  const trimmed = command?.trim();
+  if (!trimmed) return null;
+  if (/^\/?linear$/iu.test(trimmed)) return { ok: true };
+  // A slash prefix is an unambiguous command attempt; extra arguments get usage help.
+  if (/^\/linear(\s|$)/iu.test(trimmed)) return { ok: false };
+  // Bare "linear <more words>" stays a normal coding-run mention.
   return null;
 }
 
@@ -555,6 +571,38 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
           });
         }
         return json({ ok: true, selfService: "stop", outcome: result.outcome, ...(result.runId ? { runId: result.runId } : {}) });
+      }
+      const linearRequest = payload.event.type === "app_mention" ? parseLinearCommand(rawThreadActionText) : null;
+      if (linearRequest) {
+        const threadTs = payload.event.thread_ts ?? payload.event.ts;
+        if (!input.reply) {
+          return json({ ok: true, ignored: "self_service_reply_unavailable", command: "linear" });
+        }
+        if (!linearRequest.ok) {
+          await input.reply({ channelId: payload.event.channel, threadTs, text: LINEAR_USAGE });
+          return json({ ok: true, selfService: "linear", usage: true });
+        }
+        if (!input.linear) {
+          await input.reply({ channelId: payload.event.channel, threadTs, text: LINEAR_UNAVAILABLE_TEXT });
+          return json({ ok: true, selfService: "linear", unavailable: true });
+        }
+        // The Linear project is configured globally; no Project Target binding is required.
+        const reply = normalizeSelfServiceReply(
+          await input.linear({
+            teamId: payload.team_id,
+            channelId: payload.event.channel,
+            threadTs,
+            userId: payload.event.user,
+            binding: null
+          })
+        );
+        await input.reply({
+          channelId: payload.event.channel,
+          threadTs,
+          text: reply.text,
+          ...(reply.blocks?.length ? { blocks: reply.blocks } : {})
+        });
+        return json({ ok: true, selfService: "linear" });
       }
       const selfServiceCommand = payload.event.type === "app_mention" ? parseSelfServiceCommand(rawThreadActionText) : null;
       if (selfServiceCommand) {

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -299,11 +299,23 @@ export function createSlackEventsApp(input: SlackEventsAppInput) {
       });
       return c.json({ error: resolvedSlackApp.error }, 401);
     }
-    const result = await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
-    if (result.kind === "text") {
-      return c.text(result.body, result.status);
+    if (payload.type === "url_verification") {
+      const result = await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
+      if (result.kind === "text") {
+        return c.text(result.body, result.status);
+      }
+      return c.json(result.body, result.status);
     }
-    return c.json(result.body, result.status);
+    // ACK immediately; process asynchronously so a slow handler cannot miss
+    // Slack's 3s deadline. Duplicate retries are dropped by event_id dedup in
+    // the processor. Errors are logged, not surfaced (the reply, if any, is
+    // delivered out-of-band via chat.postMessage).
+    void Promise.resolve()
+      .then(() => processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true }))
+      .catch((error) => {
+        console.error("[slack] async event processing failed:", error);
+      });
+    return c.json({ ok: true }, 200);
   });
 
   return app;

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -33,6 +33,7 @@ export type SlackEventsApiIngressConfig = {
   bindingAdminUserIds?: string[];
   runTimeoutMs?: number;
   maxRequestBodyBytes?: number;
+  linear?: SlackEventProcessorInput["linear"];
 } & SlackChannelPrincipalConfig;
 
 export type SlackIngressConfig = SlackEventsApiIngressConfig;

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -161,7 +161,7 @@ export function createSlackApprovalPromptBlocks(presentation: OpenTagApprovalPro
   ];
 }
 
-function escapeSlackText(text: string): string {
+export function escapeSlackText(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 

--- a/packages/slack/test/dispatcher-events.test.ts
+++ b/packages/slack/test/dispatcher-events.test.ts
@@ -387,3 +387,16 @@ describe("Slack dispatcher-backed self-service", () => {
     ]);
   });
 });
+
+describe("linear handler passthrough", () => {
+  it("copies the configured linear handler into the processor input", () => {
+    const linear = async () => "backlog";
+    const input = createSlackDispatcherEventProcessorInput({ dispatcherUrl: "http://localhost:3030", linear });
+    expect(input.linear).toBe(linear);
+  });
+
+  it("leaves linear undefined when not configured", () => {
+    const input = createSlackDispatcherEventProcessorInput({ dispatcherUrl: "http://localhost:3030" });
+    expect(input.linear).toBeUndefined();
+  });
+});

--- a/packages/slack/test/dispatcher-events.test.ts
+++ b/packages/slack/test/dispatcher-events.test.ts
@@ -163,6 +163,48 @@ describe("Slack dispatcher-backed self-service", () => {
     expect(JSON.stringify(requests[1]?.body)).toContain("timeout policy: hard timeout after 45 second(s).");
   });
 
+  it("posts a reply with textFormat: mrkdwn without re-escaping a hand-built Slack link", async () => {
+    const requests: Array<{ url: string; authorization?: string; body?: unknown }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      const headers = init?.headers as Record<string, string> | undefined;
+      requests.push({
+        url: href,
+        ...(headers?.authorization ? { authorization: headers.authorization } : {}),
+        ...(typeof init?.body === "string" ? { body: JSON.parse(init.body) as unknown } : {})
+      });
+      if (href === "https://slack.com/api/chat.postMessage") {
+        return Response.json({ ok: true, ts: "1719187201.000100" });
+      }
+      return Response.json({ error: "unexpected_url" }, { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const processorInput = createSlackDispatcherEventProcessorInput({
+      dispatcherUrl: "http://dispatcher.test",
+      botToken: "xoxb-test",
+      fetchImpl
+    });
+
+    await processorInput.reply!({
+      channelId: "C123",
+      threadTs: "1719187200.000100",
+      text: "<https://x|A>",
+      textFormat: "mrkdwn"
+    });
+
+    expect(requests).toEqual([
+      expect.objectContaining({
+        url: "https://slack.com/api/chat.postMessage",
+        authorization: "Bearer xoxb-test",
+        body: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1719187200.000100",
+          text: "<https://x|A>"
+        })
+      })
+    ]);
+  });
+
   it("cancels a specific run through the dispatcher", async () => {
     const requests: Array<{ url: string; authorization?: string; body?: unknown }> = [];
     const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -74,3 +74,123 @@ describe("Slack thread action metadata", () => {
     expectRepoFreeMetadata(submitted[0]!.metadata);
   });
 });
+
+describe("Slack /linear self-service command", () => {
+  type Reply = { channelId: string; threadTs: string; text: string };
+
+  function linearProcessor(input: {
+    replies: Reply[];
+    runs: string[];
+    linearCalls?: number[];
+    linearReply?: string;
+    withLinearHandler?: boolean;
+  }) {
+    return createSlackEventProcessor({
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        input.runs.push("run_created");
+        return { runId: "run_1" };
+      },
+      async reply(reply) {
+        input.replies.push({ channelId: reply.channelId, threadTs: reply.threadTs, text: reply.text });
+      },
+      ...(input.withLinearHandler === false
+        ? {}
+        : {
+            async linear() {
+              input.linearCalls?.push(1);
+              return input.linearReply ?? "OpenTag project backlog — 1 open issue";
+            }
+          }),
+      now: () => "2026-07-16T00:00:00.000Z"
+    });
+  }
+
+  function mentionEvent(text: string) {
+    return {
+      type: "event_callback" as const,
+      team_id: "T123",
+      event_id: "EvLinear1",
+      authorizations: [{ user_id: "UBOT" }],
+      event: {
+        type: "app_mention" as const,
+        channel: "C123",
+        user: "U456",
+        text,
+        ts: "1719187200.000100"
+      }
+    };
+  }
+
+  it.each(["<@UBOT> linear", "<@UBOT> /linear", "<@UBOT> LINEAR", "<@UBOT>  /Linear  "])(
+    "replies with the backlog and does not create a run for %j",
+    async (text) => {
+      const replies: Reply[] = [];
+      const runs: string[] = [];
+      const linearCalls: number[] = [];
+
+      const result = await linearProcessor({ replies, runs, linearCalls }).process(mentionEvent(text), { agentId: "opentag" });
+
+      expect(result.body).toMatchObject({ ok: true, selfService: "linear" });
+      expect(linearCalls).toHaveLength(1);
+      expect(runs).toHaveLength(0);
+      expect(replies).toHaveLength(1);
+      expect(replies[0]).toMatchObject({ channelId: "C123", threadTs: "1719187200.000100" });
+      expect(replies[0]!.text).toContain("OpenTag project backlog");
+    }
+  );
+
+  it("replies usage for /linear with extra arguments and does not create a run", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+    const linearCalls: number[] = [];
+
+    const result = await linearProcessor({ replies, runs, linearCalls }).process(
+      mentionEvent("<@UBOT> /linear something else"),
+      { agentId: "opentag" }
+    );
+
+    expect(result.body).toMatchObject({ ok: true, selfService: "linear", usage: true });
+    expect(linearCalls).toHaveLength(0);
+    expect(runs).toHaveLength(0);
+    expect(replies[0]!.text).toContain("Usage");
+  });
+
+  it("does NOT intercept a bare linear mention with extra words (normal run flow)", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+    const linearCalls: number[] = [];
+
+    await linearProcessor({ replies, runs, linearCalls }).process(
+      mentionEvent("<@UBOT> linear regression in the parser, please fix"),
+      { agentId: "opentag" }
+    );
+
+    expect(linearCalls).toHaveLength(0);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("replies a safe unavailable message when no linear handler is configured", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+
+    const result = await linearProcessor({ replies, runs, withLinearHandler: false }).process(
+      mentionEvent("<@UBOT> /linear"),
+      { agentId: "opentag" }
+    );
+
+    expect(result.body).toMatchObject({ ok: true, selfService: "linear", unavailable: true });
+    expect(runs).toHaveLength(0);
+    expect(replies[0]!.text).toContain("not available");
+  });
+
+  it("lists /linear in help output", async () => {
+    const replies: Reply[] = [];
+
+    await linearProcessor({ replies, runs: [] }).process(mentionEvent("<@UBOT> /help"), { agentId: "opentag" });
+
+    expect(replies[0]!.text).toContain("/linear");
+  });
+});

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -75,6 +75,63 @@ describe("Slack thread action metadata", () => {
   });
 });
 
+describe("Slack event_id dedup", () => {
+  function dedupProcessor(input: { runs: string[] }) {
+    return createSlackEventProcessor({
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        input.runs.push("run_created");
+        return { runId: "run_1" };
+      },
+      now: () => "2026-07-16T00:00:00.000Z"
+    });
+  }
+
+  function mentionPayload(eventId: string) {
+    return {
+      type: "event_callback" as const,
+      team_id: "T123",
+      event_id: eventId,
+      authorizations: [{ user_id: "UBOT" }],
+      event: {
+        type: "app_mention" as const,
+        channel: "C123",
+        user: "U456",
+        text: "<@UBOT> fix the bug",
+        ts: "1719187200.000100"
+      }
+    };
+  }
+
+  it("drops a duplicate delivery of the same event_id and runs the handler only once", async () => {
+    const runs: string[] = [];
+    const processor = dedupProcessor({ runs });
+
+    const first = await processor.process(mentionPayload("EvDup1"), { agentId: "opentag" });
+    const second = await processor.process(mentionPayload("EvDup1"), { agentId: "opentag" });
+
+    expect(first.body).toMatchObject({ ok: true });
+    expect(first.body).not.toHaveProperty("ignored", "duplicate_event");
+    expect(second.body).toEqual({ ok: true, ignored: "duplicate_event" });
+    expect(runs).toHaveLength(1);
+  });
+
+  it("processes two different event_ids independently (no false dedup)", async () => {
+    const runs: string[] = [];
+    const processor = dedupProcessor({ runs });
+
+    const first = await processor.process(mentionPayload("EvDup2"), { agentId: "opentag" });
+    const second = await processor.process(mentionPayload("EvDup3"), { agentId: "opentag" });
+
+    expect(first.body).toMatchObject({ ok: true });
+    expect(second.body).toMatchObject({ ok: true });
+    expect(second.body).not.toHaveProperty("ignored", "duplicate_event");
+    expect(runs).toHaveLength(2);
+  });
+});
+
 describe("Slack /linear self-service command", () => {
   type Reply = { channelId: string; threadTs: string; text: string; textFormat?: "mrkdwn" };
 

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -76,13 +76,13 @@ describe("Slack thread action metadata", () => {
 });
 
 describe("Slack /linear self-service command", () => {
-  type Reply = { channelId: string; threadTs: string; text: string };
+  type Reply = { channelId: string; threadTs: string; text: string; textFormat?: "mrkdwn" };
 
   function linearProcessor(input: {
     replies: Reply[];
     runs: string[];
     linearCalls?: number[];
-    linearReply?: string;
+    linearReply?: string | { text: string; textFormat?: "mrkdwn" };
     withLinearHandler?: boolean;
   }) {
     return createSlackEventProcessor({
@@ -94,7 +94,12 @@ describe("Slack /linear self-service command", () => {
         return { runId: "run_1" };
       },
       async reply(reply) {
-        input.replies.push({ channelId: reply.channelId, threadTs: reply.threadTs, text: reply.text });
+        input.replies.push({
+          channelId: reply.channelId,
+          threadTs: reply.threadTs,
+          text: reply.text,
+          ...(reply.textFormat ? { textFormat: reply.textFormat } : {})
+        });
       },
       ...(input.withLinearHandler === false
         ? {}
@@ -192,5 +197,19 @@ describe("Slack /linear self-service command", () => {
     await linearProcessor({ replies, runs: [] }).process(mentionEvent("<@UBOT> /help"), { agentId: "opentag" });
 
     expect(replies[0]!.text).toContain("/linear");
+  });
+
+  it("forwards textFormat: mrkdwn from a linear handler reply so links are not re-escaped", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+
+    await linearProcessor({
+      replies,
+      runs,
+      linearReply: { text: "• <https://x|AMP-1> — t", textFormat: "mrkdwn" }
+    }).process(mentionEvent("<@UBOT> /linear"), { agentId: "opentag" });
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toMatchObject({ text: "• <https://x|AMP-1> — t", textFormat: "mrkdwn" });
   });
 });

--- a/packages/slack/test/ingress.test.ts
+++ b/packages/slack/test/ingress.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { computeSlackSignature, createSlackEventsApp } from "../src/ingress.js";
+
+describe("Slack Events API ack-then-async", () => {
+  const now = "2024-06-24T00:00:00.000Z";
+  const currentTimestamp = "1719187200";
+  const currentClock = () => Number(currentTimestamp) * 1000;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function sign(rawBody: string, timestamp = currentTimestamp) {
+    return computeSlackSignature({ signingSecret: "secret", timestamp, rawBody });
+  }
+
+  it("keeps url_verification synchronous and echoes the challenge", async () => {
+    const rawBody = JSON.stringify({ type: "url_verification", challenge: "abc123" });
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return null;
+      },
+      async createRun() {
+        return { runId: "run_1" };
+      },
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("abc123");
+  });
+
+  it("acks an event_callback with {ok:true} before a slow handler finishes, then still runs it", async () => {
+    const timeline: string[] = [];
+    const createRun = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      timeline.push("createRun_finished");
+      return { runId: "run_1" };
+    });
+    const rawBody = JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event_id: "EvSlow1",
+      event_time: Number(currentTimestamp),
+      authorizations: [{ user_id: "U_APP" }],
+      event: {
+        type: "app_mention",
+        user: "U456",
+        text: "<@U_APP> fix this",
+        ts: `${currentTimestamp}.000100`,
+        channel: "C123"
+      }
+    });
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      createRun,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const start = Date.now();
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+    const elapsedMs = Date.now() - start;
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(elapsedMs).toBeLessThan(30);
+    expect(timeline).toHaveLength(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(timeline).toEqual(["createRun_finished"]);
+    expect(createRun).toHaveBeenCalledOnce();
+  });
+
+  it("logs and swallows an error from asynchronous event processing without changing the ack response", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failure = new Error("boom");
+    const createRun = vi.fn(async () => {
+      throw failure;
+    });
+    const rawBody = JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event_id: "EvFail1",
+      event_time: Number(currentTimestamp),
+      authorizations: [{ user_id: "U_APP" }],
+      event: {
+        type: "app_mention",
+        user: "U456",
+        text: "<@U_APP> fix this",
+        ts: `${currentTimestamp}.000100`,
+        channel: "C123"
+      }
+    });
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      createRun,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(createRun).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith("[slack] async event processing failed:", failure);
+  });
+
+  it("acks a block_actions interactive payload with {ok:true} immediately", async () => {
+    const submitThreadAction = vi.fn(async () => ({}));
+    const interactivePayload = {
+      type: "block_actions",
+      team: { id: "T123" },
+      user: { id: "U456", username: "alice" },
+      channel: { id: "C123" },
+      message: { ts: `${currentTimestamp}.000500`, thread_ts: `${currentTimestamp}.000100` },
+      trigger_id: "trigger_apply_1",
+      actions: [
+        {
+          type: "button",
+          action_id: "opentag:apply:1",
+          value: JSON.stringify({ version: 1, command: "apply 1", proposalId: "proposal_1", intentId: "intent_1" })
+        }
+      ]
+    };
+    const rawBody = new URLSearchParams({ payload: JSON.stringify(interactivePayload) }).toString();
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        return { runId: "run_1" };
+      },
+      submitThreadAction,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(submitThreadAction).toHaveBeenCalledOnce();
+  });
+
+  it("still returns 400 synchronously for malformed JSON without invoking the processor", async () => {
+    const rawBody = "{not-json";
+    const createRun = vi.fn(async () => ({ runId: "run_1" }));
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return null;
+      },
+      createRun,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_json" });
+    expect(createRun).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a deterministic, read-only Slack self-service command — `@OpenTag linear` or `/linear` — that lists the configured Linear project's unfinished issues in the original Slack thread. No Agent Run is created, no LLM is involved, and Linear is never mutated.

Implements Stage 1 (5.1) of the Linear-led project status MVP. Linear issue: AMP-153.

### Reply format (real-Slack verified)

```
*opentag · 9 open*

🔵 *In Progress (2)*
• AMP-153 [urgent] Slack：通过 @opentag linear 查询未完成的 Linear 任务
• ...

⚪ *Todo (3)*
• ...

_Linear · queried 22:48 UTC_
```

Project name comes from Linear; issues are grouped by state (🔵 started ⚪ unstarted ⚫ backlog 🟣 triage), sorted by priority within each group, with `[urgent]`/`[high]` markers; 20-result limit with explicit truncation notice.

### Architecture

- `packages/linear/backlog.ts` — read-only GraphQL query (project name, priority, non-completed/canceled issues) through the existing `linearGraphql` helper; 10s timeout
- `packages/slack/events.ts` — deterministic command parsing (`linear` / `/linear`, case-insensitive) with an injected `linear?()` handler, intercepted before `createRun`; bare `linear <words>` still flows to the normal coding-run path
- `packages/cli/slack-linear-backlog.ts` — config resolution (`platforms.linear.token/projectId` with `OPENTAG_LINEAR_API_KEY`/`OPENTAG_LINEAR_PROJECT_ID` env fallback), mrkdwn rendering with escaping + URL percent-encoding, safe error replies
- Config: new `platforms.linear.projectId`; query-only Linear configs (token + projectId, no `webhookSecret`) are now valid and do not mount the Linear webhook ingress

### Security / governance

- Token never appears in replies, errors, or logs (leak-negative tests at both layers)
- Linear-controlled text (titles, state names, project name) is Slack-escaped; issue URLs percent-encoded
- Query failures reply with a safe message and never fall back to creating a run

### Testing

- 1592/1592 tests green, `tsc -b` clean, full build clean
- Real Slack + real Linear dogfood passed: backlog reply with clickable links, usage reply for `/linear <args>`, no run created, normal mentions unaffected
- Dogfood caught and fixed 3 real-API issues mocks couldn't: unencoded non-ASCII Linear URLs, markdown pipeline escaping hand-built mrkdwn links, and a GraphQL variable-type mismatch (`project(id:)` wants `String!`, issue filter wants `ID`)

### Follow-ups (non-blocking)

- Timeout-abort + stateType-fallback + override tests in `packages/linear`
- Relay-mode gap: the `/linear` handler is not wired on relay-hosted Slack ingress (replies with a clear unavailable message)
- Relay-mode startup logging still prints webhook-secret messaging for query-only Linear configs (pre-existing path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only Slack `/linear` (and app mention) command to display a Linear project backlog in-thread, grouped by issue state, with priority markers and a capped “more not shown” notice.
  * Introduced “query-only” Linear support via project ID (no webhook required) for backlog lookup.
* **Bug Fixes / Improvements**
  * Improved Slack event handling to acknowledge immediately, avoid duplicate processing, and support Markdown-formatted replies without re-escaping.
* **Documentation**
  * Updated the Linear Slack configuration guide to cover `/linear` query behavior, limits, and when Linear webhook ingress is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->