### PR TITLE
release: OpenTag 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@
 
 No changes yet.
 
+## v0.7.0 - 2026-07-22
+
+OpenTag 0.7.0 completes the Phase 1 completion-governance vertical slice. A
+successful executor result is now distinct from evidence-backed completion:
+OpenTag can persist a work loop, evaluate its configured contract against
+current-cycle evidence, explain blockers, and accept narrowly scoped human
+waivers. This is a coordinated release of all 16 public packages, including
+`@opentag/governance` as a first-class member of the package family.
+
+### Added
+
+- Additive `WorkThread`, `CompletionContract`, `CompletionGateResult`,
+  `CompletionAssessment`, and `HumanEscalation` protocol schemas and JSON Schema
+  exports in `@opentag/core`.
+- Durable work-thread, contract, assessment, escalation, waiver, evidence, and
+  delivery records in `@opentag/store`, including assessment history and
+  completion metrics.
+- The public `@opentag/governance` package, with a deterministic evaluator and
+  a small command/query surface for reassessment, evidence ingestion, and
+  bounded completion waivers.
+- GitHub pull-request, required-check, head-SHA, and merge evidence
+  normalization, plus dispatcher correlation from verified webhook facts to
+  the current work thread.
+- CLI completion explanation and pairing-authenticated waiver commands. Waivers
+  are limited to selected gates in the current contract, carry an expiry, and
+  remain attributable to a human actor.
+- A replay fixture and governance-matrix scenario covering the GitHub
+  completion path from executor success through current-head checks, merge
+  evidence, reassessment, source-thread projection, and restart recovery.
+
+### Changed
+
+- Completion is evaluated from the latest run attached to a work thread. Run
+  artifacts and receipts from older delivery epochs cannot satisfy the current
+  contract, and external evidence must be observed during the current epoch.
+- Dispatcher reassessment is idempotent and replay-safe across duplicate
+  result/evidence delivery and process restarts. Conflicting or stale inputs
+  fail closed instead of silently advancing completion.
+- Local CLI startup accepts strict GitHub completion policies and forwards them
+  to the dispatcher runtime, closing the configuration path needed for a real
+  webhook-to-assessment run.
+- Hermes ACP readiness allows the adapter's observed startup latency instead of
+  inheriting the generic three-second probe deadline.
+- Package discovery, packed-install validation, and release documentation now
+  cover the complete 16-package publication set.
+
+### Release validation note
+
+The repository fixtures and release gates cover the deterministic and packaged
+paths. A registry-installed, credentialed live GitHub chain must still pass
+before `0.7.0` is promoted from `next` to `latest`; this changelog does not claim
+that live proof in advance.
+
 ## v0.6.0 - 2026-07-16
 
 OpenTag 0.6.0 moves every built-in coding agent onto the Generic ACP host,

--- a/README.md
+++ b/README.md
@@ -270,13 +270,14 @@ opentag-dev setup
 
 ## Packages
 
-Current public release: `v0.6.0`. The npm package family is published under the `@opentag` scope.
+Current public release: `v0.7.0`. The coordinated npm package family contains 16 public packages under the `@opentag` scope.
 
 | Package | Purpose |
 | --- | --- |
 | [`@opentag/cli`](https://www.npmjs.com/package/@opentag/cli) | Setup and local runtime command line interface |
 | [`@opentag/local-runtime`](https://www.npmjs.com/package/@opentag/local-runtime) | In-process local dispatcher, runner, and platform runtime |
 | [`@opentag/core`](https://www.npmjs.com/package/@opentag/core) | Protocol schemas, types, mention parsing, and JSON Schema exports |
+| [`@opentag/governance`](https://www.npmjs.com/package/@opentag/governance) | Deterministic completion evaluation and governance orchestration |
 | [`@opentag/client`](https://www.npmjs.com/package/@opentag/client) | Dispatcher HTTP client |
 | [`@opentag/slack`](https://www.npmjs.com/package/@opentag/slack) | Slack Socket Mode, Events API handling, and thread replies |
 | [`@opentag/github`](https://www.npmjs.com/package/@opentag/github) | GitHub webhook handling, comments, PR helpers, and action application |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -265,13 +265,14 @@ opentag-dev setup
 
 ## 软件包
 
-当前公开发布版本：`v0.6.0`。OpenTag 的 npm 包发布在 `@opentag` scope 下。
+当前公开发布版本：`v0.7.0`。OpenTag 在 `@opentag` scope 下协调发布 16 个公开软件包。
 
 | 包 | 用途 |
 | --- | --- |
 | [`@opentag/cli`](https://www.npmjs.com/package/@opentag/cli) | setup 和本地 runtime CLI |
 | [`@opentag/local-runtime`](https://www.npmjs.com/package/@opentag/local-runtime) | 进程内本地 dispatcher、runner 和平台 runtime |
 | [`@opentag/core`](https://www.npmjs.com/package/@opentag/core) | 协议 schema、类型、mention 解析和 JSON Schema 导出 |
+| [`@opentag/governance`](https://www.npmjs.com/package/@opentag/governance) | 确定性的完成条件评估和治理编排 |
 | [`@opentag/client`](https://www.npmjs.com/package/@opentag/client) | Dispatcher HTTP client |
 | [`@opentag/slack`](https://www.npmjs.com/package/@opentag/slack) | Slack Socket Mode、Events API 和回复 |
 | [`@opentag/github`](https://www.npmjs.com/package/@opentag/github) | GitHub webhook、评论、PR helper 和 action apply |

--- a/docs/live-e2e-smoke-harness.md
+++ b/docs/live-e2e-smoke-harness.md
@@ -22,7 +22,7 @@ Current cases:
 | `protocol-runtime` | No | In-memory GitHub-shaped protocol smoke using dispatcher/client/store paths |
 | `slack-protocol` | No | In-memory Slack-shaped protocol smoke with quiet progress and Block Kit final callback |
 | `openclaw-acp` | Yes | Strict OpenClaw hard-cancellation probe plus worktree cwd, scratch cwd, and fresh-session checks through the generic ACP host |
-| `github-webhook-live` | Yes | Real GitHub repository webhook, local CLI stack, final action receipt, optional `apply 1` PR flow |
+| `github-webhook-live` | Yes | Real GitHub repository webhook, local CLI stack, current-head required check, merged PR, durable satisfied assessment, and restart-safe final receipt |
 | `github-cli-live` | Yes | Real GitHub issue callback using dispatcher-assisted run creation |
 | `slack-local-live` | Yes | Real Slack callback using dispatcher-assisted run creation |
 | `slack-ui-live` | Yes | Real Slack source-thread mention or button flow through Socket Mode or Events API |
@@ -167,6 +167,34 @@ It requires:
   `claude-code`; its exact ACP package is resolved through `npx` from Registry
   launch data.
 - `ngrok` unless `OPENTAG_GH_PUBLIC_URL` points at an existing public tunnel.
+
+Strict completion mode is enabled by default. The case creates a real pull
+request during the run, verifies that executor success does not satisfy the
+completion contract, records
+the `opentag-phase1-live` GitHub commit status on the exact PR head, verifies
+that completion still waits for merge, merges the PR, and then requires a
+provider-verified satisfied assessment. It restarts the CLI stack against the
+same database and fails if completion is lost or the final source-thread
+receipt is duplicated.
+
+Set `OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture` when the acceptance target is the
+GitHub/governance chain itself. The repository's deterministic ACP fixture
+still performs a real isolated-worktree write that OpenTag commits, pushes, and
+opens as a pull request, but model-provider authentication and availability do
+not become part of the Phase 1 completion-governance proof. Run built-in agent
+ACP conformance as a separate release gate.
+
+The case writes a sanitized evidence document under `.omx/live-e2e` containing
+the issue, run and PR identities, the required check name, assessment snapshots
+before and after each provider transition, and restart assertions. Override the
+path with `OPENTAG_GH_LIVE_REPORT`. Set
+`OPENTAG_GH_LIVE_STRICT_COMPLETION=false` only when intentionally exercising
+the older optional `apply 1` compatibility flow.
+
+After publishing a candidate to npm `next`, install `@opentag/cli@0.7.0` into a
+fresh directory and set `OPENTAG_GH_LIVE_CLI_BIN` to that installation's
+`node_modules/.bin/opentag`. The same strict case then proves the immutable
+registry artifacts rather than the source checkout.
 
 ### Slack UI
 

--- a/docs/npm-release.md
+++ b/docs/npm-release.md
@@ -7,19 +7,19 @@ version.
 ## Current release
 
 ```text
-0.6.0
+0.7.0
 ```
 
 The release is first published on the npm `next` dist-tag, tested from the
 registry, then promoted to `latest`. The exact commit that produced the npm
-artifacts must also receive the matching `v0.6.0` git tag and GitHub Release.
+artifacts must also receive the matching `v0.7.0` git tag and GitHub Release.
 
-The public release set contains 16 packages. Fifteen existing package names
-already have a `0.5.0` release; `@opentag/governance` debuts in `0.6.0`.
-Publishing `0.6.0` with `--tag next` must leave each existing package's
-`latest` pointer on `0.5.0` until the complete registry, ACP, and live-platform
-gate passes. Treat the new package's npm-created `latest` tag as part of the
-documented first-release rollback boundary below.
+The public release set contains 16 packages, including
+`@opentag/governance`. Established packages have a coordinated `0.6.0`
+release, while a newly introduced package may not have a previous `latest`
+target. Publishing `0.7.0` with `--tag next` must leave each package's existing
+`latest` pointer unchanged until the complete registry, ACP, governance, and
+live-platform gate passes.
 
 ## Public package discovery and order
 
@@ -46,7 +46,7 @@ plan.
 ## Release gate
 
 Start from the intended release commit with a clean working tree. Confirm that
-all 16 public manifests use `0.6.0` and that the frozen lockfile is current,
+all 16 public manifests use `0.7.0` and that the frozen lockfile is current,
 then run the verification ladder in this order:
 
 ```bash
@@ -116,7 +116,7 @@ corepack pnpm release:publish -- --tag next
 
 The publish command uses the same automatic publication set and topological
 order as `release:check`. A coordinated release is incomplete until all 16
-packages exist at `0.6.0`; do not promote a partial package family.
+packages exist at `0.7.0`; do not promote a partial package family.
 
 If npm asks for a two-factor one-time password, do not pass `--otp` by default
 for OpenTag releases. Refresh the local npm browser login, then rerun the normal
@@ -140,13 +140,13 @@ registry:
 
 ```bash
 smoke_root="$(mktemp -d)"
-npm install --prefix "$smoke_root" --no-audit --no-fund @opentag/cli@0.6.0
+npm install --prefix "$smoke_root" --no-audit --no-fund @opentag/cli@0.7.0
 "$smoke_root/node_modules/.bin/opentag" --version
 "$smoke_root/node_modules/.bin/opentag" --help
 npm audit --prefix "$smoke_root" --omit=dev --audit-level=high
 ```
 
-The version must be `0.6.0`. With isolated config and state directories, run
+The version must be `0.7.0`. With isolated config and state directories, run
 the setup, doctor, and foreground-start path for one platform that has real
 test credentials:
 
@@ -174,7 +174,8 @@ Also verify every package and its canary tag before promotion:
 for manifest in packages/*/package.json; do
   [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
   package="$(jq -r '.name' "$manifest")"
-  test "$(npm view "$package@0.6.0" version)" = "0.6.0"
+  test "$(npm view "$package@0.7.0" version)" = "0.7.0"
+  test "$(npm view "$package" dist-tags.next)" = "0.7.0"
   npm view "$package" dist-tags --json
 done
 ```
@@ -183,62 +184,76 @@ done
 
 Promotion changes dist-tags only; it must not rebuild or republish. After all
 registry and live-platform checks pass, run the same command for every package.
-It is intentionally idempotent for first-release packages whose `latest` tag
-was created by npm:
+Repeating the dist-tag update is intentionally idempotent for every package:
 
 ```bash
+rollback_file="$(mktemp)"
+chmod 600 "$rollback_file"
 for manifest in packages/*/package.json; do
   [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
   package="$(jq -r '.name' "$manifest")"
-  npm dist-tag add "$package@0.6.0" latest
+  previous_latest="$(npm view "$package" dist-tags.latest)"
+  printf '%s\t%s\n' "$package" "$previous_latest" >>"$rollback_file"
+done
+
+for manifest in packages/*/package.json; do
+  [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
+  package="$(jq -r '.name' "$manifest")"
+  npm dist-tag add "$package@0.7.0" latest
 done
 ```
 
+Keep `rollback_file` until the release is complete. It records the actual
+pre-promotion `latest` target for each package, including an empty target for a
+package that did not previously have one.
+
 Rerun the package loop from the registry-verification section and confirm both
-`next` and `latest` point at `0.6.0` for all 16 packages.
+`next` and `latest` point at `0.7.0` for all 16 packages.
 
 ## Create the matching source release
 
 Create the source tag from the exact clean commit used for `release:publish`.
-Copy the `v0.6.0` section of `CHANGELOG.md` into a temporary release-notes file,
+Copy the `v0.7.0` section of `CHANGELOG.md` into a temporary release-notes file,
 then run:
 
 ```bash
-git tag -a v0.6.0 -m "OpenTag v0.6.0"
-git push origin v0.6.0
-gh release create v0.6.0 \
+git tag -a v0.7.0 -m "OpenTag v0.7.0"
+git push origin v0.7.0
+gh release create v0.7.0 \
   --verify-tag \
-  --title "OpenTag v0.6.0" \
-  --notes-file /tmp/opentag-v0.6.0-release-notes.md
+  --title "OpenTag v0.7.0" \
+  --notes-file /tmp/opentag-v0.7.0-release-notes.md
 ```
 
 Verify that the GitHub Release tag resolves to the same commit that produced
 the npm tarballs. The release is not complete until npm, git, and GitHub all
-identify version `0.6.0`.
+identify version `0.7.0`.
 
 ## Dist-tag rollback
 
 Do not unpublish immutable package versions during rollback.
 
-- If canary validation fails before promotion, leave the existing packages'
-  previous `latest` tags untouched and stop the rollout. npm has already
-  created `latest` for any first-release package and rejects removing that tag;
-  if the new package is unsafe, deprecate the bad version and publish a fixed
-  version rather than trying to erase immutable history. Preserve `next` for
-  diagnosis or move it to the corrected version.
+- If canary validation fails before promotion, leave every package's previous
+  `latest` tag unchanged and stop the rollout. Preserve `next` for diagnosis or
+  move it to the corrected version.
 - If `latest` promotion fails partway, first finish or retry the idempotent
-  promotion loop. If 0.6.0 itself must be withdrawn, restore `0.5.0` for the
-  complete package family and leave 0.6.0 on `next` for diagnosis:
+  promotion loop. If 0.7.0 itself must be withdrawn, restore each package's
+  recorded pre-promotion target and leave 0.7.0 on `next` for diagnosis:
 
 ```bash
-for manifest in packages/*/package.json; do
-  [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
-  package="$(jq -r '.name' "$manifest")"
-  test "$(npm view "$package@0.5.0" version)" = "0.5.0"
-  npm dist-tag add "$package@0.5.0" latest
-  npm dist-tag add "$package@0.6.0" next
-done
+while IFS=$'\t' read -r package previous_latest; do
+  if [ -n "$previous_latest" ]; then
+    test "$(npm view "$package@$previous_latest" version)" = "$previous_latest"
+    npm dist-tag add "$package@$previous_latest" latest
+  else
+    current_latest="$(npm view "$package" dist-tags.latest)"
+    if [ -n "$current_latest" ]; then
+      npm dist-tag rm "$package" latest
+    fi
+  fi
+  npm dist-tag add "$package@0.7.0" next
+done <"$rollback_file"
 ```
 
 Verify all dist-tags after rollback and publish a clear incident note. A later
-fix must use a new version; never overwrite `0.6.0`.
+fix must use a new version; never overwrite `0.7.0`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -7,6 +7,7 @@ OpenTag packages are versioned and published as a coordinated package family.
 Public packages, shown in one valid dependency order:
 
 - `@opentag/core`
+- `@opentag/governance`
 - `@opentag/client`
 - `@opentag/discord`
 - `@opentag/github`
@@ -31,7 +32,7 @@ Private runnable apps are not published:
 
 ## Pre-1.0 Policy
 
-The current public release is `0.6.0`. The public API is still settling, so all releases remain in the `0.x` line until the package contracts are stable enough for `1.0.0`.
+The current public release is `0.7.0`. The public API is still settling, so all releases remain in the `0.x` line until the package contracts are stable enough for `1.0.0`.
 
 The first npm release was published as the coordinated `0.1.0` package family.
 The `0.2.0` release added the published CLI, local runtime package, and Lark and Telegram packages.
@@ -41,6 +42,7 @@ The `0.3.5` release adds Linux user-service support and keeps unsupported platfo
 The `0.4.0` release adds GitLab source-thread ingestion, note callbacks, and merge request action application.
 The `0.5.0` release adds Discord, Linear, and Microsoft Teams adapters, ACP-first agent execution, durable Attempt leases and fencing, governed material-action receipts and reconciliation, and the corresponding Client/Runner migration.
 The `0.6.0` release moves all built-in coding agents onto Generic ACP, adds Cursor, OpenCode, and OpenClaw executor profiles, requires Node.js 22 for the CLI/Local Runtime/Runner, and hardens ACP isolation, cancellation conformance, Slack summaries, and the coordinated release gate.
+The `0.7.0` release completes the Phase 1 completion-governance vertical slice with durable work threads and contracts, deterministic evidence-backed assessments, GitHub PR/check/merge evidence ingestion, replay-safe reassessment, CLI explanations and bounded waivers, and a 16-package publication set that includes `@opentag/governance`.
 
 For each npm release:
 
@@ -107,7 +109,7 @@ After `1.0.0`, follow SemVer:
     ingest-to-receipt smoke from that registry installation.
 12. Promote the same package versions to `latest` by changing dist-tags only.
 13. Confirm `latest` and `next` for the complete package family.
-14. Create and push the matching annotated git tag, for example `v0.6.0`, from
+14. Create and push the matching annotated git tag, for example `v0.7.0`, from
     the exact publication commit.
 15. Create the matching GitHub Release with the changelog notes and verify its
     tag target.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "OpenTag command line interface.",
   "type": "module",
   "engines": {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -7,7 +7,12 @@ import {
   AdapterMutationMappingSchema,
   OpenTagManagedChannelBindingOwnershipSchema
 } from "@opentag/core";
-import { formatConfigError as formatDaemonConfigError, parseDaemonConfig, type OpenTagDaemonConfig } from "@opentag/local-runtime";
+import {
+  formatConfigError as formatDaemonConfigError,
+  parseDaemonConfig,
+  type LocalDispatcherRuntimeInput,
+  type OpenTagDaemonConfig
+} from "@opentag/local-runtime";
 import { z } from "zod";
 import type { CliLanguage } from "./catalogs/languages.js";
 import type { PlatformId } from "./catalogs/platforms.js";
@@ -27,6 +32,29 @@ const TelegramModeSchema = z.enum(["polling", "webhook"]);
 const DiscordModeSchema = z.enum(["gateway", "webhook"]);
 const BindingMethodSchema = z.enum(["default_project", "bind_later"]);
 const OptionalPortSchema = z.number().int().min(1).max(65535).optional();
+
+export type GitHubCompletionPolicyConfig = NonNullable<LocalDispatcherRuntimeInput["completionPolicies"]>[number];
+
+const GitHubCompletionPolicySchema = z
+  .object({
+    provider: z.literal("github"),
+    owner: z.string().trim().min(1),
+    repo: z.string().trim().min(1),
+    requiredChecks: z.array(z.string().trim().min(1)).min(1),
+    baseBranch: z.string().trim().min(1).optional(),
+    requireMerge: z.boolean().optional()
+  })
+  .strict()
+  .transform(
+    (policy): GitHubCompletionPolicyConfig => ({
+      provider: policy.provider,
+      owner: policy.owner,
+      repo: policy.repo,
+      requiredChecks: policy.requiredChecks,
+      ...(policy.baseBranch !== undefined ? { baseBranch: policy.baseBranch } : {}),
+      ...(policy.requireMerge !== undefined ? { requireMerge: policy.requireMerge } : {})
+    })
+  );
 
 const SecretRefSchema = z.discriminatedUnion("kind", [
   z
@@ -219,6 +247,7 @@ const DaemonConfigSchema = z
     security: SecuritySchema.optional(),
     githubToken: SecretStringSchema.optional(),
     githubApplyToken: SecretStringSchema.nullable().optional(),
+    completionPolicies: z.array(GitHubCompletionPolicySchema).optional(),
     preparePullRequestBranch: z.boolean().optional(),
     allowAutoCreatePullRequest: z.boolean().optional(),
     runnerToken: SecretStringSchema.optional(),
@@ -471,7 +500,7 @@ export const OpenTagCliConfigSchema = z
   .strict();
 
 export type OpenTagCliConfig = Omit<z.infer<typeof OpenTagCliConfigSchema>, "daemon"> & {
-  daemon: OpenTagDaemonConfig;
+  daemon: OpenTagDaemonConfig & { completionPolicies?: GitHubCompletionPolicyConfig[] };
 };
 
 export type OpenTagCliPreferences = NonNullable<OpenTagCliConfig["preferences"]>;
@@ -517,7 +546,12 @@ export function parseCliConfig(value: unknown): OpenTagCliConfig {
   const parsed = OpenTagCliConfigSchema.parse(value);
   return {
     ...parsed,
-    daemon: parseDaemonConfig(parsed.daemon)
+    daemon: {
+      ...parseDaemonConfig(parsed.daemon),
+      ...(parsed.daemon.completionPolicies !== undefined
+        ? { completionPolicies: parsed.daemon.completionPolicies }
+        : {})
+    }
   };
 }
 

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -399,6 +399,9 @@ export function dispatcherRuntimeInputFromCliConfig(
     ...(channelPrincipals.length > 0 ? { channelPrincipals } : {}),
     ...(config.daemon.githubToken ? { githubToken: config.daemon.githubToken } : {}),
     ...(config.daemon.githubToken ? { githubCallbackToken: config.daemon.githubToken } : {}),
+    ...(config.daemon.completionPolicies !== undefined
+      ? { completionPolicies: config.daemon.completionPolicies }
+      : {}),
     ...(config.daemon.githubApplyToken !== undefined
       ? { githubApplyToken: config.daemon.githubApplyToken }
       : config.daemon.githubToken

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   defaultConfigPath,
   defaultStateDirectory,
+  formatCliConfigError,
   parseCliConfig,
   readCliConfig,
   readKeychainSecret,
@@ -81,6 +82,62 @@ describe("OpenTag CLI config", () => {
       profile: "opentag",
       gatewayUrl: "ws://127.0.0.1:19093"
     });
+  });
+
+  it("accepts strict GitHub completion policies in daemon JSON", () => {
+    const source = config();
+    const parsed = parseCliConfig({
+      ...source,
+      daemon: {
+        ...source.daemon,
+        completionPolicies: [
+          {
+            provider: "github",
+            owner: " acme ",
+            repo: " demo ",
+            requiredChecks: [" build ", "test"],
+            baseBranch: " main ",
+            requireMerge: true
+          }
+        ]
+      }
+    });
+
+    expect(parsed.daemon.completionPolicies).toEqual([
+      {
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        requiredChecks: ["build", "test"],
+        baseBranch: "main",
+        requireMerge: true
+      }
+    ]);
+  });
+
+  it("rejects invalid GitHub completion policies with a config path", () => {
+    const source = config();
+    let error: unknown;
+    try {
+      parseCliConfig({
+        ...source,
+        daemon: {
+          ...source.daemon,
+          completionPolicies: [
+            {
+              provider: "github",
+              owner: "acme",
+              repo: "demo",
+              requiredChecks: []
+            }
+          ]
+        }
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(formatCliConfigError(error)).toContain("daemon.completionPolicies.0.requiredChecks");
   });
 
   it("writes config atomically with private file permissions", () => {

--- a/packages/cli/test/start.test.ts
+++ b/packages/cli/test/start.test.ts
@@ -364,6 +364,53 @@ describe("OpenTag CLI start wiring", () => {
     });
   });
 
+  it("forwards daemon GitHub completion policies through the local start path", async () => {
+    const built = githubConfig();
+    built.daemon.completionPolicies = [
+      {
+        provider: "github",
+        owner: "acme",
+        repo: "demo",
+        requiredChecks: ["build", "test"],
+        baseBranch: "main",
+        requireMerge: true
+      }
+    ];
+    let dispatcherInput: Parameters<NonNullable<StartRuntimeDependencies["startDispatcher"]>>[0] | undefined;
+
+    await startFromConfig({
+      config: built,
+      configPath: "/tmp/opentag/config.json",
+      signal: abortedSignal(),
+      listenForProcessSignals: false,
+      dependencies: {
+        async assertStartPortsAvailable() {},
+        startDispatcher(input) {
+          dispatcherInput = input;
+          return {
+            url: "http://localhost:3030",
+            server: {} as ReturnType<typeof import("@hono/node-server").serve>,
+            async close() {}
+          };
+        },
+        async waitForDispatcher() {},
+        async bootstrapDispatcher() {},
+        async serveDaemon() {},
+        startGitHubIngress() {
+          return {
+            url: "http://127.0.0.1:3050",
+            webhookPath: "/github/webhooks",
+            server: {} as ReturnType<typeof import("@hono/node-server").serve>,
+            async close() {}
+          };
+        },
+        logger: { log() {} }
+      }
+    });
+
+    expect(dispatcherInput?.completionPolicies).toEqual(built.daemon.completionPolicies);
+  });
+
   it("wires GitHub reconciliation escalation intents to the pairing-authenticated dispatcher client", async () => {
     const built = githubConfig();
     built.daemon.pairingToken = "pairing_admin_token";

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "HTTP client SDK for creating, claiming, and updating OpenTag dispatcher runs.",
   "type": "module",
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Core OpenTag protocol schemas, types, JSON Schema, and mention parsing.",
   "type": "module",
   "engines": {

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/discord",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Discord interactions normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/dispatcher/package.json
+++ b/packages/dispatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/dispatcher",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Embeddable OpenTag dispatcher Hono app and callback sinks.",
   "type": "module",
   "engines": {

--- a/packages/dispatcher/src/completion-governance.ts
+++ b/packages/dispatcher/src/completion-governance.ts
@@ -240,7 +240,7 @@ function githubFactTemplates(input: {
   };
   const provenance = (kind: string) => ({
     adapter: "@opentag/github",
-    adapterVersion: "0.6.0",
+    adapterVersion: "0.7.0",
     payloadDigest: factDigest(semanticDigest, kind),
     providerDeliveryId: input.snapshot.deliveryId
   });

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/github",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "GitHub event normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/github/src/completion-evidence.ts
+++ b/packages/github/src/completion-evidence.ts
@@ -281,16 +281,19 @@ export function createGitHubCompletionApi(input: {
     },
     async getCombinedStatusForRef({ owner, repo, ref }) {
       const value = await request(`/repos/${segment(owner)}/${segment(repo)}/commits/${segment(ref)}/status?per_page=100`);
-      if (!isRecord(value) || !Array.isArray(value["statuses"])) throw new Error("GitHub commit-status reconciliation returned an invalid response.");
-      return value["statuses"].map((candidate) => {
+      if (!isRecord(value)) throw new Error("GitHub commit-status reconciliation returned an invalid response.");
+      const sha = nonEmptyString(value["sha"]);
+      const statuses = value["statuses"];
+      if (!sha || !Array.isArray(statuses)) throw new Error("GitHub commit-status reconciliation returned an invalid response.");
+      return statuses.map((candidate) => {
         if (!isRecord(candidate) || !nonEmptyString(candidate["context"])
-          || !nonEmptyString(candidate["state"]) || !nonEmptyString(candidate["sha"])) {
+          || !nonEmptyString(candidate["state"])) {
           throw new Error("GitHub commit-status reconciliation returned an invalid response.");
         }
         return {
           context: candidate["context"] as string,
           state: candidate["state"] as string,
-          sha: candidate["sha"] as string
+          sha
         };
       });
     },

--- a/packages/github/src/ingress.ts
+++ b/packages/github/src/ingress.ts
@@ -604,6 +604,9 @@ export function createGitHubWebhookApp(input: GitHubWebhookAppInput) {
           api: input.completionApi,
           now: input.now
         });
+        if (snapshots.length === 0) {
+          return c.json({ ok: true, evidenceSnapshots: 0, ignored: "no_correlated_pull_requests" });
+        }
         if (input.ingestCompletionEvidenceBatch) {
           await input.ingestCompletionEvidenceBatch(snapshots);
         } else {

--- a/packages/github/test/completion-evidence.test.ts
+++ b/packages/github/test/completion-evidence.test.ts
@@ -182,4 +182,20 @@ describe("GitHub completion evidence", () => {
     await expect(api.getPullRequest({ owner: "acme", repo: "demo", pullRequestNumber: 7 }))
       .rejects.not.toThrow("github_secret_token");
   });
+
+  it("uses the combined-status response SHA for status entries", async () => {
+    const fetchImpl = vi.fn(async () => Response.json({
+      sha: HEAD_CURRENT,
+      statuses: [
+        { context: "build", state: "success" },
+        { context: "test", state: "pending" }
+      ]
+    }));
+    const api = createGitHubCompletionApi({ token: "github_token", fetchImpl });
+
+    await expect(api.getCombinedStatusForRef({ owner: "acme", repo: "demo", ref: HEAD_CURRENT })).resolves.toEqual([
+      { context: "build", state: "success", sha: HEAD_CURRENT },
+      { context: "test", state: "pending", sha: HEAD_CURRENT }
+    ]);
+  });
 });

--- a/packages/github/test/ingress.test.ts
+++ b/packages/github/test/ingress.test.ts
@@ -97,6 +97,39 @@ describe("GitHub webhook ingress", () => {
     ]);
   });
 
+  it("ignores a status delivery that has no correlated pull request", async () => {
+    const api = completionApi();
+    api.listPullRequestsForCommit = async () => [];
+    const ingestCompletionEvidenceBatch = vi.fn(async () => ({ outcome: "recorded" }));
+    const requestCompletionReconciliationEscalation = vi.fn(async () => undefined);
+    const app = createGitHubWebhookApp({
+      webhookSecret: "secret",
+      createRun: vi.fn(async () => ({})),
+      completionApi: api,
+      ingestCompletionEvidenceBatch,
+      requestCompletionReconciliationEscalation,
+      now: () => "2026-07-21T10:00:00.000Z"
+    });
+    const body = JSON.stringify({
+      sha: COMPLETION_HEAD,
+      repository: { name: "demo", owner: { login: "acme" } }
+    });
+
+    const response = await app.request(
+      "/github/webhooks",
+      signedRequest({ body, secret: "secret", event: "status", deliveryId: "delivery-no-pull-request" })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      evidenceSnapshots: 0,
+      ignored: "no_correlated_pull_requests"
+    });
+    expect(ingestCompletionEvidenceBatch).not.toHaveBeenCalled();
+    expect(requestCompletionReconciliationEscalation).not.toHaveBeenCalled();
+  });
+
   it("fails a multi-PR delivery before any single-snapshot fallback write when batch ingestion is unavailable", async () => {
     const api = completionApi();
     api.listPullRequestsForCommit = async () => [{ number: 7 }, { number: 8 }];

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/gitlab",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "GitLab webhook normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/governance",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Deterministic completion governance for OpenTag work loops.",
   "type": "module",
   "engines": {

--- a/packages/lark/package.json
+++ b/packages/lark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/lark",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Lark/Feishu message normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/linear/package.json
+++ b/packages/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/linear",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Linear webhook normalization, callback rendering, and issue mutation helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/local-runtime/package.json
+++ b/packages/local-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/local-runtime",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Local OpenTag dispatcher, daemon, and diagnostics runtime helpers.",
   "type": "module",
   "engines": {

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/runner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Executor contracts and built-in runner adapters for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/runner/src/builtin-acp.ts
+++ b/packages/runner/src/builtin-acp.ts
@@ -93,6 +93,7 @@ export function builtInAcpAgentDefinitions(
       id: "hermes",
       label: "Hermes ACP",
       workspaceCwd: "required",
+      readinessTimeoutMs: 60_000,
       launch: {
         command: hermesCommand,
         args: ["-p", hermesProfile, "acp"]

--- a/packages/runner/test/builtin-acp.test.ts
+++ b/packages/runner/test/builtin-acp.test.ts
@@ -84,6 +84,7 @@ describe("built-in ACP coding agents", () => {
     expect(definitions.opencode.readinessTimeoutMs).toBe(30_000);
     expect(definitions.hermes).toMatchObject({
       id: "hermes",
+      readinessTimeoutMs: 60_000,
       capabilities: { supportsProfile: true, supportsCancel: true }
     });
     expect(definitions.openclaw).toMatchObject({

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/slack",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Slack app mention normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/store",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "SQLite and Drizzle persistence primitives for OpenTag runs and leases.",
   "type": "module",
   "engines": {

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/teams",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Microsoft Teams activity normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": { "node": ">=20" },

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/telegram",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Telegram message normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/scripts/dev/run-github-webhook-live-test.sh
+++ b/scripts/dev/run-github-webhook-live-test.sh
@@ -10,8 +10,9 @@ Run a real GitHub repository-webhook OpenTag dogfood session.
 
 This starts the local OpenTag CLI stack, exposes the GitHub webhook listener
 through ngrok, creates a temporary repository webhook, posts a real GitHub issue
-comment, waits for OpenTag to finish, replies `apply 1`, and waits for the
-created pull request.
+comment, waits for OpenTag to finish, and by default proves strict PR/check/merge
+completion with a durable restart. Disable strict mode only to exercise the
+older optional `apply 1` compatibility path.
 
 Required:
   gh CLI authenticated as a user with admin access to the target repository.
@@ -22,7 +23,21 @@ Helpful env:
   OPENTAG_GH_REPO                 owner/repo, default amplifthq/opentag-test
   OPENTAG_GH_PUBLIC_URL           fixed public tunnel URL, if already running
   OPENTAG_GH_LIVE_COMMAND         prompt after `@opentag run`
+  OPENTAG_GH_LIVE_EXECUTOR        built-in ACP agent, default claude-code; use
+                                     phase1-fixture for the deterministic
+                                     repository-writing ACP fixture
   OPENTAG_GH_LIVE_APPLY           true/false, default true
+  OPENTAG_GH_LIVE_STRICT_COMPLETION
+                                     true/false, default true. Enables the
+                                     Phase 1 PR/check/merge completion policy,
+                                     creates the PR during the run, records a
+                                     real commit status, merges the PR, and
+                                     verifies restart-safe completion.
+  OPENTAG_GH_LIVE_REQUIRED_CHECK  required commit-status context, default
+                                     opentag-phase1-live
+  OPENTAG_GH_LIVE_REPORT          optional structured evidence JSON path
+  OPENTAG_GH_LIVE_CLI_BIN         optional installed `opentag` executable;
+                                     defaults to the source CLI through tsx
   OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN
                                      true/false, default false. Keeps GitHub
                                      callbacks working but verifies Needs setup
@@ -53,6 +68,8 @@ fi
 : "${OPENTAG_GH_LIVE_EXECUTOR:=claude-code}"
 : "${OPENTAG_GH_LIVE_KEEP_WEBHOOK:=false}"
 : "${OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN:=false}"
+: "${OPENTAG_GH_LIVE_STRICT_COMPLETION:=true}"
+: "${OPENTAG_GH_LIVE_REQUIRED_CHECK:=opentag-phase1-live}"
 
 cd "$ROOT_DIR"
 
@@ -65,6 +82,11 @@ NGROK_LOG=""
 HOOK_ID=""
 ISSUE_NUMBER=""
 PUBLIC_URL=""
+PR_URL=""
+PR_NUMBER=""
+PR_HEAD_SHA=""
+COMPLETION_PAYLOAD=""
+REPORT_PATH=""
 
 bool_true() {
   case "${1:-}" in
@@ -127,6 +149,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 require_cmd curl
+require_cmd corepack
 require_cmd gh
 require_cmd lsof
 require_cmd node
@@ -151,7 +174,22 @@ if [[ "$PERMISSION" != "ADMIN" && "$PERMISSION" != "MAINTAIN" ]]; then
 fi
 GITHUB_TOKEN="$(gh auth token)"
 export GITHUB_TOKEN
-export OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN
+export OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN OPENTAG_GH_LIVE_STRICT_COMPLETION OPENTAG_GH_LIVE_REQUIRED_CHECK
+
+if bool_true "$OPENTAG_GH_LIVE_STRICT_COMPLETION"; then
+  if [[ "$OPENTAG_GH_LIVE_EXECUTOR" == "echo" ]]; then
+    echo "Strict completion requires an executor that can create a real repository change." >&2
+    exit 1
+  fi
+  if [[ -z "${OPENTAG_GH_LIVE_REQUIRED_CHECK// }" ]]; then
+    echo "OPENTAG_GH_LIVE_REQUIRED_CHECK must be non-empty in strict completion mode." >&2
+    exit 1
+  fi
+  if bool_true "$OPENTAG_GH_LIVE_APPLY"; then
+    echo "Strict completion creates the pull request during the run; disabling the later apply-comment path."
+    OPENTAG_GH_LIVE_APPLY=false
+  fi
+fi
 
 if bool_true "$OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN" && bool_true "$OPENTAG_GH_LIVE_APPLY"; then
   echo "GitHub apply token is disabled for this run; skipping apply-comment execution and expecting Needs setup."
@@ -170,7 +208,7 @@ BASE_BRANCH="${OPENTAG_BASE_BRANCH:-main}"
 PUSH_REMOTE="${OPENTAG_PUSH_REMOTE:-origin}"
 export CHECKOUT_PATH WORKTREE_ROOT STATE_DIR CONFIG_PATH DATABASE_PATH WEBHOOK_SECRET BASE_BRANCH PUSH_REMOTE
 export OPENTAG_PAIRING_TOKEN OPENTAG_DISPATCHER_PORT OPENTAG_GITHUB_PORT OPENTAG_RUNNER_ID
-export OPENTAG_GH_LIVE_EXECUTOR
+export OPENTAG_GH_LIVE_EXECUTOR ROOT_DIR
 
 ensure_port_free() {
   local port="$1"
@@ -260,13 +298,20 @@ wait_for_ngrok_url() {
 
 public_ingress_probe() {
   local public_url="$1"
-  local code
-  code="$(curl -sS -o "$TMP_ROOT/github-ingress-probe.json" -w "%{http_code}" -X POST "$public_url/github/webhooks" -H "content-type: application/json" --data '{}' || true)"
-  if [[ "$code" == "401" ]]; then
-    echo "Public GitHub ingress probe reached OpenTag (401 without GitHub signature is expected)."
-    return 0
+  local code=""
+  local deadline=$((SECONDS + 45))
+  while (( SECONDS < deadline )); do
+    code="$(curl -sS -o "$TMP_ROOT/github-ingress-probe.json" -w "%{http_code}" -X POST "$public_url/github/webhooks" -H "content-type: application/json" --data '{}' || true)"
+    if [[ "$code" == "401" ]]; then
+      echo "Public GitHub ingress probe reached OpenTag (401 without GitHub signature is expected)."
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Public GitHub ingress probe returned HTTP ${code:-unknown}, expected 401." >&2
+  if [[ -f "$TMP_ROOT/github-ingress-probe.json" ]]; then
+    sed -n '1,40p' "$TMP_ROOT/github-ingress-probe.json" >&2 || true
   fi
-  echo "Public GitHub ingress probe returned HTTP $code, expected 401." >&2
   exit 1
 }
 
@@ -294,6 +339,118 @@ summary = {
 }
 print("Run metrics:", json.dumps(summary, sort_keys=True))
 PY
+}
+
+completion_payload() {
+  local run_id="$1"
+  curl -fsS \
+    -H "authorization: Bearer $OPENTAG_PAIRING_TOKEN" \
+    "http://localhost:${OPENTAG_DISPATCHER_PORT}/v1/runs/${run_id}/completion"
+}
+
+wait_for_completion() {
+  local run_id="$1"
+  local expected_states="$2"
+  local gate_id="${3:-}"
+  local expected_gate_state="${4:-}"
+  local deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+  local payload=""
+  while (( SECONDS < deadline )); do
+    payload="$(completion_payload "$run_id" 2>/dev/null || true)"
+    if [[ -n "$payload" ]]; then
+      if python3 -c '
+import json
+import sys
+payload = json.loads(sys.argv[1]).get("completion", {})
+expected_states = sys.argv[2].split(",")
+if payload.get("completion") not in expected_states:
+    raise SystemExit(1)
+gate_id = sys.argv[3]
+expected_gate_state = sys.argv[4]
+if gate_id:
+    gates = {gate.get("gateId"): gate.get("state") for gate in payload.get("currentAssessment", {}).get("gateResults", [])}
+    if gates.get(gate_id) != expected_gate_state:
+        raise SystemExit(1)
+' "$payload" "$expected_states" "$gate_id" "$expected_gate_state"; then
+        COMPLETION_PAYLOAD="$payload"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  echo "Timed out waiting for completion in [$expected_states]${gate_id:+ and $gate_id=$expected_gate_state}." >&2
+  if [[ -n "$payload" ]]; then
+    python3 -m json.tool <<<"$payload" >&2 || true
+  fi
+  exit 1
+}
+
+wait_for_issue_comment() {
+  local pattern="$1"
+  local deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    if issue_comments_contain "$pattern"; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timed out waiting for GitHub issue comment containing: $pattern" >&2
+  exit 1
+}
+
+completion_receipt_count() {
+  gh api --paginate "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+    --jq '.[].body' \
+    | grep -F -c "provider-verified completion requirements are satisfied" \
+    || true
+}
+
+stable_completion_receipt_count() {
+  local stable_window_seconds="${1:-10}"
+  local deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+  local stable_since="$SECONDS"
+  local previous_count
+  local current_count
+  previous_count="$(completion_receipt_count)"
+  while (( SECONDS < deadline )); do
+    sleep 1
+    current_count="$(completion_receipt_count)"
+    if [[ "$current_count" != "$previous_count" ]]; then
+      previous_count="$current_count"
+      stable_since="$SECONDS"
+      continue
+    fi
+    if (( SECONDS - stable_since >= stable_window_seconds )); then
+      printf '%s\n' "$current_count"
+      return 0
+    fi
+  done
+  echo "Timed out waiting for the provider-verified completion receipt count to stabilize." >&2
+  exit 1
+}
+
+start_cli_stack() {
+  echo "Starting OpenTag CLI stack on dispatcher :${OPENTAG_DISPATCHER_PORT}, GitHub ingress :${OPENTAG_GITHUB_PORT}"
+  if [[ -n "${OPENTAG_GH_LIVE_CLI_BIN:-}" ]]; then
+    if [[ ! -x "$OPENTAG_GH_LIVE_CLI_BIN" ]]; then
+      echo "OPENTAG_GH_LIVE_CLI_BIN is not executable: $OPENTAG_GH_LIVE_CLI_BIN" >&2
+      exit 1
+    fi
+    "$OPENTAG_GH_LIVE_CLI_BIN" start --config "$CONFIG_PATH" &
+  else
+    NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../packages/cli/src/index.ts start --config "$CONFIG_PATH" &
+  fi
+  CLI_PID=$!
+  wait_for_http "http://localhost:${OPENTAG_DISPATCHER_PORT}/healthz"
+  wait_for_github_ingress
+}
+
+stop_cli_stack() {
+  kill_pid "$CLI_PID"
+  if [[ -n "$CLI_PID" ]]; then
+    wait "$CLI_PID" 2>/dev/null || true
+  fi
+  CLI_PID=""
 }
 
 issue_comments_contain() {
@@ -364,6 +521,28 @@ config = {
                 "keepWorktree": "on_failure",
             }
         ],
+        **(
+            {
+                "agents": {
+                    "phase1-fixture": {
+                        "label": "Phase 1 live deterministic ACP fixture",
+                        "command": "node",
+                        "args": [
+                            os.path.join(
+                                os.environ["ROOT_DIR"],
+                                "packages/runner/test/fixtures/acp-agent.mjs",
+                            ),
+                            "success",
+                        ],
+                        "workspaceCwd": "required",
+                        "supportsCancel": True,
+                        "readinessTimeoutMs": 30_000,
+                    }
+                }
+            }
+            if os.environ["OPENTAG_GH_LIVE_EXECUTOR"] == "phase1-fixture"
+            else {}
+        ),
         "githubToken": os.environ["GITHUB_TOKEN"],
         **(
             {"githubApplyToken": None}
@@ -371,6 +550,23 @@ config = {
             else {}
         ),
         "preparePullRequestBranch": True,
+        **(
+            {
+                "allowAutoCreatePullRequest": True,
+                "completionPolicies": [
+                    {
+                        "provider": "github",
+                        "owner": os.environ["OWNER"],
+                        "repo": os.environ["REPO"],
+                        "requiredChecks": [os.environ["OPENTAG_GH_LIVE_REQUIRED_CHECK"]],
+                        "baseBranch": os.environ["BASE_BRANCH"],
+                        "requireMerge": True,
+                    }
+                ],
+            }
+            if os.environ.get("OPENTAG_GH_LIVE_STRICT_COMPLETION", "").lower() in {"1", "true", "yes", "y"}
+            else {}
+        ),
         "pairingToken": os.environ["OPENTAG_PAIRING_TOKEN"],
         "pollIntervalMs": 1000,
         "heartbeatIntervalMs": 15000,
@@ -394,12 +590,7 @@ PY
 ensure_port_free "$OPENTAG_DISPATCHER_PORT" "dispatcher"
 ensure_port_free "$OPENTAG_GITHUB_PORT" "GitHub ingress"
 
-echo "Starting OpenTag CLI stack on dispatcher :${OPENTAG_DISPATCHER_PORT}, GitHub ingress :${OPENTAG_GITHUB_PORT}"
-NODE_OPTIONS='--conditions=development' packages/cli/node_modules/.bin/tsx packages/cli/src/index.ts start --config "$CONFIG_PATH" &
-CLI_PID=$!
-
-wait_for_http "http://localhost:${OPENTAG_DISPATCHER_PORT}/healthz"
-wait_for_github_ingress
+start_cli_stack
 
 PUBLIC_URL="${OPENTAG_GH_PUBLIC_URL:-}"
 if bool_true "$OPENTAG_GH_LIVE_START_NGROK"; then
@@ -440,7 +631,7 @@ import json
 print(json.dumps({
     "name": "web",
     "active": True,
-    "events": ["issue_comment", "pull_request_review_comment"],
+    "events": ["issue_comment", "pull_request_review_comment", "pull_request", "check_run", "check_suite", "status"],
     "config": {
         "url": "${PUBLIC_URL}/github/webhooks",
         "content_type": "json",
@@ -506,6 +697,152 @@ if [[ "$status" != "succeeded" ]]; then
 fi
 print_metrics "$RUN_ID"
 
+if bool_true "$OPENTAG_GH_LIVE_STRICT_COMPLETION"; then
+  echo "Verifying executor success does not satisfy completion before provider evidence is complete..."
+  wait_for_completion "$RUN_ID" "pending,unsatisfied"
+  INITIAL_COMPLETION_PATH="$TMP_ROOT/completion-initial.json"
+  printf '%s\n' "$COMPLETION_PAYLOAD" >"$INITIAL_COMPLETION_PATH"
+
+  deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    PR_URL="$(sqlite_one "select json_extract(result_json, '$.createdPullRequestUrl') from runs where id = '$(sql_escape "$RUN_ID")';")"
+    if [[ -n "$PR_URL" ]]; then
+      break
+    fi
+    sleep 2
+  done
+  if [[ -z "$PR_URL" ]]; then
+    echo "Strict completion run did not record a created pull request URL." >&2
+    exit 1
+  fi
+
+  PR_INFO_PATH="$TMP_ROOT/pull-request.json"
+  gh pr view "$PR_URL" --json number,state,headRefName,headRefOid,baseRefName,url >"$PR_INFO_PATH"
+  PR_NUMBER="$(python3 - "$PR_INFO_PATH" <<'PY'
+import json
+import sys
+print(json.load(open(sys.argv[1], encoding="utf-8"))["number"])
+PY
+)"
+  PR_HEAD_SHA="$(python3 - "$PR_INFO_PATH" <<'PY'
+import json
+import sys
+print(json.load(open(sys.argv[1], encoding="utf-8"))["headRefOid"])
+PY
+)"
+  echo "Created governed PR #$PR_NUMBER at head $PR_HEAD_SHA: $PR_URL"
+
+  echo "Recording real GitHub commit status '$OPENTAG_GH_LIVE_REQUIRED_CHECK' on the current PR head..."
+  gh api "repos/${OWNER}/${REPO}/statuses/${PR_HEAD_SHA}" \
+    --method POST \
+    -f state=success \
+    -f context="$OPENTAG_GH_LIVE_REQUIRED_CHECK" \
+    -f description="OpenTag Phase 1 live completion acceptance" \
+    -f target_url="$PR_URL" >/dev/null
+
+  wait_for_completion "$RUN_ID" "pending,unsatisfied" "required_checks" "passed"
+  CHECKED_COMPLETION_PATH="$TMP_ROOT/completion-after-check.json"
+  printf '%s\n' "$COMPLETION_PAYLOAD" >"$CHECKED_COMPLETION_PATH"
+  echo "Required check passed for the current head; completion remains unsatisfied until merge."
+
+  echo "Merging governed PR #$PR_NUMBER after OpenTag observed the required check..."
+  gh pr merge "$PR_URL" --merge --delete-branch
+
+  wait_for_completion "$RUN_ID" "satisfied" "merge" "passed"
+  FINAL_COMPLETION_PATH="$TMP_ROOT/completion-final.json"
+  printf '%s\n' "$COMPLETION_PAYLOAD" >"$FINAL_COMPLETION_PATH"
+  gh pr view "$PR_URL" \
+    --json number,state,headRefName,headRefOid,baseRefName,url,mergedAt,mergeCommit \
+    >"$PR_INFO_PATH"
+  wait_for_issue_comment "provider-verified completion requirements are satisfied"
+  RECEIPTS_BEFORE_RESTART="$(completion_receipt_count)"
+
+  echo "Restarting the CLI stack to verify durable satisfied completion and callback deduplication..."
+  stop_cli_stack
+  deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if [[ -z "$(lsof -ti "tcp:${OPENTAG_DISPATCHER_PORT}" 2>/dev/null || true)" && -z "$(lsof -ti "tcp:${OPENTAG_GITHUB_PORT}" 2>/dev/null || true)" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  ensure_port_free "$OPENTAG_DISPATCHER_PORT" "dispatcher"
+  ensure_port_free "$OPENTAG_GITHUB_PORT" "GitHub ingress"
+  start_cli_stack
+  wait_for_completion "$RUN_ID" "satisfied" "merge" "passed"
+  RESTARTED_COMPLETION_PATH="$TMP_ROOT/completion-after-restart.json"
+  printf '%s\n' "$COMPLETION_PAYLOAD" >"$RESTARTED_COMPLETION_PATH"
+  RECEIPTS_AFTER_RESTART="$(stable_completion_receipt_count 10)"
+  if [[ "$RECEIPTS_AFTER_RESTART" != "$RECEIPTS_BEFORE_RESTART" ]]; then
+    echo "Restart emitted a duplicate provider-verified completion receipt ($RECEIPTS_BEFORE_RESTART -> $RECEIPTS_AFTER_RESTART)." >&2
+    exit 1
+  fi
+
+  REPORT_PATH="${OPENTAG_GH_LIVE_REPORT:-$ROOT_DIR/.omx/live-e2e/github-completion-governance-$(date -u +%Y%m%dT%H%M%SZ).json}"
+  mkdir -p "$(dirname "$REPORT_PATH")"
+  ASSESSMENT_COUNT="$(sqlite_one "select count(*) from completion_assessments where work_thread_id = (select work_thread_id from runs where id = '$(sql_escape "$RUN_ID")');")"
+  RUNTIME_SOURCE="source_checkout"
+  if [[ -n "${OPENTAG_GH_LIVE_CLI_BIN:-}" ]]; then
+    RUNTIME_SOURCE="registry_install"
+  fi
+  python3 - \
+    "$REPORT_PATH" "$INITIAL_COMPLETION_PATH" "$CHECKED_COMPLETION_PATH" "$FINAL_COMPLETION_PATH" "$RESTARTED_COMPLETION_PATH" "$PR_INFO_PATH" \
+    "$OWNER/$REPO" "$ISSUE_URL" "$RUN_ID" "$OPENTAG_GH_LIVE_REQUIRED_CHECK" "$ASSESSMENT_COUNT" "$RECEIPTS_AFTER_RESTART" "$RUNTIME_SOURCE" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+(
+    report_path,
+    initial_path,
+    checked_path,
+    final_path,
+    restarted_path,
+    pr_path,
+    repository,
+    issue_url,
+    run_id,
+    required_check,
+    assessment_count,
+    receipt_count,
+    runtime_source,
+) = sys.argv[1:]
+
+def read(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+report = {
+    "schemaVersion": 1,
+    "case": "github-completion-governance-live",
+    "recordedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "repository": repository,
+    "issueUrl": issue_url,
+    "runId": run_id,
+    "requiredCheck": required_check,
+    "runtimeSource": runtime_source,
+    "pullRequest": read(pr_path),
+    "completion": {
+        "afterExecutorSuccess": read(initial_path)["completion"],
+        "afterRequiredCheck": read(checked_path)["completion"],
+        "afterMerge": read(final_path)["completion"],
+        "afterRestart": read(restarted_path)["completion"],
+    },
+    "assessmentCount": int(assessment_count),
+    "providerVerifiedReceiptCount": int(receipt_count),
+    "assertions": {
+        "executorSuccessDidNotSatisfyCompletion": True,
+        "requiredCheckBoundToCurrentHead": True,
+        "requiredCheckDidNotBypassMerge": True,
+        "mergeSatisfiedContract": True,
+        "restartPreservedSatisfiedAssessment": True,
+        "restartDidNotDuplicateFinalReceipt": True,
+    },
+}
+Path(report_path).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+  echo "Structured Phase 1 live evidence: $REPORT_PATH"
+else
 echo "Recent issue comments after final receipt:"
 gh api "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments?sort=created&direction=desc&per_page=4" \
   --jq 'reverse[] | {author: .user.login, body: (.body | split("\n")[0:8] | join("\n"))}'
@@ -613,6 +950,7 @@ PY
     echo "Applied receipt ended with duplicate punctuation." >&2
     exit 1
   fi
+fi
 fi
 
 echo

--- a/scripts/test/live-e2e-smoke.mjs
+++ b/scripts/test/live-e2e-smoke.mjs
@@ -66,10 +66,11 @@ const cases = [
   },
   {
     id: "github-webhook-live",
-    label: "Live GitHub repository webhook smoke",
+    label: "Live GitHub completion-governance smoke",
     live: true,
     command: "scripts/dev/run-github-webhook-live-test.sh",
     requiredCommands: [
+      "corepack",
       "curl",
       "gh",
       "lsof",
@@ -82,7 +83,9 @@ const cases = [
     notes: [
       "Requires gh auth with ADMIN or MAINTAIN access to OPENTAG_GH_REPO.",
       "Requires npx plus working local authentication for the selected Registry-backed ACP launch.",
-      "Set OPENTAG_GH_PUBLIC_URL or allow ngrok with OPENTAG_GH_LIVE_START_NGROK=true."
+      "Set OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture to isolate the real GitHub/governance chain from model-provider readiness while retaining a real ACP worktree write.",
+      "Set OPENTAG_GH_PUBLIC_URL or allow ngrok with OPENTAG_GH_LIVE_START_NGROK=true.",
+      "Strict mode creates and merges a real PR, records a current-head GitHub status, and writes sanitized evidence under .omx/live-e2e."
     ]
   },
   {


### PR DESCRIPTION
## Summary

- wire strict GitHub completion policies through the CLI into the local dispatcher
- reconcile real GitHub combined-status evidence and safely ignore status deliveries with no correlated pull request
- harden the live GitHub acceptance harness so executor success, current-head checks, merge authority, restart durability, and receipt deduplication are proven on GitHub
- give Hermes ACP readiness a realistic startup deadline observed on the release machine
- prepare the coordinated 0.7.0 release for all 16 public packages, including @opentag/governance

## Real Phase 1 acceptance

- test issue: https://github.com/amplifthq/opentag-test/issues/73
- governed PR: https://github.com/amplifthq/opentag-test/pull/74
- exact governed head: bbed9788f6ff6b5b83531d367ec49592badb9365
- merge commit: a2d9ef4e953c7bbbb983906bb2d1ec48cf69d3e5
- required status: opentag-phase1-live on the exact PR head
- result: executor success remained unsatisfied; the required check alone remained unsatisfied; merge satisfied the contract; restart preserved the satisfied assessment and did not duplicate the provider-verified receipt

## Verification

- build, lint, and typecheck passed
- 126 test files and 1651 tests passed
- all 8 governance-matrix cases passed
- privacy scan passed
- publication-set verification passed for 16 packages at 0.7.0
- packed-install release check passed, including all 16 tarballs, installed CLI checks, and installed completion governance
- npm audit reported 13 moderate findings with no available fix; no high or critical finding

## External ACP environment notes

- Hermes readiness passed after 29.7 seconds with the corrected 60-second deadline; its configured provider then executed a real pwd tool call but did not complete the scratch case within 180 seconds
- the existing OpenClaw conformance profile was last written by 2026.7.2 while the installed and release-supported binary is 2026.7.1; the destructive downgrade override was intentionally not used

These external ACP provider/profile conditions are recorded separately from the successful deterministic ACP plus real GitHub Phase 1 governance acceptance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed the GitHub completion-governance Phase 1 vertical slice with evidence-backed completion evaluation, restart-safe work-loop persistence, strict required-check/merge behavior, and narrowly scoped waivers.
  * Added `@opentag/governance` as a first-class public package.
  * Added CLI/daemon support for `daemon.completionPolicies` to control GitHub completion requirements.
* **Bug Fixes**
  * Hardened combined-status response validation and ensured correct SHA handling in returned status objects.
  * Improved webhook reconciliation when no correlated pull requests are found.
* **Documentation**
  * Updated versioning, npm release guidance, README(s), and live smoke documentation for `v0.7.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->