### PR TITLE
AMP-153 Slack: secure and reliable /linear backlog query

### DIFF
--- a/apps/slack-events/test/app.test.ts
+++ b/apps/slack-events/test/app.test.ts
@@ -1,15 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { computeSlackSignature, createSlackEventsApp, verifySlackTimestamp } from "../src/app.js";
 
-// The Events API ingress acks event_callback/block_actions requests with
-// {ok:true} immediately and processes them in a detached background task
-// (see packages/slack/src/ingress.ts). Tests that assert on side effects of
-// that processing (created runs, replies, etc.) need to let the background
-// task run before asserting.
-function flushAsyncEvents(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 describe("Slack events app", () => {
   const now = "2024-06-24T00:00:00.000Z";
   const currentTimestamp = "1719187200";
@@ -93,7 +84,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(createRun).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(createRun).toHaveBeenCalledOnce());
     const [event] = createRun.mock.calls[0] ?? [];
     expect(event.target.agentId).toBe("gemini");
     expect(event.metadata.repoProvider).toBe("gitlab");
@@ -151,7 +142,7 @@ describe("Slack events app", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    await flushAsyncEvents();
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
       channelId: "C123",
@@ -216,7 +207,7 @@ describe("Slack events app", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    await flushAsyncEvents();
+    await vi.waitFor(() => expect(bindChannel).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(canManageBinding).toHaveBeenCalledWith({
       action: "bind",
@@ -289,7 +280,7 @@ describe("Slack events app", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    await flushAsyncEvents();
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(bindChannel).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
@@ -347,7 +338,7 @@ describe("Slack events app", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    await flushAsyncEvents();
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(bindChannel).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
@@ -403,7 +394,7 @@ describe("Slack events app", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    await flushAsyncEvents();
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
       channelId: "C123",
@@ -460,7 +451,7 @@ describe("Slack events app", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    await flushAsyncEvents();
+    await vi.waitFor(() => expect(stopRun).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(stopRun).toHaveBeenCalledWith({
       teamId: "T123",
@@ -528,6 +519,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
+    await vi.waitFor(() => expect(submitThreadAction).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(submitThreadAction).toHaveBeenCalledWith({
       id: "approval_slack_EvAction",
@@ -630,6 +622,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
+    await vi.waitFor(() => expect(submitThreadAction).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(submitThreadAction).toHaveBeenCalledWith({
       id: "approval_slack_block_trigger_apply_1",
@@ -812,7 +805,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(createRun).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(createRun).toHaveBeenCalledOnce());
     const [event] = createRun.mock.calls[0] ?? [];
     expect(event.target.agentId).toBe("deepseek");
   });

--- a/apps/slack-events/test/app.test.ts
+++ b/apps/slack-events/test/app.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { computeSlackSignature, createSlackEventsApp, verifySlackTimestamp } from "../src/app.js";
 
+// The Events API ingress acks event_callback/block_actions requests with
+// {ok:true} immediately and processes them in a detached background task
+// (see packages/slack/src/ingress.ts). Tests that assert on side effects of
+// that processing (created runs, replies, etc.) need to let the background
+// task run before asserting.
+function flushAsyncEvents(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("Slack events app", () => {
   const now = "2024-06-24T00:00:00.000Z";
   const currentTimestamp = "1719187200";
@@ -141,7 +150,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "status" });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
       channelId: "C123",
@@ -205,7 +215,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind" });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(canManageBinding).toHaveBeenCalledWith({
       action: "bind",
@@ -277,7 +288,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", unauthorized: true });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(bindChannel).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
@@ -334,7 +346,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", usage: true });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(bindChannel).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
@@ -389,7 +402,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", unavailable: true });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
       channelId: "C123",
@@ -445,12 +459,8 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      ok: true,
-      selfService: "stop",
-      outcome: "cancelled",
-      runId: "run_active"
-    });
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await flushAsyncEvents();
     expect(createRun).not.toHaveBeenCalled();
     expect(stopRun).toHaveBeenCalledWith({
       teamId: "T123",

--- a/apps/slack-events/test/app.test.ts
+++ b/apps/slack-events/test/app.test.ts
@@ -84,7 +84,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await vi.waitFor(() => expect(createRun).toHaveBeenCalledOnce());
+    expect(createRun).toHaveBeenCalledOnce();
     const [event] = createRun.mock.calls[0] ?? [];
     expect(event.target.agentId).toBe("gemini");
     expect(event.metadata.repoProvider).toBe("gitlab");
@@ -141,8 +141,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
+    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "status" });
     expect(createRun).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
       channelId: "C123",
@@ -206,8 +205,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    await vi.waitFor(() => expect(bindChannel).toHaveBeenCalledOnce());
+    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind" });
     expect(createRun).not.toHaveBeenCalled();
     expect(canManageBinding).toHaveBeenCalledWith({
       action: "bind",
@@ -279,8 +277,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
+    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", unauthorized: true });
     expect(createRun).not.toHaveBeenCalled();
     expect(bindChannel).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
@@ -337,8 +334,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
+    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", usage: true });
     expect(createRun).not.toHaveBeenCalled();
     expect(bindChannel).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
@@ -393,8 +389,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
+    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "bind", unavailable: true });
     expect(createRun).not.toHaveBeenCalled();
     expect(reply).toHaveBeenCalledWith({
       channelId: "C123",
@@ -450,8 +445,12 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    await vi.waitFor(() => expect(stopRun).toHaveBeenCalledOnce());
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      selfService: "stop",
+      outcome: "cancelled",
+      runId: "run_active"
+    });
     expect(createRun).not.toHaveBeenCalled();
     expect(stopRun).toHaveBeenCalledWith({
       teamId: "T123",
@@ -519,7 +518,6 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await vi.waitFor(() => expect(submitThreadAction).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(submitThreadAction).toHaveBeenCalledWith({
       id: "approval_slack_EvAction",
@@ -622,7 +620,6 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await vi.waitFor(() => expect(submitThreadAction).toHaveBeenCalledOnce());
     expect(createRun).not.toHaveBeenCalled();
     expect(submitThreadAction).toHaveBeenCalledWith({
       id: "approval_slack_block_trigger_apply_1",
@@ -805,7 +802,7 @@ describe("Slack events app", () => {
     });
 
     expect(response.status).toBe(200);
-    await vi.waitFor(() => expect(createRun).toHaveBeenCalledOnce());
+    expect(createRun).toHaveBeenCalledOnce();
     const [event] = createRun.mock.calls[0] ?? [];
     expect(event.target.agentId).toBe("deepseek");
   });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -654,6 +654,7 @@ webhook path for hosted Linear OAuth App installs.
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `OPENTAG_LINEAR_API_KEY` / `OPENTAG_LINEAR_TOKEN` | none | Linear OAuth access token or raw `lin_api_...` API key used for callbacks and direct issue apply; OAuth tokens may include or omit the `Bearer ` prefix |
+| `OPENTAG_LINEAR_PROJECT_ID` | none | Linear project id used by the read-only Slack `/linear` backlog command; prefer `platforms.linear.projectId` in the OpenTag config |
 | `OPENTAG_LINEAR_GRAPHQL_URL` | `https://api.linear.app/graphql` | Optional Linear GraphQL endpoint override |
 | `OPENTAG_LINEAR_WEBHOOK_SECRET` | none | Enables dispatcher-mounted Linear webhook ingress and verifies `Linear-Signature` |
 | `OPENTAG_LINEAR_WEBHOOK_PATH` | `/linear/webhooks` | Public Linear webhook path |
@@ -836,6 +837,16 @@ before the daemon can claim and execute runs for it. Binding changes require
 the sender's Slack user id to be listed in
 `OPENTAG_SLACK_BINDING_ADMIN_USER_IDS`, or the channel binding must be updated
 from local config or the dispatcher API.
+
+Slack source-thread queries can also list the configured Linear project's
+unfinished issues with `/linear` (or the bare mention `@OpenTag linear`). The
+command is deterministic and read-only: it does not create an Agent Run, does
+not modify Linear, and replies in the original thread with issue identifiers,
+titles, states, the query timestamp, and an explicit truncation notice above
+20 results. Configure `platforms.linear.token` and `platforms.linear.projectId`
+(or the `OPENTAG_LINEAR_API_KEY` / `OPENTAG_LINEAR_PROJECT_ID` environment
+fallback). A query-only Linear config needs no `webhookSecret`; the Linear
+webhook ingress is only mounted when `webhookSecret` is present.
 
 ## Lark Ingress Environment
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -654,7 +654,7 @@ webhook path for hosted Linear OAuth App installs.
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `OPENTAG_LINEAR_API_KEY` / `OPENTAG_LINEAR_TOKEN` | none | Linear OAuth access token or raw `lin_api_...` API key used for callbacks and direct issue apply; OAuth tokens may include or omit the `Bearer ` prefix |
-| `OPENTAG_LINEAR_PROJECT_ID` | none | Linear project id used by the read-only Slack `/linear` backlog command; prefer `platforms.linear.projectId` in the OpenTag config |
+| `OPENTAG_LINEAR_PROJECT_ID` | none | Legacy project fallback for older query integrations. It does **not** authorize or route Slack `/linear`; use `platforms.linear.channels` instead. |
 | `OPENTAG_LINEAR_GRAPHQL_URL` | `https://api.linear.app/graphql` | Optional Linear GraphQL endpoint override |
 | `OPENTAG_LINEAR_WEBHOOK_SECRET` | none | Enables dispatcher-mounted Linear webhook ingress and verifies `Linear-Signature` |
 | `OPENTAG_LINEAR_WEBHOOK_PATH` | `/linear/webhooks` | Public Linear webhook path |
@@ -838,15 +838,42 @@ the sender's Slack user id to be listed in
 `OPENTAG_SLACK_BINDING_ADMIN_USER_IDS`, or the channel binding must be updated
 from local config or the dispatcher API.
 
-Slack source-thread queries can also list the configured Linear project's
-unfinished issues with `/linear` (or the bare mention `@OpenTag linear`). The
-command is deterministic and read-only: it does not create an Agent Run, does
-not modify Linear, and replies in the original thread with issue identifiers,
-titles, states, the query timestamp, and an explicit truncation notice above
-20 results. Configure `platforms.linear.token` and `platforms.linear.projectId`
-(or the `OPENTAG_LINEAR_API_KEY` / `OPENTAG_LINEAR_PROJECT_ID` environment
-fallback). A query-only Linear config needs no `webhookSecret`; the Linear
-webhook ingress is only mounted when `webhookSecret` is present.
+Slack source-thread queries can list unfinished Linear issues with `/linear`
+(or the bare mention `@OpenTag linear`). The command is deterministic and
+read-only: it does not create an Agent Run, does not modify Linear, and replies
+in the original thread with issue identifiers, titles, states, priorities,
+URLs, the query timestamp, and an explicit truncation notice above 20 results.
+
+`platforms.linear.channels` is the required Slack allowlist and project router.
+There is no global/default project for `/linear`: both `teamId` and `channelId`
+must match an entry exactly, and that entry's `projectId` is the only project
+queried. Legacy `platforms.linear.projectId` and `OPENTAG_LINEAR_PROJECT_ID`
+values do not authorize a Slack channel.
+
+```json
+{
+  "platforms": {
+    "linear": {
+      "connections": {
+        "default": { "token": { "kind": "env", "name": "OPENTAG_LINEAR_API_KEY" } }
+      },
+      "channels": [
+        { "teamId": "T123", "channelId": "C123", "projectId": "project-id", "connection": "default" }
+      ]
+    }
+  }
+}
+```
+
+`connections.default.token` is query-only and can never enable Linear apply or
+webhook mutations. A query-only config needs no `webhookSecret`. Mutation and
+webhook paths continue to require the top-level `platforms.linear.token` plus
+their existing explicit configuration. Omitting `connection` selects
+`default`; other connection names are accepted for forward-compatible config
+but fail closed at runtime until multi-workspace querying is implemented.
+For an authorized channel, query token precedence is the live OAuth token
+provider, `connections.default.token`, top-level `platforms.linear.token`,
+`OPENTAG_LINEAR_API_KEY`, then `OPENTAG_LINEAR_TOKEN`.
 
 ## Lark Ingress Environment
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -844,6 +844,16 @@ read-only: it does not create an Agent Run, does not modify Linear, and replies
 in the original thread with issue identifiers, titles, states, priorities,
 URLs, the query timestamp, and an explicit truncation notice above 20 results.
 
+Events API delivery keeps this read-only query in its own bounded, best-effort
+lane. OpenTag acknowledges an admitted `/linear` query before the Linear request
+finishes, returns `503` when that query lane is full, suppresses duplicate
+pending or completed query deliveries by Slack `event_id`, and drains admitted
+queries during graceful shutdown. An abrupt process loss can still drop an
+already acknowledged query; users can safely run the read-only command again.
+Run creation, `/stop`, `/bind`, `/unbind`, thread approvals, and interactive
+actions do not use this in-memory lane: their Events API response waits for the
+processor result, so a failure is not converted into a successful ACK.
+
 `platforms.linear.channels` is the required Slack allowlist and project router.
 There is no global/default project for `/linear`: both `teamId` and `channelId`
 must match an entry exactly, and that entry's `projectId` is the only project

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -848,8 +848,9 @@ Events API delivery keeps this read-only query in its own bounded, best-effort
 lane. OpenTag acknowledges an admitted `/linear` query before the Linear request
 finishes, returns `503` when that query lane is full, suppresses duplicate
 pending or completed query deliveries by Slack `event_id`, and drains admitted
-queries during graceful shutdown. An abrupt process loss can still drop an
-already acknowledged query; users can safely run the read-only command again.
+queries for up to 30 seconds during graceful shutdown. Work still running after
+that bound, or an abrupt process loss, can drop an already acknowledged query;
+users can safely run the read-only command again.
 Run creation, `/stop`, `/bind`, `/unbind`, thread approvals, and interactive
 actions do not use this in-memory lane: their Events API response waits for the
 processor result, so a failure is not converted into a successful ACK.

--- a/docs/platforms/slack.en.md
+++ b/docs/platforms/slack.en.md
@@ -247,6 +247,21 @@ Slack self-service commands stay Project Target based:
 
 These commands do not accept absolute local checkout paths. Local paths belong in runner config and allowlists, not in Slack history. Channel binding changes also require the sender's Slack user id to be listed in `OPENTAG_SLACK_BINDING_ADMIN_USER_IDS`; otherwise update bindings from local config or the dispatcher API. Detailed process and audit data stay local; use `opentag status --run <run_id>` or `opentag service status` for deeper inspection.
 
+The read-only `@OpenTag /linear` command uses a separate channel allowlist;
+it does not use the repository Project Target binding as authorization. Add an
+exact `(teamId, channelId)` entry under `platforms.linear.channels`, with the
+Linear `projectId` that channel may query. An unlisted channel is denied before
+OpenTag reads a Linear credential or calls Linear, and there is no global
+project fallback from `platforms.linear.projectId` or
+`OPENTAG_LINEAR_PROJECT_ID`.
+
+For query-only credentials, prefer
+`platforms.linear.connections.default.token`. That credential only powers
+backlog reads and does not create an Agent Run or enable Linear mutations. A
+query-only setup does not need `webhookSecret`. The optional `connection` field
+currently supports only `default`; other names fail closed instead of falling
+back to another workspace token.
+
 When OpenTag posts suggested actions, follow the receipt state. If it says **Ready to apply**, click **Apply 1** in Slack or type `apply 1` in the thread. Both paths apply the same source-thread action.
 If the receipt says **Needs setup**, OpenTag will show **Continue** or a setup hint instead of presenting **Apply 1** as the primary path. Configure GitHub as a repository target before expecting Slack receipts to create PRs directly.
 

--- a/docs/platforms/slack.en.md
+++ b/docs/platforms/slack.en.md
@@ -255,6 +255,14 @@ OpenTag reads a Linear credential or calls Linear, and there is no global
 project fallback from `platforms.linear.projectId` or
 `OPENTAG_LINEAR_PROJECT_ID`.
 
+In Events API mode, only an exact `@OpenTag /linear` or `@OpenTag linear` query
+uses the bounded asynchronous query lane. The lane is best effort: it is drained
+on graceful shutdown, returns `503` when full, and may lose an acknowledged
+query if the process exits abruptly. Re-run `/linear` in that case. Run
+creation, stop/bind/unbind commands, approvals, and interactive buttons remain
+outside this lane and finish processing before OpenTag returns their HTTP
+response.
+
 For query-only credentials, prefer
 `platforms.linear.connections.default.token`. That credential only powers
 backlog reads and does not create an Agent Run or enable Linear mutations. A

--- a/docs/platforms/slack.en.md
+++ b/docs/platforms/slack.en.md
@@ -257,8 +257,9 @@ project fallback from `platforms.linear.projectId` or
 
 In Events API mode, only an exact `@OpenTag /linear` or `@OpenTag linear` query
 uses the bounded asynchronous query lane. The lane is best effort: it is drained
-on graceful shutdown, returns `503` when full, and may lose an acknowledged
-query if the process exits abruptly. Re-run `/linear` in that case. Run
+for up to 30 seconds on graceful shutdown, returns `503` when full, and may lose
+an acknowledged query after that drain bound or if the process exits abruptly.
+Re-run `/linear` in that case. Run
 creation, stop/bind/unbind commands, approvals, and interactive buttons remain
 outside this lane and finish processing before OpenTag returns their HTTP
 response.

--- a/docs/platforms/slack.zh-CN.md
+++ b/docs/platforms/slack.zh-CN.md
@@ -246,6 +246,20 @@ Slack 自服务命令仍然围绕 Project Target：
 
 这些命令不接受本机绝对 checkout 路径。本机路径只应该留在 runner config 和 allowlist 里，不应该写进 Slack 历史。Slack channel 的绑定变更还要求发送者的 Slack user id 出现在 `OPENTAG_SLACK_BINDING_ADMIN_USER_IDS`；否则应从本机配置或 dispatcher API 更新绑定。详细过程和 audit 数据默认留在本机；需要更深排查时用 `opentag status --run <run_id>` 或 `opentag service status`。
 
+只读的 `@OpenTag /linear` 命令使用独立的 channel allowlist，不会把
+repository Project Target binding 当作授权依据。请在
+`platforms.linear.channels` 中加入精确匹配的 `(teamId, channelId)`，并在该
+entry 中指定这个 channel 可以查询的 Linear `projectId`。未列入 allowlist
+的 channel 会在读取 Linear credential 或调用 Linear API 之前被拒绝；
+`platforms.linear.projectId` 和 `OPENTAG_LINEAR_PROJECT_ID` 都不会作为全局
+project fallback。
+
+query-only credential 建议配置在
+`platforms.linear.connections.default.token`。它只能用于 backlog read，
+不会创建 Agent Run，也不会启用 Linear mutation；query-only 配置不需要
+`webhookSecret`。可选的 `connection` 字段目前只支持 `default`，其他名称会
+fail closed，不会回退到别的 workspace token。
+
 当 OpenTag 发出 suggested actions 时，先看 receipt state。如果显示 **Ready to apply**，可以在 Slack 里点击 **Apply 1**，也可以在线程里手动回复 `apply 1`。两种方式都会应用同一个 source-thread action。
 如果 receipt 显示 **Needs setup**，OpenTag 会显示 **Continue** 或 setup hint，而不是把 **Apply 1** 当成主路径。想让 Slack receipt 直接创建 PR，需要先配置 GitHub repository target。
 

--- a/docs/platforms/slack.zh-CN.md
+++ b/docs/platforms/slack.zh-CN.md
@@ -256,8 +256,9 @@ project fallback。
 
 在 Events API 模式里，只有精确的 `@OpenTag /linear` 或 `@OpenTag linear`
 查询会进入受限的异步 query lane。这个 lane 是 best-effort：正常关闭时会
-drain 已接收查询，队列满时返回 `503`；如果进程突然退出，已经 ACK 的查询
-仍可能丢失，此时可以安全地重新执行 `/linear`。创建 run、stop/bind/unbind、
+最多等待 30 秒 drain 已接收查询，队列满时返回 `503`；超过 drain 上限或
+进程突然退出时，已经 ACK 的查询仍可能丢失，此时可以安全地重新执行
+`/linear`。创建 run、stop/bind/unbind、
 审批和交互按钮都不会进入这条内存队列；OpenTag 会等它们处理完成后再返回
 对应的 Events API HTTP 响应。
 

--- a/docs/platforms/slack.zh-CN.md
+++ b/docs/platforms/slack.zh-CN.md
@@ -254,6 +254,13 @@ entry 中指定这个 channel 可以查询的 Linear `projectId`。未列入 all
 `platforms.linear.projectId` 和 `OPENTAG_LINEAR_PROJECT_ID` 都不会作为全局
 project fallback。
 
+在 Events API 模式里，只有精确的 `@OpenTag /linear` 或 `@OpenTag linear`
+查询会进入受限的异步 query lane。这个 lane 是 best-effort：正常关闭时会
+drain 已接收查询，队列满时返回 `503`；如果进程突然退出，已经 ACK 的查询
+仍可能丢失，此时可以安全地重新执行 `/linear`。创建 run、stop/bind/unbind、
+审批和交互按钮都不会进入这条内存队列；OpenTag 会等它们处理完成后再返回
+对应的 Events API HTTP 响应。
+
 query-only credential 建议配置在
 `platforms.linear.connections.default.token`。它只能用于 backlog read，
 不会创建 Agent Run，也不会启用 Linear mutation；query-only 配置不需要

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -323,6 +323,21 @@ const LinearAuthSchema = z.discriminatedUnion("method", [
     .strict()
 ]);
 
+const LinearChannelSchema = z
+  .object({
+    teamId: z.string().trim().min(1),
+    channelId: z.string().trim().min(1),
+    projectId: z.string().trim().min(1),
+    connection: z.string().trim().min(1).optional()
+  })
+  .strict();
+
+const LinearConnectionSchema = z
+  .object({
+    token: SecretStringSchema
+  })
+  .strict();
+
 const LinearPlatformSchema = z
   .object({
     token: SecretStringSchema.optional(),
@@ -331,6 +346,8 @@ const LinearPlatformSchema = z
     teamId: z.string().min(1).optional(),
     teamKey: z.string().min(1).optional(),
     projectId: z.string().min(1).optional(),
+    channels: z.array(LinearChannelSchema).optional(),
+    connections: z.record(z.string().trim().min(1), LinearConnectionSchema).optional(),
     graphqlUrl: z.string().url().optional(),
     webhookPath: z.string().min(1).optional(),
     port: OptionalPortSchema,
@@ -346,20 +363,41 @@ const LinearPlatformSchema = z
   })
   .strict()
   .superRefine((value, context) => {
+    const seenChannels = new Set<string>();
+    value.channels?.forEach((channel, index) => {
+      const key = `${channel.teamId}\u0000${channel.channelId}`;
+      if (seenChannels.has(key)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["channels", index],
+          message: `Duplicate Linear channel mapping for ${channel.teamId}/${channel.channelId}.`
+        });
+      }
+      seenChannels.add(key);
+    });
+
     if (value.auth?.method === "hosted_oauth_app") return;
-    if (!value.token) {
+
+    const hasConnectionToken = Object.keys(value.connections ?? {}).length > 0;
+    if (value.webhookSecret && !value.token) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["token"],
-        message: "Linear token is required unless auth.method is hosted_oauth_app."
+        message: "Linear webhook/apply configuration requires the top-level Linear token. connections.*.token is query-only."
+      });
+    } else if (!value.token && !hasConnectionToken) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["token"],
+        message: "Linear token or connections.*.token is required unless auth.method is hosted_oauth_app."
       });
     }
-    if (!value.webhookSecret && !value.projectId) {
+    if (!value.webhookSecret && !value.projectId && !value.channels?.length) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["webhookSecret"],
         message:
-          "Linear webhookSecret is required unless auth.method is hosted_oauth_app or the config is query-only (projectId set)."
+          "Linear webhookSecret is required unless auth.method is hosted_oauth_app or the config is query-only (projectId or channels set)."
       });
     }
   });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -330,6 +330,7 @@ const LinearPlatformSchema = z
     webhookSecret: SecretStringSchema.optional(),
     teamId: z.string().min(1).optional(),
     teamKey: z.string().min(1).optional(),
+    projectId: z.string().min(1).optional(),
     graphqlUrl: z.string().url().optional(),
     webhookPath: z.string().min(1).optional(),
     port: OptionalPortSchema,
@@ -353,11 +354,12 @@ const LinearPlatformSchema = z
         message: "Linear token is required unless auth.method is hosted_oauth_app."
       });
     }
-    if (!value.webhookSecret) {
+    if (!value.webhookSecret && !value.projectId) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["webhookSecret"],
-        message: "Linear webhookSecret is required unless auth.method is hosted_oauth_app."
+        message:
+          "Linear webhookSecret is required unless auth.method is hosted_oauth_app or the config is query-only (projectId set)."
       });
     }
   });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -3,6 +3,7 @@ import { doctorHasFailures, executorsFromConfig, runDoctor, type DoctorCheck } f
 import { formatConfiguredCapabilities } from "./catalogs/capabilities.js";
 import type { PlatformId } from "./catalogs/platforms.js";
 import { defaultConfigPath, readCliConfig, readRedactedCliConfig, redactedCliConfig } from "./config.js";
+import { linearBacklogConfigDiagnostics } from "./linear-backlog-config.js";
 import { relaySecurityChecksFromConfig } from "./relay-security.js";
 import { formatSecretReadiness } from "./secret-readiness.js";
 
@@ -38,6 +39,11 @@ export function appendCliDoctorChecks(config: ReturnType<typeof readCliConfig>, 
       status: check.status,
       name: check.name,
       message: check.message
+    })),
+    ...linearBacklogConfigDiagnostics(config).map((diagnostic) => ({
+      status: "warn" as const,
+      name: diagnostic.code === "legacy-project-id" ? "Linear /linear channel mapping" : "Linear workspace connection",
+      message: diagnostic.message
     }))
   ];
 }

--- a/packages/cli/src/linear-backlog-config.ts
+++ b/packages/cli/src/linear-backlog-config.ts
@@ -1,0 +1,93 @@
+import type { OpenTagCliConfig } from "./config.js";
+
+type LinearConfig = NonNullable<OpenTagCliConfig["platforms"]["linear"]>;
+
+export type LinearBacklogChannelResolution =
+  | { kind: "not-configured"; reason: "channels-missing" }
+  | { kind: "unauthorized" }
+  | { kind: "unsupported-connection"; connection: string }
+  | {
+      kind: "authorized";
+      projectId: string;
+      connection: "default";
+      graphqlUrl?: string;
+    };
+
+function nonBlank(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function resolveLinearBacklogChannel(input: {
+  linear?: LinearConfig;
+  teamId: string;
+  channelId: string;
+  env?: NodeJS.ProcessEnv;
+}): LinearBacklogChannelResolution {
+  const channels = input.linear?.channels;
+  if (!channels?.length) {
+    return { kind: "not-configured", reason: "channels-missing" };
+  }
+
+  const mapping = channels.find((candidate) => candidate.teamId === input.teamId && candidate.channelId === input.channelId);
+  if (!mapping) return { kind: "unauthorized" };
+
+  const connection = mapping.connection ?? "default";
+  if (connection !== "default") {
+    return { kind: "unsupported-connection", connection };
+  }
+
+  const graphqlUrl = nonBlank(input.linear?.graphqlUrl) ?? nonBlank(input.env?.OPENTAG_LINEAR_GRAPHQL_URL);
+  return {
+    kind: "authorized",
+    projectId: mapping.projectId,
+    connection: "default",
+    ...(graphqlUrl ? { graphqlUrl } : {})
+  };
+}
+
+export function resolveDefaultLinearBacklogToken(input: {
+  linear?: LinearConfig;
+  env?: NodeJS.ProcessEnv;
+}): string | undefined {
+  return (
+    nonBlank(input.linear?.connections?.default?.token) ??
+    nonBlank(input.linear?.token) ??
+    nonBlank(input.env?.OPENTAG_LINEAR_API_KEY) ??
+    nonBlank(input.env?.OPENTAG_LINEAR_TOKEN)
+  );
+}
+
+export type LinearBacklogConfigDiagnostic = {
+  code: "legacy-project-id" | "unsupported-connection";
+  message: string;
+};
+
+export function linearBacklogConfigDiagnostics(config: OpenTagCliConfig): LinearBacklogConfigDiagnostic[] {
+  const linear = config.platforms.linear;
+  if (!config.platforms.slack || !linear) return [];
+
+  const diagnostics: LinearBacklogConfigDiagnostic[] = [];
+  if (linear.projectId && !linear.channels?.length) {
+    diagnostics.push({
+      code: "legacy-project-id",
+      message:
+        "Linear /linear channel mapping is not configured: platforms.linear.projectId no longer authorizes Slack channels. Add platforms.linear.channels entries and restart OpenTag."
+    });
+  }
+
+  const unsupportedConnections = [
+    ...new Set(
+      (linear.channels ?? [])
+        .map((channel) => channel.connection)
+        .filter((connection): connection is string => Boolean(connection && connection !== "default"))
+    )
+  ].sort();
+  for (const connection of unsupportedConnections) {
+    diagnostics.push({
+      code: "unsupported-connection",
+      message: `Linear workspace connection ${connection} is configured for /linear, but only the default connection is supported at runtime; those channels will remain unavailable.`
+    });
+  }
+  return diagnostics;
+}

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -27,7 +27,9 @@ function safeSlackLinkUrl(value: string): string | null {
   try {
     const url = new URL(value);
     if (url.protocol !== "https:" && url.protocol !== "http:") return null;
-    return url.href;
+    // Slack uses `|` as the separator in <url|label>; URL leaves literal
+    // pipes untouched, so encode them before embedding the href in mrkdwn.
+    return url.href.replaceAll("|", "%7C");
   } catch {
     return null;
   }
@@ -43,14 +45,19 @@ function renderIssueLine(issue: LinearBacklogIssue): string {
 
 type IssueGroup = { stateName: string; stateType: string; issues: LinearBacklogIssue[] };
 
+function stateGroupKey(input: Pick<LinearBacklogIssue, "stateName" | "stateType">): string {
+  return JSON.stringify([input.stateType, input.stateName]);
+}
+
 function groupShownIssues(shown: LinearBacklogIssue[]): IssueGroup[] {
   const groups: IssueGroup[] = [];
-  const byStateName = new Map<string, IssueGroup>();
+  const byState = new Map<string, IssueGroup>();
   for (const issue of shown) {
-    let group = byStateName.get(issue.stateName);
+    const key = stateGroupKey(issue);
+    let group = byState.get(key);
     if (!group) {
       group = { stateName: issue.stateName, stateType: issue.stateType, issues: [] };
-      byStateName.set(issue.stateName, group);
+      byState.set(key, group);
       groups.push(group);
     }
     group.issues.push(issue);
@@ -78,8 +85,13 @@ export function renderSlackLinearBacklogReply(input: {
     const showingSuffix = truncated ? ` · showing ${shown.length}` : "";
     lines.push(`*${name} · ${totalLabel} open*${showingSuffix}`);
 
+    const totalByState = new Map<string, number>();
+    for (const issue of backlog.issues) {
+      const key = stateGroupKey(issue);
+      totalByState.set(key, (totalByState.get(key) ?? 0) + 1);
+    }
     for (const group of groupShownIssues(shown)) {
-      const totalInGroup = backlog.issues.filter((issue) => issue.stateName === group.stateName).length;
+      const totalInGroup = totalByState.get(stateGroupKey(group)) ?? 0;
       const shownInGroup = group.issues.length;
       const countLabel = shownInGroup < totalInGroup ? `${shownInGroup} of ${totalInGroup}` : String(totalInGroup);
       const emoji = STATE_TYPE_EMOJI[group.stateType] ?? "▫️";

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -71,7 +71,10 @@ export function createSlackLinearBacklogHandler(input: {
         fetchImpl: input.fetchImpl ?? fetch,
         timeoutMs: SLACK_LINEAR_BACKLOG_TIMEOUT_MS
       });
-      return renderSlackLinearBacklogReply({ backlog, limit: SLACK_LINEAR_BACKLOG_LIMIT, queriedAt: now() });
+      return {
+        text: renderSlackLinearBacklogReply({ backlog, limit: SLACK_LINEAR_BACKLOG_LIMIT, queriedAt: now() }),
+        textFormat: "mrkdwn" as const
+      };
     } catch (error) {
       // linearGraphql error messages contain the HTTP status and GraphQL error
       // text only — never the token — so the message is safe for local logs.

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -10,7 +10,7 @@ const NOT_CONFIGURED_TEXT =
 const UNAVAILABLE_TEXT = "Linear API is unavailable right now; try again later.";
 
 export function resolveSlackLinearBacklogSettings(input: {
-  linear?: { token?: string; projectId?: string; graphqlUrl?: string } | undefined;
+  linear?: { token?: string | undefined; projectId?: string | undefined; graphqlUrl?: string | undefined } | undefined;
   env?: NodeJS.ProcessEnv;
 }): { token: string; projectId: string; graphqlUrl?: string } | null {
   const env = input.env ?? {};

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -1,16 +1,15 @@
 import { fetchLinearProjectBacklog, type LinearBacklogIssue, type LinearProjectBacklog } from "@opentag/linear";
 import { escapeSlackText, type SlackEventProcessorInput } from "@opentag/slack";
 import type { OpenTagCliConfig } from "./config.js";
+import { resolveDefaultLinearBacklogToken, resolveLinearBacklogChannel } from "./linear-backlog-config.js";
 
 export const SLACK_LINEAR_BACKLOG_LIMIT = 20;
 export const SLACK_LINEAR_BACKLOG_TIMEOUT_MS = 10_000;
 
 const NOT_CONFIGURED_TEXT =
-  "Linear backlog is not configured. Set platforms.linear.projectId and a Linear token in the OpenTag config, or export OPENTAG_LINEAR_API_KEY and OPENTAG_LINEAR_PROJECT_ID.";
+  "Linear backlog is not configured for Slack. Add an entry to platforms.linear.channels and configure a Linear query credential.";
 const UNAVAILABLE_TEXT = "Linear API is unavailable right now; try again later.";
 
-// Emoji shown before each state-type group heading; anything not in this map
-// (unknown/future Linear state types) falls back to a neutral marker.
 const STATE_TYPE_EMOJI: Record<string, string> = {
   started: "🔵",
   unstarted: "⚪",
@@ -18,33 +17,32 @@ const STATE_TYPE_EMOJI: Record<string, string> = {
   triage: "🟣"
 };
 
-export function resolveSlackLinearBacklogSettings(input: {
-  linear?: { token?: string | undefined; projectId?: string | undefined; graphqlUrl?: string | undefined } | undefined;
-  env?: NodeJS.ProcessEnv;
-}): { token: string; projectId: string; graphqlUrl?: string } | null {
-  const env = input.env ?? {};
-  const token = input.linear?.token ?? env.OPENTAG_LINEAR_API_KEY ?? env.OPENTAG_LINEAR_TOKEN;
-  const projectId = input.linear?.projectId ?? env.OPENTAG_LINEAR_PROJECT_ID;
-  if (!token?.trim() || !projectId?.trim()) return null;
-  const graphqlUrl = input.linear?.graphqlUrl ?? env.OPENTAG_LINEAR_GRAPHQL_URL;
-  return { token: token.trim(), projectId: projectId.trim(), ...(graphqlUrl ? { graphqlUrl } : {}) };
-}
-
 function priorityMarker(priority: number): string {
   if (priority === 1) return " [urgent]";
   if (priority === 2) return " [high]";
   return "";
 }
 
+function safeSlackLinkUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
 function renderIssueLine(issue: LinearBacklogIssue): string {
   const marker = priorityMarker(issue.priority);
-  return `• <${encodeURI(issue.url)}|${escapeSlackText(issue.identifier)}>${marker} ${escapeSlackText(issue.title)}`;
+  const identifier = escapeSlackText(issue.identifier);
+  const url = safeSlackLinkUrl(issue.url);
+  const label = url ? `<${url}|${identifier}>` : identifier;
+  return `• ${label}${marker} ${escapeSlackText(issue.title)}`;
 }
 
 type IssueGroup = { stateName: string; stateType: string; issues: LinearBacklogIssue[] };
 
-// Groups the already-limited "shown" issues by stateName, preserving the
-// order in which each stateName is first encountered in the sorted list.
 function groupShownIssues(shown: LinearBacklogIssue[]): IssueGroup[] {
   const groups: IssueGroup[] = [];
   const byStateName = new Map<string, IssueGroup>();
@@ -87,9 +85,7 @@ export function renderSlackLinearBacklogReply(input: {
       const emoji = STATE_TYPE_EMOJI[group.stateType] ?? "▫️";
       lines.push("");
       lines.push(`${emoji} *${escapeSlackText(group.stateName)} (${countLabel})*`);
-      for (const issue of group.issues) {
-        lines.push(renderIssueLine(issue));
-      }
+      for (const issue of group.issues) lines.push(renderIssueLine(issue));
     }
   }
 
@@ -112,21 +108,36 @@ export function createSlackLinearBacklogHandler(input: {
   logError?: (message: string) => void;
   getToken?: () => Promise<string | undefined> | string | undefined;
 }): NonNullable<SlackEventProcessorInput["linear"]> {
+  const env = input.env ?? process.env;
   const now = input.now ?? (() => new Date().toISOString());
   const logError = input.logError ?? ((message: string) => console.error(message));
-  return async () => {
-    const settings = resolveSlackLinearBacklogSettings({
+
+  return async (context) => {
+    const resolution = resolveLinearBacklogChannel({
       ...(input.linear ? { linear: input.linear } : {}),
-      env: input.env ?? process.env
+      teamId: context.teamId,
+      channelId: context.channelId,
+      env
     });
-    if (!settings) return NOT_CONFIGURED_TEXT;
-    const freshToken = input.getToken ? await input.getToken() : undefined;
-    const token = freshToken?.trim() ? freshToken : settings.token;
+    if (resolution.kind === "not-configured") return NOT_CONFIGURED_TEXT;
+    if (resolution.kind === "unauthorized") {
+      return `Linear backlog access is not authorized for Slack channel ${escapeSlackText(context.teamId)}/${escapeSlackText(context.channelId)}.`;
+    }
+    if (resolution.kind === "unsupported-connection") {
+      return `Linear backlog is unavailable for this channel because connection ${escapeSlackText(resolution.connection)} is not supported.`;
+    }
+
     try {
+      const providedToken = input.getToken ? await input.getToken() : undefined;
+      const token =
+        providedToken?.trim() ||
+        resolveDefaultLinearBacklogToken({ ...(input.linear ? { linear: input.linear } : {}), env });
+      if (!token) return NOT_CONFIGURED_TEXT;
+
       const backlog = await fetchLinearProjectBacklog({
         token,
-        projectId: settings.projectId,
-        ...(settings.graphqlUrl ? { graphqlUrl: settings.graphqlUrl } : {}),
+        projectId: resolution.projectId,
+        ...(resolution.graphqlUrl ? { graphqlUrl: resolution.graphqlUrl } : {}),
         fetchImpl: input.fetchImpl ?? fetch,
         timeoutMs: SLACK_LINEAR_BACKLOG_TIMEOUT_MS
       });
@@ -135,8 +146,6 @@ export function createSlackLinearBacklogHandler(input: {
         textFormat: "mrkdwn" as const
       };
     } catch (error) {
-      // linearGraphql error messages contain the HTTP status and GraphQL error
-      // text only — never the token — so the message is safe for local logs.
       logError(`[slack] linear backlog query failed: ${error instanceof Error ? error.message : String(error)}`);
       return UNAVAILABLE_TEXT;
     }

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -1,5 +1,5 @@
 import { fetchLinearProjectBacklog, type LinearProjectBacklog } from "@opentag/linear";
-import type { SlackEventProcessorInput } from "@opentag/slack";
+import { escapeSlackText, type SlackEventProcessorInput } from "@opentag/slack";
 import type { OpenTagCliConfig } from "./config.js";
 
 export const SLACK_LINEAR_BACKLOG_LIMIT = 20;
@@ -40,7 +40,7 @@ export function renderSlackLinearBacklogReply(input: {
     lines.push("No unfinished issues in the configured Linear project.");
   }
   for (const issue of shown) {
-    lines.push(`• <${issue.url}|${issue.identifier}> — ${issue.title}  [${issue.stateName}]`);
+    lines.push(`• <${issue.url}|${issue.identifier}> — ${escapeSlackText(issue.title)}  [${escapeSlackText(issue.stateName)}]`);
   }
   if (input.backlog.issues.length > shown.length || input.backlog.hasMore) {
     lines.push(`Showing ${shown.length} of ${totalLabel} open issues.`);

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -1,4 +1,4 @@
-import { fetchLinearProjectBacklog, type LinearProjectBacklog } from "@opentag/linear";
+import { fetchLinearProjectBacklog, type LinearBacklogIssue, type LinearProjectBacklog } from "@opentag/linear";
 import { escapeSlackText, type SlackEventProcessorInput } from "@opentag/slack";
 import type { OpenTagCliConfig } from "./config.js";
 
@@ -8,6 +8,15 @@ export const SLACK_LINEAR_BACKLOG_TIMEOUT_MS = 10_000;
 const NOT_CONFIGURED_TEXT =
   "Linear backlog is not configured. Set platforms.linear.projectId and a Linear token in the OpenTag config, or export OPENTAG_LINEAR_API_KEY and OPENTAG_LINEAR_PROJECT_ID.";
 const UNAVAILABLE_TEXT = "Linear API is unavailable right now; try again later.";
+
+// Emoji shown before each state-type group heading; anything not in this map
+// (unknown/future Linear state types) falls back to a neutral marker.
+const STATE_TYPE_EMOJI: Record<string, string> = {
+  started: "🔵",
+  unstarted: "⚪",
+  backlog: "⚫",
+  triage: "🟣"
+};
 
 export function resolveSlackLinearBacklogSettings(input: {
   linear?: { token?: string | undefined; projectId?: string | undefined; graphqlUrl?: string | undefined } | undefined;
@@ -21,10 +30,34 @@ export function resolveSlackLinearBacklogSettings(input: {
   return { token: token.trim(), projectId: projectId.trim(), ...(graphqlUrl ? { graphqlUrl } : {}) };
 }
 
-// "2026-07-16T21:30:45.123Z" -> "2026-07-16T21:30Z": minute precision keeps the
-// reply short while still time-stamping the data source.
-function formatQueriedAt(iso: string): string {
-  return iso.replace(/:\d{2}\.\d{3}Z$/u, "Z");
+function priorityMarker(priority: number): string {
+  if (priority === 1) return " [urgent]";
+  if (priority === 2) return " [high]";
+  return "";
+}
+
+function renderIssueLine(issue: LinearBacklogIssue): string {
+  const marker = priorityMarker(issue.priority);
+  return `• <${encodeURI(issue.url)}|${escapeSlackText(issue.identifier)}>${marker} ${escapeSlackText(issue.title)}`;
+}
+
+type IssueGroup = { stateName: string; stateType: string; issues: LinearBacklogIssue[] };
+
+// Groups the already-limited "shown" issues by stateName, preserving the
+// order in which each stateName is first encountered in the sorted list.
+function groupShownIssues(shown: LinearBacklogIssue[]): IssueGroup[] {
+  const groups: IssueGroup[] = [];
+  const byStateName = new Map<string, IssueGroup>();
+  for (const issue of shown) {
+    let group = byStateName.get(issue.stateName);
+    if (!group) {
+      group = { stateName: issue.stateName, stateType: issue.stateType, issues: [] };
+      byStateName.set(issue.stateName, group);
+      groups.push(group);
+    }
+    group.issues.push(issue);
+  }
+  return groups;
 }
 
 export function renderSlackLinearBacklogReply(input: {
@@ -32,18 +65,41 @@ export function renderSlackLinearBacklogReply(input: {
   limit: number;
   queriedAt: string;
 }): string {
-  const shown = input.backlog.issues.slice(0, input.limit);
-  const totalLabel = input.backlog.hasMore ? `${input.backlog.fetched}+` : String(input.backlog.fetched);
-  const noun = input.backlog.fetched === 1 && !input.backlog.hasMore ? "open issue" : "open issues";
-  const lines = [`OpenTag project backlog — ${totalLabel} ${noun} (source: Linear, queried ${formatQueriedAt(input.queriedAt)}):`];
-  if (shown.length === 0) {
-    lines.push("No unfinished issues in the configured Linear project.");
+  const { backlog, limit, queriedAt } = input;
+  const shown = backlog.issues.slice(0, limit);
+  const name = escapeSlackText(backlog.projectName ?? "Backlog");
+  const truncated = backlog.fetched > limit || backlog.hasMore;
+  const queriedHhMm = queriedAt.slice(11, 16);
+
+  const lines: string[] = [];
+  if (backlog.fetched === 0) {
+    lines.push(`*${name} · 0 open* 🎉`);
+    lines.push("No unfinished issues in this Linear project.");
+  } else {
+    const totalLabel = backlog.hasMore ? `${backlog.fetched}+` : String(backlog.fetched);
+    const showingSuffix = truncated ? ` · showing ${shown.length}` : "";
+    lines.push(`*${name} · ${totalLabel} open*${showingSuffix}`);
+
+    for (const group of groupShownIssues(shown)) {
+      const totalInGroup = backlog.issues.filter((issue) => issue.stateName === group.stateName).length;
+      const shownInGroup = group.issues.length;
+      const countLabel = shownInGroup < totalInGroup ? `${shownInGroup} of ${totalInGroup}` : String(totalInGroup);
+      const emoji = STATE_TYPE_EMOJI[group.stateType] ?? "▫️";
+      lines.push("");
+      lines.push(`${emoji} *${escapeSlackText(group.stateName)} (${countLabel})*`);
+      for (const issue of group.issues) {
+        lines.push(renderIssueLine(issue));
+      }
+    }
   }
-  for (const issue of shown) {
-    lines.push(`• <${encodeURI(issue.url)}|${issue.identifier}> — ${escapeSlackText(issue.title)}  [${escapeSlackText(issue.stateName)}]`);
-  }
-  if (input.backlog.issues.length > shown.length || input.backlog.hasMore) {
-    lines.push(`Showing ${shown.length} of ${totalLabel} open issues.`);
+
+  lines.push("");
+  if (truncated) {
+    const hiddenCount = backlog.fetched - shown.length;
+    const hiddenLabel = backlog.hasMore ? `${hiddenCount}+` : String(hiddenCount);
+    lines.push(`_Linear · queried ${queriedHhMm} UTC · ${hiddenLabel} more not shown_`);
+  } else {
+    lines.push(`_Linear · queried ${queriedHhMm} UTC_`);
   }
   return lines.join("\n");
 }

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -40,7 +40,7 @@ export function renderSlackLinearBacklogReply(input: {
     lines.push("No unfinished issues in the configured Linear project.");
   }
   for (const issue of shown) {
-    lines.push(`• <${issue.url}|${issue.identifier}> — ${escapeSlackText(issue.title)}  [${escapeSlackText(issue.stateName)}]`);
+    lines.push(`• <${encodeURI(issue.url)}|${issue.identifier}> — ${escapeSlackText(issue.title)}  [${escapeSlackText(issue.stateName)}]`);
   }
   if (input.backlog.issues.length > shown.length || input.backlog.hasMore) {
     lines.push(`Showing ${shown.length} of ${totalLabel} open issues.`);

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -110,6 +110,7 @@ export function createSlackLinearBacklogHandler(input: {
   fetchImpl?: typeof fetch;
   now?: () => string;
   logError?: (message: string) => void;
+  getToken?: () => Promise<string | undefined> | string | undefined;
 }): NonNullable<SlackEventProcessorInput["linear"]> {
   const now = input.now ?? (() => new Date().toISOString());
   const logError = input.logError ?? ((message: string) => console.error(message));
@@ -119,9 +120,11 @@ export function createSlackLinearBacklogHandler(input: {
       env: input.env ?? process.env
     });
     if (!settings) return NOT_CONFIGURED_TEXT;
+    const freshToken = input.getToken ? await input.getToken() : undefined;
+    const token = freshToken?.trim() ? freshToken : settings.token;
     try {
       const backlog = await fetchLinearProjectBacklog({
-        token: settings.token,
+        token,
         projectId: settings.projectId,
         ...(settings.graphqlUrl ? { graphqlUrl: settings.graphqlUrl } : {}),
         fetchImpl: input.fetchImpl ?? fetch,

--- a/packages/cli/src/slack-linear-backlog.ts
+++ b/packages/cli/src/slack-linear-backlog.ts
@@ -1,0 +1,82 @@
+import { fetchLinearProjectBacklog, type LinearProjectBacklog } from "@opentag/linear";
+import type { SlackEventProcessorInput } from "@opentag/slack";
+import type { OpenTagCliConfig } from "./config.js";
+
+export const SLACK_LINEAR_BACKLOG_LIMIT = 20;
+export const SLACK_LINEAR_BACKLOG_TIMEOUT_MS = 10_000;
+
+const NOT_CONFIGURED_TEXT =
+  "Linear backlog is not configured. Set platforms.linear.projectId and a Linear token in the OpenTag config, or export OPENTAG_LINEAR_API_KEY and OPENTAG_LINEAR_PROJECT_ID.";
+const UNAVAILABLE_TEXT = "Linear API is unavailable right now; try again later.";
+
+export function resolveSlackLinearBacklogSettings(input: {
+  linear?: { token?: string; projectId?: string; graphqlUrl?: string } | undefined;
+  env?: NodeJS.ProcessEnv;
+}): { token: string; projectId: string; graphqlUrl?: string } | null {
+  const env = input.env ?? {};
+  const token = input.linear?.token ?? env.OPENTAG_LINEAR_API_KEY ?? env.OPENTAG_LINEAR_TOKEN;
+  const projectId = input.linear?.projectId ?? env.OPENTAG_LINEAR_PROJECT_ID;
+  if (!token?.trim() || !projectId?.trim()) return null;
+  const graphqlUrl = input.linear?.graphqlUrl ?? env.OPENTAG_LINEAR_GRAPHQL_URL;
+  return { token: token.trim(), projectId: projectId.trim(), ...(graphqlUrl ? { graphqlUrl } : {}) };
+}
+
+// "2026-07-16T21:30:45.123Z" -> "2026-07-16T21:30Z": minute precision keeps the
+// reply short while still time-stamping the data source.
+function formatQueriedAt(iso: string): string {
+  return iso.replace(/:\d{2}\.\d{3}Z$/u, "Z");
+}
+
+export function renderSlackLinearBacklogReply(input: {
+  backlog: LinearProjectBacklog;
+  limit: number;
+  queriedAt: string;
+}): string {
+  const shown = input.backlog.issues.slice(0, input.limit);
+  const totalLabel = input.backlog.hasMore ? `${input.backlog.fetched}+` : String(input.backlog.fetched);
+  const noun = input.backlog.fetched === 1 && !input.backlog.hasMore ? "open issue" : "open issues";
+  const lines = [`OpenTag project backlog — ${totalLabel} ${noun} (source: Linear, queried ${formatQueriedAt(input.queriedAt)}):`];
+  if (shown.length === 0) {
+    lines.push("No unfinished issues in the configured Linear project.");
+  }
+  for (const issue of shown) {
+    lines.push(`• <${issue.url}|${issue.identifier}> — ${issue.title}  [${issue.stateName}]`);
+  }
+  if (input.backlog.issues.length > shown.length || input.backlog.hasMore) {
+    lines.push(`Showing ${shown.length} of ${totalLabel} open issues.`);
+  }
+  return lines.join("\n");
+}
+
+export function createSlackLinearBacklogHandler(input: {
+  linear?: OpenTagCliConfig["platforms"]["linear"];
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  now?: () => string;
+  logError?: (message: string) => void;
+}): NonNullable<SlackEventProcessorInput["linear"]> {
+  const now = input.now ?? (() => new Date().toISOString());
+  const logError = input.logError ?? ((message: string) => console.error(message));
+  return async () => {
+    const settings = resolveSlackLinearBacklogSettings({
+      ...(input.linear ? { linear: input.linear } : {}),
+      env: input.env ?? process.env
+    });
+    if (!settings) return NOT_CONFIGURED_TEXT;
+    try {
+      const backlog = await fetchLinearProjectBacklog({
+        token: settings.token,
+        projectId: settings.projectId,
+        ...(settings.graphqlUrl ? { graphqlUrl: settings.graphqlUrl } : {}),
+        fetchImpl: input.fetchImpl ?? fetch,
+        timeoutMs: SLACK_LINEAR_BACKLOG_TIMEOUT_MS
+      });
+      return renderSlackLinearBacklogReply({ backlog, limit: SLACK_LINEAR_BACKLOG_LIMIT, queriedAt: now() });
+    } catch (error) {
+      // linearGraphql error messages contain the HTTP status and GraphQL error
+      // text only — never the token — so the message is safe for local logs.
+      logError(`[slack] linear backlog query failed: ${error instanceof Error ? error.message : String(error)}`);
+      return UNAVAILABLE_TEXT;
+    }
+  };
+}

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -511,7 +511,7 @@ function slackModeFromCliConfig(config: OpenTagCliConfig): "socket_mode" | "even
 export function slackIngressConfigFromCliConfig(
   config: OpenTagCliConfig,
   input: { env?: NodeJS.ProcessEnv } = {}
-): SlackEventsApiIngressConfig & { linear: ReturnType<typeof createSlackLinearBacklogHandler> } {
+): SlackEventsApiIngressConfig {
   const slack = requireSlackConfig(config);
   if (!slack.signingSecret) {
     throw new Error("Slack Events API mode requires platforms.slack.signingSecret.");

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -168,6 +168,15 @@ function requireLinearConfig(config: OpenTagCliConfig): NonNullable<OpenTagCliCo
   return linear;
 }
 
+// A query-only Linear config (token + projectId, no webhookSecret) powers the
+// read-only Slack /linear backlog command and must not mount webhook ingress.
+function linearIngressEnabled(
+  linear: OpenTagCliConfig["platforms"]["linear"]
+): linear is NonNullable<OpenTagCliConfig["platforms"]["linear"]> {
+  if (!linear) return false;
+  return Boolean(linear.webhookSecret) || linear.auth?.method === "hosted_oauth_app";
+}
+
 function hasStartablePlatform(config: OpenTagCliConfig): boolean {
   return Boolean(
     config.platforms.lark ||
@@ -239,7 +248,7 @@ function localStartPortChecks(config: OpenTagCliConfig): LocalPortCheck[] {
     });
   }
   const linear = config.platforms.linear;
-  if (linear) {
+  if (linearIngressEnabled(linear)) {
     checks.push({
       label: "Linear local webhook",
       port: linear.port ?? DEFAULT_LINEAR_WEBHOOK_PORT,
@@ -1007,7 +1016,7 @@ async function startLocalMode(input: StartFromConfigInput, abortController: Abor
       const handle = dependencies.startGitLabIngress(gitlabIngressConfigFromCliConfig(config));
       ingresses.push({ platform: "gitlab", url: handle.url, webhookPath: handle.webhookPath, handle });
     }
-    if (config.platforms.linear) {
+    if (linearIngressEnabled(config.platforms.linear)) {
       const linearIngressConfig = linearIngressConfigFromCliConfig(config);
       if (linearTokenProvider) {
         linearIngressConfig.getLinearToken = linearTokenProvider;

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -414,7 +414,7 @@ export function dispatcherRuntimeInputFromCliConfig(
         ? { githubApplyToken: config.daemon.githubToken }
         : {}),
     ...(gitlab ? { gitlabToken: gitlab.token, gitlabBaseUrl: gitlab.baseUrl } : {}),
-    ...(linear && linear.token
+    ...(linearIngressEnabled(linear) && linear.token
       ? {
           linearToken: linear.token,
           ...(linear.graphqlUrl ? { linearGraphqlUrl: linear.graphqlUrl } : {}),

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -47,6 +47,7 @@ import {
   type OpenTagCliConfig
 } from "./config.js";
 import { probeDispatcherHealth } from "./health.js";
+import { linearBacklogConfigDiagnostics } from "./linear-backlog-config.js";
 import { discordLocalInteractionsUrl, discordPublicInteractionsUrlPlaceholder } from "./platforms/discord/display.js";
 import { githubLocalWebhookUrl, githubPublicWebhookUrlPlaceholder, githubWebhooksSettingsUrl } from "./platforms/github/display.js";
 import { gitlabLocalWebhookUrl, gitlabProjectWebhooksSettingsUrl, gitlabPublicWebhookUrlPlaceholder } from "./platforms/gitlab/display.js";
@@ -993,7 +994,10 @@ async function startLocalMode(input: StartFromConfigInput, abortController: Abor
     refreshLinearOAuthToken: dependencies.refreshLinearOAuthToken,
     writeConfig: dependencies.writeConfig
   });
-  if (linearTokenProvider) {
+  // OAuth refresh is also used by the read-only Slack /linear handler, but a
+  // token provider only grants dispatcher mutation capability when Linear
+  // webhook/apply ingress is explicitly enabled.
+  if (linearTokenProvider && linearIngressEnabled(config.platforms.linear)) {
     dispatcherInput.linearTokenProvider = linearTokenProvider;
   }
   const dispatcher = dependencies.startDispatcher(dispatcherInput);
@@ -1050,6 +1054,7 @@ async function startLocalMode(input: StartFromConfigInput, abortController: Abor
     logger.log(`Dispatcher: ${config.daemon.dispatcherUrl}`);
     const hermesWarning = hermesProfileConfigurationWarning(config.daemon);
     if (hermesWarning) logger.log(hermesWarning);
+    for (const diagnostic of linearBacklogConfigDiagnostics(config)) logger.log(`Warning: ${diagnostic.message}`);
     for (const ingress of ingresses) {
       if (ingress.platform === "slack") {
         const slack = config.platforms.slack!;
@@ -1178,6 +1183,7 @@ async function startRelayMode(input: StartFromConfigInput, abortController: Abor
     logger.log(`Runner: ${config.daemon.runnerId}`);
     const hermesWarning = hermesProfileConfigurationWarning(config.daemon);
     if (hermesWarning) logger.log(hermesWarning);
+    for (const diagnostic of linearBacklogConfigDiagnostics(config)) logger.log(`Warning: ${diagnostic.message}`);
     if (config.platforms.github) {
       logger.log(`GitHub webhook URL: ${githubRelayWebhookUrl(config)}`);
       logger.log("GitHub webhook secret: the relay must verify the configured secret before creating runs.");

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -55,6 +55,7 @@ import { DEFAULT_GITHUB_WEBHOOK_PORT, DEFAULT_GITLAB_WEBHOOK_PORT, DEFAULT_LINEA
 import { teamsLocalWebhookUrl, teamsPublicWebhookUrlPlaceholder } from "./platforms/teams/display.js";
 import { telegramLocalWebhookUrl, telegramPublicWebhookUrlPlaceholder } from "./platforms/telegram/display.js";
 import { assertRelayTransportAllowed, relayTrustWarning } from "./relay-security.js";
+import { createSlackLinearBacklogHandler } from "./slack-linear-backlog.js";
 
 export type StartCommandOptions = {
   config?: string;
@@ -510,7 +511,7 @@ function slackModeFromCliConfig(config: OpenTagCliConfig): "socket_mode" | "even
 export function slackIngressConfigFromCliConfig(
   config: OpenTagCliConfig,
   input: { env?: NodeJS.ProcessEnv } = {}
-): SlackEventsApiIngressConfig {
+): SlackEventsApiIngressConfig & { linear: ReturnType<typeof createSlackLinearBacklogHandler> } {
   const slack = requireSlackConfig(config);
   if (!slack.signingSecret) {
     throw new Error("Slack Events API mode requires platforms.slack.signingSecret.");
@@ -533,11 +534,18 @@ export function slackIngressConfigFromCliConfig(
     ...(slack.appId ? { appId: slack.appId } : {}),
     ...(config.daemon.runTimeoutMs ? { runTimeoutMs: config.daemon.runTimeoutMs } : {}),
     ...(maxRequestBodyBytes ? { maxRequestBodyBytes } : {}),
-    ...(slack.port ? { port: slack.port } : {})
+    ...(slack.port ? { port: slack.port } : {}),
+    linear: createSlackLinearBacklogHandler({
+      ...(config.platforms.linear ? { linear: config.platforms.linear } : {}),
+      env: input.env ?? process.env
+    })
   };
 }
 
-export function slackSocketModeIngressConfigFromCliConfig(config: OpenTagCliConfig): SlackSocketModeIngressConfig {
+export function slackSocketModeIngressConfigFromCliConfig(
+  config: OpenTagCliConfig,
+  input: { env?: NodeJS.ProcessEnv } = {}
+): SlackSocketModeIngressConfig {
   const slack = requireSlackConfig(config);
   if (!slack.appToken) {
     throw new Error("Slack Socket Mode requires platforms.slack.appToken.");
@@ -557,7 +565,11 @@ export function slackSocketModeIngressConfigFromCliConfig(config: OpenTagCliConf
         }
       : {}),
     ...(config.daemon.runTimeoutMs ? { runTimeoutMs: config.daemon.runTimeoutMs } : {}),
-    ...(slack.appId ? { appId: slack.appId } : {})
+    ...(slack.appId ? { appId: slack.appId } : {}),
+    linear: createSlackLinearBacklogHandler({
+      ...(config.platforms.linear ? { linear: config.platforms.linear } : {}),
+      env: input.env ?? process.env
+    })
   };
 }
 
@@ -1000,7 +1012,7 @@ async function startLocalMode(input: StartFromConfigInput, abortController: Abor
     }
     if (config.platforms.slack) {
       if (slackModeFromCliConfig(config) === "socket_mode") {
-        const handle = dependencies.startSlackSocketModeIngress(slackSocketModeIngressConfigFromCliConfig(config));
+        const handle = dependencies.startSlackSocketModeIngress(slackSocketModeIngressConfigFromCliConfig(config, { env }));
         ingresses.push({ platform: "slack", mode: "socket_mode", handle });
         abortOnSubsystemFailure(handle.startPromise, abortController);
       } else {

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -62,6 +62,8 @@ export type StartCommandOptions = {
   background?: boolean;
 };
 
+type LinearTokenProvider = NonNullable<LocalDispatcherRuntimeInput["linearTokenProvider"]>;
+
 type Logger = Pick<Console, "log">;
 
 export type StartRuntimeDependencies = {
@@ -510,7 +512,7 @@ function slackModeFromCliConfig(config: OpenTagCliConfig): "socket_mode" | "even
 
 export function slackIngressConfigFromCliConfig(
   config: OpenTagCliConfig,
-  input: { env?: NodeJS.ProcessEnv } = {}
+  input: { env?: NodeJS.ProcessEnv; linearTokenProvider?: LinearTokenProvider } = {}
 ): SlackEventsApiIngressConfig {
   const slack = requireSlackConfig(config);
   if (!slack.signingSecret) {
@@ -537,14 +539,15 @@ export function slackIngressConfigFromCliConfig(
     ...(slack.port ? { port: slack.port } : {}),
     linear: createSlackLinearBacklogHandler({
       ...(config.platforms.linear ? { linear: config.platforms.linear } : {}),
-      env: input.env ?? process.env
+      env: input.env ?? process.env,
+      ...(input.linearTokenProvider ? { getToken: input.linearTokenProvider } : {})
     })
   };
 }
 
 export function slackSocketModeIngressConfigFromCliConfig(
   config: OpenTagCliConfig,
-  input: { env?: NodeJS.ProcessEnv } = {}
+  input: { env?: NodeJS.ProcessEnv; linearTokenProvider?: LinearTokenProvider } = {}
 ): SlackSocketModeIngressConfig {
   const slack = requireSlackConfig(config);
   if (!slack.appToken) {
@@ -568,7 +571,8 @@ export function slackSocketModeIngressConfigFromCliConfig(
     ...(slack.appId ? { appId: slack.appId } : {}),
     linear: createSlackLinearBacklogHandler({
       ...(config.platforms.linear ? { linear: config.platforms.linear } : {}),
-      env: input.env ?? process.env
+      env: input.env ?? process.env,
+      ...(input.linearTokenProvider ? { getToken: input.linearTokenProvider } : {})
     })
   };
 }
@@ -1012,11 +1016,15 @@ async function startLocalMode(input: StartFromConfigInput, abortController: Abor
     }
     if (config.platforms.slack) {
       if (slackModeFromCliConfig(config) === "socket_mode") {
-        const handle = dependencies.startSlackSocketModeIngress(slackSocketModeIngressConfigFromCliConfig(config, { env }));
+        const handle = dependencies.startSlackSocketModeIngress(
+          slackSocketModeIngressConfigFromCliConfig(config, { env, ...(linearTokenProvider ? { linearTokenProvider } : {}) })
+        );
         ingresses.push({ platform: "slack", mode: "socket_mode", handle });
         abortOnSubsystemFailure(handle.startPromise, abortController);
       } else {
-        const handle = dependencies.startSlackIngress(slackIngressConfigFromCliConfig(config, { env }));
+        const handle = dependencies.startSlackIngress(
+          slackIngressConfigFromCliConfig(config, { env, ...(linearTokenProvider ? { linearTokenProvider } : {}) })
+        );
         ingresses.push({ platform: "slack", mode: "events_api", url: handle.url, handle });
       }
     }

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -656,3 +656,163 @@ describe("query-only Linear platform config (AMP-153)", () => {
     expect(() => parseCliConfig(JSON.parse(JSON.stringify(source)))).toThrow(/token/);
   });
 });
+
+describe("Linear backlog channel config", () => {
+  it("parses query-only channels and default connection credentials without a webhook secret", () => {
+    const source = config();
+    const parsed = parseCliConfig({
+      ...source,
+      platforms: {
+        ...source.platforms,
+        linear: {
+          connections: { default: { token: "lin_query_only" } },
+          channels: [{ teamId: " T123 ", channelId: " C123 ", projectId: " project_1 " }]
+        }
+      }
+    });
+
+    expect(parsed.platforms.linear).toMatchObject({
+      connections: { default: { token: "lin_query_only" } },
+      channels: [{ teamId: "T123", channelId: "C123", projectId: "project_1" }]
+    });
+    expect(parsed.platforms.linear?.webhookSecret).toBeUndefined();
+  });
+
+  it("resolves a SecretRef used by connections.default.token", () => {
+    const previous = process.env.OPENTAG_TEST_LINEAR_QUERY_TOKEN;
+    process.env.OPENTAG_TEST_LINEAR_QUERY_TOKEN = "lin_from_env";
+    try {
+      const source = config();
+      const parsed = parseCliConfig({
+        ...source,
+        platforms: {
+          ...source.platforms,
+          linear: {
+            connections: { default: { token: { kind: "env", name: "OPENTAG_TEST_LINEAR_QUERY_TOKEN" } } },
+            channels: [{ teamId: "T123", channelId: "C123", projectId: "project_1" }]
+          }
+        }
+      });
+
+      expect(parsed.platforms.linear?.connections?.default?.token).toBe("lin_from_env");
+    } finally {
+      if (previous === undefined) delete process.env.OPENTAG_TEST_LINEAR_QUERY_TOKEN;
+      else process.env.OPENTAG_TEST_LINEAR_QUERY_TOKEN = previous;
+    }
+  });
+
+  it("rejects a channel mapping without projectId", () => {
+    const source = config();
+    expect(() =>
+      parseCliConfig({
+        ...source,
+        platforms: {
+          ...source.platforms,
+          linear: {
+            token: "lin_query_only",
+            channels: [{ teamId: "T123", channelId: "C123" }]
+          }
+        }
+      })
+    ).toThrow(/projectId/iu);
+  });
+
+  it("rejects duplicate team/channel mappings after trimming", () => {
+    const source = config();
+    expect(() =>
+      parseCliConfig({
+        ...source,
+        platforms: {
+          ...source.platforms,
+          linear: {
+            token: "lin_query_only",
+            channels: [
+              { teamId: "T123", channelId: "C123", projectId: "project_1" },
+              { teamId: " T123 ", channelId: " C123 ", projectId: "project_2" }
+            ]
+          }
+        }
+      })
+    ).toThrow(/Duplicate Linear channel mapping/iu);
+  });
+
+  it("accepts a non-default connection for fail-closed runtime handling", () => {
+    const source = config();
+    const parsed = parseCliConfig({
+      ...source,
+      platforms: {
+        ...source.platforms,
+        linear: {
+          connections: { workspace_two: { token: "lin_workspace_two" } },
+          channels: [{ teamId: "T123", channelId: "C123", projectId: "project_1", connection: "workspace_two" }]
+        }
+      }
+    });
+
+    expect(parsed.platforms.linear?.channels?.[0]?.connection).toBe("workspace_two");
+  });
+
+  it("keeps legacy projectId-only query config parseable", () => {
+    const source = config();
+    const parsed = parseCliConfig({
+      ...source,
+      platforms: { ...source.platforms, linear: { token: "lin_legacy", projectId: "project_legacy" } }
+    });
+
+    expect(parsed.platforms.linear?.projectId).toBe("project_legacy");
+  });
+
+  it("rejects channels config without any static credential or hosted OAuth", () => {
+    const source = config();
+    expect(() =>
+      parseCliConfig({
+        ...source,
+        platforms: {
+          ...source.platforms,
+          linear: { channels: [{ teamId: "T123", channelId: "C123", projectId: "project_1" }] }
+        }
+      })
+    ).toThrow(/token/iu);
+  });
+
+  it("does not allow a query-only connection token to power webhook mutations", () => {
+    const source = config();
+    expect(() =>
+      parseCliConfig({
+        ...source,
+        platforms: {
+          ...source.platforms,
+          linear: {
+            connections: { default: { token: "lin_query_only" } },
+            webhookSecret: "linear_webhook_secret",
+            projectTarget: { repoProvider: "github", owner: "acme", repo: "demo" }
+          }
+        }
+      })
+    ).toThrow(/query-only/iu);
+  });
+
+  it.each(["teamId", "channelId", "projectId", "connection"] as const)("rejects a blank %s", (field) => {
+    const source = config();
+    const channel = { teamId: "T123", channelId: "C123", projectId: "project_1", connection: "default" };
+    channel[field] = "   ";
+    expect(() =>
+      parseCliConfig({
+        ...source,
+        platforms: { ...source.platforms, linear: { token: "lin_query_only", channels: [channel] } }
+      })
+    ).toThrow();
+  });
+
+  it("redacts nested connection tokens", () => {
+    const source = config();
+    source.platforms.linear = {
+      connections: { default: { token: "lin_nested_secret" } },
+      channels: [{ teamId: "T123", channelId: "C123", projectId: "project_1" }]
+    };
+
+    const text = JSON.stringify(redactedCliConfig(source));
+    expect(text).toContain("[REDACTED]");
+    expect(text).not.toContain("lin_nested_secret");
+  });
+});

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -634,3 +634,25 @@ describe("OpenTag CLI config", () => {
     });
   });
 });
+
+describe("query-only Linear platform config (AMP-153)", () => {
+  it("accepts token + projectId without webhookSecret", () => {
+    const source = config();
+    source.platforms.linear = { token: "lin_api_secret", projectId: "proj_123" } as never;
+    const parsed = parseCliConfig(JSON.parse(JSON.stringify(source)));
+    expect(parsed.platforms.linear?.projectId).toBe("proj_123");
+    expect(parsed.platforms.linear?.webhookSecret).toBeUndefined();
+  });
+
+  it("still rejects a Linear config with neither webhookSecret nor projectId", () => {
+    const source = config();
+    source.platforms.linear = { token: "lin_api_secret" } as never;
+    expect(() => parseCliConfig(JSON.parse(JSON.stringify(source)))).toThrow(/webhookSecret/);
+  });
+
+  it("still rejects a Linear config without a token", () => {
+    const source = config();
+    source.platforms.linear = { projectId: "proj_123" } as never;
+    expect(() => parseCliConfig(JSON.parse(JSON.stringify(source)))).toThrow(/token/);
+  });
+});

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -78,6 +78,46 @@ describe("OpenTag CLI doctor relay checks", () => {
     expect(formatted).toContain("WARN relay token scope: This self-hosted MVP still uses the daemon pairing token for registration and runner calls");
   });
 
+  it("warns when legacy global Linear projectId does not authorize /linear and redacts credentials", () => {
+    const built = relayConfig("https://relay.example");
+    built.platforms.slack = {
+      mode: "events_api",
+      signingSecret: "slack_secret",
+      botToken: "xoxb-secret",
+      teamId: "T123",
+      channelId: "C123"
+    } as never;
+    built.platforms.linear = { token: "lin_supersecret", projectId: "legacy_project" } as never;
+
+    const formatted = formatCliDoctorChecks(appendCliDoctorChecks(built, []));
+    expect(formatted).toContain("WARN Linear /linear channel mapping:");
+    expect(formatted).toContain("platforms.linear.projectId no longer authorizes Slack channels");
+    expect(formatted).not.toContain("lin_supersecret");
+  });
+
+  it("warns once per unsupported Linear connection without exposing its token", () => {
+    const built = relayConfig("https://relay.example");
+    built.platforms.slack = {
+      mode: "events_api",
+      signingSecret: "slack_secret",
+      botToken: "xoxb-secret",
+      teamId: "T123",
+      channelId: "C123"
+    } as never;
+    built.platforms.linear = {
+      connections: { other: { token: "lin_other_secret" } },
+      channels: [
+        { teamId: "T123", channelId: "C1", projectId: "P1", connection: "other" },
+        { teamId: "T123", channelId: "C2", projectId: "P2", connection: "other" }
+      ]
+    } as never;
+
+    const formatted = formatCliDoctorChecks(appendCliDoctorChecks(built, []));
+    expect(formatted.match(/WARN Linear workspace connection:/gu)).toHaveLength(1);
+    expect(formatted).toContain("connection other");
+    expect(formatted).not.toContain("lin_other_secret");
+  });
+
   it("fails legacy public HTTP relay configs", () => {
     const formatted = formatCliDoctorChecks(appendCliDoctorChecks(relayConfig("http://relay.example"), []));
 

--- a/packages/cli/test/linear-backlog-config.test.ts
+++ b/packages/cli/test/linear-backlog-config.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type { OpenTagCliConfig } from "../src/config.js";
+import {
+  linearBacklogConfigDiagnostics,
+  resolveDefaultLinearBacklogToken,
+  resolveLinearBacklogChannel
+} from "../src/linear-backlog-config.js";
+
+function config(linear: OpenTagCliConfig["platforms"]["linear"]): OpenTagCliConfig {
+  return {
+    schemaVersion: 1,
+    state: { directory: "/tmp/state", databasePath: "/tmp/state/db.sqlite", worktreeRoot: "/tmp/worktrees" },
+    daemon: {
+      runnerId: "runner_1",
+      repositories: [],
+      pairingToken: "pairing",
+      dispatcherUrl: "http://127.0.0.1:3030",
+      pollIntervalMs: 1000,
+      heartbeatIntervalMs: 1000
+    },
+    platforms: {
+      slack: { botToken: "xoxb", signingSecret: "signing", teamId: "T1", channelId: "C1" },
+      ...(linear ? { linear } : {})
+    }
+  };
+}
+
+describe("resolveLinearBacklogChannel", () => {
+  it("resolves an authorized channel to its mapped project", () => {
+    expect(
+      resolveLinearBacklogChannel({
+        linear: {
+          token: "lin",
+          channels: [{ teamId: "T1", channelId: "C1", projectId: "P1" }],
+          graphqlUrl: "https://linear.example/graphql"
+        },
+        teamId: "T1",
+        channelId: "C1"
+      })
+    ).toEqual({ kind: "authorized", projectId: "P1", connection: "default", graphqlUrl: "https://linear.example/graphql" });
+  });
+
+  it.each([undefined, []])("returns not-configured when channels are %j", (channels) => {
+    expect(resolveLinearBacklogChannel({ linear: { token: "lin", channels }, teamId: "T1", channelId: "C1" })).toEqual({
+      kind: "not-configured",
+      reason: "channels-missing"
+    });
+  });
+
+  it("returns unauthorized when an allowlist exists but the channel does not match", () => {
+    expect(
+      resolveLinearBacklogChannel({
+        linear: { token: "lin", channels: [{ teamId: "T1", channelId: "C2", projectId: "P2" }] },
+        teamId: "T1",
+        channelId: "C1"
+      })
+    ).toEqual({ kind: "unauthorized" });
+  });
+
+  it("routes multiple channels to different projects", () => {
+    const linear = {
+      token: "lin",
+      channels: [
+        { teamId: "T1", channelId: "C1", projectId: "P1" },
+        { teamId: "T1", channelId: "C2", projectId: "P2" }
+      ]
+    };
+    expect(resolveLinearBacklogChannel({ linear, teamId: "T1", channelId: "C1" })).toMatchObject({ projectId: "P1" });
+    expect(resolveLinearBacklogChannel({ linear, teamId: "T1", channelId: "C2" })).toMatchObject({ projectId: "P2" });
+  });
+
+  it("does not match the same channelId across teams or with different case", () => {
+    const linear = { token: "lin", channels: [{ teamId: "T1", channelId: "C1", projectId: "P1" }] };
+    expect(resolveLinearBacklogChannel({ linear, teamId: "T2", channelId: "C1" })).toEqual({ kind: "unauthorized" });
+    expect(resolveLinearBacklogChannel({ linear, teamId: "t1", channelId: "C1" })).toEqual({ kind: "unauthorized" });
+    expect(resolveLinearBacklogChannel({ linear, teamId: "T1", channelId: "c1" })).toEqual({ kind: "unauthorized" });
+  });
+
+  it("fails closed for a non-default connection", () => {
+    expect(
+      resolveLinearBacklogChannel({
+        linear: {
+          connections: { workspace_two: { token: "lin_two" } },
+          channels: [{ teamId: "T1", channelId: "C1", projectId: "P1", connection: "workspace_two" }]
+        },
+        teamId: "T1",
+        channelId: "C1"
+      })
+    ).toEqual({ kind: "unsupported-connection", connection: "workspace_two" });
+  });
+
+  it("does not use legacy config or OPENTAG_LINEAR_PROJECT_ID as a route", () => {
+    expect(
+      resolveLinearBacklogChannel({
+        linear: { token: "lin", projectId: "legacy" },
+        teamId: "T1",
+        channelId: "C1",
+        env: { OPENTAG_LINEAR_PROJECT_ID: "env-project" }
+      })
+    ).toEqual({ kind: "not-configured", reason: "channels-missing" });
+  });
+});
+
+describe("resolveDefaultLinearBacklogToken", () => {
+  it("uses default connection, top-level, API key, then legacy env token priority", () => {
+    expect(
+      resolveDefaultLinearBacklogToken({
+        linear: { connections: { default: { token: "connection" } }, token: "top" },
+        env: { OPENTAG_LINEAR_API_KEY: "api", OPENTAG_LINEAR_TOKEN: "legacy" }
+      })
+    ).toBe("connection");
+    expect(
+      resolveDefaultLinearBacklogToken({
+        linear: { token: "top" },
+        env: { OPENTAG_LINEAR_API_KEY: "api", OPENTAG_LINEAR_TOKEN: "legacy" }
+      })
+    ).toBe("top");
+    expect(resolveDefaultLinearBacklogToken({ env: { OPENTAG_LINEAR_API_KEY: "api", OPENTAG_LINEAR_TOKEN: "legacy" } })).toBe("api");
+    expect(resolveDefaultLinearBacklogToken({ env: { OPENTAG_LINEAR_TOKEN: "legacy" } })).toBe("legacy");
+  });
+
+  it("ignores blank higher-priority values", () => {
+    expect(
+      resolveDefaultLinearBacklogToken({
+        linear: { connections: { default: { token: "   " } }, token: "  " },
+        env: { OPENTAG_LINEAR_API_KEY: " api " }
+      })
+    ).toBe("api");
+  });
+});
+
+describe("linearBacklogConfigDiagnostics", () => {
+  it("warns when a legacy projectId has no channel mappings", () => {
+    expect(linearBacklogConfigDiagnostics(config({ token: "lin", projectId: "legacy" }))).toEqual([
+      expect.objectContaining({ code: "legacy-project-id", message: expect.stringContaining("no longer authorizes") })
+    ]);
+  });
+
+  it("warns once per unsupported connection and does not include tokens", () => {
+    const diagnostics = linearBacklogConfigDiagnostics(
+      config({
+        connections: { two: { token: "supersecret" } },
+        channels: [
+          { teamId: "T1", channelId: "C1", projectId: "P1", connection: "two" },
+          { teamId: "T1", channelId: "C2", projectId: "P2", connection: "two" }
+        ]
+      })
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({ code: "unsupported-connection" });
+    expect(JSON.stringify(diagnostics)).not.toContain("supersecret");
+  });
+
+  it("does not emit /linear diagnostics without both Slack and Linear", () => {
+    const built = config({ token: "lin", projectId: "legacy" });
+    built.platforms.slack = undefined;
+    expect(linearBacklogConfigDiagnostics(built)).toEqual([]);
+  });
+});

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -192,6 +192,34 @@ describe("renderSlackLinearBacklogReply", () => {
     expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153>");
   });
 
+  it("percent-encodes literal pipes in issue URLs before embedding them in Slack link syntax", () => {
+    const piped = { ...issue(153), url: "https://linear.app/a/issue/AMP-153|spoofed" };
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [piped], fetched: 1, hasMore: false, projectName: "opentag" },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T22:48:00.000Z"
+    });
+
+    expect(text).toContain("<https://linear.app/a/issue/AMP-153%7Cspoofed|AMP-153>");
+    expect(text).not.toContain("<https://linear.app/a/issue/AMP-153|spoofed|AMP-153>");
+  });
+
+  it("keeps same-named states with different types in separate groups and counts", () => {
+    const issues = [
+      issue(1, { stateName: "Ready", stateType: "started" }),
+      issue(2, { stateName: "Ready", stateType: "unstarted" }),
+      issue(3, { stateName: "Ready", stateType: "unstarted" })
+    ];
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues, fetched: 3, hasMore: false, projectName: "opentag" },
+      limit: 2,
+      queriedAt: "2026-07-16T22:48:00.000Z"
+    });
+
+    expect(text).toContain("🔵 *Ready (1)*");
+    expect(text).toContain("⚪ *Ready (1 of 2)*");
+  });
+
   it.each(["javascript:alert(1)", "not a url"])("renders an invalid or unsafe issue URL as plain text: %s", (url) => {
     const unsafe = { ...issue(153), url };
     const text = renderSlackLinearBacklogReply({

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -263,4 +263,54 @@ describe("createSlackLinearBacklogHandler", () => {
     expect(logged.join("\n")).not.toContain("supersecret");
     expect(String(reply)).not.toContain("supersecret");
   });
+
+  it("uses the live token from getToken instead of the stale static config token", async () => {
+    let capturedAuthorization: string | undefined;
+    const capturingFetch = (async (_url: unknown, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      capturedAuthorization = headers?.authorization;
+      return new Response(
+        JSON.stringify({
+          data: {
+            project: { name: "opentag" },
+            issues: { nodes: [], pageInfo: { hasNextPage: false } }
+          }
+        }),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+    const handler = createSlackLinearBacklogHandler({
+      linear: { token: "stale_token", projectId: "proj_1" } as never,
+      env: {},
+      fetchImpl: capturingFetch,
+      getToken: async () => "fresh_token"
+    });
+    await handler(CONTEXT);
+    expect(capturedAuthorization).toBe("Bearer fresh_token");
+  });
+
+  it("falls back to the static configured token when getToken resolves undefined", async () => {
+    let capturedAuthorization: string | undefined;
+    const capturingFetch = (async (_url: unknown, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      capturedAuthorization = headers?.authorization;
+      return new Response(
+        JSON.stringify({
+          data: {
+            project: { name: "opentag" },
+            issues: { nodes: [], pageInfo: { hasNextPage: false } }
+          }
+        }),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+    const handler = createSlackLinearBacklogHandler({
+      linear: { token: "static_token", projectId: "proj_1" } as never,
+      env: {},
+      fetchImpl: capturingFetch,
+      getToken: async () => undefined
+    });
+    await handler(CONTEXT);
+    expect(capturedAuthorization).toBe("Bearer static_token");
+  });
 });

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   createSlackLinearBacklogHandler,
   renderSlackLinearBacklogReply,
-  resolveSlackLinearBacklogSettings,
   SLACK_LINEAR_BACKLOG_LIMIT
 } from "../src/slack-linear-backlog.js";
 
@@ -45,36 +44,6 @@ function backlogFetch(
       { status: 200 }
     )) as typeof fetch;
 }
-
-describe("resolveSlackLinearBacklogSettings", () => {
-  it("prefers platforms.linear over env fallback", () => {
-    const settings = resolveSlackLinearBacklogSettings({
-      linear: { token: "cfg_token", projectId: "cfg_proj" },
-      env: { OPENTAG_LINEAR_API_KEY: "env_token", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
-    });
-    expect(settings).toEqual({ token: "cfg_token", projectId: "cfg_proj" });
-  });
-
-  it("falls back to OPENTAG_LINEAR_API_KEY / OPENTAG_LINEAR_PROJECT_ID", () => {
-    const settings = resolveSlackLinearBacklogSettings({
-      env: { OPENTAG_LINEAR_API_KEY: "env_token", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
-    });
-    expect(settings).toEqual({ token: "env_token", projectId: "env_proj" });
-  });
-
-  it("accepts OPENTAG_LINEAR_TOKEN as the secondary token fallback", () => {
-    const settings = resolveSlackLinearBacklogSettings({
-      env: { OPENTAG_LINEAR_TOKEN: "env_token2", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
-    });
-    expect(settings?.token).toBe("env_token2");
-  });
-
-  it("returns null when token or projectId is missing", () => {
-    expect(resolveSlackLinearBacklogSettings({ env: { OPENTAG_LINEAR_API_KEY: "t" } })).toBeNull();
-    expect(resolveSlackLinearBacklogSettings({ env: { OPENTAG_LINEAR_PROJECT_ID: "p" } })).toBeNull();
-    expect(resolveSlackLinearBacklogSettings({})).toBeNull();
-  });
-});
 
 describe("renderSlackLinearBacklogReply", () => {
   it("renders the header with project name and total, grouped headings, and issue lines", () => {
@@ -222,6 +191,18 @@ describe("renderSlackLinearBacklogReply", () => {
     });
     expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153>");
   });
+
+  it.each(["javascript:alert(1)", "not a url"])("renders an invalid or unsafe issue URL as plain text: %s", (url) => {
+    const unsafe = { ...issue(153), url };
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [unsafe], fetched: 1, hasMore: false, projectName: "opentag" },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T22:48:00.000Z"
+    });
+    expect(text).toContain("• AMP-153 Task 153");
+    expect(text).not.toContain(`<${url}|`);
+  });
+
 });
 
 describe("createSlackLinearBacklogHandler", () => {
@@ -231,9 +212,112 @@ describe("createSlackLinearBacklogHandler", () => {
     expect(reply).toContain("Linear backlog is not configured");
   });
 
+  it.each([null, { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" }])(
+    "allows an explicitly allowlisted channel regardless of Project Target binding (%j)",
+    async (binding) => {
+      const handler = createSlackLinearBacklogHandler({
+        linear: {
+          connections: { default: { token: "lin_query" } },
+          channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_allowed" }]
+        } as never,
+        env: {},
+        fetchImpl: backlogFetch([])
+      });
+      const reply = await handler({ ...CONTEXT, binding: binding as never });
+      expect(typeof reply === "string" ? reply : reply.text).toContain("0 open");
+    }
+  );
+
+  it("fails closed before reading credentials or calling Linear for an unauthorized channel", async () => {
+    let tokenCalls = 0;
+    let fetchCalls = 0;
+    const handler = createSlackLinearBacklogHandler({
+      linear: {
+        connections: { default: { token: "lin_query" } },
+        channels: [{ teamId: "T123", channelId: "C_ALLOWED", projectId: "proj_allowed" }]
+      } as never,
+      env: {},
+      getToken: async () => {
+        tokenCalls += 1;
+        return "fresh";
+      },
+      fetchImpl: (async () => {
+        fetchCalls += 1;
+        throw new Error("must not run");
+      }) as typeof fetch
+    });
+
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("not authorized");
+    expect(reply).toContain("T123/C123");
+    expect(tokenCalls).toBe(0);
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("escapes unauthorized Slack identity text before replying", async () => {
+    const handler = createSlackLinearBacklogHandler({
+      linear: {
+        token: "lin_query",
+        channels: [{ teamId: "T_ALLOWED", channelId: "C_ALLOWED", projectId: "proj_allowed" }]
+      } as never,
+      env: {}
+    });
+    const reply = await handler({ ...CONTEXT, teamId: "<T&bad>", channelId: "<https://evil|click>" });
+    expect(reply).toContain("&lt;T&amp;bad&gt;/&lt;https://evil|click&gt;");
+    expect(reply).not.toContain("<https://evil|click>");
+  });
+
+  it("routes different allowlisted channels to their own Linear project", async () => {
+    const projectIds: string[] = [];
+    const capturingFetch = (async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { variables: { projectId: string } };
+      projectIds.push(body.variables.projectId);
+      return backlogFetch([])(_url as RequestInfo, init);
+    }) as typeof fetch;
+    const handler = createSlackLinearBacklogHandler({
+      linear: {
+        token: "lin_query",
+        projectId: "legacy_global_project",
+        channels: [
+          { teamId: "T123", channelId: "C123", projectId: "project_one" },
+          { teamId: "T123", channelId: "C456", projectId: "project_two" }
+        ]
+      } as never,
+      env: { OPENTAG_LINEAR_PROJECT_ID: "env_global_project" },
+      fetchImpl: capturingFetch
+    });
+
+    await handler(CONTEXT);
+    await handler({ ...CONTEXT, channelId: "C456" });
+    expect(projectIds).toEqual(["project_one", "project_two"]);
+  });
+
+  it("fails closed for a non-default connection without falling back to the default token", async () => {
+    let tokenCalls = 0;
+    let fetchCalls = 0;
+    const handler = createSlackLinearBacklogHandler({
+      linear: {
+        connections: { default: { token: "lin_default" }, other: { token: "lin_other" } },
+        channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1", connection: "other" }]
+      } as never,
+      getToken: async () => {
+        tokenCalls += 1;
+        return "fresh";
+      },
+      fetchImpl: (async () => {
+        fetchCalls += 1;
+        throw new Error("must not run");
+      }) as typeof fetch
+    });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("connection other is not supported");
+    expect(tokenCalls).toBe(0);
+    expect(fetchCalls).toBe(0);
+  });
+
   it("queries Linear and renders the backlog reply", async () => {
     const handler = createSlackLinearBacklogHandler({
-      linear: { token: "lin_api_test", projectId: "proj_1" } as never,
+      linear: { token: "lin_api_test", channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1" }] } as never,
       env: {},
       fetchImpl: backlogFetch([issue(153)]),
       now: () => "2026-07-16T22:48:00.000Z"
@@ -252,7 +336,7 @@ describe("createSlackLinearBacklogHandler", () => {
     const logged: string[] = [];
     const failingFetch = (async () => new Response(JSON.stringify({ errors: [{ message: "boom" }] }), { status: 500 })) as typeof fetch;
     const handler = createSlackLinearBacklogHandler({
-      linear: { token: "lin_api_supersecret", projectId: "proj_1" } as never,
+      linear: { token: "lin_api_supersecret", channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1" }] } as never,
       env: {},
       fetchImpl: failingFetch,
       logError: (message) => logged.push(message)
@@ -280,7 +364,7 @@ describe("createSlackLinearBacklogHandler", () => {
       );
     }) as typeof fetch;
     const handler = createSlackLinearBacklogHandler({
-      linear: { token: "stale_token", projectId: "proj_1" } as never,
+      linear: { token: "stale_token", channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1" }] } as never,
       env: {},
       fetchImpl: capturingFetch,
       getToken: async () => "fresh_token"
@@ -305,7 +389,7 @@ describe("createSlackLinearBacklogHandler", () => {
       );
     }) as typeof fetch;
     const handler = createSlackLinearBacklogHandler({
-      linear: { token: "static_token", projectId: "proj_1" } as never,
+      linear: { token: "static_token", channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1" }] } as never,
       env: {},
       fetchImpl: capturingFetch,
       getToken: async () => undefined
@@ -313,4 +397,79 @@ describe("createSlackLinearBacklogHandler", () => {
     await handler(CONTEXT);
     expect(capturedAuthorization).toBe("Bearer static_token");
   });
+
+  it("falls back to the static token when the live provider returns only whitespace", async () => {
+    let authorization: string | undefined;
+    const handler = createSlackLinearBacklogHandler({
+      linear: {
+        connections: { default: { token: "static_query_token" } },
+        channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1" }]
+      } as never,
+      env: {},
+      getToken: async () => "   ",
+      fetchImpl: (async (_url: unknown, init?: RequestInit) => {
+        authorization = (init?.headers as Record<string, string>).authorization;
+        return backlogFetch([])(_url as RequestInfo, init);
+      }) as typeof fetch
+    });
+    await handler(CONTEXT);
+    expect(authorization).toBe("Bearer static_query_token");
+  });
+
+  it.each([
+    ["missing project", backlogFetch([], { projectName: null })],
+    ["missing GraphQL data", (async () => new Response(JSON.stringify({}), { status: 200 })) as typeof fetch]
+  ])("never renders a successful zero-open state for %s", async (_case, fetchImpl) => {
+    const handler = createSlackLinearBacklogHandler({
+      linear: {
+        token: "lin_query",
+        channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1" }]
+      } as never,
+      env: {},
+      fetchImpl,
+      logError() {}
+    });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("unavailable");
+    expect(reply).not.toContain("0 open");
+    expect(reply).not.toContain("🎉");
+  });
+
+  it("reads the asynchronous token provider for every authorized query", async () => {
+    const authorizations: string[] = [];
+    const tokens = ["fresh_one", "fresh_two"];
+    const handler = createSlackLinearBacklogHandler({
+      linear: {
+        token: "stale",
+        channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1" }]
+      } as never,
+      env: {},
+      getToken: async () => tokens.shift(),
+      fetchImpl: (async (_url: unknown, init?: RequestInit) => {
+        authorizations.push((init?.headers as Record<string, string>).authorization);
+        return backlogFetch([])(_url as RequestInfo, init);
+      }) as typeof fetch
+    });
+    await handler(CONTEXT);
+    await handler(CONTEXT);
+    expect(authorizations).toEqual(["Bearer fresh_one", "Bearer fresh_two"]);
+  });
+
+  it("returns a safe unavailable reply when the token provider fails", async () => {
+    const logged: string[] = [];
+    const handler = createSlackLinearBacklogHandler({
+      linear: {
+        token: "stale",
+        channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_1" }]
+      } as never,
+      env: {},
+      getToken: async () => { throw new Error("refresh failed"); },
+      logError: (message) => logged.push(message)
+    });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("unavailable");
+    expect(logged.join("\n")).toContain("refresh failed");
+    expect(logged.join("\n")).not.toContain("stale");
+  });
+
 });

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSlackLinearBacklogHandler,
+  renderSlackLinearBacklogReply,
+  resolveSlackLinearBacklogSettings,
+  SLACK_LINEAR_BACKLOG_LIMIT
+} from "../src/slack-linear-backlog.js";
+
+const CONTEXT = { teamId: "T123", channelId: "C123", threadTs: "1.0", userId: "U1", binding: null };
+
+function issue(n: number, stateName = "Todo", stateType = "unstarted") {
+  return { identifier: `AMP-${n}`, title: `Task ${n}`, url: `https://linear.app/a/issue/AMP-${n}`, stateName, stateType };
+}
+
+function backlogFetch(nodes: ReturnType<typeof issue>[], hasNextPage = false): typeof fetch {
+  return (async () =>
+    new Response(
+      JSON.stringify({
+        data: {
+          issues: {
+            nodes: nodes.map((entry) => ({
+              identifier: entry.identifier,
+              title: entry.title,
+              url: entry.url,
+              state: { name: entry.stateName, type: entry.stateType }
+            })),
+            pageInfo: { hasNextPage }
+          }
+        }
+      }),
+      { status: 200 }
+    )) as typeof fetch;
+}
+
+describe("resolveSlackLinearBacklogSettings", () => {
+  it("prefers platforms.linear over env fallback", () => {
+    const settings = resolveSlackLinearBacklogSettings({
+      linear: { token: "cfg_token", projectId: "cfg_proj" },
+      env: { OPENTAG_LINEAR_API_KEY: "env_token", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
+    });
+    expect(settings).toEqual({ token: "cfg_token", projectId: "cfg_proj" });
+  });
+
+  it("falls back to OPENTAG_LINEAR_API_KEY / OPENTAG_LINEAR_PROJECT_ID", () => {
+    const settings = resolveSlackLinearBacklogSettings({
+      env: { OPENTAG_LINEAR_API_KEY: "env_token", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
+    });
+    expect(settings).toEqual({ token: "env_token", projectId: "env_proj" });
+  });
+
+  it("accepts OPENTAG_LINEAR_TOKEN as the secondary token fallback", () => {
+    const settings = resolveSlackLinearBacklogSettings({
+      env: { OPENTAG_LINEAR_TOKEN: "env_token2", OPENTAG_LINEAR_PROJECT_ID: "env_proj" }
+    });
+    expect(settings?.token).toBe("env_token2");
+  });
+
+  it("returns null when token or projectId is missing", () => {
+    expect(resolveSlackLinearBacklogSettings({ env: { OPENTAG_LINEAR_API_KEY: "t" } })).toBeNull();
+    expect(resolveSlackLinearBacklogSettings({ env: { OPENTAG_LINEAR_PROJECT_ID: "p" } })).toBeNull();
+    expect(resolveSlackLinearBacklogSettings({})).toBeNull();
+  });
+});
+
+describe("renderSlackLinearBacklogReply", () => {
+  it("renders header with count, source, query time, and one line per issue", () => {
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [issue(131, "In Progress", "started"), issue(153)], fetched: 2, hasMore: false },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T21:30:45.123Z"
+    });
+    expect(text).toContain("OpenTag project backlog — 2 open issues (source: Linear, queried 2026-07-16T21:30Z):");
+    expect(text).toContain("• <https://linear.app/a/issue/AMP-131|AMP-131> — Task 131  [In Progress]");
+    expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153> — Task 153  [Todo]");
+    expect(text).not.toContain("Showing");
+  });
+
+  it("truncates at the limit and reports shown/total", () => {
+    const issues = Array.from({ length: 25 }, (_, index) => issue(index + 1));
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues, fetched: 25, hasMore: false },
+      limit: 20,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain("25 open issues");
+    expect(text.match(/^• /gmu)).toHaveLength(20);
+    expect(text).toContain("Showing 20 of 25 open issues.");
+  });
+
+  it("marks totals as N+ when the Linear page reports more results", () => {
+    const issues = Array.from({ length: 100 }, (_, index) => issue(index + 1));
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues, fetched: 100, hasMore: true },
+      limit: 20,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain("100+ open issues");
+    expect(text).toContain("Showing 20 of 100+ open issues.");
+  });
+
+  it("renders an explicit empty-backlog line", () => {
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [], fetched: 0, hasMore: false },
+      limit: 20,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain("0 open issues");
+    expect(text).toContain("No unfinished issues in the configured Linear project.");
+  });
+});
+
+describe("createSlackLinearBacklogHandler", () => {
+  it("replies not-configured when settings are missing", async () => {
+    const handler = createSlackLinearBacklogHandler({ env: {} });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("Linear backlog is not configured");
+  });
+
+  it("queries Linear and renders the backlog reply", async () => {
+    const handler = createSlackLinearBacklogHandler({
+      linear: { token: "lin_api_test", projectId: "proj_1" } as never,
+      env: {},
+      fetchImpl: backlogFetch([issue(153)]),
+      now: () => "2026-07-16T21:30:00.000Z"
+    });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("1 open issue");
+    expect(reply).toContain("AMP-153");
+  });
+
+  it("replies a safe unavailable message on API failure and logs without the token", async () => {
+    const logged: string[] = [];
+    const failingFetch = (async () => new Response(JSON.stringify({ errors: [{ message: "boom" }] }), { status: 500 })) as typeof fetch;
+    const handler = createSlackLinearBacklogHandler({
+      linear: { token: "lin_api_supersecret", projectId: "proj_1" } as never,
+      env: {},
+      fetchImpl: failingFetch,
+      logError: (message) => logged.push(message)
+    });
+    const reply = await handler(CONTEXT);
+    expect(reply).toContain("Linear API is unavailable");
+    expect(logged.join("\n")).toContain("boom");
+    expect(logged.join("\n")).not.toContain("supersecret");
+    expect(String(reply)).not.toContain("supersecret");
+  });
+});

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -107,6 +107,26 @@ describe("renderSlackLinearBacklogReply", () => {
     expect(text).toContain("0 open issues");
     expect(text).toContain("No unfinished issues in the configured Linear project.");
   });
+
+  it("escapes Linear-controlled title and state text so hostile content cannot inject Slack mrkdwn links", () => {
+    const hostileIssue = {
+      identifier: "AMP-999",
+      title: "<https://evil.example|click here> & more",
+      url: "https://linear.app/a/issue/AMP-999",
+      stateName: "<b>Weird</b> & State",
+      stateType: "started"
+    };
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [hostileIssue], fetched: 1, hasMore: false },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain(
+      "• <https://linear.app/a/issue/AMP-999|AMP-999> — &lt;https://evil.example|click here&gt; &amp; more  [&lt;b&gt;Weird&lt;/b&gt; &amp; State]"
+    );
+    // The identifier link itself must stay unescaped so Slack still renders it as a clickable link.
+    expect(text).toContain("<https://linear.app/a/issue/AMP-999|AMP-999>");
+  });
 });
 
 describe("createSlackLinearBacklogHandler", () => {

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -127,6 +127,33 @@ describe("renderSlackLinearBacklogReply", () => {
     // The identifier link itself must stay unescaped so Slack still renders it as a clickable link.
     expect(text).toContain("<https://linear.app/a/issue/AMP-999|AMP-999>");
   });
+
+  it("percent-encodes non-ASCII characters in the Linear issue URL so Slack renders a valid link", () => {
+    const nonAsciiIssue = {
+      identifier: "AMP-153",
+      title: "Task",
+      url: "https://linear.app/amplift/issue/AMP-153/slack通过-opentag-linear-查询未完成的-linear-任务",
+      stateName: "Todo",
+      stateType: "unstarted"
+    };
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [nonAsciiIssue], fetched: 1, hasMore: false },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain(
+      "• <https://linear.app/amplift/issue/AMP-153/slack%E9%80%9A%E8%BF%87-opentag-linear-%E6%9F%A5%E8%AF%A2%E6%9C%AA%E5%AE%8C%E6%88%90%E7%9A%84-linear-%E4%BB%BB%E5%8A%A1|AMP-153>"
+    );
+  });
+
+  it("leaves an already-ASCII issue URL byte-identical", () => {
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [issue(153)], fetched: 1, hasMore: false },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T21:30:00.000Z"
+    });
+    expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153>");
+  });
 });
 
 describe("createSlackLinearBacklogHandler", () => {

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -171,8 +171,13 @@ describe("createSlackLinearBacklogHandler", () => {
       now: () => "2026-07-16T21:30:00.000Z"
     });
     const reply = await handler(CONTEXT);
-    expect(reply).toContain("1 open issue");
-    expect(reply).toContain("AMP-153");
+    expect(reply).toEqual(
+      expect.objectContaining({
+        textFormat: "mrkdwn",
+        text: expect.stringContaining("1 open issue")
+      })
+    );
+    expect(typeof reply === "string" ? reply : reply.text).toContain("AMP-153");
   });
 
   it("replies a safe unavailable message on API failure and logs without the token", async () => {

--- a/packages/cli/test/slack-linear-backlog.test.ts
+++ b/packages/cli/test/slack-linear-backlog.test.ts
@@ -8,23 +8,37 @@ import {
 
 const CONTEXT = { teamId: "T123", channelId: "C123", threadTs: "1.0", userId: "U1", binding: null };
 
-function issue(n: number, stateName = "Todo", stateType = "unstarted") {
-  return { identifier: `AMP-${n}`, title: `Task ${n}`, url: `https://linear.app/a/issue/AMP-${n}`, stateName, stateType };
+function issue(n: number, overrides: Partial<{ stateName: string; stateType: string; priority: number; title: string }> = {}) {
+  const stateName = overrides.stateName ?? "Todo";
+  const stateType = overrides.stateType ?? "unstarted";
+  return {
+    identifier: `AMP-${n}`,
+    title: overrides.title ?? `Task ${n}`,
+    url: `https://linear.app/a/issue/AMP-${n}`,
+    stateName,
+    stateType,
+    priority: overrides.priority ?? 0
+  };
 }
 
-function backlogFetch(nodes: ReturnType<typeof issue>[], hasNextPage = false): typeof fetch {
+function backlogFetch(
+  nodes: ReturnType<typeof issue>[],
+  options: { hasNextPage?: boolean; projectName?: string | null } = {}
+): typeof fetch {
   return (async () =>
     new Response(
       JSON.stringify({
         data: {
+          project: options.projectName === undefined ? { name: "opentag" } : options.projectName ? { name: options.projectName } : null,
           issues: {
             nodes: nodes.map((entry) => ({
               identifier: entry.identifier,
               title: entry.title,
               url: entry.url,
+              priority: entry.priority,
               state: { name: entry.stateName, type: entry.stateType }
             })),
-            pageInfo: { hasNextPage }
+            pageInfo: { hasNextPage: options.hasNextPage ?? false }
           }
         }
       }),
@@ -63,66 +77,119 @@ describe("resolveSlackLinearBacklogSettings", () => {
 });
 
 describe("renderSlackLinearBacklogReply", () => {
-  it("renders header with count, source, query time, and one line per issue", () => {
+  it("renders the header with project name and total, grouped headings, and issue lines", () => {
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [issue(131, "In Progress", "started"), issue(153)], fetched: 2, hasMore: false },
+      backlog: {
+        issues: [
+          issue(140, { stateName: "In Progress", stateType: "started", priority: 1, title: "显示生成失败重试机制" }),
+          issue(131, { stateName: "In Progress", stateType: "started", title: "这个ocr把他主人的名字都搞错了；代办 ocr 优化" }),
+          issue(153, { priority: 2, title: "Slack：通过 @opentag linear 查询未完成的 Linear 任务" }),
+          issue(132, { title: "显示生成失败，the provider returned an empty draft" })
+        ],
+        fetched: 4,
+        hasMore: false,
+        projectName: "opentag"
+      },
       limit: SLACK_LINEAR_BACKLOG_LIMIT,
-      queriedAt: "2026-07-16T21:30:45.123Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
-    expect(text).toContain("OpenTag project backlog — 2 open issues (source: Linear, queried 2026-07-16T21:30Z):");
-    expect(text).toContain("• <https://linear.app/a/issue/AMP-131|AMP-131> — Task 131  [In Progress]");
-    expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153> — Task 153  [Todo]");
-    expect(text).not.toContain("Showing");
+
+    const lines = text.split("\n");
+    expect(lines).toEqual([
+      "*opentag · 4 open*",
+      "",
+      "🔵 *In Progress (2)*",
+      "• <https://linear.app/a/issue/AMP-140|AMP-140> [urgent] 显示生成失败重试机制",
+      "• <https://linear.app/a/issue/AMP-131|AMP-131> 这个ocr把他主人的名字都搞错了；代办 ocr 优化",
+      "",
+      "⚪ *Todo (2)*",
+      "• <https://linear.app/a/issue/AMP-153|AMP-153> [high] Slack：通过 @opentag linear 查询未完成的 Linear 任务",
+      "• <https://linear.app/a/issue/AMP-132|AMP-132> 显示生成失败，the provider returned an empty draft",
+      "",
+      "_Linear · queried 22:48 UTC_"
+    ]);
   });
 
-  it("truncates at the limit and reports shown/total", () => {
-    const issues = Array.from({ length: 25 }, (_, index) => issue(index + 1));
+  it("falls back to 'Backlog' as the header name when no project name is available", () => {
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues, fetched: 25, hasMore: false },
-      limit: 20,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      backlog: { issues: [issue(1)], fetched: 1, hasMore: false, projectName: null },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
-    expect(text).toContain("25 open issues");
-    expect(text.match(/^• /gmu)).toHaveLength(20);
-    expect(text).toContain("Showing 20 of 25 open issues.");
+    expect(text).toContain("*Backlog · 1 open*");
   });
 
-  it("marks totals as N+ when the Linear page reports more results", () => {
+  it("uses no priority marker and a single space before the title when priority has no urgent/high marker", () => {
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [issue(1, { priority: 3 })], fetched: 1, hasMore: false, projectName: "opentag" },
+      limit: SLACK_LINEAR_BACKLOG_LIMIT,
+      queriedAt: "2026-07-16T22:48:00.000Z"
+    });
+    expect(text).toContain("• <https://linear.app/a/issue/AMP-1|AMP-1> Task 1");
+  });
+
+  it("truncates at the limit, marks a partially-shown group heading, and reports the hidden count in the footer", () => {
+    const inProgress = Array.from({ length: 2 }, (_, index) => issue(index + 1, { stateName: "In Progress", stateType: "started" }));
+    const todo = Array.from({ length: 30 }, (_, index) => issue(1000 + index));
+    const text = renderSlackLinearBacklogReply({
+      backlog: { issues: [...inProgress, ...todo], fetched: 32, hasMore: false, projectName: "opentag" },
+      limit: 20,
+      queriedAt: "2026-07-16T22:48:00.000Z"
+    });
+
+    expect(text).toContain("*opentag · 32 open* · showing 20");
+    expect(text).toContain("🔵 *In Progress (2)*");
+    expect(text).toContain("⚪ *Todo (18 of 30)*");
+    expect(text.match(/^• /gmu)).toHaveLength(20);
+    expect(text).toContain("_Linear · queried 22:48 UTC · 12 more not shown_");
+  });
+
+  it("renders N+ totals and hidden counts when Linear reports more pages via hasMore", () => {
     const issues = Array.from({ length: 100 }, (_, index) => issue(index + 1));
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues, fetched: 100, hasMore: true },
+      backlog: { issues, fetched: 100, hasMore: true, projectName: "opentag" },
       limit: 20,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
-    expect(text).toContain("100+ open issues");
-    expect(text).toContain("Showing 20 of 100+ open issues.");
+
+    expect(text).toContain("*opentag · 100+ open* · showing 20");
+    expect(text).toContain("_Linear · queried 22:48 UTC · 80+ more not shown_");
   });
 
-  it("renders an explicit empty-backlog line", () => {
+  it("renders the empty-backlog layout", () => {
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [], fetched: 0, hasMore: false },
+      backlog: { issues: [], fetched: 0, hasMore: false, projectName: "opentag" },
       limit: 20,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
-    expect(text).toContain("0 open issues");
-    expect(text).toContain("No unfinished issues in the configured Linear project.");
+
+    expect(text.split("\n")).toEqual([
+      "*opentag · 0 open* 🎉",
+      "No unfinished issues in this Linear project.",
+      "",
+      "_Linear · queried 22:48 UTC_"
+    ]);
   });
 
-  it("escapes Linear-controlled title and state text so hostile content cannot inject Slack mrkdwn links", () => {
+  it("escapes Linear-controlled title, state, and project name so hostile content cannot inject Slack mrkdwn", () => {
     const hostileIssue = {
       identifier: "AMP-999",
       title: "<https://evil.example|click here> & more",
       url: "https://linear.app/a/issue/AMP-999",
       stateName: "<b>Weird</b> & State",
-      stateType: "started"
+      stateType: "started",
+      priority: 0
     };
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [hostileIssue], fetched: 1, hasMore: false },
+      backlog: { issues: [hostileIssue], fetched: 1, hasMore: false, projectName: "<script>evil</script>" },
       limit: SLACK_LINEAR_BACKLOG_LIMIT,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
+
+    expect(text).toContain("*&lt;script&gt;evil&lt;/script&gt; · 1 open*");
+    expect(text).toContain("🔵 *&lt;b&gt;Weird&lt;/b&gt; &amp; State (1)*");
     expect(text).toContain(
-      "• <https://linear.app/a/issue/AMP-999|AMP-999> — &lt;https://evil.example|click here&gt; &amp; more  [&lt;b&gt;Weird&lt;/b&gt; &amp; State]"
+      "• <https://linear.app/a/issue/AMP-999|AMP-999> &lt;https://evil.example|click here&gt; &amp; more"
     );
     // The identifier link itself must stay unescaped so Slack still renders it as a clickable link.
     expect(text).toContain("<https://linear.app/a/issue/AMP-999|AMP-999>");
@@ -134,23 +201,24 @@ describe("renderSlackLinearBacklogReply", () => {
       title: "Task",
       url: "https://linear.app/amplift/issue/AMP-153/slack通过-opentag-linear-查询未完成的-linear-任务",
       stateName: "Todo",
-      stateType: "unstarted"
+      stateType: "unstarted",
+      priority: 0
     };
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [nonAsciiIssue], fetched: 1, hasMore: false },
+      backlog: { issues: [nonAsciiIssue], fetched: 1, hasMore: false, projectName: "opentag" },
       limit: SLACK_LINEAR_BACKLOG_LIMIT,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
     expect(text).toContain(
-      "• <https://linear.app/amplift/issue/AMP-153/slack%E9%80%9A%E8%BF%87-opentag-linear-%E6%9F%A5%E8%AF%A2%E6%9C%AA%E5%AE%8C%E6%88%90%E7%9A%84-linear-%E4%BB%BB%E5%8A%A1|AMP-153>"
+      "<https://linear.app/amplift/issue/AMP-153/slack%E9%80%9A%E8%BF%87-opentag-linear-%E6%9F%A5%E8%AF%A2%E6%9C%AA%E5%AE%8C%E6%88%90%E7%9A%84-linear-%E4%BB%BB%E5%8A%A1|AMP-153>"
     );
   });
 
   it("leaves an already-ASCII issue URL byte-identical", () => {
     const text = renderSlackLinearBacklogReply({
-      backlog: { issues: [issue(153)], fetched: 1, hasMore: false },
+      backlog: { issues: [issue(153)], fetched: 1, hasMore: false, projectName: "opentag" },
       limit: SLACK_LINEAR_BACKLOG_LIMIT,
-      queriedAt: "2026-07-16T21:30:00.000Z"
+      queriedAt: "2026-07-16T22:48:00.000Z"
     });
     expect(text).toContain("• <https://linear.app/a/issue/AMP-153|AMP-153>");
   });
@@ -168,13 +236,13 @@ describe("createSlackLinearBacklogHandler", () => {
       linear: { token: "lin_api_test", projectId: "proj_1" } as never,
       env: {},
       fetchImpl: backlogFetch([issue(153)]),
-      now: () => "2026-07-16T21:30:00.000Z"
+      now: () => "2026-07-16T22:48:00.000Z"
     });
     const reply = await handler(CONTEXT);
     expect(reply).toEqual(
       expect.objectContaining({
         textFormat: "mrkdwn",
-        text: expect.stringContaining("1 open issue")
+        text: expect.stringContaining("opentag · 1 open")
       })
     );
     expect(typeof reply === "string" ? reply : reply.text).toContain("AMP-153");

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -407,6 +407,13 @@ describe("OpenTag CLI start wiring", () => {
     });
   });
 
+  it("does not forward the Linear token to the dispatcher for a query-only Linear config", () => {
+    const built = linearConfig();
+    built.platforms.linear = { token: "lin_api_qo", projectId: "proj_qo" } as never;
+
+    expect(dispatcherRuntimeInputFromCliConfig(built)).not.toHaveProperty("linearToken");
+  });
+
   it("refreshes and persists Linear OAuth app tokens before they expire", async () => {
     const built = linearOAuthConfig();
     const configPath = join(tempDir(), "config.json");

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -1307,3 +1307,17 @@ describe("OpenTag CLI start wiring", () => {
     expect(shouldRethrowAbortReason({ shutdownRequested: false, reason: "stopped" })).toBe(false);
   });
 });
+
+describe("slack linear backlog wiring (AMP-153)", () => {
+  it("attaches a linear handler to the Socket Mode ingress config", () => {
+    const built = slackSocketModeConfig();
+    const ingressConfig = slackSocketModeIngressConfigFromCliConfig(built, { env: {} });
+    expect(typeof ingressConfig.linear).toBe("function");
+  });
+
+  it("attaches a linear handler to the Events API ingress config", () => {
+    const built = slackConfig();
+    const ingressConfig = slackIngressConfigFromCliConfig(built, { env: {} });
+    expect(typeof ingressConfig.linear).toBe("function");
+  });
+});

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -414,6 +414,26 @@ describe("OpenTag CLI start wiring", () => {
     expect(dispatcherRuntimeInputFromCliConfig(built)).not.toHaveProperty("linearToken");
   });
 
+  it("does not forward a top-level token used only by channel-routed /linear queries", () => {
+    const built = slackConfig();
+    built.platforms.linear = {
+      token: "lin_query_only",
+      channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_qo" }]
+    } as never;
+
+    expect(dispatcherRuntimeInputFromCliConfig(built)).not.toHaveProperty("linearToken");
+  });
+
+  it("does not forward connections.default query credentials to the dispatcher", () => {
+    const built = slackConfig();
+    built.platforms.linear = {
+      connections: { default: { token: "lin_query_only" } },
+      channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_qo" }]
+    } as never;
+
+    expect(dispatcherRuntimeInputFromCliConfig(built)).not.toHaveProperty("linearToken");
+  });
+
   it("refreshes and persists Linear OAuth app tokens before they expire", async () => {
     const built = linearOAuthConfig();
     const configPath = join(tempDir(), "config.json");
@@ -500,6 +520,93 @@ describe("OpenTag CLI start wiring", () => {
     });
 
     expect(capturedTokenProvider).toEqual(expect.any(Function));
+  });
+
+  it("keeps query-only Linear OAuth refresh out of the dispatcher while preserving it for Slack /linear", async () => {
+    const built = slackConfig();
+    built.platforms.linear = {
+      token: "access_old",
+      auth: {
+        method: "oauth_app",
+        actor: "app",
+        clientId: "linear_client_id",
+        refreshToken: "refresh_old",
+        accessTokenExpiresAt: "2026-07-07T00:04:00.000Z"
+      },
+      channels: [{ teamId: "T123", channelId: "C123", projectId: "proj_query_only" }]
+    } as never;
+    let dispatcherInput: Parameters<NonNullable<StartRuntimeDependencies["startDispatcher"]>>[0] | undefined;
+    let linearHandler: ReturnType<typeof slackIngressConfigFromCliConfig>["linear"];
+    let refreshCalls = 0;
+
+    await startFromConfig({
+      config: built,
+      configPath: "/tmp/opentag/config.json",
+      signal: abortedSignal(),
+      listenForProcessSignals: false,
+      dependencies: {
+        async assertStartPortsAvailable() {},
+        startDispatcher(input) {
+          dispatcherInput = input;
+          return {
+            url: "http://localhost:3030",
+            server: {} as ReturnType<typeof import("@hono/node-server").serve>,
+            async close() {}
+          };
+        },
+        async waitForDispatcher() {},
+        async bootstrapDispatcher() {},
+        startSlackIngress(input) {
+          linearHandler = input.linear;
+          return {
+            url: "http://127.0.0.1:3040",
+            server: {} as ReturnType<typeof import("@hono/node-server").serve>,
+            async close() {}
+          };
+        },
+        async serveDaemon() {},
+        logger: { log() {} },
+        now: () => new Date("2026-07-07T00:00:00.000Z"),
+        readConfig() {
+          return built;
+        },
+        writeConfig() {},
+        async refreshLinearOAuthToken() {
+          refreshCalls += 1;
+          return { accessToken: "access_new", refreshToken: "refresh_new", expiresIn: 86_400 };
+        }
+      }
+    });
+
+    expect(dispatcherInput).not.toHaveProperty("linearToken");
+    expect(dispatcherInput).not.toHaveProperty("linearTokenProvider");
+    expect(linearHandler).toEqual(expect.any(Function));
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer access_new");
+      return new Response(
+        JSON.stringify({
+          data: {
+            project: { name: "opentag" },
+            issues: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } }
+          }
+        }),
+        { status: 200 }
+      );
+    });
+    try {
+      const reply = await linearHandler?.({
+        teamId: "T123",
+        channelId: "C123",
+        threadTs: "1.0",
+        userId: "U123",
+        binding: null
+      });
+      expect(typeof reply === "string" ? reply : reply?.text).toContain("0 open");
+      expect(refreshCalls).toBe(1);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("derives dispatcher input for Telegram from saved setup config", () => {

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -1327,4 +1327,22 @@ describe("slack linear backlog wiring (AMP-153)", () => {
     const ingressConfig = slackIngressConfigFromCliConfig(built, { env: {} });
     expect(typeof ingressConfig.linear).toBe("function");
   });
+
+  it("still attaches a linear handler when a linearTokenProvider is threaded through Socket Mode config", () => {
+    const built = slackSocketModeConfig();
+    const ingressConfig = slackSocketModeIngressConfigFromCliConfig(built, {
+      env: {},
+      linearTokenProvider: async () => "fresh_token"
+    });
+    expect(typeof ingressConfig.linear).toBe("function");
+  });
+
+  it("still attaches a linear handler when a linearTokenProvider is threaded through Events API config", () => {
+    const built = slackConfig();
+    const ingressConfig = slackIngressConfigFromCliConfig(built, {
+      env: {},
+      linearTokenProvider: async () => "fresh_token"
+    });
+    expect(typeof ingressConfig.linear).toBe("function");
+  });
 });

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -1,0 +1,74 @@
+import { linearGraphql, type FetchLike } from "./graphql.js";
+
+export const LINEAR_BACKLOG_PAGE_SIZE = 100;
+export const DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS = 10_000;
+
+export type LinearBacklogIssue = {
+  identifier: string;
+  title: string;
+  url: string;
+  stateName: string;
+  stateType: string;
+};
+
+export type LinearProjectBacklog = {
+  issues: LinearBacklogIssue[];
+  fetched: number;
+  hasMore: boolean;
+};
+
+const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $first: Int!) {
+  issues(
+    filter: {
+      project: { id: { eq: $projectId } }
+      state: { type: { nin: ["completed", "canceled"] } }
+    }
+    first: $first
+  ) {
+    nodes { identifier title url state { name type } }
+    pageInfo { hasNextPage }
+  }
+}`;
+
+const STATE_TYPE_ORDER: Record<string, number> = { started: 0, unstarted: 1, backlog: 2, triage: 3 };
+
+function issueNumber(identifier: string): number {
+  const value = Number(identifier.split("-")[1]);
+  return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+}
+
+export async function fetchLinearProjectBacklog(input: {
+  token: string;
+  projectId: string;
+  graphqlUrl?: string;
+  fetchImpl: FetchLike;
+  timeoutMs?: number;
+}): Promise<LinearProjectBacklog> {
+  const data = await linearGraphql<{
+    issues: {
+      nodes: Array<{ identifier: string; title: string; url: string; state: { name: string; type: string } }>;
+      pageInfo: { hasNextPage: boolean };
+    };
+  }>({
+    token: input.token,
+    ...(input.graphqlUrl ? { graphqlUrl: input.graphqlUrl } : {}),
+    query: BACKLOG_QUERY,
+    variables: { projectId: input.projectId, first: LINEAR_BACKLOG_PAGE_SIZE },
+    fetchImpl: input.fetchImpl,
+    timeoutMs: input.timeoutMs ?? DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS
+  });
+  const issues = data.issues.nodes
+    .map((node) => ({
+      identifier: node.identifier,
+      title: node.title,
+      url: node.url,
+      stateName: node.state.name,
+      stateType: node.state.type
+    }))
+    .sort(
+      (a, b) =>
+        (STATE_TYPE_ORDER[a.stateType] ?? 9) - (STATE_TYPE_ORDER[b.stateType] ?? 9) ||
+        issueNumber(a.identifier) - issueNumber(b.identifier)
+    );
+  return { issues, fetched: issues.length, hasMore: data.issues.pageInfo.hasNextPage };
+}

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -9,15 +9,18 @@ export type LinearBacklogIssue = {
   url: string;
   stateName: string;
   stateType: string;
+  priority: number;
 };
 
 export type LinearProjectBacklog = {
   issues: LinearBacklogIssue[];
   fetched: number;
   hasMore: boolean;
+  projectName: string | null;
 };
 
 const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $first: Int!) {
+  project(id: $projectId) { name }
   issues(
     filter: {
       project: { id: { eq: $projectId } }
@@ -25,7 +28,7 @@ const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $first: Int!
     }
     first: $first
   ) {
-    nodes { identifier title url state { name type } }
+    nodes { identifier title url priority state { name type } }
     pageInfo { hasNextPage }
   }
 }`;
@@ -37,6 +40,13 @@ function issueNumber(identifier: string): number {
   return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
 }
 
+// Linear priority semantics: 0 none, 1 urgent, 2 high, 3 medium, 4 low.
+// Rank "none" after every set priority so unprioritized issues sort last
+// within their state type.
+function priorityRank(priority: number): number {
+  return priority === 0 ? 5 : priority;
+}
+
 export async function fetchLinearProjectBacklog(input: {
   token: string;
   projectId: string;
@@ -45,8 +55,15 @@ export async function fetchLinearProjectBacklog(input: {
   timeoutMs?: number;
 }): Promise<LinearProjectBacklog> {
   const data = await linearGraphql<{
+    project: { name: string } | null;
     issues: {
-      nodes: Array<{ identifier: string; title: string; url: string; state: { name: string; type: string } }>;
+      nodes: Array<{
+        identifier: string;
+        title: string;
+        url: string;
+        priority: number | null;
+        state: { name: string; type: string };
+      }>;
       pageInfo: { hasNextPage: boolean };
     };
   }>({
@@ -63,12 +80,19 @@ export async function fetchLinearProjectBacklog(input: {
       title: node.title,
       url: node.url,
       stateName: node.state.name,
-      stateType: node.state.type
+      stateType: node.state.type,
+      priority: node.priority ?? 0
     }))
     .sort(
       (a, b) =>
         (STATE_TYPE_ORDER[a.stateType] ?? 9) - (STATE_TYPE_ORDER[b.stateType] ?? 9) ||
+        priorityRank(a.priority) - priorityRank(b.priority) ||
         issueNumber(a.identifier) - issueNumber(b.identifier)
     );
-  return { issues, fetched: issues.length, hasMore: data.issues.pageInfo.hasNextPage };
+  return {
+    issues,
+    fetched: issues.length,
+    hasMore: data.issues.pageInfo.hasNextPage,
+    projectName: data.project?.name ?? null
+  };
 }

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -19,8 +19,8 @@ export type LinearProjectBacklog = {
   projectName: string | null;
 };
 
-const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $first: Int!) {
-  project(id: $projectId) { name }
+const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey: String!, $first: Int!) {
+  project(id: $projectKey) { name }
   issues(
     filter: {
       project: { id: { eq: $projectId } }
@@ -70,7 +70,7 @@ export async function fetchLinearProjectBacklog(input: {
     token: input.token,
     ...(input.graphqlUrl ? { graphqlUrl: input.graphqlUrl } : {}),
     query: BACKLOG_QUERY,
-    variables: { projectId: input.projectId, first: LINEAR_BACKLOG_PAGE_SIZE },
+    variables: { projectId: input.projectId, projectKey: input.projectId, first: LINEAR_BACKLOG_PAGE_SIZE },
     fetchImpl: input.fetchImpl,
     timeoutMs: input.timeoutMs ?? DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS
   });

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -45,17 +45,77 @@ type LinearBacklogNode = {
   identifier: string;
   title: string;
   url: string;
-  priority: number | null;
+  priority?: number | null;
   state: { name: string; type: string };
 };
 
 type LinearBacklogPage = {
-  project: { name: string } | null;
+  project: { name: string };
   issues: {
     nodes: LinearBacklogNode[];
     pageInfo: { hasNextPage: boolean; endCursor: string | null };
   };
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function invalidBacklogResponse(detail: string): Error {
+  return new Error(`Linear API returned an invalid backlog response (${detail}).`);
+}
+
+function parseBacklogPage(value: unknown): LinearBacklogPage {
+  if (!isRecord(value)) throw invalidBacklogResponse("missing data object");
+  if (value.project == null) {
+    throw new Error("Linear project not found or inaccessible; check the channel-mapped project ID and the token's access.");
+  }
+  if (!isRecord(value.project) || typeof value.project.name !== "string") {
+    throw invalidBacklogResponse("missing project name");
+  }
+  if (!isRecord(value.issues)) throw invalidBacklogResponse("missing issues object");
+  if (!Array.isArray(value.issues.nodes)) throw invalidBacklogResponse("missing issue nodes");
+  if (!isRecord(value.issues.pageInfo) || typeof value.issues.pageInfo.hasNextPage !== "boolean") {
+    throw invalidBacklogResponse("missing pagination metadata");
+  }
+  const endCursor = value.issues.pageInfo.endCursor;
+  if (endCursor !== undefined && endCursor !== null && typeof endCursor !== "string") {
+    throw invalidBacklogResponse("invalid endCursor");
+  }
+
+  const nodes = value.issues.nodes.map((node, index): LinearBacklogNode => {
+    if (
+      !isRecord(node) ||
+      typeof node.identifier !== "string" ||
+      typeof node.title !== "string" ||
+      typeof node.url !== "string" ||
+      (node.priority !== undefined && node.priority !== null && typeof node.priority !== "number") ||
+      !isRecord(node.state) ||
+      typeof node.state.name !== "string" ||
+      typeof node.state.type !== "string"
+    ) {
+      throw invalidBacklogResponse(`invalid issue node at index ${index}`);
+    }
+    return {
+      identifier: node.identifier,
+      title: node.title,
+      url: node.url,
+      ...(node.priority !== undefined ? { priority: node.priority as number | null } : {}),
+      state: { name: node.state.name, type: node.state.type }
+    };
+  });
+
+  return {
+    project: { name: value.project.name },
+    issues: {
+      nodes,
+      pageInfo: {
+        hasNextPage: value.issues.pageInfo.hasNextPage,
+        endCursor: typeof endCursor === "string" ? endCursor : null
+      }
+    }
+  };
+}
 
 function issueNumber(identifier: string): number {
   const value = Number(identifier.split("-")[1]);
@@ -96,7 +156,7 @@ export async function fetchLinearProjectBacklog(input: {
   let projectName: string | null = null;
 
   for (let pageNumber = 1; pageNumber <= LINEAR_BACKLOG_MAX_PAGES; pageNumber += 1) {
-    const data = await linearGraphql<LinearBacklogPage>({
+    const rawData = await linearGraphql<unknown>({
       token: input.token,
       ...(input.graphqlUrl ? { graphqlUrl: input.graphqlUrl } : {}),
       query: BACKLOG_QUERY,
@@ -109,9 +169,7 @@ export async function fetchLinearProjectBacklog(input: {
       fetchImpl: input.fetchImpl,
       timeoutMs: remainingTimeoutMs(deadlineMs)
     });
-    if (data.project == null) {
-      throw new Error("Linear project not found or inaccessible; check the channel-mapped project ID and the token's access.");
-    }
+    const data = parseBacklogPage(rawData);
     projectName ??= data.project.name;
     nodes.push(...data.issues.nodes);
 

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -74,6 +74,9 @@ export async function fetchLinearProjectBacklog(input: {
     fetchImpl: input.fetchImpl,
     timeoutMs: input.timeoutMs ?? DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS
   });
+  if (data.project == null) {
+    throw new Error("Linear project not found or inaccessible; check platforms.linear.projectId and the token's access.");
+  }
   const issues = data.issues.nodes
     .map((node) => ({
       identifier: node.identifier,
@@ -93,6 +96,6 @@ export async function fetchLinearProjectBacklog(input: {
     issues,
     fetched: issues.length,
     hasMore: data.issues.pageInfo.hasNextPage,
-    projectName: data.project?.name ?? null
+    projectName: data.project.name
   };
 }

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -1,6 +1,7 @@
 import { linearGraphql, type FetchLike } from "./graphql.js";
 
 export const LINEAR_BACKLOG_PAGE_SIZE = 100;
+export const LINEAR_BACKLOG_MAX_PAGES = 100;
 export const DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS = 10_000;
 
 export type LinearBacklogIssue = {
@@ -19,13 +20,10 @@ export type LinearProjectBacklog = {
   projectName: string | null;
 };
 
-// Server-side priority ordering (Descending: Urgent -> High -> ... -> No priority
-// last) so the first $first rows returned are the globally highest-priority
-// issues, not just the $first most-recently-created ones. Without this, a
-// project with >100 unfinished issues could have higher-priority issues on
-// later pages silently dropped before the local sort below ever sees them,
-// making the "top 20 by priority" wrong. This keeps the request count at 1.
-const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey: String!, $first: Int!) {
+// The final display order is state-first, then priority, so no server-side
+// ordering can make a single page globally correct. Fetch every unfinished
+// issue page, then apply the local comparator once to the complete result.
+const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey: String!, $first: Int!, $after: String) {
   project(id: $projectKey) { name }
   issues(
     filter: {
@@ -34,17 +32,38 @@ const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey:
     }
     sort: [{ priority: { order: Descending } }]
     first: $first
+    after: $after
   ) {
     nodes { identifier title url priority state { name type } }
-    pageInfo { hasNextPage }
+    pageInfo { hasNextPage endCursor }
   }
 }`;
 
 const STATE_TYPE_ORDER: Record<string, number> = { started: 0, unstarted: 1, backlog: 2, triage: 3 };
 
+type LinearBacklogNode = {
+  identifier: string;
+  title: string;
+  url: string;
+  priority: number | null;
+  state: { name: string; type: string };
+};
+
+type LinearBacklogPage = {
+  project: { name: string } | null;
+  issues: {
+    nodes: LinearBacklogNode[];
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
 function issueNumber(identifier: string): number {
   const value = Number(identifier.split("-")[1]);
   return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+}
+
+function compareIdentifier(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 // Linear priority semantics: 0 none, 1 urgent, 2 high, 3 medium, 4 low.
@@ -54,6 +73,14 @@ function priorityRank(priority: number): number {
   return priority === 0 ? 5 : priority;
 }
 
+function remainingTimeoutMs(deadlineMs: number): number {
+  const remaining = deadlineMs - Date.now();
+  if (remaining <= 0) {
+    throw new Error("Linear backlog query timed out before all pages were fetched.");
+  }
+  return remaining;
+}
+
 export async function fetchLinearProjectBacklog(input: {
   token: string;
   projectId: string;
@@ -61,30 +88,49 @@ export async function fetchLinearProjectBacklog(input: {
   fetchImpl: FetchLike;
   timeoutMs?: number;
 }): Promise<LinearProjectBacklog> {
-  const data = await linearGraphql<{
-    project: { name: string } | null;
-    issues: {
-      nodes: Array<{
-        identifier: string;
-        title: string;
-        url: string;
-        priority: number | null;
-        state: { name: string; type: string };
-      }>;
-      pageInfo: { hasNextPage: boolean };
-    };
-  }>({
-    token: input.token,
-    ...(input.graphqlUrl ? { graphqlUrl: input.graphqlUrl } : {}),
-    query: BACKLOG_QUERY,
-    variables: { projectId: input.projectId, projectKey: input.projectId, first: LINEAR_BACKLOG_PAGE_SIZE },
-    fetchImpl: input.fetchImpl,
-    timeoutMs: input.timeoutMs ?? DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS
-  });
-  if (data.project == null) {
-    throw new Error("Linear project not found or inaccessible; check platforms.linear.projectId and the token's access.");
+  const timeoutMs = input.timeoutMs ?? DEFAULT_LINEAR_BACKLOG_TIMEOUT_MS;
+  const deadlineMs = Date.now() + timeoutMs;
+  const nodes: LinearBacklogNode[] = [];
+  const seenCursors = new Set<string>();
+  let after: string | undefined;
+  let projectName: string | null = null;
+
+  for (let pageNumber = 1; pageNumber <= LINEAR_BACKLOG_MAX_PAGES; pageNumber += 1) {
+    const data = await linearGraphql<LinearBacklogPage>({
+      token: input.token,
+      ...(input.graphqlUrl ? { graphqlUrl: input.graphqlUrl } : {}),
+      query: BACKLOG_QUERY,
+      variables: {
+        projectId: input.projectId,
+        projectKey: input.projectId,
+        first: LINEAR_BACKLOG_PAGE_SIZE,
+        ...(after ? { after } : {})
+      },
+      fetchImpl: input.fetchImpl,
+      timeoutMs: remainingTimeoutMs(deadlineMs)
+    });
+    if (data.project == null) {
+      throw new Error("Linear project not found or inaccessible; check the channel-mapped project ID and the token's access.");
+    }
+    projectName ??= data.project.name;
+    nodes.push(...data.issues.nodes);
+
+    if (!data.issues.pageInfo.hasNextPage) break;
+    const endCursor = data.issues.pageInfo.endCursor?.trim();
+    if (!endCursor) {
+      throw new Error("Linear backlog pagination returned hasNextPage without an endCursor.");
+    }
+    if (seenCursors.has(endCursor)) {
+      throw new Error("Linear backlog pagination returned a repeated endCursor.");
+    }
+    if (pageNumber === LINEAR_BACKLOG_MAX_PAGES) {
+      throw new Error(`Linear backlog pagination exceeded the ${LINEAR_BACKLOG_MAX_PAGES}-page safety limit.`);
+    }
+    seenCursors.add(endCursor);
+    after = endCursor;
   }
-  const issues = data.issues.nodes
+
+  const issues = nodes
     .map((node) => ({
       identifier: node.identifier,
       title: node.title,
@@ -97,12 +143,13 @@ export async function fetchLinearProjectBacklog(input: {
       (a, b) =>
         (STATE_TYPE_ORDER[a.stateType] ?? 9) - (STATE_TYPE_ORDER[b.stateType] ?? 9) ||
         priorityRank(a.priority) - priorityRank(b.priority) ||
-        issueNumber(a.identifier) - issueNumber(b.identifier)
+        issueNumber(a.identifier) - issueNumber(b.identifier) ||
+        compareIdentifier(a.identifier, b.identifier)
     );
   return {
     issues,
     fetched: issues.length,
-    hasMore: data.issues.pageInfo.hasNextPage,
-    projectName: data.project.name
+    hasMore: false,
+    projectName
   };
 }

--- a/packages/linear/src/backlog.ts
+++ b/packages/linear/src/backlog.ts
@@ -19,6 +19,12 @@ export type LinearProjectBacklog = {
   projectName: string | null;
 };
 
+// Server-side priority ordering (Descending: Urgent -> High -> ... -> No priority
+// last) so the first $first rows returned are the globally highest-priority
+// issues, not just the $first most-recently-created ones. Without this, a
+// project with >100 unfinished issues could have higher-priority issues on
+// later pages silently dropped before the local sort below ever sees them,
+// making the "top 20 by priority" wrong. This keeps the request count at 1.
 const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey: String!, $first: Int!) {
   project(id: $projectKey) { name }
   issues(
@@ -26,6 +32,7 @@ const BACKLOG_QUERY = `query OpenTagProjectBacklog($projectId: ID!, $projectKey:
       project: { id: { eq: $projectId } }
       state: { type: { nin: ["completed", "canceled"] } }
     }
+    sort: [{ priority: { order: Descending } }]
     first: $first
   ) {
     nodes { identifier title url priority state { name type } }

--- a/packages/linear/src/index.ts
+++ b/packages/linear/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./agent.js";
 export * from "./apply.js";
+export * from "./backlog.js";
 export * from "./discovery.js";
 export * from "./graphql.js";
 export * from "./ingress.js";

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -63,10 +63,10 @@ describe("fetchLinearProjectBacklog", () => {
     expect(calls).toHaveLength(1);
     const query = String(calls[0]!.body.query);
     expect(query).toContain('nin: ["completed", "canceled"]');
-    expect(query).toContain("project(id: $projectId)");
+    expect(query).toContain("project(id: $projectKey)");
     expect(query).toContain("priority");
     expect(query).not.toContain("mutation");
-    expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", first: 100 });
+    expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", projectKey: "proj_1", first: 100 });
   });
 
   it("sorts by state type (started, unstarted, backlog) then priority then issue number", async () => {

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -5,52 +5,178 @@ type FetchCall = { url: string; body: Record<string, unknown> };
 
 function fetchStub(input: {
   calls: FetchCall[];
-  nodes: Array<{ identifier: string; title: string; url: string; state: { name: string; type: string } }>;
+  project?: { name: string } | null;
+  nodes: Array<{
+    identifier: string;
+    title: string;
+    url: string;
+    priority?: number | null;
+    state: { name: string; type: string };
+  }>;
   hasNextPage?: boolean;
 }): typeof fetch {
   return (async (url: RequestInfo | URL, init?: RequestInit) => {
     input.calls.push({ url: String(url), body: JSON.parse(String(init?.body)) as Record<string, unknown> });
     return new Response(
-      JSON.stringify({ data: { issues: { nodes: input.nodes, pageInfo: { hasNextPage: input.hasNextPage ?? false } } } }),
+      JSON.stringify({
+        data: {
+          project: input.project ?? null,
+          issues: { nodes: input.nodes, pageInfo: { hasNextPage: input.hasNextPage ?? false } }
+        }
+      }),
       { status: 200 }
     );
   }) as typeof fetch;
 }
 
-const AMP_153 = { identifier: "AMP-153", title: "Slack linear command", url: "https://linear.app/a/issue/AMP-153", state: { name: "Todo", type: "unstarted" } };
-const AMP_131 = { identifier: "AMP-131", title: "OCR fix", url: "https://linear.app/a/issue/AMP-131", state: { name: "In Progress", type: "started" } };
-const AMP_9 = { identifier: "AMP-9", title: "Old backlog item", url: "https://linear.app/a/issue/AMP-9", state: { name: "Backlog", type: "backlog" } };
+const AMP_153 = {
+  identifier: "AMP-153",
+  title: "Slack linear command",
+  url: "https://linear.app/a/issue/AMP-153",
+  priority: 2,
+  state: { name: "Todo", type: "unstarted" }
+};
+const AMP_131 = {
+  identifier: "AMP-131",
+  title: "OCR fix",
+  url: "https://linear.app/a/issue/AMP-131",
+  priority: 0,
+  state: { name: "In Progress", type: "started" }
+};
+const AMP_9 = {
+  identifier: "AMP-9",
+  title: "Old backlog item",
+  url: "https://linear.app/a/issue/AMP-9",
+  priority: 4,
+  state: { name: "Backlog", type: "backlog" }
+};
 
 describe("fetchLinearProjectBacklog", () => {
-  it("queries unfinished project issues and excludes completed/canceled state types", async () => {
+  it("queries unfinished project issues, the project name, and excludes completed/canceled state types", async () => {
     const calls: FetchCall[] = [];
-    await fetchLinearProjectBacklog({ token: "lin_api_test", projectId: "proj_1", fetchImpl: fetchStub({ calls, nodes: [] }) });
+    await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls, project: null, nodes: [] })
+    });
 
     expect(calls).toHaveLength(1);
     const query = String(calls[0]!.body.query);
     expect(query).toContain('nin: ["completed", "canceled"]');
+    expect(query).toContain("project(id: $projectId)");
+    expect(query).toContain("priority");
     expect(query).not.toContain("mutation");
     expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", first: 100 });
   });
 
-  it("sorts by state type (started, unstarted, backlog) then issue number", async () => {
+  it("sorts by state type (started, unstarted, backlog) then priority then issue number", async () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], nodes: [AMP_9, AMP_153, AMP_131] })
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [AMP_9, AMP_153, AMP_131] })
     });
 
     expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-131", "AMP-153", "AMP-9"]);
-    expect(backlog.issues[0]).toEqual({ identifier: "AMP-131", title: "OCR fix", url: "https://linear.app/a/issue/AMP-131", stateName: "In Progress", stateType: "started" });
+    expect(backlog.issues[0]).toEqual({
+      identifier: "AMP-131",
+      title: "OCR fix",
+      url: "https://linear.app/a/issue/AMP-131",
+      stateName: "In Progress",
+      stateType: "started",
+      priority: 0
+    });
     expect(backlog.fetched).toBe(3);
     expect(backlog.hasMore).toBe(false);
+  });
+
+  it("sorts by priority within a single state type: urgent, then high, then medium, then none", async () => {
+    const none = {
+      identifier: "AMP-4",
+      title: "None",
+      url: "https://linear.app/a/issue/AMP-4",
+      priority: 0,
+      state: { name: "Todo", type: "unstarted" }
+    };
+    const medium = {
+      identifier: "AMP-3",
+      title: "Medium",
+      url: "https://linear.app/a/issue/AMP-3",
+      priority: 3,
+      state: { name: "Todo", type: "unstarted" }
+    };
+    const urgent = {
+      identifier: "AMP-1",
+      title: "Urgent",
+      url: "https://linear.app/a/issue/AMP-1",
+      priority: 1,
+      state: { name: "Todo", type: "unstarted" }
+    };
+    const high = {
+      identifier: "AMP-2",
+      title: "High",
+      url: "https://linear.app/a/issue/AMP-2",
+      priority: 2,
+      state: { name: "Todo", type: "unstarted" }
+    };
+
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [none, medium, urgent, high] })
+    });
+
+    expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-1", "AMP-2", "AMP-3", "AMP-4"]);
+  });
+
+  it("maps the project name from the GraphQL response", async () => {
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [] })
+    });
+
+    expect(backlog.projectName).toBe("opentag");
+  });
+
+  it("maps a missing project to a null project name", async () => {
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [] })
+    });
+
+    expect(backlog.projectName).toBeNull();
+  });
+
+  it("maps missing or null priority to 0", async () => {
+    const missingPriorityField = {
+      identifier: "AMP-5",
+      title: "No priority field",
+      url: "https://linear.app/a/issue/AMP-5",
+      state: { name: "Todo", type: "unstarted" }
+    };
+    const nullPriority = {
+      identifier: "AMP-6",
+      title: "Null priority",
+      url: "https://linear.app/a/issue/AMP-6",
+      priority: null,
+      state: { name: "Todo", type: "unstarted" }
+    };
+
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [missingPriorityField, nullPriority] })
+    });
+
+    expect(backlog.issues.every((issue) => issue.priority === 0)).toBe(true);
   });
 
   it("reports hasMore from pageInfo.hasNextPage", async () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], nodes: [AMP_153], hasNextPage: true })
+      fetchImpl: fetchStub({ calls: [], project: null, nodes: [AMP_153], hasNextPage: true })
     });
 
     expect(backlog.hasMore).toBe(true);

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { fetchLinearProjectBacklog } from "../src/backlog.js";
+
+type FetchCall = { url: string; body: Record<string, unknown> };
+
+function fetchStub(input: {
+  calls: FetchCall[];
+  nodes: Array<{ identifier: string; title: string; url: string; state: { name: string; type: string } }>;
+  hasNextPage?: boolean;
+}): typeof fetch {
+  return (async (url: RequestInfo | URL, init?: RequestInit) => {
+    input.calls.push({ url: String(url), body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+    return new Response(
+      JSON.stringify({ data: { issues: { nodes: input.nodes, pageInfo: { hasNextPage: input.hasNextPage ?? false } } } }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+}
+
+const AMP_153 = { identifier: "AMP-153", title: "Slack linear command", url: "https://linear.app/a/issue/AMP-153", state: { name: "Todo", type: "unstarted" } };
+const AMP_131 = { identifier: "AMP-131", title: "OCR fix", url: "https://linear.app/a/issue/AMP-131", state: { name: "In Progress", type: "started" } };
+const AMP_9 = { identifier: "AMP-9", title: "Old backlog item", url: "https://linear.app/a/issue/AMP-9", state: { name: "Backlog", type: "backlog" } };
+
+describe("fetchLinearProjectBacklog", () => {
+  it("queries unfinished project issues and excludes completed/canceled state types", async () => {
+    const calls: FetchCall[] = [];
+    await fetchLinearProjectBacklog({ token: "lin_api_test", projectId: "proj_1", fetchImpl: fetchStub({ calls, nodes: [] }) });
+
+    expect(calls).toHaveLength(1);
+    const query = String(calls[0]!.body.query);
+    expect(query).toContain('nin: ["completed", "canceled"]');
+    expect(query).not.toContain("mutation");
+    expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", first: 100 });
+  });
+
+  it("sorts by state type (started, unstarted, backlog) then issue number", async () => {
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], nodes: [AMP_9, AMP_153, AMP_131] })
+    });
+
+    expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-131", "AMP-153", "AMP-9"]);
+    expect(backlog.issues[0]).toEqual({ identifier: "AMP-131", title: "OCR fix", url: "https://linear.app/a/issue/AMP-131", stateName: "In Progress", stateType: "started" });
+    expect(backlog.fetched).toBe(3);
+    expect(backlog.hasMore).toBe(false);
+  });
+
+  it("reports hasMore from pageInfo.hasNextPage", async () => {
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], nodes: [AMP_153], hasNextPage: true })
+    });
+
+    expect(backlog.hasMore).toBe(true);
+  });
+
+  it("propagates GraphQL failures without embedding the token", async () => {
+    const failingFetch = (async () =>
+      new Response(JSON.stringify({ errors: [{ message: "rate limited" }] }), { status: 429 })) as typeof fetch;
+
+    await expect(
+      fetchLinearProjectBacklog({ token: "lin_api_supersecret", projectId: "proj_1", fetchImpl: failingFetch })
+    ).rejects.toThrow(/rate limited/);
+    await expect(
+      fetchLinearProjectBacklog({ token: "lin_api_supersecret", projectId: "proj_1", fetchImpl: failingFetch })
+    ).rejects.not.toThrow(/supersecret/);
+  });
+});

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -1,27 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { fetchLinearProjectBacklog } from "../src/backlog.js";
+import { fetchLinearProjectBacklog, LINEAR_BACKLOG_MAX_PAGES } from "../src/backlog.js";
 
-type FetchCall = { url: string; body: Record<string, unknown> };
+type BacklogNode = {
+  identifier: string;
+  title: string;
+  url: string;
+  priority?: number | null;
+  state: { name: string; type: string };
+};
 
-function fetchStub(input: {
-  calls: FetchCall[];
+type BacklogPage = {
   project?: { name: string } | null;
-  nodes: Array<{
-    identifier: string;
-    title: string;
-    url: string;
-    priority?: number | null;
-    state: { name: string; type: string };
-  }>;
+  nodes: BacklogNode[];
   hasNextPage?: boolean;
-}): typeof fetch {
+  endCursor?: string | null;
+};
+
+type FetchCall = { url: string; body: { query?: unknown; variables?: unknown } };
+
+function fetchStub(input: { calls: FetchCall[]; pages: BacklogPage[] }): typeof fetch {
+  let pageIndex = 0;
   return (async (url: RequestInfo | URL, init?: RequestInit) => {
-    input.calls.push({ url: String(url), body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+    input.calls.push({ url: String(url), body: JSON.parse(String(init?.body)) as FetchCall["body"] });
+    const page = input.pages[pageIndex++];
+    if (!page) throw new Error(`Unexpected backlog page request ${pageIndex}.`);
     return new Response(
       JSON.stringify({
         data: {
-          project: input.project ?? null,
-          issues: { nodes: input.nodes, pageInfo: { hasNextPage: input.hasNextPage ?? false } }
+          project: page.project === undefined ? { name: "opentag" } : page.project,
+          issues: {
+            nodes: page.nodes,
+            pageInfo: { hasNextPage: page.hasNextPage ?? false, endCursor: page.endCursor ?? null }
+          }
         }
       }),
       { status: 200 }
@@ -52,29 +62,77 @@ const AMP_9 = {
 };
 
 describe("fetchLinearProjectBacklog", () => {
-  it("queries unfinished project issues, the project name, and excludes completed/canceled state types", async () => {
+  it("queries unfinished project issues with cursor pagination and no mutation", async () => {
     const calls: FetchCall[] = [];
     await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls, project: { name: "opentag" }, nodes: [] })
+      fetchImpl: fetchStub({ calls, pages: [{ project: { name: "opentag" }, nodes: [] }] })
     });
 
     expect(calls).toHaveLength(1);
     const query = String(calls[0]!.body.query);
     expect(query).toContain('nin: ["completed", "canceled"]');
+    expect(query).toContain("$projectId: ID!");
+    expect(query).toContain("$projectKey: String!");
+    expect(query).not.toContain("$projectKey: ID!");
+    expect(query).toContain("$after: String");
     expect(query).toContain("project(id: $projectKey)");
     expect(query).toContain("priority");
     expect(query).toContain("sort: [{ priority: { order: Descending } }]");
+    expect(query).toContain("after: $after");
+    expect(query).toContain("pageInfo { hasNextPage endCursor }");
     expect(query).not.toContain("mutation");
     expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", projectKey: "proj_1", first: 100 });
+  });
+
+  it("paginates every unfinished issue before applying the global display sort", async () => {
+    const calls: FetchCall[] = [];
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      identifier: `AMP-${index + 1}`,
+      title: `Unstarted ${index + 1}`,
+      url: `https://linear.app/a/issue/AMP-${index + 1}`,
+      priority: 1,
+      state: { name: "Todo", type: "unstarted" }
+    }));
+    const pageTwoStarted = {
+      identifier: "AMP-1001",
+      title: "Started issue from page two",
+      url: "https://linear.app/a/issue/AMP-1001",
+      priority: 0,
+      state: { name: "In Progress", type: "started" }
+    };
+
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({
+        calls,
+        pages: [
+          { nodes: firstPage, hasNextPage: true, endCursor: "cursor_1" },
+          { nodes: [pageTwoStarted], hasNextPage: false }
+        ]
+      })
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", projectKey: "proj_1", first: 100 });
+    expect(calls[1]!.body.variables).toEqual({
+      projectId: "proj_1",
+      projectKey: "proj_1",
+      first: 100,
+      after: "cursor_1"
+    });
+    expect(backlog.issues[0]?.identifier).toBe("AMP-1001");
+    expect(backlog.fetched).toBe(101);
+    expect(backlog.hasMore).toBe(false);
   });
 
   it("sorts by state type (started, unstarted, backlog) then priority then issue number", async () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [AMP_9, AMP_153, AMP_131] })
+      fetchImpl: fetchStub({ calls: [], pages: [{ nodes: [AMP_9, AMP_153, AMP_131] }] })
     });
 
     expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-131", "AMP-153", "AMP-9"]);
@@ -123,17 +181,31 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [none, medium, urgent, high] })
+      fetchImpl: fetchStub({ calls: [], pages: [{ nodes: [none, medium, urgent, high] }] })
     });
 
     expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-1", "AMP-2", "AMP-3", "AMP-4"]);
+  });
+
+  it("uses the full identifier as a stable tie-breaker when issue numbers match", async () => {
+    const sameNumber = [
+      { ...AMP_153, identifier: "OTHER-5", priority: 2 },
+      { ...AMP_153, identifier: "AMP-5", priority: 2 }
+    ];
+    const backlog = await fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], pages: [{ nodes: sameNumber }] })
+    });
+
+    expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-5", "OTHER-5"]);
   });
 
   it("maps the project name from the GraphQL response", async () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [] })
+      fetchImpl: fetchStub({ calls: [], pages: [{ project: { name: "opentag" }, nodes: [] }] })
     });
 
     expect(backlog.projectName).toBe("opentag");
@@ -143,7 +215,7 @@ describe("fetchLinearProjectBacklog", () => {
     const resultPromise = fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [] })
+      fetchImpl: fetchStub({ calls: [], pages: [{ project: null, nodes: [] }] })
     });
 
     await expect(resultPromise).rejects.toThrow(/not found or inaccessible/i);
@@ -167,20 +239,51 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [missingPriorityField, nullPriority] })
+      fetchImpl: fetchStub({ calls: [], pages: [{ nodes: [missingPriorityField, nullPriority] }] })
     });
 
     expect(backlog.issues.every((issue) => issue.priority === 0)).toBe(true);
   });
 
-  it("reports hasMore from pageInfo.hasNextPage", async () => {
-    const backlog = await fetchLinearProjectBacklog({
+  it("rejects hasNextPage without an endCursor rather than returning a partial backlog", async () => {
+    const resultPromise = fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [AMP_153], hasNextPage: true })
+      fetchImpl: fetchStub({ calls: [], pages: [{ nodes: [AMP_153], hasNextPage: true }] })
     });
 
-    expect(backlog.hasMore).toBe(true);
+    await expect(resultPromise).rejects.toThrow(/without an endCursor/i);
+  });
+
+  it("rejects repeated cursors rather than looping or returning a partial backlog", async () => {
+    const resultPromise = fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({
+        calls: [],
+        pages: [
+          { nodes: [AMP_153], hasNextPage: true, endCursor: "cursor_1" },
+          { nodes: [AMP_131], hasNextPage: true, endCursor: "cursor_1" }
+        ]
+      })
+    });
+
+    await expect(resultPromise).rejects.toThrow(/repeated endCursor/i);
+  });
+
+  it("rejects pagination beyond the explicit page safety limit instead of rendering partial results", async () => {
+    const pages = Array.from({ length: LINEAR_BACKLOG_MAX_PAGES }, (_, index) => ({
+      nodes: [AMP_153],
+      hasNextPage: true,
+      endCursor: `cursor_${index + 1}`
+    }));
+    const resultPromise = fetchLinearProjectBacklog({
+      token: "lin_api_test",
+      projectId: "proj_1",
+      fetchImpl: fetchStub({ calls: [], pages })
+    });
+
+    await expect(resultPromise).rejects.toThrow(/page safety limit/i);
   });
 
   it("propagates GraphQL failures without embedding the token", async () => {

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -65,6 +65,7 @@ describe("fetchLinearProjectBacklog", () => {
     expect(query).toContain('nin: ["completed", "canceled"]');
     expect(query).toContain("project(id: $projectKey)");
     expect(query).toContain("priority");
+    expect(query).toContain("sort: [{ priority: { order: Descending } }]");
     expect(query).not.toContain("mutation");
     expect(calls[0]!.body.variables).toEqual({ projectId: "proj_1", projectKey: "proj_1", first: 100 });
   });

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -221,6 +221,36 @@ describe("fetchLinearProjectBacklog", () => {
     await expect(resultPromise).rejects.toThrow(/not found or inaccessible/i);
   });
 
+  it.each([
+    ["issues object", { project: { name: "opentag" }, issues: null }],
+    ["issue nodes", { project: { name: "opentag" }, issues: { nodes: null, pageInfo: { hasNextPage: false } } }],
+    ["pagination metadata", { project: { name: "opentag" }, issues: { nodes: [], pageInfo: null } }]
+  ])("rejects a malformed Linear backlog response with missing %s", async (_case, data) => {
+    const malformedFetch = (async () =>
+      new Response(JSON.stringify({ data }), { status: 200 })) as typeof fetch;
+
+    await expect(
+      fetchLinearProjectBacklog({ token: "lin_api_test", projectId: "proj_1", fetchImpl: malformedFetch })
+    ).rejects.toThrow(/invalid backlog response/i);
+  });
+
+  it("rejects malformed issue nodes with a safe structural error", async () => {
+    const malformedFetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            project: { name: "opentag" },
+            issues: { nodes: [{ identifier: "AMP-1" }], pageInfo: { hasNextPage: false, endCursor: null } }
+          }
+        }),
+        { status: 200 }
+      )) as typeof fetch;
+
+    await expect(
+      fetchLinearProjectBacklog({ token: "lin_api_test", projectId: "proj_1", fetchImpl: malformedFetch })
+    ).rejects.toThrow(/invalid issue node/i);
+  });
+
   it("maps missing or null priority to 0", async () => {
     const missingPriorityField = {
       identifier: "AMP-5",

--- a/packages/linear/test/backlog.test.ts
+++ b/packages/linear/test/backlog.test.ts
@@ -57,7 +57,7 @@ describe("fetchLinearProjectBacklog", () => {
     await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls, project: null, nodes: [] })
+      fetchImpl: fetchStub({ calls, project: { name: "opentag" }, nodes: [] })
     });
 
     expect(calls).toHaveLength(1);
@@ -73,7 +73,7 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [AMP_9, AMP_153, AMP_131] })
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [AMP_9, AMP_153, AMP_131] })
     });
 
     expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-131", "AMP-153", "AMP-9"]);
@@ -122,7 +122,7 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [none, medium, urgent, high] })
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [none, medium, urgent, high] })
     });
 
     expect(backlog.issues.map((issue) => issue.identifier)).toEqual(["AMP-1", "AMP-2", "AMP-3", "AMP-4"]);
@@ -138,14 +138,14 @@ describe("fetchLinearProjectBacklog", () => {
     expect(backlog.projectName).toBe("opentag");
   });
 
-  it("maps a missing project to a null project name", async () => {
-    const backlog = await fetchLinearProjectBacklog({
+  it("rejects when the Linear project is missing or inaccessible instead of resolving an empty backlog", async () => {
+    const resultPromise = fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
       fetchImpl: fetchStub({ calls: [], project: null, nodes: [] })
     });
 
-    expect(backlog.projectName).toBeNull();
+    await expect(resultPromise).rejects.toThrow(/not found or inaccessible/i);
   });
 
   it("maps missing or null priority to 0", async () => {
@@ -166,7 +166,7 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [missingPriorityField, nullPriority] })
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [missingPriorityField, nullPriority] })
     });
 
     expect(backlog.issues.every((issue) => issue.priority === 0)).toBe(true);
@@ -176,7 +176,7 @@ describe("fetchLinearProjectBacklog", () => {
     const backlog = await fetchLinearProjectBacklog({
       token: "lin_api_test",
       projectId: "proj_1",
-      fetchImpl: fetchStub({ calls: [], project: null, nodes: [AMP_153], hasNextPage: true })
+      fetchImpl: fetchStub({ calls: [], project: { name: "opentag" }, nodes: [AMP_153], hasNextPage: true })
     });
 
     expect(backlog.hasMore).toBe(true);

--- a/packages/slack/src/dispatcher-events.ts
+++ b/packages/slack/src/dispatcher-events.ts
@@ -289,6 +289,7 @@ export function createSlackDispatcherEventProcessorInput(config: SlackDispatcher
             channelId: input.channelId,
             threadTs: input.threadTs,
             text: input.text,
+            ...(input.textFormat ? { textFormat: input.textFormat } : {}),
             ...(input.blocks?.length ? { blocks: input.blocks } : {})
           })
         )

--- a/packages/slack/src/dispatcher-events.ts
+++ b/packages/slack/src/dispatcher-events.ts
@@ -16,6 +16,7 @@ export type SlackDispatcherEventConfig = {
   bindingAdminUserIds?: string[];
   runTimeoutMs?: number;
   fetchImpl?: typeof fetch;
+  linear?: SlackEventProcessorInput["linear"];
 } & SlackChannelPrincipalConfig;
 
 function assertSlackChannelPrincipalConfig(config: {
@@ -272,6 +273,7 @@ export function createSlackDispatcherEventProcessorInput(config: SlackDispatcher
         return doctorUnavailable({ teamId: input.teamId, channelId: input.channelId, binding: input.binding, error });
       }
     },
+    ...(config.linear ? { linear: config.linear } : {}),
     now: () => new Date().toISOString()
   };
   if (config.botToken) {

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -603,7 +603,7 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
           await input.reply({ channelId: payload.event.channel, threadTs, text: LINEAR_UNAVAILABLE_TEXT });
           return json({ ok: true, selfService: "linear", unavailable: true });
         }
-        // The Linear project is configured globally; no Project Target binding is required.
+        // /linear authorization and project routing are enforced by the injected handler before credentials or APIs are used; repository binding is intentionally not its authorization source.
         const reply = normalizeSelfServiceReply(
           await input.linear({
             teamId: payload.team_id,

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -329,6 +329,19 @@ function doctorReply(input: SlackSelfServiceContext): SlackSelfServiceReply {
 }
 
 export function createSlackEventProcessor(input: SlackEventProcessorInput) {
+  const MAX_SEEN_EVENT_IDS = 1000;
+  const seenEventIds = new Set<string>();
+  function markEventSeen(eventId: string): "new" | "duplicate" {
+    if (seenEventIds.has(eventId)) return "duplicate";
+    seenEventIds.add(eventId);
+    // Bounded: evict oldest insertion when over cap (Set preserves insertion order).
+    if (seenEventIds.size > MAX_SEEN_EVENT_IDS) {
+      const oldest = seenEventIds.values().next().value;
+      if (oldest !== undefined) seenEventIds.delete(oldest);
+    }
+    return "new";
+  }
+
   async function processBlockActions(payload: SlackInteractivePayload, slackApp: SlackAppRuntimeConfig): Promise<SlackEventProcessorResult> {
     const action = payload.actions?.find((candidate) => {
       if (candidate.action_id?.startsWith("opentag:")) return true;
@@ -424,6 +437,9 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
       }
       if (!payload.team_id || !payload.event.channel || !payload.event.user || !payload.event.text || !payload.event.ts || !payload.event_id) {
         return json({ error: "invalid_event_payload" }, 400);
+      }
+      if (markEventSeen(payload.event_id) === "duplicate") {
+        return json({ ok: true, ignored: "duplicate_event" });
       }
 
       const rawThreadActionText =

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -88,6 +88,7 @@ export type SlackAppRuntimeConfig = {
 
 export type SlackSelfServiceReply = {
   text: string;
+  textFormat?: "mrkdwn";
   blocks?: SlackBlock[];
 };
 
@@ -120,7 +121,7 @@ export type SlackEventProcessorInput = {
   submitThreadAction?(action: SlackThreadActionInput): Promise<unknown>;
   bindChannel?(input: { teamId: string; channelId: string; repoProvider: string; owner: string; repo: string }): Promise<void>;
   unbindChannel?(input: { teamId: string; channelId: string }): Promise<void>;
-  reply?(input: { channelId: string; threadTs: string; text: string; blocks?: SlackBlock[] }): Promise<void>;
+  reply?(input: { channelId: string; threadTs: string; text: string; textFormat?: "mrkdwn"; blocks?: SlackBlock[] }): Promise<void>;
   status?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
   doctor?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
   linear?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
@@ -600,6 +601,7 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
           channelId: payload.event.channel,
           threadTs,
           text: reply.text,
+          ...(reply.textFormat ? { textFormat: reply.textFormat } : {}),
           ...(reply.blocks?.length ? { blocks: reply.blocks } : {})
         });
         return json({ ok: true, selfService: "linear" });

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -123,6 +123,7 @@ export type SlackEventProcessorInput = {
   reply?(input: { channelId: string; threadTs: string; text: string; blocks?: SlackBlock[] }): Promise<void>;
   status?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
   doctor?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
+  linear?(input: SlackSelfServiceContext): Promise<SlackSelfServiceReply | string>;
   stopRun?(input: { teamId: string; channelId: string; runId?: string; requestedBy: string }): Promise<SlackStopRunResult>;
   canManageBinding?(input: SlackBindingManagementContext): Promise<boolean> | boolean;
   now(): string;
@@ -155,6 +156,7 @@ const HELP_TEXT = [
   "- @mention the app with `/bind <owner>/<repo>` or `/bind <provider>:<owner>/<repo>` to connect this Slack channel to a Project Target.",
   "- @mention the app with `/status` to see the Project Target, active run, queued follow-ups, and next safe action.",
   "- @mention the app with `/doctor` to see a redacted readiness summary for this Slack channel.",
+  "- @mention the app with `/linear` to list unfinished Linear issues for the configured Linear project (read-only).",
   "- @mention the app with `/stop [run_id]` to request cancellation for the active channel run or a specific run; OpenTag will not treat stop as successful completion.",
   "- @mention the app with `/unbind confirm` to disconnect this Slack channel from its Project Target; this does not delete local checkout config.",
   "- Reply in a source thread with `apply 1`, `approve 1`, `reject 1`, or `continue 1` when OpenTag posts source-thread actions.",
@@ -170,6 +172,10 @@ const STOP_UNAVAILABLE_TEXT = [
   "Run cancellation from this Slack ingress is not configured.",
   "OpenTag will not treat a stop request as a successful completion. Use `opentag status --run <run_id>` for audit detail, or `opentag service stop` if you need to stop the local background service."
 ].join("\n");
+const LINEAR_UNAVAILABLE_TEXT =
+  "Linear backlog is not available on this OpenTag runtime. Start OpenTag with `opentag start` after configuring platforms.linear, or update the ingress deployment.";
+const LINEAR_USAGE =
+  "Usage: @mention the app with `/linear` to list unfinished Linear issues for the configured Linear project (read-only).";
 const BINDING_AUTH_DENIED_TEXT =
   "Only an authorized Slack binding manager can change this channel's Project Target. Ask an admin to run the command or update local OpenTag channel bindings.";
 
@@ -183,6 +189,16 @@ function parseSelfServiceCommand(command: string | null): "help" | "status" | "d
   if (/^\/help(\s|$)/.test(trimmed)) return "help";
   if (/^\/status(\s|$)/.test(trimmed)) return "status";
   if (/^\/doctor(\s|$)/.test(trimmed)) return "doctor";
+  return null;
+}
+
+function parseLinearCommand(command: string | null): { ok: true } | { ok: false } | null {
+  const trimmed = command?.trim();
+  if (!trimmed) return null;
+  if (/^\/?linear$/iu.test(trimmed)) return { ok: true };
+  // A slash prefix is an unambiguous command attempt; extra arguments get usage help.
+  if (/^\/linear(\s|$)/iu.test(trimmed)) return { ok: false };
+  // Bare "linear <more words>" stays a normal coding-run mention.
   return null;
 }
 
@@ -555,6 +571,38 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
           });
         }
         return json({ ok: true, selfService: "stop", outcome: result.outcome, ...(result.runId ? { runId: result.runId } : {}) });
+      }
+      const linearRequest = payload.event.type === "app_mention" ? parseLinearCommand(rawThreadActionText) : null;
+      if (linearRequest) {
+        const threadTs = payload.event.thread_ts ?? payload.event.ts;
+        if (!input.reply) {
+          return json({ ok: true, ignored: "self_service_reply_unavailable", command: "linear" });
+        }
+        if (!linearRequest.ok) {
+          await input.reply({ channelId: payload.event.channel, threadTs, text: LINEAR_USAGE });
+          return json({ ok: true, selfService: "linear", usage: true });
+        }
+        if (!input.linear) {
+          await input.reply({ channelId: payload.event.channel, threadTs, text: LINEAR_UNAVAILABLE_TEXT });
+          return json({ ok: true, selfService: "linear", unavailable: true });
+        }
+        // The Linear project is configured globally; no Project Target binding is required.
+        const reply = normalizeSelfServiceReply(
+          await input.linear({
+            teamId: payload.team_id,
+            channelId: payload.event.channel,
+            threadTs,
+            userId: payload.event.user,
+            binding: null
+          })
+        );
+        await input.reply({
+          channelId: payload.event.channel,
+          threadTs,
+          text: reply.text,
+          ...(reply.blocks?.length ? { blocks: reply.blocks } : {})
+        });
+        return json({ ok: true, selfService: "linear" });
       }
       const selfServiceCommand = payload.event.type === "app_mention" ? parseSelfServiceCommand(rawThreadActionText) : null;
       if (selfServiceCommand) {

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -203,6 +203,35 @@ function parseLinearCommand(command: string | null): { ok: true } | { ok: false 
   return null;
 }
 
+type SlackLinearBacklogQueryPayload = SlackEventEnvelope & {
+  type: "event_callback";
+  team_id: string;
+  event_id: string;
+  event: NonNullable<SlackEventEnvelope["event"]> & {
+    type: "app_mention";
+    user: string;
+    text: string;
+    ts: string;
+    channel: string;
+  };
+};
+
+export function isSlackLinearBacklogQuery(payload: SlackIngressPayload): payload is SlackLinearBacklogQueryPayload {
+  if (payload.type !== "event_callback" || payload.event?.type !== "app_mention") return false;
+  if (
+    !payload.team_id ||
+    !payload.event_id ||
+    !payload.event.user ||
+    !payload.event.text ||
+    !payload.event.ts ||
+    !payload.event.channel
+  ) {
+    return false;
+  }
+  const command = stripSlackAppMention(payload.event.text, payload.authorizations?.[0]?.user_id);
+  return parseLinearCommand(command)?.ok === true;
+}
+
 function parseStopCommand(command: string | null): { runId?: string } | null {
   const match = command?.trim().match(/^\/stop(?:\s+(\S+))?\s*$/);
   if (!match) return null;
@@ -329,19 +358,6 @@ function doctorReply(input: SlackSelfServiceContext): SlackSelfServiceReply {
 }
 
 export function createSlackEventProcessor(input: SlackEventProcessorInput) {
-  const MAX_SEEN_EVENT_IDS = 1000;
-  const seenEventIds = new Set<string>();
-  function markEventSeen(eventId: string): "new" | "duplicate" {
-    if (seenEventIds.has(eventId)) return "duplicate";
-    seenEventIds.add(eventId);
-    // Bounded: evict oldest insertion when over cap (Set preserves insertion order).
-    if (seenEventIds.size > MAX_SEEN_EVENT_IDS) {
-      const oldest = seenEventIds.values().next().value;
-      if (oldest !== undefined) seenEventIds.delete(oldest);
-    }
-    return "new";
-  }
-
   async function processBlockActions(payload: SlackInteractivePayload, slackApp: SlackAppRuntimeConfig): Promise<SlackEventProcessorResult> {
     const action = payload.actions?.find((candidate) => {
       if (candidate.action_id?.startsWith("opentag:")) return true;
@@ -438,10 +454,6 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
       if (!payload.team_id || !payload.event.channel || !payload.event.user || !payload.event.text || !payload.event.ts || !payload.event_id) {
         return json({ error: "invalid_event_payload" }, 400);
       }
-      if (markEventSeen(payload.event_id) === "duplicate") {
-        return json({ ok: true, ignored: "duplicate_event" });
-      }
-
       const rawThreadActionText =
         payload.event.type === "app_mention"
           ? stripSlackAppMention(payload.event.text, payload.authorizations?.[0]?.user_id)

--- a/packages/slack/src/events.ts
+++ b/packages/slack/src/events.ts
@@ -203,12 +203,11 @@ function parseLinearCommand(command: string | null): { ok: true } | { ok: false 
   return null;
 }
 
-type SlackLinearBacklogQueryPayload = SlackEventEnvelope & {
+type WellFormedSlackEventPayload = SlackEventEnvelope & {
   type: "event_callback";
   team_id: string;
   event_id: string;
   event: NonNullable<SlackEventEnvelope["event"]> & {
-    type: "app_mention";
     user: string;
     text: string;
     ts: string;
@@ -216,18 +215,24 @@ type SlackLinearBacklogQueryPayload = SlackEventEnvelope & {
   };
 };
 
+function isWellFormedSlackEventPayload(payload: SlackIngressPayload): payload is WellFormedSlackEventPayload {
+  if (payload.type !== "event_callback" || !payload.event) return false;
+  return Boolean(
+    payload.team_id &&
+      payload.event_id &&
+      payload.event.user &&
+      payload.event.text &&
+      payload.event.ts &&
+      payload.event.channel
+  );
+}
+
+type SlackLinearBacklogQueryPayload = WellFormedSlackEventPayload & {
+  event: WellFormedSlackEventPayload["event"] & { type: "app_mention" };
+};
+
 export function isSlackLinearBacklogQuery(payload: SlackIngressPayload): payload is SlackLinearBacklogQueryPayload {
-  if (payload.type !== "event_callback" || payload.event?.type !== "app_mention") return false;
-  if (
-    !payload.team_id ||
-    !payload.event_id ||
-    !payload.event.user ||
-    !payload.event.text ||
-    !payload.event.ts ||
-    !payload.event.channel
-  ) {
-    return false;
-  }
+  if (!isWellFormedSlackEventPayload(payload) || payload.event.type !== "app_mention") return false;
   const command = stripSlackAppMention(payload.event.text, payload.authorizations?.[0]?.user_id);
   return parseLinearCommand(command)?.ok === true;
 }
@@ -451,7 +456,7 @@ export function createSlackEventProcessor(input: SlackEventProcessorInput) {
       if (payload.event.type === "message" && (payload.event.subtype || payload.event.bot_id)) {
         return json({ ok: true });
       }
-      if (!payload.team_id || !payload.event.channel || !payload.event.user || !payload.event.text || !payload.event.ts || !payload.event_id) {
+      if (!isWellFormedSlackEventPayload(payload)) {
         return json({ error: "invalid_event_payload" }, 400);
       }
       const rawThreadActionText =

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -299,11 +299,23 @@ export function createSlackEventsApp(input: SlackEventsAppInput) {
       });
       return c.json({ error: resolvedSlackApp.error }, 401);
     }
-    const result = await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
-    if (result.kind === "text") {
-      return c.text(result.body, result.status);
+    if (payload.type === "url_verification") {
+      const result = await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
+      if (result.kind === "text") {
+        return c.text(result.body, result.status);
+      }
+      return c.json(result.body, result.status);
     }
-    return c.json(result.body, result.status);
+    // ACK immediately; process asynchronously so a slow handler cannot miss
+    // Slack's 3s deadline. Duplicate retries are dropped by event_id dedup in
+    // the processor. Errors are logged, not surfaced (the reply, if any, is
+    // delivered out-of-band via chat.postMessage).
+    void Promise.resolve()
+      .then(() => processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true }))
+      .catch((error) => {
+        console.error("[slack] async event processing failed:", error);
+      });
+    return c.json({ ok: true }, 200);
   });
 
   return app;

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -20,6 +20,8 @@ export type SlackEventsAppInput = {
     payload?: Record<string, unknown>;
   }): Promise<void>;
   maxRequestBodyBytes?: number;
+  maxAsyncConcurrency?: number;
+  maxAsyncOutstanding?: number;
 } & SlackEventProcessorInput;
 
 export type SlackEventsApiIngressConfig = {
@@ -33,10 +35,83 @@ export type SlackEventsApiIngressConfig = {
   bindingAdminUserIds?: string[];
   runTimeoutMs?: number;
   maxRequestBodyBytes?: number;
+  maxAsyncConcurrency?: number;
+  maxAsyncOutstanding?: number;
   linear?: SlackEventProcessorInput["linear"];
 } & SlackChannelPrincipalConfig;
 
 export type SlackIngressConfig = SlackEventsApiIngressConfig;
+
+
+const DEFAULT_SLACK_ASYNC_CONCURRENCY = 8;
+const DEFAULT_SLACK_ASYNC_MAX_OUTSTANDING = 100;
+
+type AsyncTask = () => Promise<void>;
+
+function positiveInteger(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 1) throw new Error(`${name} must be a positive integer.`);
+  return resolved;
+}
+
+function createBoundedAsyncExecutor(input: {
+  concurrency: number;
+  maxOutstanding: number;
+  onError(error: unknown): void;
+}) {
+  let active = 0;
+  const queue: AsyncTask[] = [];
+
+  function drain(): void {
+    while (active < input.concurrency && queue.length > 0) {
+      const task = queue.shift()!;
+      active += 1;
+      void Promise.resolve()
+        .then(task)
+        .catch(input.onError)
+        .finally(() => {
+          active -= 1;
+          drain();
+        });
+    }
+  }
+
+  return {
+    tryEnqueue(task: AsyncTask): boolean {
+      if (active + queue.length >= input.maxOutstanding) return false;
+      queue.push(task);
+      drain();
+      return true;
+    }
+  };
+}
+
+function recordSlackAsyncQueueFull(input: {
+  recordControlPlaneEvent?: SlackEventsAppInput["recordControlPlaneEvent"];
+  apiAppId?: string;
+  maxAsyncConcurrency: number;
+  maxAsyncOutstanding: number;
+}): void {
+  void (async () => {
+    try {
+      await input.recordControlPlaneEvent?.({
+        type: "availability.backpressure",
+        severity: "warn",
+        subject: "slack:POST /slack/events",
+        payload: {
+          provider: "slack",
+          endpoint: "POST /slack/events",
+          reason: "async_queue_full",
+          maxAsyncConcurrency: input.maxAsyncConcurrency,
+          maxAsyncOutstanding: input.maxAsyncOutstanding,
+          ...(input.apiAppId ? { apiAppId: input.apiAppId } : {})
+        }
+      });
+    } catch {
+      // Backpressure must remain visible to Slack even when audit reporting is unavailable.
+    }
+  })();
+}
 
 export type SlackIngressHandle = {
   url: string;
@@ -192,6 +267,23 @@ export function createSlackEventsApp(input: SlackEventsAppInput) {
   const app = new Hono();
   const processor = createSlackEventProcessor(input);
   const maxRequestBodyBytes = input.maxRequestBodyBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES;
+  const maxAsyncConcurrency = positiveInteger(
+    input.maxAsyncConcurrency,
+    DEFAULT_SLACK_ASYNC_CONCURRENCY,
+    "maxAsyncConcurrency"
+  );
+  const maxAsyncOutstanding = positiveInteger(
+    input.maxAsyncOutstanding,
+    DEFAULT_SLACK_ASYNC_MAX_OUTSTANDING,
+    "maxAsyncOutstanding"
+  );
+  const asyncExecutor = createBoundedAsyncExecutor({
+    concurrency: maxAsyncConcurrency,
+    maxOutstanding: maxAsyncOutstanding,
+    onError(error) {
+      console.error("[slack] async event processing failed:", error);
+    }
+  });
 
   function parseSlackPayload(rawBody: string, contentType?: string): unknown | null {
     try {
@@ -306,15 +398,22 @@ export function createSlackEventsApp(input: SlackEventsAppInput) {
       }
       return c.json(result.body, result.status);
     }
-    // ACK immediately; process asynchronously so a slow handler cannot miss
-    // Slack's 3s deadline. Duplicate retries are dropped by event_id dedup in
-    // the processor. Errors are logged, not surfaced (the reply, if any, is
-    // delivered out-of-band via chat.postMessage).
-    void Promise.resolve()
-      .then(() => processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true }))
-      .catch((error) => {
-        console.error("[slack] async event processing failed:", error);
+    // Reserve a bounded async slot before ACKing. Accepted work is processed
+    // out-of-band so slow Linear/dispatcher/Slack calls cannot consume Slack's
+    // three-second acknowledgement window. A full queue returns 503 so Slack
+    // can retry instead of allowing unbounded detached promises to accumulate.
+    const accepted = asyncExecutor.tryEnqueue(async () => {
+      await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
+    });
+    if (!accepted) {
+      recordSlackAsyncQueueFull({
+        recordControlPlaneEvent: input.recordControlPlaneEvent,
+        ...(payload.api_app_id ? { apiAppId: payload.api_app_id } : {}),
+        maxAsyncConcurrency,
+        maxAsyncOutstanding
       });
+      return c.json({ error: "slack_async_queue_full" }, 503);
+    }
     return c.json({ ok: true }, 200);
   });
 
@@ -338,6 +437,8 @@ export function startSlackIngress(config: SlackEventsApiIngressConfig): SlackIng
         }
       ],
       ...(config.maxRequestBodyBytes ? { maxRequestBodyBytes: config.maxRequestBodyBytes } : {}),
+      ...(config.maxAsyncConcurrency ? { maxAsyncConcurrency: config.maxAsyncConcurrency } : {}),
+      ...(config.maxAsyncOutstanding ? { maxAsyncOutstanding: config.maxAsyncOutstanding } : {}),
       async recordControlPlaneEvent(event) {
         await dispatcherClient.recordControlPlaneEvent(event);
       },

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -33,6 +33,7 @@ export type SlackEventsApiIngressConfig = {
   bindingAdminUserIds?: string[];
   runTimeoutMs?: number;
   maxRequestBodyBytes?: number;
+  linear?: SlackEventProcessorInput["linear"];
 } & SlackChannelPrincipalConfig;
 
 export type SlackIngressConfig = SlackEventsApiIngressConfig;

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -436,9 +436,9 @@ export function startSlackIngress(config: SlackEventsApiIngressConfig): SlackIng
           ...(config.callbackUri ? { callbackUri: config.callbackUri } : {})
         }
       ],
-      ...(config.maxRequestBodyBytes ? { maxRequestBodyBytes: config.maxRequestBodyBytes } : {}),
-      ...(config.maxAsyncConcurrency ? { maxAsyncConcurrency: config.maxAsyncConcurrency } : {}),
-      ...(config.maxAsyncOutstanding ? { maxAsyncOutstanding: config.maxAsyncOutstanding } : {}),
+      ...(config.maxRequestBodyBytes !== undefined ? { maxRequestBodyBytes: config.maxRequestBodyBytes } : {}),
+      ...(config.maxAsyncConcurrency !== undefined ? { maxAsyncConcurrency: config.maxAsyncConcurrency } : {}),
+      ...(config.maxAsyncOutstanding !== undefined ? { maxAsyncOutstanding: config.maxAsyncOutstanding } : {}),
       async recordControlPlaneEvent(event) {
         await dispatcherClient.recordControlPlaneEvent(event);
       },

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -50,6 +50,7 @@ export type SlackIngressConfig = SlackEventsApiIngressConfig;
 
 const DEFAULT_LINEAR_QUERY_CONCURRENCY = 8;
 const DEFAULT_LINEAR_QUERY_MAX_OUTSTANDING = 100;
+const DEFAULT_LINEAR_QUERY_DRAIN_TIMEOUT_MS = 30_000;
 const MAX_COMPLETED_LINEAR_QUERY_EVENT_IDS = 1000;
 
 type AsyncTask = () => Promise<void>;
@@ -63,6 +64,7 @@ function positiveInteger(value: number | undefined, fallback: number, name: stri
 function createBoundedAsyncExecutor(input: {
   concurrency: number;
   maxOutstanding: number;
+  drainTimeoutMs: number;
   onError(error: unknown): void;
 }) {
   let active = 0;
@@ -101,7 +103,16 @@ function createBoundedAsyncExecutor(input: {
     closeAndDrain(): Promise<void> {
       accepting = false;
       if (active === 0 && queue.length === 0) return Promise.resolve();
-      return new Promise((resolve) => idleWaiters.add(resolve));
+      return new Promise((resolve) => {
+        let timeout: ReturnType<typeof setTimeout>;
+        const resolveWaiter = () => {
+          clearTimeout(timeout);
+          idleWaiters.delete(resolveWaiter);
+          resolve();
+        };
+        idleWaiters.add(resolveWaiter);
+        timeout = setTimeout(resolveWaiter, input.drainTimeoutMs);
+      });
     }
   };
 }
@@ -306,6 +317,7 @@ export function createSlackEventsAppRuntime(input: SlackEventsAppInput): SlackEv
   const linearQueryExecutor = createBoundedAsyncExecutor({
     concurrency: maxLinearQueryConcurrency,
     maxOutstanding: maxLinearQueryOutstanding,
+    drainTimeoutMs: DEFAULT_LINEAR_QUERY_DRAIN_TIMEOUT_MS,
     onError(error) {
       console.error("[slack] async /linear query processing failed:", error);
     }
@@ -433,7 +445,10 @@ export function createSlackEventsAppRuntime(input: SlackEventsAppInput): SlackEv
       pendingLinearQueryEventIds.add(payload.event_id);
       const accepted = linearQueryExecutor.tryEnqueue(async () => {
         try {
-          await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
+          const result = await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
+          if (result.status < 200 || result.status >= 300) {
+            throw new Error(`Slack /linear query processing returned HTTP ${result.status}.`);
+          }
           rememberCompletedLinearQuery(payload.event_id);
         } finally {
           pendingLinearQueryEventIds.delete(payload.event_id);

--- a/packages/slack/src/ingress.ts
+++ b/packages/slack/src/ingress.ts
@@ -4,7 +4,13 @@ import { createOpenTagClient } from "@opentag/client";
 import { DEFAULT_MAX_REQUEST_BODY_BYTES, RequestBodyTooLargeError, readRequestTextWithLimit } from "@opentag/core";
 import { Hono } from "hono";
 import { createSlackDispatcherEventProcessorInput, type SlackChannelPrincipalConfig } from "./dispatcher-events.js";
-import { createSlackEventProcessor, type SlackAppRuntimeConfig, type SlackEventProcessorInput, type SlackIngressPayload } from "./events.js";
+import {
+  createSlackEventProcessor,
+  isSlackLinearBacklogQuery,
+  type SlackAppRuntimeConfig,
+  type SlackEventProcessorInput,
+  type SlackIngressPayload
+} from "./events.js";
 
 export type SlackEventsAppInput = {
   slackApps: Array<
@@ -20,8 +26,8 @@ export type SlackEventsAppInput = {
     payload?: Record<string, unknown>;
   }): Promise<void>;
   maxRequestBodyBytes?: number;
-  maxAsyncConcurrency?: number;
-  maxAsyncOutstanding?: number;
+  maxLinearQueryConcurrency?: number;
+  maxLinearQueryOutstanding?: number;
 } & SlackEventProcessorInput;
 
 export type SlackEventsApiIngressConfig = {
@@ -35,16 +41,16 @@ export type SlackEventsApiIngressConfig = {
   bindingAdminUserIds?: string[];
   runTimeoutMs?: number;
   maxRequestBodyBytes?: number;
-  maxAsyncConcurrency?: number;
-  maxAsyncOutstanding?: number;
+  maxLinearQueryConcurrency?: number;
+  maxLinearQueryOutstanding?: number;
   linear?: SlackEventProcessorInput["linear"];
 } & SlackChannelPrincipalConfig;
 
 export type SlackIngressConfig = SlackEventsApiIngressConfig;
 
-
-const DEFAULT_SLACK_ASYNC_CONCURRENCY = 8;
-const DEFAULT_SLACK_ASYNC_MAX_OUTSTANDING = 100;
+const DEFAULT_LINEAR_QUERY_CONCURRENCY = 8;
+const DEFAULT_LINEAR_QUERY_MAX_OUTSTANDING = 100;
+const MAX_COMPLETED_LINEAR_QUERY_EVENT_IDS = 1000;
 
 type AsyncTask = () => Promise<void>;
 
@@ -60,7 +66,15 @@ function createBoundedAsyncExecutor(input: {
   onError(error: unknown): void;
 }) {
   let active = 0;
+  let accepting = true;
   const queue: AsyncTask[] = [];
+  const idleWaiters = new Set<() => void>();
+
+  function resolveIdleWaiters(): void {
+    if (active !== 0 || queue.length !== 0) return;
+    for (const resolve of idleWaiters) resolve();
+    idleWaiters.clear();
+  }
 
   function drain(): void {
     while (active < input.concurrency && queue.length > 0) {
@@ -72,25 +86,31 @@ function createBoundedAsyncExecutor(input: {
         .finally(() => {
           active -= 1;
           drain();
+          resolveIdleWaiters();
         });
     }
   }
 
   return {
     tryEnqueue(task: AsyncTask): boolean {
-      if (active + queue.length >= input.maxOutstanding) return false;
+      if (!accepting || active + queue.length >= input.maxOutstanding) return false;
       queue.push(task);
       drain();
       return true;
+    },
+    closeAndDrain(): Promise<void> {
+      accepting = false;
+      if (active === 0 && queue.length === 0) return Promise.resolve();
+      return new Promise((resolve) => idleWaiters.add(resolve));
     }
   };
 }
 
-function recordSlackAsyncQueueFull(input: {
+function recordSlackLinearQueryQueueFull(input: {
   recordControlPlaneEvent?: SlackEventsAppInput["recordControlPlaneEvent"];
   apiAppId?: string;
-  maxAsyncConcurrency: number;
-  maxAsyncOutstanding: number;
+  maxLinearQueryConcurrency: number;
+  maxLinearQueryOutstanding: number;
 }): void {
   void (async () => {
     try {
@@ -101,9 +121,10 @@ function recordSlackAsyncQueueFull(input: {
         payload: {
           provider: "slack",
           endpoint: "POST /slack/events",
-          reason: "async_queue_full",
-          maxAsyncConcurrency: input.maxAsyncConcurrency,
-          maxAsyncOutstanding: input.maxAsyncOutstanding,
+          lane: "linear_query",
+          reason: "linear_query_queue_full",
+          maxLinearQueryConcurrency: input.maxLinearQueryConcurrency,
+          maxLinearQueryOutstanding: input.maxLinearQueryOutstanding,
           ...(input.apiAppId ? { apiAppId: input.apiAppId } : {})
         }
       });
@@ -116,6 +137,11 @@ function recordSlackAsyncQueueFull(input: {
 export type SlackIngressHandle = {
   url: string;
   server: ReturnType<typeof serve>;
+  close(): Promise<void>;
+};
+
+export type SlackEventsAppRuntime = {
+  app: Hono;
   close(): Promise<void>;
 };
 
@@ -263,27 +289,36 @@ function isSlackIngressPayload(value: unknown): value is SlackIngressPayload {
   return isSlackEventEnvelope(value) || isSlackInteractivePayload(value);
 }
 
-export function createSlackEventsApp(input: SlackEventsAppInput) {
+export function createSlackEventsAppRuntime(input: SlackEventsAppInput): SlackEventsAppRuntime {
   const app = new Hono();
   const processor = createSlackEventProcessor(input);
   const maxRequestBodyBytes = input.maxRequestBodyBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES;
-  const maxAsyncConcurrency = positiveInteger(
-    input.maxAsyncConcurrency,
-    DEFAULT_SLACK_ASYNC_CONCURRENCY,
-    "maxAsyncConcurrency"
+  const maxLinearQueryConcurrency = positiveInteger(
+    input.maxLinearQueryConcurrency,
+    DEFAULT_LINEAR_QUERY_CONCURRENCY,
+    "maxLinearQueryConcurrency"
   );
-  const maxAsyncOutstanding = positiveInteger(
-    input.maxAsyncOutstanding,
-    DEFAULT_SLACK_ASYNC_MAX_OUTSTANDING,
-    "maxAsyncOutstanding"
+  const maxLinearQueryOutstanding = positiveInteger(
+    input.maxLinearQueryOutstanding,
+    DEFAULT_LINEAR_QUERY_MAX_OUTSTANDING,
+    "maxLinearQueryOutstanding"
   );
-  const asyncExecutor = createBoundedAsyncExecutor({
-    concurrency: maxAsyncConcurrency,
-    maxOutstanding: maxAsyncOutstanding,
+  const linearQueryExecutor = createBoundedAsyncExecutor({
+    concurrency: maxLinearQueryConcurrency,
+    maxOutstanding: maxLinearQueryOutstanding,
     onError(error) {
-      console.error("[slack] async event processing failed:", error);
+      console.error("[slack] async /linear query processing failed:", error);
     }
   });
+  const pendingLinearQueryEventIds = new Set<string>();
+  const completedLinearQueryEventIds = new Set<string>();
+
+  function rememberCompletedLinearQuery(eventId: string): void {
+    completedLinearQueryEventIds.add(eventId);
+    if (completedLinearQueryEventIds.size <= MAX_COMPLETED_LINEAR_QUERY_EVENT_IDS) return;
+    const oldest = completedLinearQueryEventIds.values().next().value;
+    if (oldest !== undefined) completedLinearQueryEventIds.delete(oldest);
+  }
 
   function parseSlackPayload(rawBody: string, contentType?: string): unknown | null {
     try {
@@ -391,33 +426,46 @@ export function createSlackEventsApp(input: SlackEventsAppInput) {
       });
       return c.json({ error: resolvedSlackApp.error }, 401);
     }
-    if (payload.type === "url_verification") {
-      const result = await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
-      if (result.kind === "text") {
-        return c.text(result.body, result.status);
+    if (isSlackLinearBacklogQuery(payload)) {
+      if (pendingLinearQueryEventIds.has(payload.event_id) || completedLinearQueryEventIds.has(payload.event_id)) {
+        return c.json({ ok: true, ignored: "duplicate_linear_query" }, 200);
       }
-      return c.json(result.body, result.status);
-    }
-    // Reserve a bounded async slot before ACKing. Accepted work is processed
-    // out-of-band so slow Linear/dispatcher/Slack calls cannot consume Slack's
-    // three-second acknowledgement window. A full queue returns 503 so Slack
-    // can retry instead of allowing unbounded detached promises to accumulate.
-    const accepted = asyncExecutor.tryEnqueue(async () => {
-      await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
-    });
-    if (!accepted) {
-      recordSlackAsyncQueueFull({
+      pendingLinearQueryEventIds.add(payload.event_id);
+      const accepted = linearQueryExecutor.tryEnqueue(async () => {
+        try {
+          await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
+          rememberCompletedLinearQuery(payload.event_id);
+        } finally {
+          pendingLinearQueryEventIds.delete(payload.event_id);
+        }
+      });
+      if (!accepted) pendingLinearQueryEventIds.delete(payload.event_id);
+      if (accepted) return c.json({ ok: true }, 200);
+
+      recordSlackLinearQueryQueueFull({
         recordControlPlaneEvent: input.recordControlPlaneEvent,
         ...(payload.api_app_id ? { apiAppId: payload.api_app_id } : {}),
-        maxAsyncConcurrency,
-        maxAsyncOutstanding
+        maxLinearQueryConcurrency,
+        maxLinearQueryOutstanding
       });
-      return c.json({ error: "slack_async_queue_full" }, 503);
+      return c.json({ error: "slack_linear_query_queue_full" }, 503);
     }
-    return c.json({ ok: true }, 200);
+
+    const result = await processor.process(payload, resolvedSlackApp.slackApp, { signatureVerified: true });
+    if (result.kind === "text") return c.text(result.body, result.status);
+    return c.json(result.body, result.status);
   });
 
-  return app;
+  return {
+    app,
+    close() {
+      return linearQueryExecutor.closeAndDrain();
+    }
+  };
+}
+
+export function createSlackEventsApp(input: SlackEventsAppInput) {
+  return createSlackEventsAppRuntime(input).app;
 }
 
 export function startSlackIngress(config: SlackEventsApiIngressConfig): SlackIngressHandle {
@@ -426,32 +474,37 @@ export function startSlackIngress(config: SlackEventsApiIngressConfig): SlackIng
     dispatcherUrl: config.dispatcherUrl,
     ...(config.dispatcherToken ? { pairingToken: config.dispatcherToken } : {})
   });
+  const eventsApp = createSlackEventsAppRuntime({
+    slackApps: [
+      {
+        signingSecret: config.signingSecret,
+        agentId: config.agentId ?? "opentag",
+        ...(config.appId ? { appId: config.appId } : {}),
+        ...(config.callbackUri ? { callbackUri: config.callbackUri } : {})
+      }
+    ],
+    ...(config.maxRequestBodyBytes !== undefined ? { maxRequestBodyBytes: config.maxRequestBodyBytes } : {}),
+    ...(config.maxLinearQueryConcurrency !== undefined
+      ? { maxLinearQueryConcurrency: config.maxLinearQueryConcurrency }
+      : {}),
+    ...(config.maxLinearQueryOutstanding !== undefined
+      ? { maxLinearQueryOutstanding: config.maxLinearQueryOutstanding }
+      : {}),
+    async recordControlPlaneEvent(event) {
+      await dispatcherClient.recordControlPlaneEvent(event);
+    },
+    ...createSlackDispatcherEventProcessorInput(config)
+  });
   const server = serve({
-    fetch: createSlackEventsApp({
-      slackApps: [
-        {
-          signingSecret: config.signingSecret,
-          agentId: config.agentId ?? "opentag",
-          ...(config.appId ? { appId: config.appId } : {}),
-          ...(config.callbackUri ? { callbackUri: config.callbackUri } : {})
-        }
-      ],
-      ...(config.maxRequestBodyBytes !== undefined ? { maxRequestBodyBytes: config.maxRequestBodyBytes } : {}),
-      ...(config.maxAsyncConcurrency !== undefined ? { maxAsyncConcurrency: config.maxAsyncConcurrency } : {}),
-      ...(config.maxAsyncOutstanding !== undefined ? { maxAsyncOutstanding: config.maxAsyncOutstanding } : {}),
-      async recordControlPlaneEvent(event) {
-        await dispatcherClient.recordControlPlaneEvent(event);
-      },
-      ...createSlackDispatcherEventProcessorInput(config)
-    }).fetch,
+    fetch: eventsApp.app.fetch,
     port
   });
 
   return {
     url: `http://localhost:${port}`,
     server,
-    close() {
-      return new Promise((resolve, reject) => {
+    async close() {
+      const serverClosed = new Promise<void>((resolve, reject) => {
         server.close((error?: Error) => {
           if (error) {
             reject(error);
@@ -460,6 +513,7 @@ export function startSlackIngress(config: SlackEventsApiIngressConfig): SlackIng
           resolve();
         });
       });
+      await Promise.all([serverClosed, eventsApp.close()]);
     }
   };
 }

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -161,7 +161,7 @@ export function createSlackApprovalPromptBlocks(presentation: OpenTagApprovalPro
   ];
 }
 
-function escapeSlackText(text: string): string {
+export function escapeSlackText(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 

--- a/packages/slack/test/dispatcher-events.test.ts
+++ b/packages/slack/test/dispatcher-events.test.ts
@@ -387,3 +387,16 @@ describe("Slack dispatcher-backed self-service", () => {
     ]);
   });
 });
+
+describe("linear handler passthrough", () => {
+  it("copies the configured linear handler into the processor input", () => {
+    const linear = async () => "backlog";
+    const input = createSlackDispatcherEventProcessorInput({ dispatcherUrl: "http://localhost:3030", linear });
+    expect(input.linear).toBe(linear);
+  });
+
+  it("leaves linear undefined when not configured", () => {
+    const input = createSlackDispatcherEventProcessorInput({ dispatcherUrl: "http://localhost:3030" });
+    expect(input.linear).toBeUndefined();
+  });
+});

--- a/packages/slack/test/dispatcher-events.test.ts
+++ b/packages/slack/test/dispatcher-events.test.ts
@@ -163,6 +163,48 @@ describe("Slack dispatcher-backed self-service", () => {
     expect(JSON.stringify(requests[1]?.body)).toContain("timeout policy: hard timeout after 45 second(s).");
   });
 
+  it("posts a reply with textFormat: mrkdwn without re-escaping a hand-built Slack link", async () => {
+    const requests: Array<{ url: string; authorization?: string; body?: unknown }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      const headers = init?.headers as Record<string, string> | undefined;
+      requests.push({
+        url: href,
+        ...(headers?.authorization ? { authorization: headers.authorization } : {}),
+        ...(typeof init?.body === "string" ? { body: JSON.parse(init.body) as unknown } : {})
+      });
+      if (href === "https://slack.com/api/chat.postMessage") {
+        return Response.json({ ok: true, ts: "1719187201.000100" });
+      }
+      return Response.json({ error: "unexpected_url" }, { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const processorInput = createSlackDispatcherEventProcessorInput({
+      dispatcherUrl: "http://dispatcher.test",
+      botToken: "xoxb-test",
+      fetchImpl
+    });
+
+    await processorInput.reply!({
+      channelId: "C123",
+      threadTs: "1719187200.000100",
+      text: "<https://x|A>",
+      textFormat: "mrkdwn"
+    });
+
+    expect(requests).toEqual([
+      expect.objectContaining({
+        url: "https://slack.com/api/chat.postMessage",
+        authorization: "Bearer xoxb-test",
+        body: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1719187200.000100",
+          text: "<https://x|A>"
+        })
+      })
+    ]);
+  });
+
   it("cancels a specific run through the dispatcher", async () => {
     const requests: Array<{ url: string; authorization?: string; body?: unknown }> = [];
     const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -130,6 +130,19 @@ describe("Slack event_id dedup", () => {
     expect(second.body).not.toHaveProperty("ignored", "duplicate_event");
     expect(runs).toHaveLength(2);
   });
+
+  it("evicts the oldest event_id after the 1000-entry bound", async () => {
+    const runs: string[] = [];
+    const processor = dedupProcessor({ runs });
+    await processor.process(mentionPayload("EvOldest"), { agentId: "opentag" });
+    for (let index = 0; index < 1000; index += 1) {
+      await processor.process(mentionPayload(`EvFill${index}`), { agentId: "opentag" });
+    }
+
+    const retriedOldest = await processor.process(mentionPayload("EvOldest"), { agentId: "opentag" });
+    expect(retriedOldest.body).not.toHaveProperty("ignored", "duplicate_event");
+    expect(runs).toHaveLength(1002);
+  });
 });
 
 describe("Slack /linear self-service command", () => {
@@ -203,6 +216,67 @@ describe("Slack /linear self-service command", () => {
       expect(replies[0]!.text).toContain("OpenTag project backlog");
     }
   );
+
+  it("deduplicates retried /linear deliveries before a second query or reply", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+    const linearCalls: number[] = [];
+    const processor = linearProcessor({ replies, runs, linearCalls });
+
+    const first = await processor.process(mentionEvent("<@UBOT> /linear"), { agentId: "opentag" });
+    const retry = await processor.process(mentionEvent("<@UBOT> /linear"), { agentId: "opentag" });
+
+    expect(first.body).toMatchObject({ ok: true, selfService: "linear" });
+    expect(retry.body).toEqual({ ok: true, ignored: "duplicate_event" });
+    expect(linearCalls).toHaveLength(1);
+    expect(replies).toHaveLength(1);
+    expect(runs).toHaveLength(0);
+  });
+
+  it("passes Slack identity context with binding:null and never resolves a Project Target binding", async () => {
+    const contexts: unknown[] = [];
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+    let bindingCalls = 0;
+    const processor = createSlackEventProcessor({
+      async resolveChannelBinding() {
+        bindingCalls += 1;
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        runs.push("run_created");
+        return { runId: "run_1" };
+      },
+      async linear(context) {
+        contexts.push(context);
+        return { text: "• <https://x|AMP-1>", textFormat: "mrkdwn" };
+      },
+      async reply(reply) {
+        replies.push(reply);
+      },
+      now: () => "2026-07-16T00:00:00.000Z"
+    });
+    const payload = mentionEvent("<@UBOT> /linear");
+    payload.event.thread_ts = "1719187000.000050";
+
+    await processor.process(payload, { agentId: "opentag" });
+
+    expect(bindingCalls).toBe(0);
+    expect(runs).toHaveLength(0);
+    expect(contexts).toEqual([{
+      teamId: "T123",
+      channelId: "C123",
+      threadTs: "1719187000.000050",
+      userId: "U456",
+      binding: null
+    }]);
+    expect(replies[0]).toMatchObject({
+      channelId: "C123",
+      threadTs: "1719187000.000050",
+      text: "• <https://x|AMP-1>",
+      textFormat: "mrkdwn"
+    });
+  });
 
   it("replies usage for /linear with extra arguments and does not create a run", async () => {
     const replies: Reply[] = [];

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -74,3 +74,123 @@ describe("Slack thread action metadata", () => {
     expectRepoFreeMetadata(submitted[0]!.metadata);
   });
 });
+
+describe("Slack /linear self-service command", () => {
+  type Reply = { channelId: string; threadTs: string; text: string };
+
+  function linearProcessor(input: {
+    replies: Reply[];
+    runs: string[];
+    linearCalls?: number[];
+    linearReply?: string;
+    withLinearHandler?: boolean;
+  }) {
+    return createSlackEventProcessor({
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        input.runs.push("run_created");
+        return { runId: "run_1" };
+      },
+      async reply(reply) {
+        input.replies.push({ channelId: reply.channelId, threadTs: reply.threadTs, text: reply.text });
+      },
+      ...(input.withLinearHandler === false
+        ? {}
+        : {
+            async linear() {
+              input.linearCalls?.push(1);
+              return input.linearReply ?? "OpenTag project backlog — 1 open issue";
+            }
+          }),
+      now: () => "2026-07-16T00:00:00.000Z"
+    });
+  }
+
+  function mentionEvent(text: string) {
+    return {
+      type: "event_callback" as const,
+      team_id: "T123",
+      event_id: "EvLinear1",
+      authorizations: [{ user_id: "UBOT" }],
+      event: {
+        type: "app_mention" as const,
+        channel: "C123",
+        user: "U456",
+        text,
+        ts: "1719187200.000100"
+      }
+    };
+  }
+
+  it.each(["<@UBOT> linear", "<@UBOT> /linear", "<@UBOT> LINEAR", "<@UBOT>  /Linear  "])(
+    "replies with the backlog and does not create a run for %j",
+    async (text) => {
+      const replies: Reply[] = [];
+      const runs: string[] = [];
+      const linearCalls: number[] = [];
+
+      const result = await linearProcessor({ replies, runs, linearCalls }).process(mentionEvent(text), { agentId: "opentag" });
+
+      expect(result.body).toMatchObject({ ok: true, selfService: "linear" });
+      expect(linearCalls).toHaveLength(1);
+      expect(runs).toHaveLength(0);
+      expect(replies).toHaveLength(1);
+      expect(replies[0]).toMatchObject({ channelId: "C123", threadTs: "1719187200.000100" });
+      expect(replies[0]!.text).toContain("OpenTag project backlog");
+    }
+  );
+
+  it("replies usage for /linear with extra arguments and does not create a run", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+    const linearCalls: number[] = [];
+
+    const result = await linearProcessor({ replies, runs, linearCalls }).process(
+      mentionEvent("<@UBOT> /linear something else"),
+      { agentId: "opentag" }
+    );
+
+    expect(result.body).toMatchObject({ ok: true, selfService: "linear", usage: true });
+    expect(linearCalls).toHaveLength(0);
+    expect(runs).toHaveLength(0);
+    expect(replies[0]!.text).toContain("Usage");
+  });
+
+  it("does NOT intercept a bare linear mention with extra words (normal run flow)", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+    const linearCalls: number[] = [];
+
+    await linearProcessor({ replies, runs, linearCalls }).process(
+      mentionEvent("<@UBOT> linear regression in the parser, please fix"),
+      { agentId: "opentag" }
+    );
+
+    expect(linearCalls).toHaveLength(0);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("replies a safe unavailable message when no linear handler is configured", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+
+    const result = await linearProcessor({ replies, runs, withLinearHandler: false }).process(
+      mentionEvent("<@UBOT> /linear"),
+      { agentId: "opentag" }
+    );
+
+    expect(result.body).toMatchObject({ ok: true, selfService: "linear", unavailable: true });
+    expect(runs).toHaveLength(0);
+    expect(replies[0]!.text).toContain("not available");
+  });
+
+  it("lists /linear in help output", async () => {
+    const replies: Reply[] = [];
+
+    await linearProcessor({ replies, runs: [] }).process(mentionEvent("<@UBOT> /help"), { agentId: "opentag" });
+
+    expect(replies[0]!.text).toContain("/linear");
+  });
+});

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -75,6 +75,63 @@ describe("Slack thread action metadata", () => {
   });
 });
 
+describe("Slack event_id dedup", () => {
+  function dedupProcessor(input: { runs: string[] }) {
+    return createSlackEventProcessor({
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        input.runs.push("run_created");
+        return { runId: "run_1" };
+      },
+      now: () => "2026-07-16T00:00:00.000Z"
+    });
+  }
+
+  function mentionPayload(eventId: string) {
+    return {
+      type: "event_callback" as const,
+      team_id: "T123",
+      event_id: eventId,
+      authorizations: [{ user_id: "UBOT" }],
+      event: {
+        type: "app_mention" as const,
+        channel: "C123",
+        user: "U456",
+        text: "<@UBOT> fix the bug",
+        ts: "1719187200.000100"
+      }
+    };
+  }
+
+  it("drops a duplicate delivery of the same event_id and runs the handler only once", async () => {
+    const runs: string[] = [];
+    const processor = dedupProcessor({ runs });
+
+    const first = await processor.process(mentionPayload("EvDup1"), { agentId: "opentag" });
+    const second = await processor.process(mentionPayload("EvDup1"), { agentId: "opentag" });
+
+    expect(first.body).toMatchObject({ ok: true });
+    expect(first.body).not.toHaveProperty("ignored", "duplicate_event");
+    expect(second.body).toEqual({ ok: true, ignored: "duplicate_event" });
+    expect(runs).toHaveLength(1);
+  });
+
+  it("processes two different event_ids independently (no false dedup)", async () => {
+    const runs: string[] = [];
+    const processor = dedupProcessor({ runs });
+
+    const first = await processor.process(mentionPayload("EvDup2"), { agentId: "opentag" });
+    const second = await processor.process(mentionPayload("EvDup3"), { agentId: "opentag" });
+
+    expect(first.body).toMatchObject({ ok: true });
+    expect(second.body).toMatchObject({ ok: true });
+    expect(second.body).not.toHaveProperty("ignored", "duplicate_event");
+    expect(runs).toHaveLength(2);
+  });
+});
+
 describe("Slack /linear self-service command", () => {
   type Reply = { channelId: string; threadTs: string; text: string; textFormat?: "mrkdwn" };
 

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -76,13 +76,13 @@ describe("Slack thread action metadata", () => {
 });
 
 describe("Slack /linear self-service command", () => {
-  type Reply = { channelId: string; threadTs: string; text: string };
+  type Reply = { channelId: string; threadTs: string; text: string; textFormat?: "mrkdwn" };
 
   function linearProcessor(input: {
     replies: Reply[];
     runs: string[];
     linearCalls?: number[];
-    linearReply?: string;
+    linearReply?: string | { text: string; textFormat?: "mrkdwn" };
     withLinearHandler?: boolean;
   }) {
     return createSlackEventProcessor({
@@ -94,7 +94,12 @@ describe("Slack /linear self-service command", () => {
         return { runId: "run_1" };
       },
       async reply(reply) {
-        input.replies.push({ channelId: reply.channelId, threadTs: reply.threadTs, text: reply.text });
+        input.replies.push({
+          channelId: reply.channelId,
+          threadTs: reply.threadTs,
+          text: reply.text,
+          ...(reply.textFormat ? { textFormat: reply.textFormat } : {})
+        });
       },
       ...(input.withLinearHandler === false
         ? {}
@@ -192,5 +197,19 @@ describe("Slack /linear self-service command", () => {
     await linearProcessor({ replies, runs: [] }).process(mentionEvent("<@UBOT> /help"), { agentId: "opentag" });
 
     expect(replies[0]!.text).toContain("/linear");
+  });
+
+  it("forwards textFormat: mrkdwn from a linear handler reply so links are not re-escaped", async () => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+
+    await linearProcessor({
+      replies,
+      runs,
+      linearReply: { text: "• <https://x|AMP-1> — t", textFormat: "mrkdwn" }
+    }).process(mentionEvent("<@UBOT> /linear"), { agentId: "opentag" });
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toMatchObject({ text: "• <https://x|AMP-1> — t", textFormat: "mrkdwn" });
   });
 });

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { createSlackEventProcessor, type SlackThreadActionInput } from "../src/events.js";
+import {
+  createSlackEventProcessor,
+  isSlackLinearBacklogQuery,
+  type SlackEventEnvelope,
+  type SlackThreadActionInput
+} from "../src/events.js";
 
 function repoFreeProcessor(submitted: SlackThreadActionInput[]) {
   return createSlackEventProcessor({
@@ -128,6 +133,29 @@ describe("Slack /linear self-service command", () => {
       }
     };
   }
+
+  it.each([
+    ["team_id", (payload: SlackEventEnvelope) => delete payload.team_id],
+    ["event_id", (payload: SlackEventEnvelope) => delete payload.event_id],
+    ["event.user", (payload: SlackEventEnvelope) => payload.event && delete payload.event.user],
+    ["event.text", (payload: SlackEventEnvelope) => payload.event && delete payload.event.text],
+    ["event.ts", (payload: SlackEventEnvelope) => payload.event && delete payload.event.ts],
+    ["event.channel", (payload: SlackEventEnvelope) => payload.event && delete payload.event.channel]
+  ])("consistently rejects /linear payloads missing %s before routing or processing", async (_field, omitField) => {
+    const replies: Reply[] = [];
+    const runs: string[] = [];
+    const linearCalls: number[] = [];
+    const payload: SlackEventEnvelope = mentionEvent("<@UBOT> /linear");
+    omitField(payload);
+
+    expect(isSlackLinearBacklogQuery(payload)).toBe(false);
+    await expect(
+      linearProcessor({ replies, runs, linearCalls }).process(payload, { agentId: "opentag" })
+    ).resolves.toMatchObject({ status: 400, body: { error: "invalid_event_payload" } });
+    expect(linearCalls).toHaveLength(0);
+    expect(replies).toHaveLength(0);
+    expect(runs).toHaveLength(0);
+  });
 
   it.each(["<@UBOT> linear", "<@UBOT> /linear", "<@UBOT> LINEAR", "<@UBOT>  /Linear  "])(
     "replies with the backlog and does not create a run for %j",

--- a/packages/slack/test/events.test.ts
+++ b/packages/slack/test/events.test.ts
@@ -75,76 +75,6 @@ describe("Slack thread action metadata", () => {
   });
 });
 
-describe("Slack event_id dedup", () => {
-  function dedupProcessor(input: { runs: string[] }) {
-    return createSlackEventProcessor({
-      async resolveChannelBinding() {
-        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
-      },
-      async createRun() {
-        input.runs.push("run_created");
-        return { runId: "run_1" };
-      },
-      now: () => "2026-07-16T00:00:00.000Z"
-    });
-  }
-
-  function mentionPayload(eventId: string) {
-    return {
-      type: "event_callback" as const,
-      team_id: "T123",
-      event_id: eventId,
-      authorizations: [{ user_id: "UBOT" }],
-      event: {
-        type: "app_mention" as const,
-        channel: "C123",
-        user: "U456",
-        text: "<@UBOT> fix the bug",
-        ts: "1719187200.000100"
-      }
-    };
-  }
-
-  it("drops a duplicate delivery of the same event_id and runs the handler only once", async () => {
-    const runs: string[] = [];
-    const processor = dedupProcessor({ runs });
-
-    const first = await processor.process(mentionPayload("EvDup1"), { agentId: "opentag" });
-    const second = await processor.process(mentionPayload("EvDup1"), { agentId: "opentag" });
-
-    expect(first.body).toMatchObject({ ok: true });
-    expect(first.body).not.toHaveProperty("ignored", "duplicate_event");
-    expect(second.body).toEqual({ ok: true, ignored: "duplicate_event" });
-    expect(runs).toHaveLength(1);
-  });
-
-  it("processes two different event_ids independently (no false dedup)", async () => {
-    const runs: string[] = [];
-    const processor = dedupProcessor({ runs });
-
-    const first = await processor.process(mentionPayload("EvDup2"), { agentId: "opentag" });
-    const second = await processor.process(mentionPayload("EvDup3"), { agentId: "opentag" });
-
-    expect(first.body).toMatchObject({ ok: true });
-    expect(second.body).toMatchObject({ ok: true });
-    expect(second.body).not.toHaveProperty("ignored", "duplicate_event");
-    expect(runs).toHaveLength(2);
-  });
-
-  it("evicts the oldest event_id after the 1000-entry bound", async () => {
-    const runs: string[] = [];
-    const processor = dedupProcessor({ runs });
-    await processor.process(mentionPayload("EvOldest"), { agentId: "opentag" });
-    for (let index = 0; index < 1000; index += 1) {
-      await processor.process(mentionPayload(`EvFill${index}`), { agentId: "opentag" });
-    }
-
-    const retriedOldest = await processor.process(mentionPayload("EvOldest"), { agentId: "opentag" });
-    expect(retriedOldest.body).not.toHaveProperty("ignored", "duplicate_event");
-    expect(runs).toHaveLength(1002);
-  });
-});
-
 describe("Slack /linear self-service command", () => {
   type Reply = { channelId: string; threadTs: string; text: string; textFormat?: "mrkdwn" };
 
@@ -216,22 +146,6 @@ describe("Slack /linear self-service command", () => {
       expect(replies[0]!.text).toContain("OpenTag project backlog");
     }
   );
-
-  it("deduplicates retried /linear deliveries before a second query or reply", async () => {
-    const replies: Reply[] = [];
-    const runs: string[] = [];
-    const linearCalls: number[] = [];
-    const processor = linearProcessor({ replies, runs, linearCalls });
-
-    const first = await processor.process(mentionEvent("<@UBOT> /linear"), { agentId: "opentag" });
-    const retry = await processor.process(mentionEvent("<@UBOT> /linear"), { agentId: "opentag" });
-
-    expect(first.body).toMatchObject({ ok: true, selfService: "linear" });
-    expect(retry.body).toEqual({ ok: true, ignored: "duplicate_event" });
-    expect(linearCalls).toHaveLength(1);
-    expect(replies).toHaveLength(1);
-    expect(runs).toHaveLength(0);
-  });
 
   it("passes Slack identity context with binding:null and never resolves a Project Target binding", async () => {
     const contexts: unknown[] = [];

--- a/packages/slack/test/ingress.test.ts
+++ b/packages/slack/test/ingress.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { computeSlackSignature, createSlackEventsApp } from "../src/ingress.js";
+import { computeSlackSignature, createSlackEventsApp, startSlackIngress } from "../src/ingress.js";
 
 describe("Slack Events API ack-then-async", () => {
   const now = "2024-06-24T00:00:00.000Z";
@@ -44,8 +44,12 @@ describe("Slack Events API ack-then-async", () => {
 
   it("acks an event_callback with {ok:true} before a slow handler finishes, then still runs it", async () => {
     const timeline: string[] = [];
+    let releaseCreateRun!: () => void;
+    const createRunGate = new Promise<void>((resolve) => {
+      releaseCreateRun = resolve;
+    });
     const createRun = vi.fn(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 30));
+      await createRunGate;
       timeline.push("createRun_finished");
       return { runId: "run_1" };
     });
@@ -73,7 +77,6 @@ describe("Slack Events API ack-then-async", () => {
       clock: currentClock
     });
 
-    const start = Date.now();
     const response = await app.request("/slack/events", {
       method: "POST",
       headers: {
@@ -83,16 +86,16 @@ describe("Slack Events API ack-then-async", () => {
       },
       body: rawBody
     });
-    const elapsedMs = Date.now() - start;
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(elapsedMs).toBeLessThan(30);
     expect(timeline).toHaveLength(0);
 
-    await new Promise((resolve) => setTimeout(resolve, 60));
-    expect(timeline).toEqual(["createRun_finished"]);
-    expect(createRun).toHaveBeenCalledOnce();
+    releaseCreateRun();
+    await vi.waitFor(() => {
+      expect(timeline).toEqual(["createRun_finished"]);
+      expect(createRun).toHaveBeenCalledOnce();
+    });
   });
 
   it("logs and swallows an error from asynchronous event processing without changing the ack response", async () => {
@@ -138,9 +141,10 @@ describe("Slack Events API ack-then-async", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(createRun).toHaveBeenCalledOnce();
-    expect(consoleError).toHaveBeenCalledWith("[slack] async event processing failed:", failure);
+    await vi.waitFor(() => {
+      expect(createRun).toHaveBeenCalledOnce();
+      expect(consoleError).toHaveBeenCalledWith("[slack] async event processing failed:", failure);
+    });
   });
 
   it("acks a block_actions interactive payload with {ok:true} immediately", async () => {
@@ -187,8 +191,21 @@ describe("Slack Events API ack-then-async", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(submitThreadAction).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(submitThreadAction).toHaveBeenCalledOnce());
+  });
+
+  it.each([
+    ["maxAsyncConcurrency", { maxAsyncConcurrency: 0 }],
+    ["maxAsyncOutstanding", { maxAsyncOutstanding: 0 }]
+  ])("preserves a zero %s setting so startup validation rejects it", (name, limits) => {
+    expect(() =>
+      startSlackIngress({
+        signingSecret: "secret",
+        dispatcherUrl: "http://127.0.0.1:1",
+        port: -1,
+        ...limits
+      })
+    ).toThrow(`${name} must be a positive integer.`);
   });
 
   it("bounds active plus queued event processing and returns 503 without starting overflow work", async () => {

--- a/packages/slack/test/ingress.test.ts
+++ b/packages/slack/test/ingress.test.ts
@@ -191,6 +191,163 @@ describe("Slack Events API ack-then-async", () => {
     expect(submitThreadAction).toHaveBeenCalledOnce();
   });
 
+  it("bounds active plus queued event processing and returns 503 without starting overflow work", async () => {
+    const releases: Array<() => void> = [];
+    const started: string[] = [];
+    const audits: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      maxAsyncConcurrency: 1,
+      maxAsyncOutstanding: 2,
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun(event) {
+        const eventId = String(event.metadata.sourceDeliveryId);
+        started.push(eventId);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        return { runId: `run_${eventId}` };
+      },
+      async recordControlPlaneEvent(event) {
+        audits.push(event);
+      },
+      now: () => now,
+      clock: currentClock
+    });
+
+    async function deliver(eventId: string) {
+      const rawBody = JSON.stringify({
+        type: "event_callback",
+        team_id: "T123",
+        event_id: eventId,
+        event_time: Number(currentTimestamp),
+        authorizations: [{ user_id: "U_APP" }],
+        event: {
+          type: "app_mention",
+          user: "U456",
+          text: "<@U_APP> fix this",
+          ts: `${currentTimestamp}.${eventId.slice(-1).padStart(6, "0")}`,
+          channel: "C123"
+        }
+      });
+      return app.request("/slack/events", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-slack-request-timestamp": currentTimestamp,
+          "x-slack-signature": sign(rawBody)
+        },
+        body: rawBody
+      });
+    }
+
+    const first = await deliver("EvBound1");
+    const second = await deliver("EvBound2");
+    const overflow = await deliver("EvBound3");
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(overflow.status).toBe(503);
+    await expect(overflow.json()).resolves.toEqual({ error: "slack_async_queue_full" });
+    await vi.waitFor(() => expect(started).toEqual(["EvBound1"]));
+    expect(started).not.toContain("EvBound3");
+    await vi.waitFor(() => expect(audits).toContainEqual(expect.objectContaining({
+      type: "availability.backpressure",
+      payload: expect.objectContaining({ reason: "async_queue_full", maxAsyncOutstanding: 2 })
+    })));
+
+    releases.shift()?.();
+    await vi.waitFor(() => expect(started).toEqual(["EvBound1", "EvBound2"]));
+    releases.shift()?.();
+  });
+
+  it("keeps a queue-full 503 response safe when backpressure auditing rejects", async () => {
+    const release = new Promise<void>(() => {});
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      maxAsyncConcurrency: 1,
+      maxAsyncOutstanding: 1,
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        await release;
+        return { runId: "never" };
+      },
+      async recordControlPlaneEvent() {
+        throw new Error("audit unavailable");
+      },
+      now: () => now,
+      clock: currentClock
+    });
+    async function deliver(eventId: string) {
+      const rawBody = JSON.stringify({
+        type: "event_callback",
+        team_id: "T123",
+        event_id: eventId,
+        authorizations: [{ user_id: "U_APP" }],
+        event: { type: "app_mention", user: "U456", text: "<@U_APP> fix", ts: `${currentTimestamp}.1`, channel: "C123" }
+      });
+      return app.request("/slack/events", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-slack-request-timestamp": currentTimestamp,
+          "x-slack-signature": sign(rawBody)
+        },
+        body: rawBody
+      });
+    }
+
+    expect((await deliver("EvAudit1")).status).toBe(200);
+    const overflow = await deliver("EvAudit2");
+    expect(overflow.status).toBe(503);
+    await expect(overflow.json()).resolves.toEqual({ error: "slack_async_queue_full" });
+  });
+
+  it("releases an async slot after rejected processing so later deliveries can run", async () => {
+    let attempts = 0;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      maxAsyncConcurrency: 1,
+      maxAsyncOutstanding: 1,
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        attempts += 1;
+        if (attempts === 1) throw new Error("first failed");
+        return { runId: "run_ok" };
+      },
+      now: () => now,
+      clock: currentClock
+    });
+
+    async function deliver(eventId: string) {
+      const rawBody = JSON.stringify({
+        type: "event_callback",
+        team_id: "T123",
+        event_id: eventId,
+        authorizations: [{ user_id: "U_APP" }],
+        event: { type: "app_mention", user: "U456", text: "<@U_APP> fix", ts: `${currentTimestamp}.1`, channel: "C123" }
+      });
+      return app.request("/slack/events", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-slack-request-timestamp": currentTimestamp,
+          "x-slack-signature": sign(rawBody)
+        },
+        body: rawBody
+      });
+    }
+
+    expect((await deliver("EvRelease1")).status).toBe(200);
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect((await deliver("EvRelease2")).status).toBe(200);
+    await vi.waitFor(() => expect(attempts).toBe(2));
+  });
+
   it("still returns 400 synchronously for malformed JSON without invoking the processor", async () => {
     const rawBody = "{not-json";
     const createRun = vi.fn(async () => ({ runId: "run_1" }));

--- a/packages/slack/test/ingress.test.ts
+++ b/packages/slack/test/ingress.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { computeSlackSignature, createSlackEventsApp } from "../src/ingress.js";
+
+describe("Slack Events API ack-then-async", () => {
+  const now = "2024-06-24T00:00:00.000Z";
+  const currentTimestamp = "1719187200";
+  const currentClock = () => Number(currentTimestamp) * 1000;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function sign(rawBody: string, timestamp = currentTimestamp) {
+    return computeSlackSignature({ signingSecret: "secret", timestamp, rawBody });
+  }
+
+  it("keeps url_verification synchronous and echoes the challenge", async () => {
+    const rawBody = JSON.stringify({ type: "url_verification", challenge: "abc123" });
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return null;
+      },
+      async createRun() {
+        return { runId: "run_1" };
+      },
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("abc123");
+  });
+
+  it("acks an event_callback with {ok:true} before a slow handler finishes, then still runs it", async () => {
+    const timeline: string[] = [];
+    const createRun = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      timeline.push("createRun_finished");
+      return { runId: "run_1" };
+    });
+    const rawBody = JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event_id: "EvSlow1",
+      event_time: Number(currentTimestamp),
+      authorizations: [{ user_id: "U_APP" }],
+      event: {
+        type: "app_mention",
+        user: "U456",
+        text: "<@U_APP> fix this",
+        ts: `${currentTimestamp}.000100`,
+        channel: "C123"
+      }
+    });
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      createRun,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const start = Date.now();
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+    const elapsedMs = Date.now() - start;
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(elapsedMs).toBeLessThan(30);
+    expect(timeline).toHaveLength(0);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(timeline).toEqual(["createRun_finished"]);
+    expect(createRun).toHaveBeenCalledOnce();
+  });
+
+  it("logs and swallows an error from asynchronous event processing without changing the ack response", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failure = new Error("boom");
+    const createRun = vi.fn(async () => {
+      throw failure;
+    });
+    const rawBody = JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event_id: "EvFail1",
+      event_time: Number(currentTimestamp),
+      authorizations: [{ user_id: "U_APP" }],
+      event: {
+        type: "app_mention",
+        user: "U456",
+        text: "<@U_APP> fix this",
+        ts: `${currentTimestamp}.000100`,
+        channel: "C123"
+      }
+    });
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      createRun,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(createRun).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith("[slack] async event processing failed:", failure);
+  });
+
+  it("acks a block_actions interactive payload with {ok:true} immediately", async () => {
+    const submitThreadAction = vi.fn(async () => ({}));
+    const interactivePayload = {
+      type: "block_actions",
+      team: { id: "T123" },
+      user: { id: "U456", username: "alice" },
+      channel: { id: "C123" },
+      message: { ts: `${currentTimestamp}.000500`, thread_ts: `${currentTimestamp}.000100` },
+      trigger_id: "trigger_apply_1",
+      actions: [
+        {
+          type: "button",
+          action_id: "opentag:apply:1",
+          value: JSON.stringify({ version: 1, command: "apply 1", proposalId: "proposal_1", intentId: "intent_1" })
+        }
+      ]
+    };
+    const rawBody = new URLSearchParams({ payload: JSON.stringify(interactivePayload) }).toString();
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      },
+      async createRun() {
+        return { runId: "run_1" };
+      },
+      submitThreadAction,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(submitThreadAction).toHaveBeenCalledOnce();
+  });
+
+  it("still returns 400 synchronously for malformed JSON without invoking the processor", async () => {
+    const rawBody = "{not-json";
+    const createRun = vi.fn(async () => ({ runId: "run_1" }));
+    const app = createSlackEventsApp({
+      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
+      async resolveChannelBinding() {
+        return null;
+      },
+      createRun,
+      now: () => now,
+      clock: currentClock
+    });
+
+    const response = await app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_json" });
+    expect(createRun).not.toHaveBeenCalled();
+  });
+});

--- a/packages/slack/test/ingress.test.ts
+++ b/packages/slack/test/ingress.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { computeSlackSignature, createSlackEventsApp, startSlackIngress } from "../src/ingress.js";
+import {
+  computeSlackSignature,
+  createSlackEventsApp,
+  createSlackEventsAppRuntime,
+  startSlackIngress
+} from "../src/ingress.js";
 
-describe("Slack Events API ack-then-async", () => {
+describe("Slack Events API delivery lanes", () => {
   const now = "2024-06-24T00:00:00.000Z";
   const currentTimestamp = "1719187200";
   const currentClock = () => Number(currentTimestamp) * 1000;
@@ -10,145 +15,161 @@ describe("Slack Events API ack-then-async", () => {
     vi.restoreAllMocks();
   });
 
+  function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => {
+      resolve = done;
+    });
+    return { promise, resolve };
+  }
+
   function sign(rawBody: string, timestamp = currentTimestamp) {
     return computeSlackSignature({ signingSecret: "secret", timestamp, rawBody });
   }
 
-  it("keeps url_verification synchronous and echoes the challenge", async () => {
-    const rawBody = JSON.stringify({ type: "url_verification", challenge: "abc123" });
-    const app = createSlackEventsApp({
+  function eventBody(eventId: string, text: string) {
+    return JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event_id: eventId,
+      event_time: Number(currentTimestamp),
+      authorizations: [{ user_id: "U_APP" }],
+      event: {
+        type: "app_mention",
+        user: "U456",
+        text: `<@U_APP> ${text}`,
+        ts: `${currentTimestamp}.${eventId.replace(/\D/gu, "").padStart(6, "0").slice(-6)}`,
+        channel: "C123"
+      }
+    });
+  }
+
+  function deliver(app: ReturnType<typeof createSlackEventsApp>, rawBody: string, contentType = "application/json") {
+    return app.request("/slack/events", {
+      method: "POST",
+      headers: {
+        "content-type": contentType,
+        "x-slack-request-timestamp": currentTimestamp,
+        "x-slack-signature": sign(rawBody)
+      },
+      body: rawBody
+    });
+  }
+
+  function baseInput() {
+    return {
       slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
       async resolveChannelBinding() {
-        return null;
+        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
       },
       async createRun() {
         return { runId: "run_1" };
       },
       now: () => now,
       clock: currentClock
-    });
+    };
+  }
 
-    const response = await app.request("/slack/events", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-slack-request-timestamp": currentTimestamp,
-        "x-slack-signature": sign(rawBody)
-      },
-      body: rawBody
-    });
+  it("keeps url_verification synchronous and echoes the challenge", async () => {
+    const rawBody = JSON.stringify({ type: "url_verification", challenge: "abc123" });
+    const response = await deliver(createSlackEventsApp(baseInput()), rawBody);
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("abc123");
   });
 
-  it("acks an event_callback with {ok:true} before a slow handler finishes, then still runs it", async () => {
-    const timeline: string[] = [];
-    let releaseCreateRun!: () => void;
-    const createRunGate = new Promise<void>((resolve) => {
-      releaseCreateRun = resolve;
+  it.each(["/linear", "linear"])("acks the exact %j query before the slow query and reply finish", async (command) => {
+    const queryGate = deferred();
+    const linear = vi.fn(async () => {
+      await queryGate.promise;
+      return "Linear backlog";
     });
+    const reply = vi.fn(async () => {});
+    const app = createSlackEventsApp({ ...baseInput(), linear, reply });
+
+    const response = await deliver(app, eventBody(`EvLinear${command.length}`, command));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    await vi.waitFor(() => expect(linear).toHaveBeenCalledOnce());
+    expect(reply).not.toHaveBeenCalled();
+
+    queryGate.resolve();
+    await vi.waitFor(() =>
+      expect(reply).toHaveBeenCalledWith({ channelId: "C123", threadTs: expect.any(String), text: "Linear backlog" })
+    );
+  });
+
+  it("keeps normal run creation synchronous instead of acknowledging memory-only work", async () => {
+    const createRunGate = deferred();
     const createRun = vi.fn(async () => {
-      await createRunGate;
-      timeline.push("createRun_finished");
+      await createRunGate.promise;
       return { runId: "run_1" };
     });
-    const rawBody = JSON.stringify({
-      type: "event_callback",
-      team_id: "T123",
-      event_id: "EvSlow1",
-      event_time: Number(currentTimestamp),
-      authorizations: [{ user_id: "U_APP" }],
-      event: {
-        type: "app_mention",
-        user: "U456",
-        text: "<@U_APP> fix this",
-        ts: `${currentTimestamp}.000100`,
-        channel: "C123"
-      }
-    });
-    const app = createSlackEventsApp({
-      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
-      async resolveChannelBinding() {
-        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
-      },
-      createRun,
-      now: () => now,
-      clock: currentClock
+    const app = createSlackEventsApp({ ...baseInput(), createRun });
+    let requestSettled = false;
+
+    const responsePromise = deliver(app, eventBody("EvRun1", "fix this")).finally(() => {
+      requestSettled = true;
     });
 
-    const response = await app.request("/slack/events", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-slack-request-timestamp": currentTimestamp,
-        "x-slack-signature": sign(rawBody)
-      },
-      body: rawBody
-    });
+    await vi.waitFor(() => expect(createRun).toHaveBeenCalledOnce());
+    expect(requestSettled).toBe(false);
+    createRunGate.resolve();
 
+    const response = await responsePromise;
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(timeline).toHaveLength(0);
-
-    releaseCreateRun();
-    await vi.waitFor(() => {
-      expect(timeline).toEqual(["createRun_finished"]);
-      expect(createRun).toHaveBeenCalledOnce();
-    });
   });
 
-  it("logs and swallows an error from asynchronous event processing without changing the ack response", async () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    const failure = new Error("boom");
+  it("allows a failed control delivery to be retried because it is never marked seen in memory", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    let attempts = 0;
     const createRun = vi.fn(async () => {
-      throw failure;
+      attempts += 1;
+      if (attempts === 1) throw new Error("dispatcher unavailable");
+      return { runId: "run_retry" };
     });
-    const rawBody = JSON.stringify({
-      type: "event_callback",
-      team_id: "T123",
-      event_id: "EvFail1",
-      event_time: Number(currentTimestamp),
-      authorizations: [{ user_id: "U_APP" }],
-      event: {
-        type: "app_mention",
-        user: "U456",
-        text: "<@U_APP> fix this",
-        ts: `${currentTimestamp}.000100`,
-        channel: "C123"
-      }
-    });
-    const app = createSlackEventsApp({
-      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
-      async resolveChannelBinding() {
-        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
-      },
-      createRun,
-      now: () => now,
-      clock: currentClock
-    });
+    const app = createSlackEventsApp({ ...baseInput(), createRun });
+    const rawBody = eventBody("EvRunRetry1", "fix this");
 
-    const response = await app.request("/slack/events", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-slack-request-timestamp": currentTimestamp,
-        "x-slack-signature": sign(rawBody)
-      },
-      body: rawBody
-    });
+    expect((await deliver(app, rawBody)).status).toBe(500);
+    const retry = await deliver(app, rawBody);
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-
-    await vi.waitFor(() => {
-      expect(createRun).toHaveBeenCalledOnce();
-      expect(consoleError).toHaveBeenCalledWith("[slack] async event processing failed:", failure);
-    });
+    expect(retry.status).toBe(200);
+    await expect(retry.json()).resolves.toEqual({ ok: true });
+    expect(createRun).toHaveBeenCalledTimes(2);
   });
 
-  it("acks a block_actions interactive payload with {ok:true} immediately", async () => {
-    const submitThreadAction = vi.fn(async () => ({}));
+  it("keeps /linear usage errors synchronous because they do not call Linear", async () => {
+    const replyGate = deferred();
+    const linear = vi.fn(async () => "should not run");
+    const reply = vi.fn(async () => {
+      await replyGate.promise;
+    });
+    const app = createSlackEventsApp({ ...baseInput(), linear, reply });
+    let requestSettled = false;
+
+    const responsePromise = deliver(app, eventBody("EvLinearUsage1", "/linear unexpected")).finally(() => {
+      requestSettled = true;
+    });
+
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledOnce());
+    expect(requestSettled).toBe(false);
+    expect(linear).not.toHaveBeenCalled();
+    replyGate.resolve();
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, selfService: "linear", usage: true });
+  });
+
+  it("keeps block action approval processing synchronous", async () => {
+    const actionGate = deferred();
+    const submitThreadAction = vi.fn(async () => {
+      await actionGate.promise;
+      return {};
+    });
     const interactivePayload = {
       type: "block_actions",
       team: { id: "T123" },
@@ -165,38 +186,25 @@ describe("Slack Events API ack-then-async", () => {
       ]
     };
     const rawBody = new URLSearchParams({ payload: JSON.stringify(interactivePayload) }).toString();
-    const app = createSlackEventsApp({
-      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
-      async resolveChannelBinding() {
-        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
-      },
-      async createRun() {
-        return { runId: "run_1" };
-      },
-      submitThreadAction,
-      now: () => now,
-      clock: currentClock
-    });
+    const app = createSlackEventsApp({ ...baseInput(), submitThreadAction });
+    let requestSettled = false;
 
-    const response = await app.request("/slack/events", {
-      method: "POST",
-      headers: {
-        "content-type": "application/x-www-form-urlencoded",
-        "x-slack-request-timestamp": currentTimestamp,
-        "x-slack-signature": sign(rawBody)
-      },
-      body: rawBody
+    const responsePromise = deliver(app, rawBody, "application/x-www-form-urlencoded").finally(() => {
+      requestSettled = true;
     });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
 
     await vi.waitFor(() => expect(submitThreadAction).toHaveBeenCalledOnce());
+    expect(requestSettled).toBe(false);
+    actionGate.resolve();
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
   });
 
   it.each([
-    ["maxAsyncConcurrency", { maxAsyncConcurrency: 0 }],
-    ["maxAsyncOutstanding", { maxAsyncOutstanding: 0 }]
+    ["maxLinearQueryConcurrency", { maxLinearQueryConcurrency: 0 }],
+    ["maxLinearQueryOutstanding", { maxLinearQueryOutstanding: 0 }]
   ])("preserves a zero %s setting so startup validation rejects it", (name, limits) => {
     expect(() =>
       startSlackIngress({
@@ -208,185 +216,153 @@ describe("Slack Events API ack-then-async", () => {
     ).toThrow(`${name} must be a positive integer.`);
   });
 
-  it("bounds active plus queued event processing and returns 503 without starting overflow work", async () => {
+  it("bounds only /linear query work and returns 503 without starting overflow work", async () => {
     const releases: Array<() => void> = [];
     const started: string[] = [];
     const audits: Array<{ type: string; payload?: Record<string, unknown> }> = [];
     const app = createSlackEventsApp({
-      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
-      maxAsyncConcurrency: 1,
-      maxAsyncOutstanding: 2,
-      async resolveChannelBinding() {
-        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
-      },
-      async createRun(event) {
-        const eventId = String(event.metadata.sourceDeliveryId);
-        started.push(eventId);
+      ...baseInput(),
+      maxLinearQueryConcurrency: 1,
+      maxLinearQueryOutstanding: 2,
+      async linear(context) {
+        started.push(context.threadTs);
         await new Promise<void>((resolve) => releases.push(resolve));
-        return { runId: `run_${eventId}` };
+        return "Linear backlog";
       },
+      async reply() {},
       async recordControlPlaneEvent(event) {
         audits.push(event);
-      },
-      now: () => now,
-      clock: currentClock
+      }
     });
 
-    async function deliver(eventId: string) {
-      const rawBody = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event_id: eventId,
-        event_time: Number(currentTimestamp),
-        authorizations: [{ user_id: "U_APP" }],
-        event: {
-          type: "app_mention",
-          user: "U456",
-          text: "<@U_APP> fix this",
-          ts: `${currentTimestamp}.${eventId.slice(-1).padStart(6, "0")}`,
-          channel: "C123"
-        }
-      });
-      return app.request("/slack/events", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-slack-request-timestamp": currentTimestamp,
-          "x-slack-signature": sign(rawBody)
-        },
-        body: rawBody
-      });
-    }
+    const first = await deliver(app, eventBody("EvLinearBound1", "/linear"));
+    const second = await deliver(app, eventBody("EvLinearBound2", "/linear"));
+    const overflow = await deliver(app, eventBody("EvLinearBound3", "/linear"));
 
-    const first = await deliver("EvBound1");
-    const second = await deliver("EvBound2");
-    const overflow = await deliver("EvBound3");
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
     expect(overflow.status).toBe(503);
-    await expect(overflow.json()).resolves.toEqual({ error: "slack_async_queue_full" });
-    await vi.waitFor(() => expect(started).toEqual(["EvBound1"]));
-    expect(started).not.toContain("EvBound3");
-    await vi.waitFor(() => expect(audits).toContainEqual(expect.objectContaining({
-      type: "availability.backpressure",
-      payload: expect.objectContaining({ reason: "async_queue_full", maxAsyncOutstanding: 2 })
-    })));
+    await expect(overflow.json()).resolves.toEqual({ error: "slack_linear_query_queue_full" });
+    await vi.waitFor(() => expect(started).toHaveLength(1));
+    await vi.waitFor(() =>
+      expect(audits).toContainEqual(
+        expect.objectContaining({
+          type: "availability.backpressure",
+          payload: expect.objectContaining({
+            lane: "linear_query",
+            reason: "linear_query_queue_full",
+            maxLinearQueryOutstanding: 2
+          })
+        })
+      )
+    );
 
     releases.shift()?.();
-    await vi.waitFor(() => expect(started).toEqual(["EvBound1", "EvBound2"]));
+    await vi.waitFor(() => expect(started).toHaveLength(2));
     releases.shift()?.();
   });
 
-  it("keeps a queue-full 503 response safe when backpressure auditing rejects", async () => {
-    const release = new Promise<void>(() => {});
+  it("does not let a saturated /linear query lane block normal control work", async () => {
+    const queryGate = deferred();
+    const createRun = vi.fn(async () => ({ runId: "run_control" }));
     const app = createSlackEventsApp({
-      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
-      maxAsyncConcurrency: 1,
-      maxAsyncOutstanding: 1,
-      async resolveChannelBinding() {
-        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+      ...baseInput(),
+      createRun,
+      maxLinearQueryConcurrency: 1,
+      maxLinearQueryOutstanding: 1,
+      async linear() {
+        await queryGate.promise;
+        return "Linear backlog";
       },
-      async createRun() {
-        await release;
-        return { runId: "never" };
-      },
-      async recordControlPlaneEvent() {
-        throw new Error("audit unavailable");
-      },
-      now: () => now,
-      clock: currentClock
+      async reply() {}
     });
-    async function deliver(eventId: string) {
-      const rawBody = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event_id: eventId,
-        authorizations: [{ user_id: "U_APP" }],
-        event: { type: "app_mention", user: "U456", text: "<@U_APP> fix", ts: `${currentTimestamp}.1`, channel: "C123" }
-      });
-      return app.request("/slack/events", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-slack-request-timestamp": currentTimestamp,
-          "x-slack-signature": sign(rawBody)
-        },
-        body: rawBody
-      });
-    }
 
-    expect((await deliver("EvAudit1")).status).toBe(200);
-    const overflow = await deliver("EvAudit2");
-    expect(overflow.status).toBe(503);
-    await expect(overflow.json()).resolves.toEqual({ error: "slack_async_queue_full" });
+    expect((await deliver(app, eventBody("EvLinearBusy1", "/linear"))).status).toBe(200);
+    expect((await deliver(app, eventBody("EvLinearBusy2", "/linear"))).status).toBe(503);
+
+    const controlResponse = await deliver(app, eventBody("EvControl1", "fix this"));
+    expect(controlResponse.status).toBe(200);
+    await expect(controlResponse.json()).resolves.toEqual({ ok: true });
+    expect(createRun).toHaveBeenCalledOnce();
+
+    queryGate.resolve();
   });
 
-  it("releases an async slot after rejected processing so later deliveries can run", async () => {
-    let attempts = 0;
+  it("deduplicates only pending or completed /linear queries and permits retry after failure", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    const app = createSlackEventsApp({
-      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
-      maxAsyncConcurrency: 1,
-      maxAsyncOutstanding: 1,
-      async resolveChannelBinding() {
-        return { teamId: "T123", channelId: "C123", repoProvider: "github", owner: "acme", repo: "demo" };
+    const replyGate = deferred();
+    const linear = vi.fn(async () => "Linear backlog");
+    let replyAttempts = 0;
+    const reply = vi.fn(async () => {
+      replyAttempts += 1;
+      if (replyAttempts === 1) {
+        await replyGate.promise;
+        throw new Error("Slack reply failed");
+      }
+    });
+    const app = createSlackEventsApp({ ...baseInput(), linear, reply });
+    const rawBody = eventBody("EvLinearRetry1", "/linear");
+
+    expect((await deliver(app, rawBody)).status).toBe(200);
+    const pendingDuplicate = await deliver(app, rawBody);
+    await expect(pendingDuplicate.json()).resolves.toEqual({ ok: true, ignored: "duplicate_linear_query" });
+    expect(linear).toHaveBeenCalledOnce();
+
+    replyGate.resolve();
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        "[slack] async /linear query processing failed:",
+        expect.objectContaining({ message: "Slack reply failed" })
+      )
+    );
+
+    expect((await deliver(app, rawBody)).status).toBe(200);
+    await vi.waitFor(() => expect(linear).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledTimes(2));
+
+    const completedDuplicate = await deliver(app, rawBody);
+    await expect(completedDuplicate.json()).resolves.toEqual({ ok: true, ignored: "duplicate_linear_query" });
+    expect(linear).toHaveBeenCalledTimes(2);
+  });
+
+  it("drains active and queued /linear queries when the app runtime closes", async () => {
+    const releases: Array<() => void> = [];
+    const started: string[] = [];
+    const runtime = createSlackEventsAppRuntime({
+      ...baseInput(),
+      maxLinearQueryConcurrency: 1,
+      maxLinearQueryOutstanding: 2,
+      async linear(context) {
+        started.push(context.threadTs);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        return "Linear backlog";
       },
-      async createRun() {
-        attempts += 1;
-        if (attempts === 1) throw new Error("first failed");
-        return { runId: "run_ok" };
-      },
-      now: () => now,
-      clock: currentClock
+      async reply() {}
     });
 
-    async function deliver(eventId: string) {
-      const rawBody = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event_id: eventId,
-        authorizations: [{ user_id: "U_APP" }],
-        event: { type: "app_mention", user: "U456", text: "<@U_APP> fix", ts: `${currentTimestamp}.1`, channel: "C123" }
-      });
-      return app.request("/slack/events", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-slack-request-timestamp": currentTimestamp,
-          "x-slack-signature": sign(rawBody)
-        },
-        body: rawBody
-      });
-    }
+    expect((await deliver(runtime.app, eventBody("EvLinearDrain1", "/linear"))).status).toBe(200);
+    expect((await deliver(runtime.app, eventBody("EvLinearDrain2", "/linear"))).status).toBe(200);
+    await vi.waitFor(() => expect(started).toHaveLength(1));
 
-    expect((await deliver("EvRelease1")).status).toBe(200);
-    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
-    expect((await deliver("EvRelease2")).status).toBe(200);
-    await vi.waitFor(() => expect(attempts).toBe(2));
+    let closeSettled = false;
+    const closePromise = runtime.close().finally(() => {
+      closeSettled = true;
+    });
+    expect(closeSettled).toBe(false);
+
+    releases.shift()?.();
+    await vi.waitFor(() => expect(started).toHaveLength(2));
+    expect(closeSettled).toBe(false);
+    releases.shift()?.();
+
+    await closePromise;
+    expect(closeSettled).toBe(true);
   });
 
   it("still returns 400 synchronously for malformed JSON without invoking the processor", async () => {
-    const rawBody = "{not-json";
     const createRun = vi.fn(async () => ({ runId: "run_1" }));
-    const app = createSlackEventsApp({
-      slackApps: [{ signingSecret: "secret", agentId: "opentag" }],
-      async resolveChannelBinding() {
-        return null;
-      },
-      createRun,
-      now: () => now,
-      clock: currentClock
-    });
-
-    const response = await app.request("/slack/events", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-slack-request-timestamp": currentTimestamp,
-        "x-slack-signature": sign(rawBody)
-      },
-      body: rawBody
-    });
+    const rawBody = "{not-json";
+    const response = await deliver(createSlackEventsApp({ ...baseInput(), createRun }), rawBody);
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "invalid_json" });

--- a/packages/slack/test/ingress.test.ts
+++ b/packages/slack/test/ingress.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as slackEvents from "../src/events.js";
 import {
   computeSlackSignature,
   createSlackEventsApp,
@@ -12,6 +13,7 @@ describe("Slack Events API delivery lanes", () => {
   const currentClock = () => Number(currentTimestamp) * 1000;
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -325,6 +327,29 @@ describe("Slack Events API delivery lanes", () => {
     expect(linear).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps a /linear delivery retryable when the processor returns a non-2xx result", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const process = vi.fn(async () => ({
+      kind: "json" as const,
+      status: 400 as const,
+      body: { error: "invalid_event_payload" }
+    }));
+    vi.spyOn(slackEvents, "createSlackEventProcessor").mockReturnValue({ process });
+    const app = createSlackEventsApp(baseInput());
+    const rawBody = eventBody("EvLinearNon2xx1", "/linear");
+
+    expect((await deliver(app, rawBody)).status).toBe(200);
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        "[slack] async /linear query processing failed:",
+        expect.objectContaining({ message: "Slack /linear query processing returned HTTP 400." })
+      )
+    );
+
+    expect((await deliver(app, rawBody)).status).toBe(200);
+    await vi.waitFor(() => expect(process).toHaveBeenCalledTimes(2));
+  });
+
   it("drains active and queued /linear queries when the app runtime closes", async () => {
     const releases: Array<() => void> = [];
     const started: string[] = [];
@@ -357,6 +382,38 @@ describe("Slack Events API delivery lanes", () => {
 
     await closePromise;
     expect(closeSettled).toBe(true);
+  });
+
+  it("bounds graceful close when /linear query work never becomes idle", async () => {
+    const queryGate = deferred();
+    const linear = vi.fn(async () => {
+      await queryGate.promise;
+      return "Linear backlog";
+    });
+    const runtime = createSlackEventsAppRuntime({ ...baseInput(), linear, async reply() {} });
+
+    expect((await deliver(runtime.app, eventBody("EvLinearDrainTimeout1", "/linear"))).status).toBe(200);
+    await vi.waitFor(() => expect(linear).toHaveBeenCalledOnce());
+
+    vi.useFakeTimers();
+    let closeSettled = false;
+    const closePromise = runtime.close().finally(() => {
+      closeSettled = true;
+    });
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(closeSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await closePromise;
+    expect(closeSettled).toBe(true);
+
+    queryGate.resolve();
+    await vi.runAllTicks();
+  });
+
+  it("resolves graceful close immediately when the /linear query lane is already idle", async () => {
+    const runtime = createSlackEventsAppRuntime(baseInput());
+
+    await expect(runtime.close()).resolves.toBeUndefined();
   });
 
   it("still returns 400 synchronously for malformed JSON without invoking the processor", async () => {


### PR DESCRIPTION
## Summary

- Add a deterministic, read-only Slack `@OpenTag linear` / `/linear` command that lists unfinished issues without creating an Agent Run or enabling Linear mutations.
- Require an exact Slack `(teamId, channelId)` allowlist and route each authorized channel to its configured Linear project.
- Separate backlog-query credentials from apply credentials, including OAuth query-only mode, while still resolving refreshed OAuth tokens for each query.
- Put only exact `/linear` queries in an independent bounded, best-effort asynchronous lane; keep run creation, stop/bind/unbind, approvals, and interactive actions synchronous with the Events API response.
- Deduplicate only pending or successfully completed `/linear` deliveries by `event_id`, permit retry after processing failure, return `503` when the query lane is full, and drain admitted query work during graceful shutdown.
- Paginate all unfinished Linear issues before applying the final state/priority/identifier sort; fail safely on missing projects, malformed cursors, timeout, repeated cursors, or the 100-page safety limit.

## Delivery semantics

- The `/linear` lane is intentionally best effort rather than a durable inbox. An abrupt process loss can drop an already acknowledged read-only query; the user can safely run `/linear` again.
- Slack control and mutation paths never rely on an ACK-after-memory-queue contract. Their HTTP response waits for processing, so downstream failure is not converted into a successful acknowledgment.
- Linear issue creation remains on the governed apply path and does not use the query-only credential or the `/linear` query lane.

## Validation

- Focused Slack/CLI suite: 124 related tests passed.
- Full test suite: 124 files, 1,662 tests passed.
- `corepack pnpm typecheck` — passed.
- `corepack pnpm lint` — passed.
- `corepack pnpm build` — passed.
- `corepack pnpm release:publication-set` — 15 publishable packages passed.
- `corepack pnpm release:check` — packed install and CLI smoke passed.
- `git diff --check` — passed.

## Notes

- Supersedes closed PR #97 while retaining the completed authorization, credential-boundary, pagination, rendering, and defensive-validation fixes.
- The `/linear` path remains query-only: no Agent Run, LLM invocation, apply plan, or Linear mutation is created.
- Pagination is bounded at 100 pages / 10,000 issues and uses one overall 10-second query budget; it returns a safe error instead of a partial, incorrectly sorted backlog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only Slack `/linear` command and a corresponding self-service mention to browse unfinished Linear backlog items with safe, formatted replies (including truncation after 20).
  * Introduced bounded async processing for Linear Slack queries, with duplicate suppression, capacity backpressure, and graceful drain behavior.
  * Added channel-specific Linear authorization plus query-only credential support.
* **Documentation**
  * Expanded Slack setup/config docs, including precise allowlist rules, credential precedence, and Events API delivery semantics.
* **Bug Fixes**
  * Improved CLI configuration validation/diagnostics and fail-closed behavior for unauthorized channels, unsupported connections, and malformed/unsafe inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->