### PR TITLE
Stabilize completion waiver clock test

### DIFF
--- a/packages/dispatcher/test/completion-governance.test.ts
+++ b/packages/dispatcher/test/completion-governance.test.ts
@@ -1040,7 +1040,11 @@ describe("dispatcher completion governance", () => {
   });
 
   it("applies and replays a bounded current-contract waiver with one semantic callback", async () => {
-    const setup = await startRun({ runId: "run_waived", completionPolicies: [strictPolicy] });
+    const setup = await startRun({
+      runId: "run_waived",
+      completionPolicies: [strictPolicy],
+      completionNow: () => "2026-07-21T10:11:00.000Z"
+    });
     await completeRun({ setup, runId: "run_waived", conclusion: "success" });
     const body = {
       actor: { provider: "github", providerUserId: "owner-1", handle: "repo-owner" },


### PR DESCRIPTION
## Summary

- inject the existing completion-governance test clock into the bounded active-waiver scenario
- keep the fixture inside its intended waiver window regardless of the wall-clock date
- leave production completion-governance behavior and the dedicated waiver-expiry test unchanged

## Root cause

The test used a fixed `expiresAt` value of `2026-07-22T10:10:00.000Z` while evaluating the waiver against the real system clock. It passed locally before that instant, then returned `404 completion_not_available` in GitHub Actions after the fixture expired. The test is intended to verify an active bounded waiver, not expiration behavior.

## Impact

This is a test-only determinism fix. It does not change runtime code, waiver semantics, or API behavior.

## Validation

- exact previously failing test: 1 passed
- `packages/dispatcher/test/completion-governance.test.ts`: 36 passed
- full test suite: 128 files, 1664 tests passed
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for completion waiver recording and replay scenarios.
  * Added deterministic time handling to ensure time-dependent validation behaves consistently across test runs.
  * No user-facing functionality or public API changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->