### PR TITLE
Keep OpenClaw preflight internal

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -6,7 +6,6 @@ export * from "./echo.js";
 export * from "./executor.js";
 export * from "./git.js";
 export * from "./hermes-profile.js";
-export * from "./openclaw-preflight.js";
 export * from "./result.js";
 export * from "./security.js";
 export * from "./session-profile.js";

--- a/packages/runner/test/openclaw-preflight.test.ts
+++ b/packages/runner/test/openclaw-preflight.test.ts
@@ -3,12 +3,19 @@ import {
   checkOpenClawCompatibility,
   type OpenClawCommandResult
 } from "../src/openclaw-preflight.js";
+import * as runnerPublicApi from "../src/index.js";
 
 function result(stdout: string, exitCode = 0, stderr = ""): OpenClawCommandResult {
   return { exitCode, stdout, stderr };
 }
 
 describe("OpenClaw compatibility preflight", () => {
+  it("keeps the OpenClaw compatibility helpers out of the public runner API", () => {
+    expect(runnerPublicApi).not.toHaveProperty("checkOpenClawCompatibility");
+    expect(runnerPublicApi).not.toHaveProperty("createOpenClawPreflight");
+    expect(runnerPublicApi).not.toHaveProperty("parseOpenClawCliVersion");
+  });
+
   it("rejects an installed CLI older than the configured profile authority before querying Gateway", async () => {
     const run = vi.fn(async () => result("OpenClaw 2026.7.1 (2d2ddc4)\n"));
 


### PR DESCRIPTION
## Summary

- remove the accidental `@opentag/runner` root export for OpenClaw compatibility helpers
- keep the helpers available to the built-in ACP runner through the existing internal import
- add a regression test that locks the public runner API boundary

## Why

These helpers support runner startup behavior but are not a supported consumer API. Keeping them out of the package root avoids committing to an unnecessary public surface.

## Impact

Runtime compatibility checks are unchanged. This PR does not change package versions and does not publish a release.

## Validation

- runner tests: 105 passed
- full test suite: 1,665 passed
- workspace build
- workspace typecheck
- workspace lint
- clean packed-package install and CLI smoke check (`release:check`), with 0 production dependency vulnerabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed OpenClaw preflight helpers from the runner package’s public API.
  * Existing runner functionality and other public exports remain unchanged.

* **Tests**
  * Added coverage to verify that preflight helpers are not publicly exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->