### PR TITLE
Harden provider compatibility, Teams auth, and runtime dependencies

### DIFF
--- a/apps/dispatcher/package.json
+++ b/apps/dispatcher/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/dispatcher": "workspace:*",
     "@opentag/local-runtime": "workspace:*"
   },

--- a/apps/slack-events/package.json
+++ b/apps/slack-events/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/client": "workspace:*",
     "@opentag/core": "workspace:*",
     "@opentag/slack": "workspace:*",

--- a/apps/telegram-events/package.json
+++ b/apps/telegram-events/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/client": "workspace:*",
     "@opentag/core": "workspace:*",
     "@opentag/telegram": "workspace:*",

--- a/docs/acp-agent-integration.md
+++ b/docs/acp-agent-integration.md
@@ -91,6 +91,12 @@ OPENTAG_OPENCLAW_PROFILE=opentag-conformance \
 corepack pnpm smoke:openclaw-acp-conformance
 ```
 
+Normal runtime startup also performs a bounded, read-only compatibility
+preflight. It checks the CLI version and selected Gateway/profile before
+spawning `openclaw acp`; an optional `expectedVersion` daemon setting can pin
+the operator-approved version. A mismatch is a setup failure, and OpenTag never
+uses a downgrade override or mutates the provider-owned profile to make it pass.
+
 The gate checks exact worktree and scratch writes plus distinct disposable
 Gateway session keys. For hard cancellation, it waits until a real long-running
 shell command writes its start marker, cancels the ACP session, then waits beyond
@@ -108,6 +114,12 @@ not weaken that assertion or reinterpret it as a provider-admission gate.
 
 This OpenClaw-specific gate complements rather than replaces the generic ACP
 executor, governance, and privacy suites required by the checklist below.
+
+For provider-backed conformance, a verified scratch marker proves only that a
+tool ran in the supplied cwd. If the provider/runtime then omits the ACP
+`session/prompt` stop response until the deadline, the gate records
+`needs_setup` with that tool evidence; it does not claim completion and does not
+misdiagnose the configured provider behavior as an OpenTag protocol pass.
 
 ## ACP session lifecycle
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,10 +320,19 @@ the OpenTag runtime should not depend on that ambient selection:
   "openclaw": {
     "command": "openclaw",
     "profile": "opentag",
-    "gatewayUrl": "ws://127.0.0.1:19093"
+    "gatewayUrl": "ws://127.0.0.1:19093",
+    "expectedVersion": "2026.7.2"
   }
 }
 ```
+
+Before OpenTag starts the ACP bridge, it performs a bounded, read-only
+compatibility preflight. The preflight verifies the installed CLI version,
+queries the selected Gateway/profile, and requires the CLI and Gateway versions
+to match. `expectedVersion` adds an explicit operator-owned version authority;
+the equivalent environment variable is `OPENTAG_OPENCLAW_EXPECTED_VERSION`.
+Version skew fails closed with upgrade/profile-selection guidance. OpenTag does
+not rewrite, downgrade, or delete the selected OpenClaw profile.
 
 OpenClaw is available for normal ACP runs and retains failed or cancelled
 workspaces for inspection. Its current capability is `supportsCancel: false`:
@@ -572,6 +581,7 @@ for repeatable setups.
 | `OPENTAG_OPENCLAW_COMMAND` | `openclaw` | OpenClaw CLI command used by the built-in ACP launch and CLI detection |
 | `OPENTAG_OPENCLAW_PROFILE` | OpenClaw default | Optional profile passed before the `acp` subcommand |
 | `OPENTAG_OPENCLAW_GATEWAY_URL` | OpenClaw default | Optional Gateway WebSocket URL passed as `acp --url <url>` |
+| `OPENTAG_OPENCLAW_EXPECTED_VERSION` | unset | Optional exact CLI/Gateway version authority checked before ACP startup |
 | `OPENTAG_AGENT_PROFILE` | none | Fixed executor-neutral agent session identity |
 | `OPENTAG_AGENT_PROFILE_TEMPLATE` | derived per run | Executor-neutral profile template; supports tokens such as `{provider}`, `{projectTarget}`, `{accountId}`, `{conversationId}`, `{owner}`, `{repo}`, `{actorId}`, and `{runId}` |
 | `OPENTAG_SECURITY_MODE` | none | `enforce`, `audit`, or `off` |

--- a/examples/embedded-dispatcher/package.json
+++ b/examples/embedded-dispatcher/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/client": "workspace:*",
     "@opentag/core": "workspace:*",
     "@opentag/dispatcher": "workspace:*",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -197,7 +197,8 @@ const OpenClawSchema = z
   .object({
     command: z.string().trim().min(1).optional(),
     profile: z.string().trim().min(1).optional(),
-    gatewayUrl: z.string().url().optional()
+    gatewayUrl: z.string().url().optional(),
+    expectedVersion: z.string().trim().min(1).optional()
   })
   .strict();
 

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -72,7 +72,8 @@ describe("OpenTag CLI config", () => {
         openclaw: {
           command: "/opt/openclaw/bin/openclaw",
           profile: "opentag",
-          gatewayUrl: "ws://127.0.0.1:19093"
+          gatewayUrl: "ws://127.0.0.1:19093",
+          expectedVersion: "2026.7.2"
         }
       }
     });
@@ -80,7 +81,8 @@ describe("OpenTag CLI config", () => {
     expect(parsed.daemon.openclaw).toEqual({
       command: "/opt/openclaw/bin/openclaw",
       profile: "opentag",
-      gatewayUrl: "ws://127.0.0.1:19093"
+      gatewayUrl: "ws://127.0.0.1:19093",
+      expectedVersion: "2026.7.2"
     });
   });
 

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -35,7 +35,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/client": "workspace:*",
     "hono": "^4.6.15",
     "@opentag/core": "workspace:*"

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -34,7 +34,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/client": "workspace:*",
     "hono": "^4.6.15",
     "@opentag/core": "workspace:*"

--- a/packages/linear/package.json
+++ b/packages/linear/package.json
@@ -34,7 +34,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/client": "workspace:*",
     "@opentag/core": "workspace:*",
     "hono": "^4.6.15"

--- a/packages/local-runtime/package.json
+++ b/packages/local-runtime/package.json
@@ -65,7 +65,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/client": "workspace:*",
     "@opentag/core": "workspace:*",
     "@opentag/discord": "workspace:*",

--- a/packages/local-runtime/src/config.ts
+++ b/packages/local-runtime/src/config.ts
@@ -103,7 +103,8 @@ const HermesAcpConfigSchema = z.object({
 const OpenClawAcpConfigSchema = z.object({
   command: z.string().trim().min(1).optional(),
   profile: z.string().trim().min(1).optional(),
-  gatewayUrl: z.string().url().optional()
+  gatewayUrl: z.string().url().optional(),
+  expectedVersion: z.string().trim().min(1).optional()
 });
 
 const AgentSessionProfileConfigSchema = z.object({
@@ -469,12 +470,13 @@ export function loadConfigFromEnv(): OpenTagDaemonConfig {
           }
         }
       : {}),
-    ...(process.env.OPENTAG_OPENCLAW_COMMAND || process.env.OPENTAG_OPENCLAW_PROFILE || process.env.OPENTAG_OPENCLAW_GATEWAY_URL
+    ...(process.env.OPENTAG_OPENCLAW_COMMAND || process.env.OPENTAG_OPENCLAW_PROFILE || process.env.OPENTAG_OPENCLAW_GATEWAY_URL || process.env.OPENTAG_OPENCLAW_EXPECTED_VERSION
       ? {
           openclaw: {
             ...(process.env.OPENTAG_OPENCLAW_COMMAND ? { command: process.env.OPENTAG_OPENCLAW_COMMAND } : {}),
             ...(process.env.OPENTAG_OPENCLAW_PROFILE ? { profile: process.env.OPENTAG_OPENCLAW_PROFILE } : {}),
-            ...(process.env.OPENTAG_OPENCLAW_GATEWAY_URL ? { gatewayUrl: process.env.OPENTAG_OPENCLAW_GATEWAY_URL } : {})
+            ...(process.env.OPENTAG_OPENCLAW_GATEWAY_URL ? { gatewayUrl: process.env.OPENTAG_OPENCLAW_GATEWAY_URL } : {}),
+            ...(process.env.OPENTAG_OPENCLAW_EXPECTED_VERSION ? { expectedVersion: process.env.OPENTAG_OPENCLAW_EXPECTED_VERSION } : {})
           }
         }
       : {}),

--- a/packages/local-runtime/src/runtime.ts
+++ b/packages/local-runtime/src/runtime.ts
@@ -45,7 +45,8 @@ export function builtInAcpOptionsFromConfig(config: OpenTagDaemonConfig): BuiltI
     openclaw: {
       ...(config.openclaw?.command ? { command: config.openclaw.command } : {}),
       ...(config.openclaw?.profile ? { profile: config.openclaw.profile } : {}),
-      ...(config.openclaw?.gatewayUrl ? { gatewayUrl: config.openclaw.gatewayUrl } : {})
+      ...(config.openclaw?.gatewayUrl ? { gatewayUrl: config.openclaw.gatewayUrl } : {}),
+      ...(config.openclaw?.expectedVersion ? { expectedVersion: config.openclaw.expectedVersion } : {})
     }
   };
 }

--- a/packages/local-runtime/test/config.test.ts
+++ b/packages/local-runtime/test/config.test.ts
@@ -60,7 +60,8 @@ describe("parseDaemonConfig ACP agents", () => {
       openclaw: {
         command: "/opt/openclaw/bin/openclaw",
         profile: "opentag",
-        gatewayUrl: "ws://127.0.0.1:19093"
+        gatewayUrl: "ws://127.0.0.1:19093",
+        expectedVersion: "2026.7.2"
       }
     });
 
@@ -68,7 +69,8 @@ describe("parseDaemonConfig ACP agents", () => {
       openclaw: {
         command: "/opt/openclaw/bin/openclaw",
         profile: "opentag",
-        gatewayUrl: "ws://127.0.0.1:19093"
+        gatewayUrl: "ws://127.0.0.1:19093",
+        expectedVersion: "2026.7.2"
       }
     });
     expect(executorsFromConfig(config).openclaw).toMatchObject({
@@ -469,6 +471,28 @@ describe("parseDaemonConfig secret refs", () => {
         } else {
           process.env[key] = value;
         }
+      }
+    }
+  });
+
+  it("loads the OpenClaw version authority from env without changing the selected profile", () => {
+    const previous = {
+      OPENTAG_CONFIG_PATH: process.env.OPENTAG_CONFIG_PATH,
+      OPENTAG_OPENCLAW_PROFILE: process.env.OPENTAG_OPENCLAW_PROFILE,
+      OPENTAG_OPENCLAW_EXPECTED_VERSION: process.env.OPENTAG_OPENCLAW_EXPECTED_VERSION
+    };
+    delete process.env.OPENTAG_CONFIG_PATH;
+    process.env.OPENTAG_OPENCLAW_PROFILE = "opentag";
+    process.env.OPENTAG_OPENCLAW_EXPECTED_VERSION = "2026.7.2";
+    try {
+      expect(loadConfigFromEnv().openclaw).toEqual({
+        profile: "opentag",
+        expectedVersion: "2026.7.2"
+      });
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
       }
     }
   });

--- a/packages/runner/src/acp-agent.ts
+++ b/packages/runner/src/acp-agent.ts
@@ -16,6 +16,7 @@ export type AcpAgentCandidate = {
     version: string;
   };
   launch: AcpAgentLaunchSpec;
+  preflight?: () => Promise<{ ready: boolean; reason?: string }>;
   sessionModeId?: string;
   capabilities?: {
     supportsProfile?: boolean;
@@ -31,7 +32,7 @@ export type AcpAgentDefinition = AcpAgentCandidate & {
 
 export type AcpAgentExecutorOptions = Omit<
   AcpExecutorOptions,
-  "manifest" | "sessionModeId" | "capabilityOverrides" | "launchEnvironment"
+  "manifest" | "sessionModeId" | "capabilityOverrides" | "launchEnvironment" | "preflight"
 >;
 
 export function createAcpAgentManifest(definition: AcpAgentDefinition): OpenTagIntegrationManifest {
@@ -70,6 +71,7 @@ export function createAcpAgentExecutor(
       ? { readinessTimeoutMs: definition.readinessTimeoutMs }
       : {}),
     ...(definition.launchEnvironment ? { launchEnvironment: definition.launchEnvironment } : {}),
+    ...(definition.preflight ? { preflight: definition.preflight } : {}),
     ...(definition.sessionModeId ? { sessionModeId: definition.sessionModeId } : {}),
     ...(definition.capabilities ? { capabilityOverrides: definition.capabilities } : {})
   });

--- a/packages/runner/src/acp-executor.ts
+++ b/packages/runner/src/acp-executor.ts
@@ -274,6 +274,7 @@ export type AcpPermissionResolver = (request: AcpPermissionRequest) => Promise<A
 export type AcpExecutorOptions = {
   manifest: OpenTagIntegrationManifestInput;
   launchEnvironment?: Readonly<Record<string, string>>;
+  preflight?: () => Promise<{ ready: boolean; reason?: string }>;
   permissionResolver?: AcpPermissionResolver;
   runner?: CommandRunner;
   cancelGraceMs?: number;
@@ -724,6 +725,17 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
   const cancelGraceMs = options.cancelGraceMs ?? DEFAULT_CANCEL_GRACE_MS;
   const readinessTimeoutMs = options.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS;
   const supportsCancel = options.capabilityOverrides?.supportsCancel ?? false;
+  const runPreflight = async (): Promise<{ ready: boolean; reason?: string }> => {
+    if (!options.preflight) return { ready: true };
+    try {
+      return await options.preflight();
+    } catch {
+      return {
+        ready: false,
+        reason: `ACP provider compatibility preflight failed for ${manifest.id}.`
+      };
+    }
+  };
   const terminateActiveChild = (active: ActiveRun, child: ChildProcessWithoutNullStreams): Promise<boolean> => {
     if (!active.terminationPromise) {
       active.terminationPromise = terminateChild(child, cancelGraceMs, runner).then((confirmed) => {
@@ -781,6 +793,8 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
       } catch (error) {
         return { ready: false, reason: error instanceof Error ? error.message : String(error) };
       }
+      const preflight = await runPreflight();
+      if (!preflight.ready) return preflight;
       return probeAcpInitialization({
         manifest,
         cwd: childCwd,
@@ -803,6 +817,12 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
       let worktreeCreated = false;
       let changedFileCount: number | undefined;
       try {
+        const preflight = await runPreflight();
+        if (!preflight.ready) {
+          const reason = preflight.reason ?? `ACP provider compatibility preflight failed for ${manifest.id}.`;
+          await sink.emit({ type: "executor.failed", message: reason, at: new Date().toISOString() });
+          throw new AcpPublicFailure(reason);
+        }
         if (workspace.kind === "repository") {
           executionPath = executionPathForAttempt({
             workspace,

--- a/packages/runner/src/builtin-acp.ts
+++ b/packages/runner/src/builtin-acp.ts
@@ -6,6 +6,7 @@ import {
 } from "./acp-agent.js";
 import type { ExecutorAdapter } from "./executor.js";
 import { DEFAULT_HERMES_PROFILE } from "./hermes-profile.js";
+import { createOpenClawPreflight } from "./openclaw-preflight.js";
 import type { RunnerSecurityPolicy } from "./security.js";
 
 export type BuiltInAcpAgentId = "codex" | "claude-code" | "cursor" | "opencode" | "hermes" | "openclaw";
@@ -20,6 +21,7 @@ export type BuiltInAcpAgentOptions = {
     command?: string;
     profile?: string;
     gatewayUrl?: string;
+    expectedVersion?: string;
   };
 };
 
@@ -35,6 +37,7 @@ export function builtInAcpAgentDefinitions(
     "acp",
     ...(options.openclaw?.gatewayUrl ? ["--url", options.openclaw.gatewayUrl] : [])
   ];
+  const openclawCommand = options.openclaw?.command ?? "openclaw";
 
   return {
     codex: {
@@ -105,8 +108,14 @@ export function builtInAcpAgentDefinitions(
       label: "OpenClaw ACP",
       workspaceCwd: "required",
       readinessTimeoutMs: 30_000,
+      preflight: createOpenClawPreflight({
+        command: openclawCommand,
+        ...(options.openclaw?.profile ? { profile: options.openclaw.profile } : {}),
+        ...(options.openclaw?.gatewayUrl ? { gatewayUrl: options.openclaw.gatewayUrl } : {}),
+        ...(options.openclaw?.expectedVersion ? { expectedVersion: options.openclaw.expectedVersion } : {})
+      }),
       launch: {
-        command: options.openclaw?.command ?? "openclaw",
+        command: openclawCommand,
         args: openclawArgs
       },
       capabilities: { supportsProfile: true, supportsCancel: false }

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -6,6 +6,7 @@ export * from "./echo.js";
 export * from "./executor.js";
 export * from "./git.js";
 export * from "./hermes-profile.js";
+export * from "./openclaw-preflight.js";
 export * from "./result.js";
 export * from "./security.js";
 export * from "./session-profile.js";

--- a/packages/runner/src/openclaw-preflight.ts
+++ b/packages/runner/src/openclaw-preflight.ts
@@ -1,0 +1,113 @@
+import { execFile } from "node:child_process";
+
+const OPENCLAW_PREFLIGHT_TIMEOUT_MS = 15_000;
+
+export type OpenClawCommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+type OpenClawCommandRunner = (
+  command: string,
+  args: string[],
+  timeoutMs: number
+) => Promise<OpenClawCommandResult>;
+
+export type OpenClawCompatibilityOptions = {
+  command: string;
+  profile?: string;
+  gatewayUrl?: string;
+  expectedVersion?: string;
+  run?: OpenClawCommandRunner;
+};
+
+function runBoundedCommand(command: string, args: string[], timeoutMs: number): Promise<OpenClawCommandResult> {
+  return new Promise((resolve) => {
+    execFile(
+      command,
+      args,
+      { encoding: "utf8", timeout: timeoutMs, killSignal: "SIGKILL" },
+      (error, stdout, stderr) => {
+        resolve({
+          exitCode: error ? (typeof error.code === "number" ? error.code : 1) : 0,
+          stdout: String(stdout),
+          stderr: String(stderr)
+        });
+      }
+    );
+  });
+}
+
+export function parseOpenClawCliVersion(output: string): string | undefined {
+  return /^OpenClaw\s+([^\s]+)/mu.exec(output.trim())?.[1];
+}
+
+function gatewayVersion(output: string): { ready: boolean; version?: string } | undefined {
+  try {
+    const status = JSON.parse(output) as {
+      gateway?: { version?: unknown };
+      rpc?: { ok?: unknown; version?: unknown; server?: { version?: unknown } };
+    };
+    const version = status.rpc?.server?.version ?? status.rpc?.version ?? status.gateway?.version;
+    return {
+      ready: status.rpc?.ok === true,
+      ...(typeof version === "string" && version.trim() ? { version: version.trim() } : {})
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function profileLabel(profile: string | undefined): string {
+  return profile ? `profile '${profile}'` : "the ambient profile";
+}
+
+export async function checkOpenClawCompatibility(
+  options: OpenClawCompatibilityOptions
+): Promise<{ ready: boolean; reason?: string }> {
+  const run = options.run ?? runBoundedCommand;
+  const cli = await run(options.command, ["--version"], OPENCLAW_PREFLIGHT_TIMEOUT_MS);
+  const cliVersion = cli.exitCode === 0 ? parseOpenClawCliVersion(cli.stdout) : undefined;
+  if (!cliVersion) {
+    return {
+      ready: false,
+      reason: "OpenClaw CLI version could not be verified before ACP startup; install a compatible CLI and retry."
+    };
+  }
+  if (options.expectedVersion && cliVersion !== options.expectedVersion) {
+    return {
+      ready: false,
+      reason: `OpenClaw CLI ${cliVersion} does not match expected ${options.expectedVersion}; upgrade the CLI and Gateway or select a compatible profile.`
+    };
+  }
+
+  const gatewayArgs = [
+    ...(options.profile ? ["--profile", options.profile] : []),
+    "gateway",
+    "status",
+    "--json",
+    ...(options.gatewayUrl ? ["--url", options.gatewayUrl] : [])
+  ];
+  const gateway = await run(options.command, gatewayArgs, OPENCLAW_PREFLIGHT_TIMEOUT_MS);
+  const status = gateway.exitCode === 0 ? gatewayVersion(gateway.stdout) : undefined;
+  if (!status?.ready || !status.version) {
+    return {
+      ready: false,
+      reason: `OpenClaw CLI ${cliVersion} could not verify Gateway compatibility for ${profileLabel(options.profile)}; upgrade the CLI and Gateway or select a compatible profile. OpenTag did not rewrite or downgrade the profile.`
+    };
+  }
+  if (status.version !== cliVersion) {
+    return {
+      ready: false,
+      reason: `OpenClaw Gateway ${status.version} is incompatible with CLI ${cliVersion}; upgrade both to the same version or select a compatible profile.`
+    };
+  }
+  return { ready: true };
+}
+
+export function createOpenClawPreflight(
+  options: Omit<OpenClawCompatibilityOptions, "run">
+): () => Promise<{ ready: boolean; reason?: string }> {
+  return () => checkOpenClawCompatibility(options);
+}

--- a/packages/runner/test/acp-executor.test.ts
+++ b/packages/runner/test/acp-executor.test.ts
@@ -170,6 +170,25 @@ describe("ACP executor", () => {
     await expect(executor.canRun(input({ kind: "scratch", path: scratch }, "run_readiness"))).resolves.toEqual({ ready: true });
   });
 
+  it("fails closed before ACP startup when a provider compatibility preflight rejects the runtime", async () => {
+    const scratch = tempDir("preflight-rejected");
+    const preflight = vi.fn(async () => ({
+      ready: false as const,
+      reason: "OpenClaw CLI 2026.7.1 is incompatible with the selected 2026.7.2 profile."
+    }));
+    const executor = createAcpExecutor({ manifest: manifest(), preflight });
+
+    await expect(executor.canRun(input({ kind: "scratch", path: scratch }, "run_preflight_readiness"))).resolves.toEqual({
+      ready: false,
+      reason: "OpenClaw CLI 2026.7.1 is incompatible with the selected 2026.7.2 profile."
+    });
+    await expect(
+      executor.run(input({ kind: "scratch", path: scratch }, "run_preflight_rejected"), { emit: async () => undefined })
+    ).rejects.toThrow(/incompatible with the selected 2026\.7\.2 profile/u);
+    expect(existsSync(join(scratch, "acp-session.json"))).toBe(false);
+    expect(preflight).toHaveBeenCalledTimes(2);
+  });
+
   it("reports an unavailable ACP adapter as not ready", async () => {
     const scratch = tempDir("readiness-missing");
     const configured = manifest();

--- a/packages/runner/test/builtin-acp-conformance-script.test.ts
+++ b/packages/runner/test/builtin-acp-conformance-script.test.ts
@@ -1,8 +1,12 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   classifyAcpConformanceFailure,
   cancellationConformanceApplies,
   propagatedConformanceStatus,
+  providerRuntimeTimeoutAfterVerifiedTool,
   withDeadline
 } from "../../../scripts/test/builtin-acp-conformance.js";
 
@@ -13,6 +17,7 @@ describe("built-in ACP conformance failure classification", () => {
     "Error calling LLM API: insufficient quota",
     "Model configured-model not found",
     "Hermes profile 'opentag' is not ready: Profile 'opentag' does not exist",
+    "Hermes provider/runtime did not complete the ACP prompt after verified tool execution before the deadline.",
     "ACP bridge failed: connect ECONNREFUSED 127.0.0.1:18789"
   ])("records provider state without treating it as an implementation diagnosis: %s", (message) => {
     expect(classifyAcpConformanceFailure(new Error(message))).toBe("needs_setup");
@@ -20,6 +25,7 @@ describe("built-in ACP conformance failure classification", () => {
 
   it("classifies protocol and process-tree failures as conformance failures", () => {
     expect(classifyAcpConformanceFailure(new Error("Cancelled tool process 42 is still alive."))).toBe("failed_conformance");
+    expect(classifyAcpConformanceFailure(new Error("hermes run 'scratch' exceeded 15000ms."))).toBe("failed_conformance");
   });
 
   it("keeps best-effort cancellation providers in the batch without claiming process-tree conformance", () => {
@@ -49,5 +55,46 @@ describe("built-in ACP conformance failure classification", () => {
     await expect(withDeadline(new Promise<never>(() => undefined), 10, "test operation timed out")).rejects.toThrow(
       "test operation timed out"
     );
+  });
+
+  it("reclassifies only a deadline with a valid observed tool marker as external provider/runtime state", async () => {
+    const root = mkdtempSync(join(tmpdir(), "opentag-hermes-provider-timeout-"));
+    const markerPath = join(root, "marker.json");
+    const nonce = "verified-tool";
+    writeFileSync(markerPath, `${JSON.stringify({ nonce, pwd: root })}\n`);
+    try {
+      let deadline: unknown;
+      try {
+        await withDeadline(new Promise<never>(() => undefined), 5, "Hermes run exceeded its deadline.");
+      } catch (error) {
+        deadline = error;
+      }
+      const providerTimeout = providerRuntimeTimeoutAfterVerifiedTool({
+        agent: "hermes",
+        error: deadline,
+        markerPath,
+        nonce,
+        expectedCwd: root
+      });
+
+      expect(providerTimeout).toBeInstanceOf(Error);
+      expect(classifyAcpConformanceFailure(providerTimeout)).toBe("needs_setup");
+      expect(providerRuntimeTimeoutAfterVerifiedTool({
+        agent: "hermes",
+        error: new Error("transport failed"),
+        markerPath,
+        nonce,
+        expectedCwd: root
+      })).toBeUndefined();
+      expect(providerRuntimeTimeoutAfterVerifiedTool({
+        agent: "codex",
+        error: deadline,
+        markerPath,
+        nonce,
+        expectedCwd: root
+      })).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/runner/test/builtin-acp.test.ts
+++ b/packages/runner/test/builtin-acp.test.ts
@@ -8,7 +8,8 @@ describe("built-in ACP coding agents", () => {
       openclaw: {
         command: "/opt/openclaw/bin/openclaw",
         profile: "opentag-review",
-        gatewayUrl: "ws://127.0.0.1:19093"
+        gatewayUrl: "ws://127.0.0.1:19093",
+        expectedVersion: "2026.7.2"
       }
     });
 
@@ -90,6 +91,7 @@ describe("built-in ACP coding agents", () => {
     expect(definitions.openclaw).toMatchObject({
       id: "openclaw",
       launch: { command: "openclaw", args: ["acp"] },
+      preflight: expect.any(Function),
       capabilities: { supportsProfile: true, supportsCancel: false }
     });
   });

--- a/packages/runner/test/openclaw-preflight.test.ts
+++ b/packages/runner/test/openclaw-preflight.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  checkOpenClawCompatibility,
+  type OpenClawCommandResult
+} from "../src/openclaw-preflight.js";
+
+function result(stdout: string, exitCode = 0, stderr = ""): OpenClawCommandResult {
+  return { exitCode, stdout, stderr };
+}
+
+describe("OpenClaw compatibility preflight", () => {
+  it("rejects an installed CLI older than the configured profile authority before querying Gateway", async () => {
+    const run = vi.fn(async () => result("OpenClaw 2026.7.1 (2d2ddc4)\n"));
+
+    await expect(checkOpenClawCompatibility({
+      command: "openclaw",
+      profile: "opentag",
+      expectedVersion: "2026.7.2",
+      run
+    })).resolves.toEqual({
+      ready: false,
+      reason: expect.stringMatching(/CLI 2026\.7\.1.*expected 2026\.7\.2.*upgrade/iu)
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a profile or Gateway that the selected CLI cannot inspect without rewriting it", async () => {
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce(result("OpenClaw 2026.7.1 (2d2ddc4)\n"))
+      .mockResolvedValueOnce(result("", 1, "Profile was written by a newer OpenClaw"));
+
+    const compatibility = await checkOpenClawCompatibility({
+      command: "openclaw",
+      profile: "opentag",
+      gatewayUrl: "ws://127.0.0.1:19093",
+      run
+    });
+
+    expect(compatibility).toEqual({
+      ready: false,
+      reason: expect.stringMatching(/profile 'opentag'.*upgrade.*compatible profile/iu)
+    });
+    expect(compatibility.reason).not.toContain("Profile was written by a newer OpenClaw");
+    expect(run).toHaveBeenNthCalledWith(2, "openclaw", [
+      "--profile", "opentag", "gateway", "status", "--json", "--url", "ws://127.0.0.1:19093"
+    ], 15_000);
+  });
+
+  it("rejects CLI and Gateway version skew and accepts an exact compatible pair", async () => {
+    const mismatchRun = vi
+      .fn()
+      .mockResolvedValueOnce(result("OpenClaw 2026.7.2 (new)\n"))
+      .mockResolvedValueOnce(result(JSON.stringify({ rpc: { ok: true, version: "2026.7.1" } })));
+
+    await expect(checkOpenClawCompatibility({
+      command: "openclaw",
+      profile: "opentag",
+      expectedVersion: "2026.7.2",
+      run: mismatchRun
+    })).resolves.toEqual({
+      ready: false,
+      reason: expect.stringMatching(/Gateway 2026\.7\.1.*CLI 2026\.7\.2/iu)
+    });
+
+    const compatibleRun = vi
+      .fn()
+      .mockResolvedValueOnce(result("OpenClaw 2026.7.2 (new)\n"))
+      .mockResolvedValueOnce(result(JSON.stringify({ rpc: { ok: true, server: { version: "2026.7.2" } } })));
+    await expect(checkOpenClawCompatibility({
+      command: "openclaw",
+      profile: "opentag",
+      expectedVersion: "2026.7.2",
+      run: compatibleRun
+    })).resolves.toEqual({ ready: true });
+  });
+});

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -35,7 +35,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^2.0.11",
     "@opentag/client": "workspace:*",
     "@opentag/core": "workspace:*",
     "hono": "^4.6.15",

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -23,11 +23,10 @@
   },
   "dependencies": {
     "@opentag/core": "workspace:*",
-    "botframework-connector": "^4.23.3",
-    "hono": "^4.12.27"
+    "hono": "^4.12.27",
+    "jose": "^5.9.6"
   },
   "devDependencies": {
-    "jose": "^5.9.6",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   }

--- a/packages/teams/src/auth.ts
+++ b/packages/teams/src/auth.ts
@@ -1,16 +1,12 @@
-import {
-  AuthenticationConfiguration,
-  AuthenticationConstants,
-  BotFrameworkAuthenticationFactory,
-  PasswordServiceClientCredentialFactory,
-  type BotFrameworkAuthentication
-} from "botframework-connector";
+import { importJWK, jwtVerify, type JWK } from "jose";
 
 /** Bot Framework OpenID metadata document; it points at the signing JWKS. */
 const DEFAULT_OPENID_METADATA_URL = "https://login.botframework.com/v1/.well-known/openidconfiguration";
+const BOT_FRAMEWORK_TOKEN_ISSUER = "https://api.botframework.com";
 const TEAMS_CHANNEL_ID = "msteams";
 const JWKS_CACHE_MS = 5 * 60_000;
 const METADATA_REQUEST_TIMEOUT_MS = 15_000;
+const TOKEN_CLOCK_TOLERANCE_SECONDS = 5 * 60;
 
 export type TeamsAuthResult = { ok: true } | { ok: false; reason: string };
 
@@ -19,13 +15,15 @@ export type TeamsAuthConfig = {
   appId: string;
   /** Override the Bot Framework OpenID metadata document URL. */
   openIdMetadataUrl?: string;
-  /** Injectable official authenticator for focused tests. Production builds one from Bot Framework SDK. */
-  botFrameworkAuthentication?: Pick<BotFrameworkAuthentication, "authenticateRequest">;
-  /** Fetch implementation used by the Teams endorsement precheck. */
+  /** Optional additional authenticator; built-in JOSE validation always runs first. */
+  botFrameworkAuthentication?: {
+    authenticateRequest(activity: unknown, authorizationHeader: string): Promise<unknown>;
+  };
+  /** Fetch implementation used to load Bot Framework OpenID metadata and signing keys. */
   fetchImpl?: typeof fetch;
 };
 
-type JwkWithEndorsements = {
+type JwkWithEndorsements = JWK & {
   kid?: string;
   endorsements?: unknown;
 };
@@ -34,25 +32,6 @@ type CachedJwks = {
   expiresAt: number;
   keys: JwkWithEndorsements[];
 };
-
-function createOfficialBotFrameworkAuthentication(input: { appId: string; openIdMetadataUrl: string }): BotFrameworkAuthentication {
-  return BotFrameworkAuthenticationFactory.create(
-    "",
-    true,
-    AuthenticationConstants.ToChannelFromBotLoginUrl,
-    AuthenticationConstants.ToChannelFromBotOAuthScope,
-    AuthenticationConstants.ToBotFromChannelTokenIssuer,
-    AuthenticationConstants.OAuthUrl,
-    input.openIdMetadataUrl,
-    AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl,
-    "urn:botframework:azure",
-    // Inbound validation only needs appId matching; password is used when the
-    // official auth object later creates outbound credentials, which this
-    // OpenTag wrapper does not use.
-    new PasswordServiceClientCredentialFactory(input.appId, ""),
-    new AuthenticationConfiguration([TEAMS_CHANNEL_ID])
-  );
-}
 
 function bearerToken(authorizationHeader: string | undefined): string | null {
   const match = /^Bearer\s+(.+)$/i.exec((authorizationHeader ?? "").trim());
@@ -81,7 +60,7 @@ function tokenAlg(token: string): string | null {
   return typeof decoded?.alg === "string" && decoded.alg ? decoded.alg : null;
 }
 
-function createTeamsEndorsementValidator(input: { metadataUrl: string; fetchImpl: typeof fetch; now?: () => number }) {
+function createTeamsSigningKeyResolver(input: { metadataUrl: string; fetchImpl: typeof fetch; now?: () => number }) {
   const now = input.now ?? (() => Date.now());
   let cached: CachedJwks | null = null;
 
@@ -116,7 +95,9 @@ function createTeamsEndorsementValidator(input: { metadataUrl: string; fetchImpl
     return keys;
   }
 
-  return async (token: string): Promise<TeamsAuthResult> => {
+  return async (token: string): Promise<
+    { ok: true; key: JwkWithEndorsements } | { ok: false; reason: string }
+  > => {
     const kid = tokenKid(token);
     if (!kid) return { ok: false, reason: "invalid_token" };
     const keys = await loadKeys();
@@ -125,16 +106,15 @@ function createTeamsEndorsementValidator(input: { metadataUrl: string; fetchImpl
     const endorsements = Array.isArray(key.endorsements)
       ? key.endorsements.filter((value): value is string => typeof value === "string")
       : [];
-    return endorsements.includes(TEAMS_CHANNEL_ID) ? { ok: true } : { ok: false, reason: "endorsement_missing" };
+    return endorsements.includes(TEAMS_CHANNEL_ID)
+      ? { ok: true, key }
+      : { ok: false, reason: "endorsement_missing" };
   };
 }
 
 export function createTeamsAuthenticator(config: TeamsAuthConfig) {
   const openIdMetadataUrl = config.openIdMetadataUrl ?? DEFAULT_OPENID_METADATA_URL;
-  const officialAuth =
-    config.botFrameworkAuthentication ??
-    createOfficialBotFrameworkAuthentication({ appId: config.appId, openIdMetadataUrl });
-  const validateTeamsEndorsement = createTeamsEndorsementValidator({
+  const resolveTeamsSigningKey = createTeamsSigningKeyResolver({
     metadataUrl: openIdMetadataUrl,
     fetchImpl: config.fetchImpl ?? fetch
   });
@@ -160,10 +140,23 @@ export function createTeamsAuthenticator(config: TeamsAuthConfig) {
       }
 
       try {
-        const endorsement = await validateTeamsEndorsement(token);
-        if (!endorsement.ok) return endorsement;
+        const signingKey = await resolveTeamsSigningKey(token);
+        if (!signingKey.ok) return signingKey;
 
-        await officialAuth.authenticateRequest(input.activity as never, input.authorizationHeader ?? "");
+        const verificationKey = await importJWK(signingKey.key, "RS256");
+        const verified = await jwtVerify(token, verificationKey, {
+          algorithms: ["RS256"],
+          issuer: BOT_FRAMEWORK_TOKEN_ISSUER,
+          audience: config.appId,
+          requiredClaims: ["exp"],
+          clockTolerance: TOKEN_CLOCK_TOLERANCE_SECONDS
+        });
+        if (verified.payload.serviceurl !== input.activity.serviceUrl) {
+          return { ok: false, reason: "serviceUrl_mismatch" };
+        }
+        if (config.botFrameworkAuthentication) {
+          await config.botFrameworkAuthentication.authenticateRequest(input.activity, input.authorizationHeader ?? "");
+        }
         return { ok: true };
       } catch (error) {
         const message = error instanceof Error ? error.message : "";

--- a/packages/teams/test/auth.test.ts
+++ b/packages/teams/test/auth.test.ts
@@ -62,11 +62,15 @@ async function setup(endorsements: string[] | null = ["msteams"]) {
     (jwk as JWK & { endorsements?: string[] }).endorsements = endorsements;
   }
   const openIdMetadataUrl = await startOpenIdServer(jwk);
-  async function mint(claims: Record<string, unknown>, issuer: string = ISSUER) {
+  async function mint(
+    claims: Record<string, unknown>,
+    issuer: string = ISSUER,
+    expirationTime: string | number = "5m"
+  ) {
     return new SignJWT(claims)
       .setProtectedHeader({ alg: "RS256", kid: "test-key" })
       .setIssuer(issuer)
-      .setExpirationTime("5m")
+      .setExpirationTime(expirationTime)
       .sign(privateKey);
   }
   return { openIdMetadataUrl, mint };
@@ -158,6 +162,69 @@ describe("teams inbound JWT authentication", () => {
     const token = await mint({ aud: "app-123", serviceurl: SERVICE_URL }, "https://evil.example");
     const result = await auth.verify(verifyInput(token));
     expect(result).toEqual({ ok: false, reason: expect.stringMatching(/issuer|invalid_token/i) });
+  });
+
+  it("rejects a token whose signature does not match the advertised key", async () => {
+    const { openIdMetadataUrl } = await setup();
+    const { privateKey } = await generateKeyPair("RS256");
+    const token = await new SignJWT({ aud: "app-123", serviceurl: SERVICE_URL })
+      .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+      .setIssuer(ISSUER)
+      .setExpirationTime("5m")
+      .sign(privateKey);
+    const result = await createTeamsAuthenticator({ appId: "app-123", openIdMetadataUrl }).verify(verifyInput(token));
+    expect(result).toEqual({ ok: false, reason: "invalid_token" });
+  });
+
+  it("does not let an injected authenticator bypass the built-in signature verification", async () => {
+    const { openIdMetadataUrl } = await setup();
+    const { privateKey } = await generateKeyPair("RS256");
+    const token = await new SignJWT({ aud: "app-123", serviceurl: SERVICE_URL })
+      .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+      .setIssuer(ISSUER)
+      .setExpirationTime("5m")
+      .sign(privateKey);
+    const result = await createTeamsAuthenticator({
+      appId: "app-123",
+      openIdMetadataUrl,
+      botFrameworkAuthentication: { authenticateRequest: async () => ({}) }
+    }).verify(verifyInput(token));
+    expect(result).toEqual({ ok: false, reason: "invalid_token" });
+  });
+
+  it("rejects expired tokens beyond the five-minute clock tolerance", async () => {
+    const { openIdMetadataUrl, mint } = await setup();
+    const token = await mint({ aud: "app-123", serviceurl: SERVICE_URL }, ISSUER, "-10m");
+    const result = await createTeamsAuthenticator({ appId: "app-123", openIdMetadataUrl }).verify(verifyInput(token));
+    expect(result).toEqual({ ok: false, reason: "invalid_token" });
+  });
+
+  it("rejects tokens without an expiration claim", async () => {
+    const { publicKey, privateKey } = await generateKeyPair("RS256");
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = "missing-exp-key";
+    jwk.alg = "RS256";
+    (jwk as JWK & { endorsements?: string[] }).endorsements = ["msteams"];
+    const metadataUrl = await startOpenIdServer(jwk);
+    const token = await new SignJWT({ aud: "app-123", serviceurl: SERVICE_URL })
+      .setProtectedHeader({ alg: "RS256", kid: "missing-exp-key" })
+      .setIssuer(ISSUER)
+      .sign(privateKey);
+    const result = await createTeamsAuthenticator({ appId: "app-123", openIdMetadataUrl: metadataUrl }).verify(
+      verifyInput(token)
+    );
+    expect(result).toEqual({ ok: false, reason: "invalid_token" });
+  });
+
+  it("rejects tokens that are not valid for more than the five-minute clock tolerance", async () => {
+    const { openIdMetadataUrl, mint } = await setup();
+    const token = await mint({
+      aud: "app-123",
+      serviceurl: SERVICE_URL,
+      nbf: Math.floor(Date.now() / 1000) + 10 * 60
+    });
+    const result = await createTeamsAuthenticator({ appId: "app-123", openIdMetadataUrl }).verify(verifyInput(token));
+    expect(result).toEqual({ ok: false, reason: "invalid_token" });
   });
 
   it("rejects a missing Authorization header", async () => {

--- a/packages/teams/test/dependency-compatibility.test.ts
+++ b/packages/teams/test/dependency-compatibility.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("Teams transitive dependency compatibility", () => {
+  it("publishes the maintained JWT verifier without the vulnerable Bot Framework UUID graph", () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8")
+    ) as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+
+    expect(packageJson.dependencies?.["botframework-connector"]).toBeUndefined();
+    expect(packageJson.dependencies?.jose).toBe("^5.9.6");
+    expect(packageJson.devDependencies?.jose).toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
   apps/dispatcher:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/dispatcher':
         specifier: workspace:*
         version: link:../../packages/dispatcher
@@ -141,8 +141,8 @@ importers:
   apps/slack-events:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/client':
         specifier: workspace:*
         version: link:../../packages/client
@@ -169,8 +169,8 @@ importers:
   apps/telegram-events:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/client':
         specifier: workspace:*
         version: link:../../packages/client
@@ -213,8 +213,8 @@ importers:
   examples/embedded-dispatcher:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/client':
         specifier: workspace:*
         version: link:../../packages/client
@@ -390,8 +390,8 @@ importers:
   packages/github:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/client':
         specifier: workspace:*
         version: link:../client
@@ -412,8 +412,8 @@ importers:
   packages/gitlab:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/client':
         specifier: workspace:*
         version: link:../client
@@ -466,8 +466,8 @@ importers:
   packages/linear:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/client':
         specifier: workspace:*
         version: link:../client
@@ -488,8 +488,8 @@ importers:
   packages/local-runtime:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/client':
         specifier: workspace:*
         version: link:../client
@@ -553,8 +553,8 @@ importers:
   packages/slack:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^2.0.11
+        version: 2.0.11(hono@4.12.27)
       '@opentag/client':
         specifier: workspace:*
         version: link:../client
@@ -804,9 +804,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -1710,8 +1710,8 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
-  protobufjs@7.6.4:
-    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -2145,7 +2145,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
+  '@hono/node-server@2.0.11(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -2169,7 +2169,7 @@ snapshots:
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       qs: 6.15.3
       ws: 8.21.0
     transitivePeerDependencies:
@@ -2965,7 +2965,7 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  protobufjs@7.6.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,16 +605,13 @@ importers:
       '@opentag/core':
         specifier: workspace:*
         version: link:../core
-      botframework-connector:
-        specifier: ^4.23.3
-        version: 4.23.3
       hono:
         specifier: ^4.12.27
         version: 4.12.27
-    devDependencies:
       jose:
         specifier: ^5.9.6
         version: 5.10.0
+    devDependencies:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -644,65 +641,6 @@ packages:
     resolution: {integrity: sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
-
-  '@azure/abort-controller@2.1.2':
-    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
-    engines: {node: '>=18.0.0'}
-
-  '@azure/core-auth@1.10.1':
-    resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/core-client@1.10.2':
-    resolution: {integrity: sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/core-http-compat@2.4.0':
-    resolution: {integrity: sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@azure/core-client': ^1.10.0
-      '@azure/core-rest-pipeline': ^1.22.0
-
-  '@azure/core-rest-pipeline@1.24.0':
-    resolution: {integrity: sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/core-tracing@1.3.1':
-    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/core-util@1.13.1':
-    resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/identity@4.13.1':
-    resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/logger@1.3.0':
-    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/msal-browser@5.17.0':
-    resolution: {integrity: sha512-/yTnW2TCk9Mh+2b/NOaHAN+MryUNxzRTaJD/YtrqOA9bpBWfTXn/iyReRbaLrK/btBo3stEzLyEvuWp2NZ5DuA==}
-    engines: {node: '>=0.8.0'}
-
-  '@azure/msal-common@14.16.1':
-    resolution: {integrity: sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==}
-    engines: {node: '>=0.8.0'}
-
-  '@azure/msal-common@16.11.1':
-    resolution: {integrity: sha512-yPohvMwWLv1XnaWnIUyKUh8CvcVChCGqG/VluGwfGmaAfrZTNt5yQ+sIs462Sgw6+e2K83KGmMJ860p73ZSCrw==}
-    engines: {node: '>=0.8.0'}
-
-  '@azure/msal-node@2.16.3':
-    resolution: {integrity: sha512-CO+SE4weOsfJf+C5LM8argzvotrXw252/ZU6SM2Tz63fEblhH1uuVaaO4ISYFuN4Q6BhTo7I3qIdi8ydUQCqhw==}
-    engines: {node: '>=16'}
-
-  '@azure/msal-node@5.4.0':
-    resolution: {integrity: sha512-6EZEParwHRlnSSIikw8FNAnAzwmh71uhveUXdPNFeZFviJ9SH+rwFiurhjzXqICYTrpm3E+dj693QOwfPbJXAQ==}
-    engines: {node: '>=20'}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -1167,18 +1105,11 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/jsonwebtoken@9.0.6':
-    resolution: {integrity: sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==}
-
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@typespec/ts-http-runtime@0.3.6':
-    resolution: {integrity: sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==}
-    engines: {node: '>=20.0.0'}
 
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
@@ -1214,16 +1145,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adaptivecards@1.2.3:
-    resolution: {integrity: sha512-amQ5OSW3OpIkrxVKLjxVBPk/T49yuOtnqs1z5ZPfZr0+OpTovzmiHbyoAGDIsu5SNYHwOZFp/3LGOnRaALFa/g==}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
-
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1245,10 +1169,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  base64url@3.0.1:
-    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
-    engines: {node: '>=6.0.0'}
-
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
@@ -1261,30 +1181,11 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  botbuilder-stdlib@4.23.3-internal:
-    resolution: {integrity: sha512-fwvIHnKU8sXo1gTww+m/k8wnuM5ktVBAV/3vWJ+ou40zapy1HYjWQuu6sVCRFgMUngpKwhdmoOQsTXsp58SNtA==}
-
-  botframework-connector@4.23.3:
-    resolution: {integrity: sha512-sChwCFJr3xhcMCYChaOxJoE8/YgdjOPWzGwz5JAxZDwhbQonwYX5O/6Z9EA+wB3TCFNEh642SGeC/rOitaTnGQ==}
-
-  botframework-schema@4.23.3:
-    resolution: {integrity: sha512-/W0uWxZ3fuPLAImZRLnPTbs49Z2xMpJSIzIBxSfvwO0aqv9GsM3bTk3zlNdJ1xr40SshQ7WiH2H1hgjBALwYJw==}
-
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-
-  bundle-name@4.1.0:
-    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
-    engines: {node: '>=18'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1345,9 +1246,6 @@ packages:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
 
-  cross-fetch@4.1.0:
-    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
-
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -1375,18 +1273,6 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-
-  default-browser-id@5.0.1:
-    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
-    engines: {node: '>=18'}
-
-  default-browser@5.5.0:
-    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
-    engines: {node: '>=18'}
-
-  define-lazy-prop@3.0.0:
-    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
-    engines: {node: '>=12'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1491,9 +1377,6 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1620,17 +1503,9 @@ packages:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
-
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1644,20 +1519,6 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  is-docker@3.0.0:
-    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
-
-  is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
-    engines: {node: '>=14.16'}
-    hasBin: true
-
-  is-wsl@3.1.1:
-    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
-    engines: {node: '>=16'}
-
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
@@ -1670,16 +1531,6 @@ packages:
 
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
-
-  jsonwebtoken@9.0.3:
-    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
-    engines: {node: '>=12', npm: '>=6'}
-
-  jwa@2.0.1:
-    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
-
-  jws@4.0.1:
-    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1699,29 +1550,8 @@ packages:
   lodash.identity@3.0.0:
     resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
 
-  lodash.includes@4.3.0:
-    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-
-  lodash.isboolean@3.0.3:
-    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
-
-  lodash.isinteger@4.0.4:
-    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
-
-  lodash.isnumber@3.0.3:
-    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
-
-  lodash.isplainobject@4.0.6:
-    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
-
-  lodash.isstring@4.0.1:
-    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
-
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
-  lodash.once@4.1.1:
-    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.pickby@4.6.0:
     resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
@@ -1778,15 +1608,6 @@ packages:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   npx-import-light@1.0.0:
     resolution: {integrity: sha512-OgOY4wh4tfj6G7nKYobbpYg2yhYH/19dz/ZRzcOGN+rP3wjLHTRb6ZMM5UshLu4gbDdwwZ8VX2fXBr4krsYHzQ==}
 
@@ -1810,13 +1631,6 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  open@10.2.0:
-    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
-    engines: {node: '>=18'}
-
-  openssl-wrapper@0.3.4:
-    resolution: {integrity: sha512-iITsrx6Ho8V3/2OVtmZzzX8wQaKAaFXEJQdzoPUZDtyf5jWFlqo+h+OhGT4TATQ47f9ACKHua8nw7Qoy85aeKQ==}
 
   package-config@5.0.0:
     resolution: {integrity: sha512-GYTTew2slBcYdvRHqjhwaaydVMvn/qrGC323+nKclYioNSLTDUM/lGgtGTgyHVtYcozb+XkE8CNhwcraOmZ9Mg==}
@@ -1946,13 +1760,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rsa-pem-from-mod-exp@0.8.6:
-    resolution: {integrity: sha512-c5ouQkOvGHF1qomUUDJGFcXsomeSO2gbEs6hVhMAtlkE1CuaZase/WzoaKFG/EZQuNmq6pw/EMCeEnDvOgCJYQ==}
-
-  run-applescript@7.1.0:
-    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
-    engines: {node: '>=18'}
-
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -2080,18 +1887,12 @@ packages:
     resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
     engines: {node: '>=20'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -2139,16 +1940,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2223,12 +2014,6 @@ packages:
       jsdom:
         optional: true
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2248,10 +2033,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  wsl-utils@0.1.0:
-    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
-    engines: {node: '>=18'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -2274,102 +2055,6 @@ snapshots:
   '@agentclientprotocol/sdk@1.2.1(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
-
-  '@azure/abort-controller@2.1.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@azure/core-auth@1.10.1':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/core-client@1.10.2':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-rest-pipeline': 1.24.0
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.2)(@azure/core-rest-pipeline@1.24.0)':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-client': 1.10.2
-      '@azure/core-rest-pipeline': 1.24.0
-
-  '@azure/core-rest-pipeline@1.24.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
-      '@typespec/ts-http-runtime': 0.3.6
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/core-tracing@1.3.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@azure/core-util@1.13.1':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.3.6
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/identity@4.13.1':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.2
-      '@azure/core-rest-pipeline': 1.24.0
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
-      '@azure/msal-browser': 5.17.0
-      '@azure/msal-node': 5.4.0
-      open: 10.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/logger@1.3.0':
-    dependencies:
-      '@typespec/ts-http-runtime': 0.3.6
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/msal-browser@5.17.0':
-    dependencies:
-      '@azure/msal-common': 16.11.1
-
-  '@azure/msal-common@14.16.1': {}
-
-  '@azure/msal-common@16.11.1': {}
-
-  '@azure/msal-node@2.16.3':
-    dependencies:
-      '@azure/msal-common': 14.16.1
-      jsonwebtoken: 9.0.3
-      uuid: 8.3.2
-
-  '@azure/msal-node@5.4.0':
-    dependencies:
-      '@azure/msal-common': 16.11.1
-      jsonwebtoken: 9.0.3
 
   '@clack/core@0.5.0':
     dependencies:
@@ -2745,10 +2430,6 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/jsonwebtoken@9.0.6':
-    dependencies:
-      '@types/node': 22.20.0
-
   '@types/node@22.20.0':
     dependencies:
       undici-types: 6.21.0
@@ -2756,14 +2437,6 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.20.0
-
-  '@typespec/ts-http-runtime@0.3.6':
-    dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitest/expect@3.2.6':
     dependencies:
@@ -2809,15 +2482,11 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  adaptivecards@1.2.3: {}
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  agent-base@7.1.4: {}
 
   any-promise@1.3.0: {}
 
@@ -2839,8 +2508,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  base64url@3.0.1: {}
-
   before-after-hook@4.0.0: {}
 
   better-sqlite3@11.10.0:
@@ -2858,63 +2525,12 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  botbuilder-stdlib@4.23.3-internal:
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.2
-      '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.2)(@azure/core-rest-pipeline@1.24.0)
-      '@azure/core-rest-pipeline': 1.24.0
-      '@azure/core-tracing': 1.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  botframework-connector@4.23.3:
-    dependencies:
-      '@azure/core-rest-pipeline': 1.24.0
-      '@azure/identity': 4.13.1
-      '@azure/msal-node': 2.16.3
-      '@types/jsonwebtoken': 9.0.6
-      axios: 1.18.1
-      base64url: 3.0.1
-      botbuilder-stdlib: 4.23.3-internal
-      botframework-schema: 4.23.3
-      buffer: 6.0.3
-      cross-fetch: 4.1.0
-      https-proxy-agent: 7.0.6
-      jsonwebtoken: 9.0.3
-      node-fetch: 2.7.0
-      openssl-wrapper: 0.3.4
-      rsa-pem-from-mod-exp: 0.8.6
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - debug
-      - encoding
-      - supports-color
-
-  botframework-schema@4.23.3:
-    dependencies:
-      adaptivecards: 1.2.3
-      uuid: 10.0.0
-      zod: 3.25.76
-
   bottleneck@2.19.5: {}
-
-  buffer-equal-constant-time@1.0.1: {}
 
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  bundle-name@4.1.0:
-    dependencies:
-      run-applescript: 7.1.0
 
   bundle-require@5.1.0(esbuild@0.28.1):
     dependencies:
@@ -2965,12 +2581,6 @@ snapshots:
 
   content-type@2.0.0: {}
 
-  cross-fetch@4.1.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
   dateformat@4.6.3: {}
 
   debug@4.4.3:
@@ -2987,15 +2597,6 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
-  default-browser-id@5.0.1: {}
-
-  default-browser@5.5.0:
-    dependencies:
-      bundle-name: 4.1.0
-      default-browser-id: 5.0.1
-
-  define-lazy-prop@3.0.0: {}
-
   delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
@@ -3010,10 +2611,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  ecdsa-sig-formatter@1.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
 
   end-of-stream@1.4.5:
     dependencies:
@@ -3146,23 +2743,9 @@ snapshots:
 
   hono@4.12.27: {}
 
-  http-proxy-agent@7.0.2:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -3175,16 +2758,6 @@ snapshots:
 
   ini@1.3.8: {}
 
-  is-docker@3.0.0: {}
-
-  is-inside-container@1.0.0:
-    dependencies:
-      is-docker: 3.0.0
-
-  is-wsl@3.1.1:
-    dependencies:
-      is-inside-container: 1.0.0
-
   jose@5.10.0: {}
 
   joycon@3.1.1: {}
@@ -3192,30 +2765,6 @@ snapshots:
   js-tokens@9.0.1: {}
 
   json-with-bigint@3.5.8: {}
-
-  jsonwebtoken@9.0.3:
-    dependencies:
-      jws: 4.0.1
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
-      ms: 2.1.3
-      semver: 7.8.5
-
-  jwa@2.0.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jws@4.0.1:
-    dependencies:
-      jwa: 2.0.1
-      safe-buffer: 5.2.1
 
   lilconfig@3.1.3: {}
 
@@ -3227,21 +2776,7 @@ snapshots:
 
   lodash.identity@3.0.0: {}
 
-  lodash.includes@4.3.0: {}
-
-  lodash.isboolean@3.0.3: {}
-
-  lodash.isinteger@4.0.4: {}
-
-  lodash.isnumber@3.0.3: {}
-
-  lodash.isplainobject@4.0.6: {}
-
-  lodash.isstring@4.0.1: {}
-
   lodash.merge@4.6.2: {}
-
-  lodash.once@4.1.1: {}
 
   lodash.pickby@4.6.0: {}
 
@@ -3290,10 +2825,6 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   npx-import-light@1.0.0: {}
 
   object-assign@4.1.1: {}
@@ -3313,15 +2844,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  open@10.2.0:
-    dependencies:
-      default-browser: 5.5.0
-      define-lazy-prop: 3.0.0
-      is-inside-container: 1.0.0
-      wsl-utils: 0.1.0
-
-  openssl-wrapper@0.3.4: {}
 
   package-config@5.0.0:
     dependencies:
@@ -3525,10 +3047,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
-  rsa-pem-from-mod-exp@0.8.6: {}
-
-  run-applescript@7.1.0: {}
-
   safe-buffer@5.2.1: {}
 
   safe-stable-stringify@2.5.0: {}
@@ -3657,13 +3175,9 @@ snapshots:
 
   toad-cache@3.7.1: {}
 
-  tr46@0.0.3: {}
-
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
-
-  tslib@2.8.1: {}
 
   tsup@8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
@@ -3714,10 +3228,6 @@ snapshots:
   universal-user-agent@7.0.3: {}
 
   util-deprecate@1.0.2: {}
-
-  uuid@10.0.0: {}
-
-  uuid@8.3.2: {}
 
   vite-node@3.2.4(@types/node@22.20.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -3795,13 +3305,6 @@ snapshots:
       - tsx
       - yaml
 
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -3810,10 +3313,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
-
-  wsl-utils@0.1.0:
-    dependencies:
-      is-wsl: 3.1.1
 
   yaml@2.9.0: {}
 

--- a/scripts/release/check-cli-package.mjs
+++ b/scripts/release/check-cli-package.mjs
@@ -194,6 +194,27 @@ function checkInstalledCompletionGovernance(installDir) {
   run(commandPath(installDir, "opentag"), ["completion", "waive", "--help"], { cwd: installDir });
 }
 
+function checkInstalledTeamsAuthDependencies(installDir) {
+  const probe = `
+    import { readFileSync } from "node:fs";
+    import { createRequire } from "node:module";
+    import { dirname, resolve } from "node:path";
+
+    const require = createRequire(import.meta.url);
+    const teamsEntry = require.resolve("@opentag/teams");
+    const teamsPackage = JSON.parse(readFileSync(resolve(dirname(teamsEntry), "../package.json"), "utf8"));
+    if (teamsPackage.dependencies?.["botframework-connector"]) {
+      throw new Error("Packed @opentag/teams still publishes the vulnerable Bot Framework UUID dependency graph.");
+    }
+    if (!teamsPackage.dependencies?.jose) {
+      throw new Error("Packed @opentag/teams does not publish its JOSE runtime dependency.");
+    }
+    const requireFromTeams = createRequire(teamsEntry);
+    requireFromTeams.resolve("jose");
+  `;
+  run(process.execPath, ["--input-type=module", "--eval", probe], { cwd: installDir });
+}
+
 const tempRoot = mkdtempSync(path.join(tmpdir(), "opentag-release-check-"));
 const packDir = path.join(tempRoot, "packs");
 const installDir = path.join(tempRoot, "install");
@@ -227,6 +248,9 @@ try {
 
   console.log("Checking installed completion governance...");
   checkInstalledCompletionGovernance(installDir);
+
+  console.log("Checking installed Teams authentication dependencies...");
+  checkInstalledTeamsAuthDependencies(installDir);
 
   console.log("");
   console.log("OpenTag CLI package check passed.");

--- a/scripts/release/check-cli-package.mjs
+++ b/scripts/release/check-cli-package.mjs
@@ -198,18 +198,17 @@ function checkInstalledTeamsAuthDependencies(installDir) {
   const probe = `
     import { readFileSync } from "node:fs";
     import { createRequire } from "node:module";
-    import { dirname, resolve } from "node:path";
+    import { resolve } from "node:path";
 
-    const require = createRequire(import.meta.url);
-    const teamsEntry = require.resolve("@opentag/teams");
-    const teamsPackage = JSON.parse(readFileSync(resolve(dirname(teamsEntry), "../package.json"), "utf8"));
+    const teamsPackagePath = resolve("node_modules/@opentag/teams/package.json");
+    const teamsPackage = JSON.parse(readFileSync(teamsPackagePath, "utf8"));
     if (teamsPackage.dependencies?.["botframework-connector"]) {
       throw new Error("Packed @opentag/teams still publishes the vulnerable Bot Framework UUID dependency graph.");
     }
     if (!teamsPackage.dependencies?.jose) {
       throw new Error("Packed @opentag/teams does not publish its JOSE runtime dependency.");
     }
-    const requireFromTeams = createRequire(teamsEntry);
+    const requireFromTeams = createRequire(teamsPackagePath);
     requireFromTeams.resolve("jose");
   `;
   run(process.execPath, ["--input-type=module", "--eval", probe], { cwd: installDir });

--- a/scripts/test/builtin-acp-conformance.ts
+++ b/scripts/test/builtin-acp-conformance.ts
@@ -91,6 +91,7 @@ const providerStatusPatterns = [
   /\bECONNREFUSED\b/u,
   /gateway .*?(?:not ready|unavailable|connection failed)/iu,
   /inference provider/iu,
+  /provider\/runtime did not complete the ACP prompt after verified tool execution/iu,
   /error calling (?:the )?llm api/iu,
   /model .*?(?:not found|unavailable|unsupported)/iu,
   /profile .*?(?:does not exist|not found|not ready)/iu
@@ -263,6 +264,22 @@ function assertMarker(path: string, nonce: string, expectedCwd: string): void {
   assert(realpathSync(marker.pwd) === realpathSync(expectedCwd), `Tool ran in '${marker.pwd}', expected '${expectedCwd}'.`);
 }
 
+export function providerRuntimeTimeoutAfterVerifiedTool(input: {
+  agent: string;
+  error: unknown;
+  markerPath: string;
+  nonce: string;
+  expectedCwd: string;
+}): Error | undefined {
+  if (input.agent !== "hermes" || !(input.error instanceof ConformanceDeadlineError) || !existsSync(input.markerPath)) {
+    return undefined;
+  }
+  assertMarker(input.markerPath, input.nonce, input.expectedCwd);
+  return new Error(
+    `${input.agent} provider/runtime did not complete the ACP prompt after verified tool execution before the deadline.`
+  );
+}
+
 async function runCase(
   agent: string,
   caseId: CaseId,
@@ -371,15 +388,29 @@ async function testAgent(definition: AcpAgentDefinition, root: string): Promise<
       "Do not change directories and do not use an absolute destination path.",
       `Verify the file, then include exactly ${sentinel} in the final response.`
     ].join(" ");
-    const result = await boundedRun(
-      agent,
-      executor(),
-      runInput(`conformance-${agent}-scratch`, { kind: "scratch", path: scratch }, prompt),
-      failureDiagnostics
-    );
+    const markerPath = join(scratch, markerName);
+    let result: Awaited<ReturnType<ReturnType<typeof executor>["run"]>>;
+    try {
+      result = await boundedRun(
+        agent,
+        executor(),
+        runInput(`conformance-${agent}-scratch`, { kind: "scratch", path: scratch }, prompt),
+        failureDiagnostics
+      );
+    } catch (error) {
+      const providerTimeout = providerRuntimeTimeoutAfterVerifiedTool({
+        agent,
+        error,
+        markerPath,
+        nonce,
+        expectedCwd: scratch
+      });
+      if (providerTimeout) throw providerTimeout;
+      throw error;
+    }
     assert(result.conclusion === "success", `${agent} scratch run concluded '${result.conclusion}'.`);
     assert(result.summary.includes(sentinel), `${agent} scratch response omitted ${sentinel}.`);
-    assertMarker(join(scratch, markerName), nonce, scratch);
+    assertMarker(markerPath, nonce, scratch);
   });
   if (scratchStatus !== "passed") {
     for (const caseId of cases.filter((id) => id === "worktree-cwd" || id === "cancel-process-tree")) {


### PR DESCRIPTION
## Summary

- distinguish Hermes provider/runtime timeouts that happen after verified scratch tool execution from OpenTag host-conformance failures
- add a bounded, fail-closed OpenClaw CLI/Gateway compatibility preflight with optional expected-version configuration
- replace the archived Bot Framework authentication dependency with direct JOSE verification for Teams, removing the vulnerable transitive UUID graph
- upgrade `@hono/node-server` to `2.0.11` across all runtime consumers and refresh the Lark SDK's transitive `protobufjs` resolution to `7.6.5`
- make the packed-package release check compatible with ESM-only package exports

## Why

The live Phase 1 closeout exposed three provider/runtime compatibility gaps:

1. Hermes could complete the requested scratch tool action but fail to finish the external ACP prompt before the conformance deadline. The harness now preserves verified tool evidence while reporting the remaining timeout as external provider/runtime behavior.
2. OpenClaw profiles and Gateways can be newer than the locally available CLI. OpenTag now checks CLI and Gateway versions before ACP startup and fails with actionable remediation without rewriting or downgrading profiles.
3. The Teams package inherited vulnerable UUID versions through the archived Bot Framework SDK. Authentication now verifies the Bot Framework signing key, RS256 algorithm, issuer, audience, expiry, Teams endorsement, and activity service URL directly with `jose`.

The dependency refresh also clears the current moderate advisories for Hono's Node adapter and protobuf schema parsing.

## User and developer impact

- incompatible OpenClaw installations fail before starting an ACP run, with the selected profile/version mismatch explained
- Hermes scratch diagnostics separate verified side effects from external provider completion failures
- Teams inbound authentication remains fail-closed without the vulnerable Bot Framework dependency chain
- Hono ingress servers remain on the supported `serve({ fetch, port, hostname })` API and now require Node.js 20+, which matches the repository runtime and CI
- workspace and packed consumer installs audit clean

## Validation

- `corepack pnpm install --frozen-lockfile`
- focused Hono ingress and Lark regression suite: 14 files, 229 tests passed
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm test`: 128 files, 1664 tests passed
- `corepack pnpm audit --json`: 0 vulnerabilities
- `corepack pnpm release:check`: all public packages built and packed; clean npm install and consumer audit passed with 0 vulnerabilities
- `git diff --check`

## Notes

- no OpenClaw profile downgrade or rewrite is performed
- no new npm package has been published by this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw integrations now perform a read-only compatibility check before starting, including CLI/Gateway version validation.
  * Added optional `expectedVersion` configuration via settings or environment variables.
  * Teams authentication now validates tokens directly with stronger signature, issuer, audience, expiry, and service URL checks.

* **Bug Fixes**
  * Improved classification of provider timeouts and ACP conformance failures.

* **Documentation**
  * Clarified OpenClaw startup requirements, version checks, and failure behavior.

* **Chores**
  * Updated server packages and runtime dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->