### PR TITLE
Phase 4: add governed factory workstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ OpenTag's CLI path is local-first.
 | `opentag service uninstall` | Uninstall the OpenTag background service |
 | `opentag service autostart enable` | Enable background service login autostart |
 | `opentag service autostart disable` | Disable background service login autostart |
-| `opentag status` | Show local config and runtime status; add `--run <run_id>` or `--channel provider:account/conversation` for scoped detail |
+| `opentag status` | Show local config and runtime status; add `--run <run_id>`, `--channel provider:account/conversation`, or `--workstream <id>` for scoped detail |
 | `opentag cancel` | Request cancellation for a run or the active run in a source container |
 | `opentag completion escalations --run <run_id>` | List structured human escalations, audiences, options, expiry, and attribution for a run |
 | `opentag completion acknowledge --escalation <id> ...` | Attribute acknowledgement without resolving the blocking escalation |
@@ -280,7 +280,7 @@ Current public release: `v0.7.0`. The coordinated npm package family contains 16
 | [`@opentag/cli`](https://www.npmjs.com/package/@opentag/cli) | Setup and local runtime command line interface |
 | [`@opentag/local-runtime`](https://www.npmjs.com/package/@opentag/local-runtime) | In-process local dispatcher, runner, and platform runtime |
 | [`@opentag/core`](https://www.npmjs.com/package/@opentag/core) | Protocol schemas, types, mention parsing, and JSON Schema exports |
-| [`@opentag/governance`](https://www.npmjs.com/package/@opentag/governance) | Deterministic completion evaluation and governance orchestration |
+| [`@opentag/governance`](https://www.npmjs.com/package/@opentag/governance) | Deterministic completion, routing, and workstream evaluation |
 | [`@opentag/client`](https://www.npmjs.com/package/@opentag/client) | Dispatcher HTTP client |
 | [`@opentag/slack`](https://www.npmjs.com/package/@opentag/slack) | Slack Socket Mode, Events API handling, and thread replies |
 | [`@opentag/github`](https://www.npmjs.com/package/@opentag/github) | GitHub webhook handling, comments, PR helpers, and action application |

--- a/docs/replay-harness.md
+++ b/docs/replay-harness.md
@@ -67,6 +67,27 @@ lineage, a single end-to-end completion metric, restart recovery, and concise
 CLI/source-thread explanations. A real provider proof remains a separate live
 gate with configured credentials, signed ingress, and API reconciliation.
 
+## Workstream Evaluation Replay
+
+A Phase 4A workstream replay adds recipe and batch facts without weakening the
+single-Run proof. The normalized input includes:
+
+- one immutable recipe snapshot and its budget digest;
+- a WorkThread-only workstream membership snapshot;
+- a batch id, normalized request digest, ordered stable item ids, and durable
+  per-item receipts;
+- the Run, routing, fenced Attempt, evidence, and CompletionAssessment facts
+  already exercised by the strict completion replay;
+- a fixed evaluation timestamp.
+
+Replay the same input once in a fresh database and once after reopening the
+database. The canonical workstream metrics and evaluation digest must match.
+The test must also prove that an exact batch replay does not repeat completed
+items or callbacks, a conflicting digest is rejected, stale Attempt fencing is
+preserved, and accepted outcomes come only from the authoritative current
+CompletionAssessment. No provider API is called and the evaluation cannot
+write a CompletionAssessment.
+
 ## Product Boundary
 
 Replay fixtures should reinforce OpenTag's boundary:

--- a/docs/software-factory-control-plane.md
+++ b/docs/software-factory-control-plane.md
@@ -913,10 +913,20 @@ A recipe must not:
 - bypass normal admission, permission, receipt, evidence, or completion rules;
 - create a general-purpose agent-chat topology in the human thread.
 
-The initial workstream representation should be a recipe-owned grouping of
-`WorkItemReference` or `WorkThread` keys. Dependencies remain in the external
-work system or a recipe adapter. OpenTag should not add a general DAG scheduler
-until at least two real factory recipes require the same dependency semantics.
+The initial workstream representation is a recipe-owned grouping of durable
+`WorkThread` keys. A `WorkItemReference` remains the external identity carried
+by its WorkThread; it is not a second, partially governed membership root.
+Dependencies remain in the external work system or a recipe adapter. OpenTag
+should not add a general DAG scheduler until at least two real factory recipes
+require the same dependency semantics.
+
+Recipe budgets are enforced where work becomes executable. Concurrency,
+per-Run attempt count, fixed abstract cost units per Attempt, and allowed runner
+locality are checked in the same store transaction that changes a Run from
+`queued` to `assigned` and creates its fenced Attempt. Cost units are a stable
+capacity-accounting abstraction, not currency or provider billing. Locality is
+always intersected with the Run's captured access constraints and therefore can
+only narrow placement.
 
 ## Trust, privacy, and data placement
 
@@ -1379,6 +1389,34 @@ Exit gate:
 > and measure accepted outcomes, while Linear/GitHub/Jira remains the planning
 > system of record.
 
+#### Phase 4A implementation boundary
+
+The first Phase 4 delivery is intentionally smaller than the complete phase:
+
+- immutable, versioned recipe snapshots;
+- WorkThread-only workstream membership;
+- durable batch headers and ordered item receipts, persisted before processing;
+- the existing managed-channel, admission, follow-up, permission, receipt,
+  evidence, and completion path for every admitted item;
+- attempt-claim enforcement for workstream concurrency, per-Run attempt count,
+  fixed attempt cost units, and locality;
+- workstream metrics derived from Runs, fenced Attempts, and authoritative
+  current CompletionAssessments;
+- deterministic, side-effect-free evaluation with a canonical input digest;
+- one bounded exception summary per batch instead of routine per-item source
+  thread acknowledgements.
+
+A repeated batch id with the same normalized request digest returns or resumes
+the same durable receipt. Reusing the id with different input is a conflict.
+An item is not reported as admitted until its Run or follow-up outcome has been
+durably recorded. Expired processing leases may be recovered without repeating
+completed items.
+
+Phase 4A does not add provider cost reconciliation, mutable workstream state,
+dependency scheduling, adaptive routing, a planning UI, or an operator console.
+Its evaluation output is an immutable observation; it cannot update a live
+CompletionAssessment.
+
 ## Compatibility and migration
 
 1. Add schemas and tables without changing existing required fields.
@@ -1415,6 +1453,15 @@ Exit gate:
 - No eligible runner results in queue or a decision, never unsafe fallback.
 - Revoked access blocks new attempts.
 - Retry budget is enforced under concurrent evidence and result events.
+- Workstream attempt budgets are checked atomically with Attempt creation, so
+  concurrent claims cannot oversubscribe the configured limit.
+- Recipe locality never widens the captured agent access profile.
+- Batch input and all item identities are durable before the first item is
+  admitted; exact replay resumes, while a conflicting replay is rejected.
+- A recovered batch does not repeat completed items or routine source-thread
+  callbacks, and emits at most one idempotent exception summary.
+- Workstream accepted-outcome metrics use the current authoritative assessment
+  for each member WorkThread rather than Run success or executor self-report.
 - A stopped run does not auto-pass completion or auto-promote paused follow-ups.
 
 ### Adapter contract tests

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,6 +33,8 @@ For GitHub, GitLab, Linear, or Discord webhook deployments that use an already c
 
 `opentag status --run <run_id>` shows the local context packet, agent work ledger, produced artifacts, callback delivery, and safe next actions without turning the source thread into an agent log stream.
 
+`opentag status --workstream <workstream_id>` shows the workstream state and next action first, followed by recipe budgets, accepted outcomes, and bounded exception detail. Healthy workstreams stay quiet. Add `--json` to receive structured `workstream`, `recipe`, `metrics`, and `evaluation` objects for automation.
+
 External local runtimes can report lifecycle hooks through the public [Hook Ingest Contract](../../docs/hook-ingest.md): `opentag ingest-template --format manifest` prints the manifest, and `opentag ingest` records audit-visible progress or terminal state through runner-scoped auth.
 
 ## Commands

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -158,6 +158,8 @@ program
   .option("--config <path>", "Config file path")
   .option("--run <runId>", "Show audit details for one run")
   .option("--channel <provider:account/conversation>", "Show active run and queued follow-ups for one source container")
+  .option("--workstream <workstreamId>", "Show budget and accepted-outcome health for one factory workstream")
+  .option("--json", "Print structured --workstream status as JSON")
   .action(runCliAction(runStatusCommand));
 
 program

--- a/packages/cli/src/status.ts
+++ b/packages/cli/src/status.ts
@@ -16,9 +16,13 @@ import {
   type OpenTagEvent,
   type OpenTagRun,
   type AcceptedCompletionMetrics,
+  type FactoryRecipeSnapshot,
   type RunnerDirectoryEntry,
   type RoutingDecision,
-  type PlatformLivenessStrategy
+  type PlatformLivenessStrategy,
+  type Workstream,
+  type WorkstreamEvaluation,
+  type WorkstreamMetrics
 } from "@opentag/core";
 import { DEFAULT_AGENT_SESSION_PROFILE_TEMPLATE } from "@opentag/local-runtime";
 import { formatConfiguredCapabilities } from "./catalogs/capabilities.js";
@@ -42,6 +46,8 @@ export type StatusCommandOptions = {
   config?: string;
   run?: string;
   channel?: string;
+  workstream?: string;
+  json?: boolean;
 };
 
 export type StatusSummary = {
@@ -100,6 +106,16 @@ export type ChannelStatusSummary = {
   conversationId: string;
   runTimeoutPolicy: string;
   status: ChannelRuntimeStatus;
+};
+
+export type WorkstreamStatusSummary = {
+  configPath: string;
+  dispatcherUrl: string;
+  recipe: FactoryRecipeSnapshot;
+  workstream: Workstream;
+  metrics: WorkstreamMetrics;
+  evaluation: WorkstreamEvaluation;
+  alerts: ControlPlaneAlert[];
 };
 
 export function parseChannelRef(ref: string): { provider: string; accountId: string; conversationId: string } {
@@ -291,6 +307,53 @@ export async function getChannelStatusSummary(input: {
     channel: input.channel,
     ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {})
   });
+}
+
+export async function getWorkstreamStatusSummary(input: {
+  workstreamId: string;
+  configPath?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<WorkstreamStatusSummary> {
+  const configPath = input.configPath ?? defaultConfigPath();
+  const config = readCliConfig(configPath);
+  return workstreamStatusFromConfig({
+    config,
+    configPath,
+    workstreamId: input.workstreamId,
+    ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {})
+  });
+}
+
+export async function workstreamStatusFromConfig(input: {
+  config: OpenTagCliConfig;
+  configPath: string;
+  workstreamId: string;
+  fetchImpl?: typeof fetch;
+}): Promise<WorkstreamStatusSummary> {
+  const token = runnerDispatcherToken(input.config.daemon);
+  const client = createOpenTagClient({
+    dispatcherUrl: input.config.daemon.dispatcherUrl,
+    ...(token ? { pairingToken: token } : {}),
+    ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {})
+  });
+  const { workstream } = await client.getWorkstream({ id: input.workstreamId });
+  const [recipe, metrics, evaluation, alerts] = await Promise.all([
+    client.getFactoryRecipeSnapshot({ id: workstream.recipeId, version: workstream.recipeVersion }),
+    client.getWorkstreamMetrics({ id: workstream.id }),
+    client.getWorkstreamEvaluation({ id: workstream.id }),
+    client.listControlPlaneAlerts({ limit: 100 })
+  ]);
+  return {
+    configPath: input.configPath,
+    dispatcherUrl: input.config.daemon.dispatcherUrl,
+    recipe: recipe.recipe,
+    workstream,
+    metrics: metrics.metrics,
+    evaluation: evaluation.evaluation,
+    alerts: alerts.alerts.filter((alert) =>
+      alert.subject === workstream.id || alert.subject === `workstream:${workstream.id}`
+    )
+  };
 }
 
 export async function channelStatusFromConfig(input: {
@@ -900,6 +963,74 @@ export function formatCompletionExplanation(completion: CompletionExplanation): 
   ];
 }
 
+function workstreamNextAction(summary: WorkstreamStatusSummary): string {
+  if (summary.evaluation.status === "blocked") {
+    return "Resolve the blocking budget violations before admitting or claiming more work.";
+  }
+  if (summary.evaluation.status === "attention_required") {
+    return "Review the bounded exception summary and address the affected runs.";
+  }
+  if (summary.metrics.acceptedWorkThreadCount === 0) {
+    return "Wait for governed completion evidence; no work thread has an accepted outcome yet.";
+  }
+  return "No action required; continue monitoring accepted outcomes.";
+}
+
+function formatWorkstreamExceptions(summary: WorkstreamStatusSummary): string[] {
+  const violations = summary.evaluation.violations.slice(0, 5);
+  const alerts = summary.alerts.slice(0, 5);
+  if (violations.length === 0 && alerts.length === 0) return [];
+  return [
+    "Exceptions:",
+    ...violations.map((violation) =>
+      `  budget: ${violation.code} - ${violation.message} (actual=${violation.actual}${violation.limit !== undefined ? `, limit=${violation.limit}` : ""})`
+    ),
+    ...(summary.evaluation.violations.length > violations.length
+      ? [`  budget: ${summary.evaluation.violations.length - violations.length} more violation(s) omitted`]
+      : []),
+    ...alerts.map((alert) => `  alert: ${alert.severity}/${alert.type} - ${alert.reason}; next=${alert.nextAction}`),
+    ...(summary.alerts.length > alerts.length ? [`  alert: ${summary.alerts.length - alerts.length} more alert(s) omitted`] : [])
+  ];
+}
+
+export function formatWorkstreamStatus(summary: WorkstreamStatusSummary): string {
+  const { budgets } = summary.recipe;
+  const metrics = summary.metrics;
+  return [
+    `Workstream: ${summary.workstream.id} (${summary.workstream.name})`,
+    `State: ${summary.evaluation.status}`,
+    `Next action: ${workstreamNextAction(summary)}`,
+    "Accepted Outcomes:",
+    `  work threads: ${metrics.acceptedWorkThreadCount}/${metrics.workThreadCount}`,
+    "Budget:",
+    `  concurrency: ${metrics.activeRunCount}/${budgets.maxConcurrentRuns}; blocked runs=${metrics.budgetBlockedRunCount}`,
+    `  attempts: ${metrics.totalAttempts}; per-run limit=${budgets.maxAttemptsPerRun}; exceeded runs=${metrics.attemptsPerRunExceededCount}`,
+    `  cost units: ${metrics.totalCostUnits}/${budgets.maxCostUnits}; per attempt=${budgets.costUnitsPerAttempt}`,
+    `  allowed localities: ${budgets.allowedLocalities.join(", ")}`,
+    ...formatWorkstreamExceptions(summary),
+    "Details:",
+    `  recipe: ${summary.recipe.id}@${summary.recipe.version} (${summary.recipe.name})`,
+    `  members: ${summary.workstream.members.length}`,
+    `  runs: ${metrics.runCount}; queued=${metrics.queuedRunCount}; active=${metrics.activeRunCount}; needs-human=${metrics.needsHumanRunCount}; terminal=${metrics.terminalRunCount}; failed=${metrics.failedRunCount}`,
+    `  attempts by locality: local=${metrics.attemptsByLocality.local}; private=${metrics.attemptsByLocality.private}; hosted=${metrics.attemptsByLocality.hosted}; unknown=${metrics.attemptsByLocality.unknown}`,
+    `  evaluated: ${summary.evaluation.evaluatedAt}`,
+    `  config: ${summary.configPath}`,
+    `  dispatcher: ${summary.dispatcherUrl}`
+  ].join("\n");
+}
+
+export function workstreamStatusJson(summary: WorkstreamStatusSummary): Record<string, unknown> {
+  return {
+    state: summary.evaluation.status,
+    nextAction: workstreamNextAction(summary),
+    workstream: summary.workstream,
+    recipe: summary.recipe,
+    metrics: summary.metrics,
+    evaluation: summary.evaluation,
+    alerts: summary.alerts
+  };
+}
+
 function projectTargetLabel(input: ChannelRuntimeStatus["binding"]): string | undefined {
   if (!input.repoProvider || !input.owner || !input.repo) return undefined;
   return `${input.repoProvider}:${input.owner}/${input.repo}`;
@@ -948,8 +1079,22 @@ export function formatChannelStatus(summary: ChannelStatusSummary): string {
 }
 
 export async function runStatusCommand(options: StatusCommandOptions): Promise<void> {
+  if (options.json && !options.workstream) {
+    throw new Error("Use --json with --workstream.");
+  }
   if (options.run && options.channel) {
     throw new Error("Use either --run or --channel, not both.");
+  }
+  if (options.workstream && (options.run || options.channel)) {
+    throw new Error("Use only one of --run, --channel, or --workstream.");
+  }
+  if (options.workstream) {
+    const summary = await getWorkstreamStatusSummary({
+      workstreamId: options.workstream,
+      ...(options.config ? { configPath: options.config } : {})
+    });
+    console.log(options.json ? JSON.stringify(workstreamStatusJson(summary), null, 2) : formatWorkstreamStatus(summary));
+    return;
   }
   if (options.run) {
     console.log(formatRunStatus(await getRunStatusSummary({ runId: options.run, ...(options.config ? { configPath: options.config } : {}) })));

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -11,10 +11,14 @@ import {
   formatCompletionExplanation,
   formatRunStatus,
   formatStatus,
+  formatWorkstreamStatus,
   getStatusSummary,
   runStatusCommand,
   runStatusFromConfig,
-  statusFromConfig
+  statusFromConfig,
+  workstreamStatusFromConfig,
+  workstreamStatusJson,
+  type WorkstreamStatusSummary
 } from "../src/status.js";
 
 function tempDir(): string {
@@ -156,6 +160,75 @@ const runEvent: OpenTagEvent = {
   callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
   metadata: { owner: "acme", repo: "demo" }
 };
+
+function workstreamStatusFixture(overrides: {
+  state?: "healthy" | "attention_required" | "blocked";
+  acceptedWorkThreadCount?: number;
+  violations?: WorkstreamStatusSummary["evaluation"]["violations"];
+  alerts?: WorkstreamStatusSummary["alerts"];
+} = {}): WorkstreamStatusSummary {
+  const digest = `sha256:${"a".repeat(64)}`;
+  const workstreamId = "workstream_cli_1";
+  const acceptedWorkThreadCount = overrides.acceptedWorkThreadCount ?? 2;
+  return {
+    configPath: "/tmp/opentag.json",
+    dispatcherUrl: "http://dispatcher.test",
+    recipe: {
+      id: "recipe_cli_1",
+      version: 1,
+      name: "Maintenance",
+      budgets: {
+        maxConcurrentRuns: 2,
+        maxAttemptsPerRun: 3,
+        maxCostUnits: 20,
+        costUnitsPerAttempt: 2,
+        allowedLocalities: ["private"]
+      },
+      createdAt: "2026-07-26T00:00:00.000Z",
+      contentDigest: digest
+    },
+    workstream: {
+      id: workstreamId,
+      recipeId: "recipe_cli_1",
+      recipeVersion: 1,
+      name: "July maintenance",
+      members: [
+        { kind: "work_thread", workThreadId: "thread_1" },
+        { kind: "work_thread", workThreadId: "thread_2" }
+      ],
+      createdAt: "2026-07-26T00:01:00.000Z",
+      contentDigest: digest
+    },
+    metrics: {
+      workstreamId,
+      workThreadCount: 2,
+      acceptedWorkThreadCount,
+      runCount: 2,
+      queuedRunCount: 0,
+      activeRunCount: 0,
+      needsHumanRunCount: 0,
+      terminalRunCount: 2,
+      failedRunCount: 0,
+      budgetBlockedRunCount: 0,
+      exceptionCount: 0,
+      totalAttempts: 2,
+      attemptsPerRunExceededCount: 0,
+      totalCostUnits: 4,
+      attemptsByLocality: { local: 0, private: 2, hosted: 0, unknown: 0 }
+    },
+    evaluation: {
+      workstreamId,
+      recipeId: "recipe_cli_1",
+      recipeVersion: 1,
+      status: overrides.state ?? "healthy",
+      inputDigest: digest,
+      evaluatedAt: "2026-07-26T00:05:00.000Z",
+      acceptedWorkThreadCount,
+      violations: overrides.violations ?? []
+    },
+    alerts: overrides.alerts ?? []
+  };
+}
 
 function completionExplanationFixture(): CompletionExplanation {
   const evaluatedAt = "2026-07-21T10:05:00.000Z";
@@ -1516,9 +1589,176 @@ describe("OpenTag CLI status", () => {
     expect(formatChannelStatus(summary)).toContain("Stop/timeout: cancellation is explicit and is not reported as successful completion; timeout policy: hard timeout after 45 second(s).");
   });
 
+  it("keeps healthy workstream output quiet and orders state before budget detail", () => {
+    const formatted = formatWorkstreamStatus(workstreamStatusFixture());
+
+    expect(formatted.split("\n").slice(0, 3)).toEqual([
+      "Workstream: workstream_cli_1 (July maintenance)",
+      "State: healthy",
+      "Next action: No action required; continue monitoring accepted outcomes."
+    ]);
+    expect(formatted).toContain("Accepted Outcomes:\n  work threads: 2/2\nBudget:");
+    expect(formatted).toContain("cost units: 4/20; per attempt=2");
+    expect(formatted).not.toContain("Exceptions:");
+  });
+
+  it("shows a bounded exception summary for blocked workstreams", () => {
+    const violations = Array.from({ length: 6 }, (_, index) => ({
+      code: "budget_blocked_runs" as const,
+      message: `Blocked run ${index + 1}`,
+      actual: index + 1,
+      limit: 0
+    }));
+    const formatted = formatWorkstreamStatus(workstreamStatusFixture({ state: "blocked", violations }));
+
+    expect(formatted).toContain("State: blocked");
+    expect(formatted).toContain("Next action: Resolve the blocking budget violations");
+    expect(formatted).toContain("Blocked run 5");
+    expect(formatted).not.toContain("Blocked run 6");
+    expect(formatted).toContain("1 more violation(s) omitted");
+  });
+
+  it("calls the workstream status endpoints and returns structured JSON data", async () => {
+    const fixture = workstreamStatusFixture();
+    const requests: string[] = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      requests.push(href);
+      if (href.endsWith("/v1/workstreams/workstream_cli_1")) return Response.json({ workstream: fixture.workstream });
+      if (href.endsWith("/v1/factory-recipes/recipe_cli_1/versions/1")) return Response.json({ recipe: fixture.recipe });
+      if (href.endsWith("/v1/workstreams/workstream_cli_1/metrics")) return Response.json({ metrics: fixture.metrics });
+      if (href.endsWith("/v1/workstreams/workstream_cli_1/evaluation")) return Response.json({ evaluation: fixture.evaluation });
+      if (href.endsWith("/v1/control-plane-alerts?limit=100")) {
+        return Response.json({
+          alerts: [{
+            id: "alert_other",
+            type: "workstream_budget",
+            severity: "warn",
+            eventType: "factory.workstream.budget_blocked",
+            count: 1,
+            threshold: 1,
+            firstSeenAt: "2026-07-26T00:04:00.000Z",
+            lastSeenAt: "2026-07-26T00:04:00.000Z",
+            subject: "another_workstream",
+            reason: "Another workstream needs attention.",
+            nextAction: "Inspect it."
+          }, ...Array.from({ length: 6 }, (_, index) => ({
+            id: `alert_${index + 1}`,
+            type: "workstream_budget",
+            severity: "warn" as const,
+            eventType: "factory.workstream.budget_blocked",
+            count: 1,
+            threshold: 1,
+            firstSeenAt: "2026-07-26T00:04:00.000Z",
+            lastSeenAt: "2026-07-26T00:04:00.000Z",
+            subject: "workstream_cli_1",
+            reason: `Workstream alert ${index + 1}.`,
+            nextAction: "Inspect it."
+          }))]
+        });
+      }
+      return Response.json({ error: "unexpected_url", href }, { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const summary = await workstreamStatusFromConfig({
+      config: config(),
+      configPath: "/tmp/opentag/config.json",
+      workstreamId: fixture.workstream.id,
+      fetchImpl
+    });
+
+    expect(requests).toHaveLength(5);
+    expect(summary.alerts).toHaveLength(6);
+    expect(formatWorkstreamStatus(summary)).toContain("alert: 1 more alert(s) omitted");
+    expect(workstreamStatusJson(summary)).toMatchObject({
+      state: "healthy",
+      workstream: { id: "workstream_cli_1" },
+      metrics: { acceptedWorkThreadCount: 2 },
+      evaluation: { status: "healthy" }
+    });
+  });
+
+  it("prints structured workstream status in command JSON mode", async () => {
+    const fixture = workstreamStatusFixture();
+    const configPath = join(tempDir(), "config.json");
+    writeFileSync(configPath, JSON.stringify(config()), { mode: 0o600 });
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.endsWith("/v1/workstreams/workstream_cli_1")) return Response.json({ workstream: fixture.workstream });
+      if (href.endsWith("/v1/factory-recipes/recipe_cli_1/versions/1")) return Response.json({ recipe: fixture.recipe });
+      if (href.endsWith("/v1/workstreams/workstream_cli_1/metrics")) return Response.json({ metrics: fixture.metrics });
+      if (href.endsWith("/v1/workstreams/workstream_cli_1/evaluation")) return Response.json({ evaluation: fixture.evaluation });
+      if (href.endsWith("/v1/control-plane-alerts?limit=100")) return Response.json({ alerts: [] });
+      return Response.json({ error: "unexpected_url", href }, { status: 500 });
+    }) as unknown as typeof fetch;
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", fetchImpl);
+
+    try {
+      await runStatusCommand({ config: configPath, workstream: fixture.workstream.id, json: true });
+      expect(log).toHaveBeenCalledOnce();
+      expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+        state: "healthy",
+        workstream: { id: "workstream_cli_1" },
+        metrics: { acceptedWorkThreadCount: 2 },
+        evaluation: { status: "healthy" }
+      });
+    } finally {
+      log.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("explains zero accepted outcomes without changing the healthy evaluation", () => {
+    const summary = workstreamStatusFixture({ acceptedWorkThreadCount: 0 });
+    expect(formatWorkstreamStatus(summary)).toContain(
+      "Next action: Wait for governed completion evidence; no work thread has an accepted outcome yet."
+    );
+    expect(workstreamStatusJson(summary)).toMatchObject({ state: "healthy", metrics: { acceptedWorkThreadCount: 0 } });
+  });
+
+  it("preserves a workstream API 404 instead of rendering fabricated status", async () => {
+    await expect(workstreamStatusFromConfig({
+      config: config(),
+      configPath: "/tmp/opentag/config.json",
+      workstreamId: "missing",
+      fetchImpl: async () => Response.json({ error: "workstream_not_found" }, { status: 404 })
+    })).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("does not hide control-plane alert failures from workstream status", async () => {
+    const fixture = workstreamStatusFixture();
+    await expect(workstreamStatusFromConfig({
+      config: config(),
+      configPath: "/tmp/opentag/config.json",
+      workstreamId: fixture.workstream.id,
+      fetchImpl: async (url) => {
+        const href = String(url);
+        if (href.endsWith("/v1/workstreams/workstream_cli_1")) return Response.json({ workstream: fixture.workstream });
+        if (href.endsWith("/v1/factory-recipes/recipe_cli_1/versions/1")) return Response.json({ recipe: fixture.recipe });
+        if (href.endsWith("/v1/workstreams/workstream_cli_1/metrics")) return Response.json({ metrics: fixture.metrics });
+        if (href.endsWith("/v1/workstreams/workstream_cli_1/evaluation")) return Response.json({ evaluation: fixture.evaluation });
+        return Response.json({ error: "alerts_unavailable" }, { status: 503 });
+      }
+    })).rejects.toMatchObject({ status: 503 });
+  });
+
   it("rejects ambiguous run and channel status requests", async () => {
     await expect(runStatusCommand({ run: "run_1", channel: "lark:tenant_1/oc_chat" })).rejects.toThrow(
       "Use either --run or --channel, not both."
     );
+  });
+
+  it("rejects workstream status combined with legacy status selectors", async () => {
+    await expect(runStatusCommand({ run: "run_1", workstream: "workstream_1" })).rejects.toThrow(
+      "Use only one of --run, --channel, or --workstream."
+    );
+    await expect(runStatusCommand({ channel: "lark:tenant_1/oc_chat", workstream: "workstream_1" })).rejects.toThrow(
+      "Use only one of --run, --channel, or --workstream."
+    );
+  });
+
+  it("rejects JSON mode without a workstream selector", async () => {
+    await expect(runStatusCommand({ json: true })).rejects.toThrow("Use --json with --workstream.");
   });
 });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,9 +10,17 @@ import {
   OpenTagRunResultSchema,
   OpenTagRunSchema,
   AcceptedCompletionMetricsSchema,
+  FactoryRecipeSnapshotInputSchema,
+  FactoryRecipeSnapshotSchema,
   RoutingDecisionSchema,
   RunnerDirectoryEntrySchema,
   RunAdmissionDecisionSchema,
+  WorkstreamAdmissionBatchInputSchema,
+  WorkstreamAdmissionBatchReceiptSchema,
+  WorkstreamEvaluationSchema,
+  WorkstreamMetricsSchema,
+  WorkstreamInputSchema,
+  WorkstreamSchema,
   type ActorIdentity,
   type Action,
   type ActionPermissionRequest,
@@ -32,6 +40,8 @@ import {
   type OpenTagRun,
   type OpenTagRunResult,
   type AcceptedCompletionMetrics,
+  type FactoryRecipeSnapshot,
+  type FactoryRecipeSnapshotInput,
   type PolicyRule,
   type ProposalLineage,
   type RoutingDecision,
@@ -41,7 +51,24 @@ import {
   type RunEventImportance,
   type RunEventVisibility,
   type SuggestedChangesSnapshot,
-  type VerificationEvidence
+  type VerificationEvidence,
+  type Workstream,
+  type WorkstreamAdmissionBatchInput,
+  type WorkstreamAdmissionBatchReceipt,
+  type WorkstreamEvaluation,
+  type WorkstreamInput,
+  type WorkstreamMetrics
+} from "@opentag/core";
+
+export type {
+  FactoryRecipeSnapshot,
+  FactoryRecipeSnapshotInput,
+  Workstream,
+  WorkstreamAdmissionBatchInput,
+  WorkstreamAdmissionBatchReceipt,
+  WorkstreamEvaluation,
+  WorkstreamInput,
+  WorkstreamMetrics
 } from "@opentag/core";
 
 export type ClaimedOpenTagRun = {
@@ -474,6 +501,14 @@ export type OpenTagClient = {
   unbindChannel(input: { provider: string; accountId: string; conversationId: string }): Promise<void>;
   bindSlackChannel(input: SlackChannelBindingInput): Promise<void>;
   getSlackChannelBinding(input: { teamId: string; channelId: string }): Promise<{ binding: SlackChannelBindingInput }>;
+  createFactoryRecipeSnapshot(input: FactoryRecipeSnapshotInput): Promise<{ recipe: FactoryRecipeSnapshot }>;
+  getFactoryRecipeSnapshot(input: { id: string; version: number }): Promise<{ recipe: FactoryRecipeSnapshot }>;
+  createWorkstream(input: WorkstreamInput): Promise<{ workstream: Workstream }>;
+  getWorkstream(input: { id: string }): Promise<{ workstream: Workstream }>;
+  createWorkstreamAdmissionBatch(input: WorkstreamAdmissionBatchInput): Promise<{ receipt: WorkstreamAdmissionBatchReceipt }>;
+  getWorkstreamAdmissionBatch(input: { id: string }): Promise<{ receipt: WorkstreamAdmissionBatchReceipt }>;
+  getWorkstreamMetrics(input: { id: string }): Promise<{ metrics: WorkstreamMetrics }>;
+  getWorkstreamEvaluation(input: { id: string }): Promise<{ evaluation: WorkstreamEvaluation }>;
   createRun(input: CreateRunInput): Promise<CreateRunResult>;
   getFollowUpRequest(input: { id: string }): Promise<{ followUpRequest: import("@opentag/core").FollowUpRequest }>;
   createRunFromFollowUpRequest(input: { id: string; runId: string }): Promise<{ followUpRequest: import("@opentag/core").FollowUpRequest; run: OpenTagRun }>;
@@ -898,6 +933,88 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
       });
       await assertOk(response, "getSlackChannelBinding");
       return (await response.json()) as { binding: SlackChannelBindingInput };
+    },
+
+    async createFactoryRecipeSnapshot(input) {
+      const recipe = FactoryRecipeSnapshotInputSchema.parse(input);
+      const response = await fetchImpl(`${baseUrl}/v1/factory-recipes`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify(recipe)
+      });
+      await assertOk(response, "createFactoryRecipeSnapshot");
+      const body = (await response.json()) as { recipe?: unknown };
+      return { recipe: FactoryRecipeSnapshotSchema.parse(body.recipe) };
+    },
+
+    async getFactoryRecipeSnapshot(input) {
+      const response = await fetchImpl(
+        `${baseUrl}/v1/factory-recipes/${encodeURIComponent(input.id)}/versions/${input.version}`,
+        { headers: authHeaders(options.pairingToken) }
+      );
+      await assertOk(response, "getFactoryRecipeSnapshot");
+      const body = (await response.json()) as { recipe?: unknown };
+      return { recipe: FactoryRecipeSnapshotSchema.parse(body.recipe) };
+    },
+
+    async createWorkstream(input) {
+      const workstream = WorkstreamInputSchema.parse(input);
+      const response = await fetchImpl(`${baseUrl}/v1/workstreams`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify(workstream)
+      });
+      await assertOk(response, "createWorkstream");
+      const body = (await response.json()) as { workstream?: unknown };
+      return { workstream: WorkstreamSchema.parse(body.workstream) };
+    },
+
+    async getWorkstream(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/workstreams/${encodeURIComponent(input.id)}`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getWorkstream");
+      const body = (await response.json()) as { workstream?: unknown };
+      return { workstream: WorkstreamSchema.parse(body.workstream) };
+    },
+
+    async createWorkstreamAdmissionBatch(input) {
+      const batch = WorkstreamAdmissionBatchInputSchema.parse(input);
+      const response = await fetchImpl(`${baseUrl}/v1/workstream-batches`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify(batch)
+      });
+      await assertOk(response, "createWorkstreamAdmissionBatch");
+      const body = (await response.json()) as { receipt?: unknown };
+      return { receipt: WorkstreamAdmissionBatchReceiptSchema.parse(body.receipt) };
+    },
+
+    async getWorkstreamAdmissionBatch(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/workstream-batches/${encodeURIComponent(input.id)}`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getWorkstreamAdmissionBatch");
+      const body = (await response.json()) as { receipt?: unknown };
+      return { receipt: WorkstreamAdmissionBatchReceiptSchema.parse(body.receipt) };
+    },
+
+    async getWorkstreamMetrics(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/workstreams/${encodeURIComponent(input.id)}/metrics`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getWorkstreamMetrics");
+      const body = (await response.json()) as { metrics?: unknown };
+      return { metrics: WorkstreamMetricsSchema.parse(body.metrics) };
+    },
+
+    async getWorkstreamEvaluation(input) {
+      const response = await fetchImpl(`${baseUrl}/v1/workstreams/${encodeURIComponent(input.id)}/evaluation`, {
+        headers: authHeaders(options.pairingToken)
+      });
+      await assertOk(response, "getWorkstreamEvaluation");
+      const body = (await response.json()) as { evaluation?: unknown };
+      return { evaluation: WorkstreamEvaluationSchema.parse(body.evaluation) };
     },
 
     async createRun(input) {

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -98,6 +98,180 @@ function completionExplanationFixture() {
 }
 
 describe("@opentag/client", () => {
+  it("uses the additive factory workstream API routes and parses their contracts", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const digest = `sha256:${"a".repeat(64)}`;
+    const recipe = {
+      id: "recipe/1",
+      version: 2,
+      name: "Repository maintenance",
+      budgets: {
+        maxConcurrentRuns: 2,
+        maxAttemptsPerRun: 3,
+        maxCostUnits: 12,
+        costUnitsPerAttempt: 2,
+        allowedLocalities: ["private"]
+      },
+      createdAt: "2026-07-26T00:00:00.000Z",
+      contentDigest: digest
+    } as const;
+    const workstream = {
+      id: "workstream/1",
+      recipeId: recipe.id,
+      recipeVersion: recipe.version,
+      name: "July maintenance",
+      members: [{ kind: "work_thread", workThreadId: "thread_1" }],
+      createdAt: "2026-07-26T00:01:00.000Z",
+      contentDigest: digest
+    } as const;
+    const batch = {
+      id: "batch/1",
+      workstreamId: workstream.id,
+      items: [{ itemId: "item_1", runId: "run_1", workThreadId: "thread_1", event }],
+      createdAt: "2026-07-26T00:02:00.000Z",
+      contentDigest: digest
+    } as const;
+    const result = {
+      batchId: batch.id,
+      workstreamId: workstream.id,
+      inputDigest: digest,
+      results: [{ itemId: "item_1", index: 0, runId: "run_1", status: "created" }],
+      summary: {
+        totalItems: 1,
+        createdCount: 1,
+        idempotentReplayCount: 0,
+        followUpQueuedCount: 0,
+        needsHumanDecisionCount: 0,
+        rejectedCount: 0,
+        exceptionCount: 0,
+        omittedExceptionCount: 0,
+        exceptions: []
+      },
+      completedAt: "2026-07-26T00:03:00.000Z"
+    } as const;
+    const receipt = {
+      batch,
+      status: "completed",
+      items: [{
+        itemId: "item_1",
+        index: 0,
+        runId: "run_1",
+        workThreadId: "thread_1",
+        status: "completed",
+        result: result.results[0]
+      }],
+      result,
+      updatedAt: result.completedAt,
+      completedAt: result.completedAt
+    } as const;
+    const metrics = {
+      workstreamId: workstream.id,
+      workThreadCount: 1,
+      acceptedWorkThreadCount: 1,
+      runCount: 1,
+      queuedRunCount: 0,
+      activeRunCount: 0,
+      needsHumanRunCount: 0,
+      terminalRunCount: 1,
+      failedRunCount: 0,
+      budgetBlockedRunCount: 0,
+      exceptionCount: 0,
+      totalAttempts: 1,
+      attemptsPerRunExceededCount: 0,
+      totalCostUnits: 2,
+      attemptsByLocality: { local: 0, private: 1, hosted: 0, unknown: 0 }
+    } as const;
+    const evaluation = {
+      workstreamId: workstream.id,
+      recipeId: recipe.id,
+      recipeVersion: recipe.version,
+      status: "healthy",
+      inputDigest: digest,
+      evaluatedAt: "2026-07-26T00:04:00.000Z",
+      acceptedWorkThreadCount: 1,
+      violations: []
+    } as const;
+    const responses = [
+      { recipe }, { recipe }, { workstream }, { workstream }, { receipt }, { receipt }, { metrics }, { evaluation }
+    ];
+    const client = createOpenTagClient({
+      dispatcherUrl: "http://dispatcher.test/",
+      pairingToken: "runner_token",
+      fetchImpl: async (url, init) => {
+        requests.push({ url: String(url), init });
+        return jsonResponse(responses.shift());
+      }
+    });
+
+    await expect(client.createFactoryRecipeSnapshot({
+      id: recipe.id,
+      version: recipe.version,
+      name: recipe.name,
+      budgets: recipe.budgets
+    })).resolves.toEqual({ recipe });
+    await expect(client.getFactoryRecipeSnapshot({ id: recipe.id, version: recipe.version })).resolves.toEqual({ recipe });
+    await expect(client.createWorkstream({
+      id: workstream.id,
+      recipeId: workstream.recipeId,
+      recipeVersion: workstream.recipeVersion,
+      name: workstream.name,
+      members: workstream.members
+    })).resolves.toEqual({ workstream });
+    await expect(client.getWorkstream({ id: workstream.id })).resolves.toEqual({ workstream });
+    await expect(client.createWorkstreamAdmissionBatch({
+      id: batch.id,
+      workstreamId: batch.workstreamId,
+      items: batch.items
+    })).resolves.toEqual({ receipt });
+    await expect(client.getWorkstreamAdmissionBatch({ id: batch.id })).resolves.toEqual({ receipt });
+    await expect(client.getWorkstreamMetrics({ id: workstream.id })).resolves.toEqual({ metrics });
+    await expect(client.getWorkstreamEvaluation({ id: workstream.id })).resolves.toEqual({ evaluation });
+
+    expect(requests.map(({ url, init }) => [url, init?.method ?? "GET"])).toEqual([
+      ["http://dispatcher.test/v1/factory-recipes", "POST"],
+      ["http://dispatcher.test/v1/factory-recipes/recipe%2F1/versions/2", "GET"],
+      ["http://dispatcher.test/v1/workstreams", "POST"],
+      ["http://dispatcher.test/v1/workstreams/workstream%2F1", "GET"],
+      ["http://dispatcher.test/v1/workstream-batches", "POST"],
+      ["http://dispatcher.test/v1/workstream-batches/batch%2F1", "GET"],
+      ["http://dispatcher.test/v1/workstreams/workstream%2F1/metrics", "GET"],
+      ["http://dispatcher.test/v1/workstreams/workstream%2F1/evaluation", "GET"]
+    ]);
+    expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({
+      id: recipe.id,
+      version: recipe.version,
+      name: recipe.name,
+      budgets: recipe.budgets
+    });
+    expect(JSON.parse(String(requests[4]?.init?.body))).toEqual({
+      id: batch.id,
+      workstreamId: batch.workstreamId,
+      items: batch.items
+    });
+  });
+
+  it("preserves factory API response details in HTTP errors", async () => {
+    const client = createOpenTagClient({
+      dispatcherUrl: "http://dispatcher.test",
+      fetchImpl: async () => jsonResponse({ error: "workstream_not_found", id: "missing" }, 404)
+    });
+
+    await expect(client.getWorkstream({ id: "missing" })).rejects.toMatchObject({
+      name: "OpenTagClientHttpError",
+      status: 404,
+      responseBody: JSON.stringify({ error: "workstream_not_found", id: "missing" })
+    });
+  });
+
+  it("rejects malformed factory responses instead of returning untyped data", async () => {
+    const client = createOpenTagClient({
+      dispatcherUrl: "http://dispatcher.test",
+      fetchImpl: async () => jsonResponse({ metrics: { workstreamId: "workstream_1" } })
+    });
+
+    await expect(client.getWorkstreamMetrics({ id: "workstream_1" })).rejects.toMatchObject({ name: "ZodError" });
+  });
+
   it("reports a fenced executor preflight rejection through the runner-scoped route", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const client = createOpenTagClient({

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,6 +16,7 @@ pnpm add @opentag/core
 - `OpenTagEvent`, `OpenTagRun`, `OpenTagRunResult`: TypeScript types inferred from the schemas.
 - `CompletionContract`, `CompletionAssessment`, `HumanEscalation`: additive completion-governance protocol objects that keep executor outcome separate from accepted work completion.
 - `RunnerDirectoryEntry`, `RoutingDecision`, `AcceptedCompletionMetrics`: additive schemas for current runner readiness, explainable placement, and accepted outcomes by runner or executor.
+- `FactoryRecipeSnapshot`, `Workstream`, `WorkstreamAdmissionBatchReceipt`, `WorkstreamMetrics`, `WorkstreamEvaluation`: immutable factory grouping, replay-safe batch receipt, and accepted-outcome evaluation contracts.
 - `parseOpenTagMention`: extracts an `@opentag` command from workspace text.
 - `commandFromRawText`: maps raw command text to a normalized intent.
 - `OpenTagJsonSchemas`: JSON Schema definitions for systems that do not use TypeScript or Zod.

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -1,0 +1,427 @@
+import { z } from "zod";
+import { RunnerLocalitySchema } from "./routing.js";
+import { OpenTagEventSchema } from "./schema.js";
+
+const Sha256DigestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/u);
+const NonNegativeIntegerSchema = z.number().int().nonnegative();
+
+const UniqueLocalitiesSchema = z.array(RunnerLocalitySchema).min(1).max(3).superRefine((localities, ctx) => {
+  localities.forEach((locality, index) => {
+    if (localities.indexOf(locality) !== index) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Allowed runner localities must be unique.",
+        path: [index]
+      });
+    }
+  });
+});
+
+export const FactoryRecipeBudgetSchema = z.object({
+  maxConcurrentRuns: z.number().int().min(1).max(1_000),
+  maxAttemptsPerRun: z.number().int().min(1).max(100),
+  maxCostUnits: z.number().int().positive(),
+  costUnitsPerAttempt: z.number().int().positive(),
+  allowedLocalities: UniqueLocalitiesSchema
+}).strict().superRefine((budget, ctx) => {
+  if (budget.costUnitsPerAttempt > budget.maxCostUnits) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "costUnitsPerAttempt cannot exceed maxCostUnits.",
+      path: ["costUnitsPerAttempt"]
+    });
+  }
+});
+
+export const FactoryRecipeSnapshotInputSchema = z.object({
+  id: z.string().min(1),
+  version: z.number().int().positive(),
+  name: z.string().min(1),
+  completionProfileId: z.string().min(1).optional(),
+  budgets: FactoryRecipeBudgetSchema
+}).strict();
+
+export const FactoryRecipeSnapshotSchema = FactoryRecipeSnapshotInputSchema.extend({
+  createdAt: z.string().datetime(),
+  contentDigest: Sha256DigestSchema
+}).strict();
+
+export const WorkstreamMemberSchema = z.object({
+  kind: z.literal("work_thread"),
+  workThreadId: z.string().min(1)
+}).strict();
+
+export const WorkstreamInputSchema = z.object({
+  id: z.string().min(1),
+  recipeId: z.string().min(1),
+  recipeVersion: z.number().int().positive(),
+  name: z.string().min(1),
+  members: z.array(WorkstreamMemberSchema).min(1).max(1_000).superRefine((members, ctx) => {
+    const seen = new Set<string>();
+    members.forEach((member, index) => {
+      if (seen.has(member.workThreadId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Workstream member keys must be unique.",
+          path: [index, "workThreadId"]
+        });
+      }
+      seen.add(member.workThreadId);
+    });
+  })
+}).strict();
+
+export const WorkstreamSchema = WorkstreamInputSchema.extend({
+  createdAt: z.string().datetime(),
+  contentDigest: Sha256DigestSchema
+}).strict();
+
+export const WorkstreamAdmissionBatchItemSchema = z.object({
+  itemId: z.string().min(1),
+  runId: z.string().min(1),
+  workThreadId: z.string().min(1),
+  event: OpenTagEventSchema
+}).strict();
+
+export const WorkstreamAdmissionBatchInputSchema = z.object({
+  id: z.string().min(1),
+  workstreamId: z.string().min(1),
+  items: z.array(WorkstreamAdmissionBatchItemSchema).min(1).max(1_000).superRefine((items, ctx) => {
+    const itemIds = new Set<string>();
+    const runIds = new Set<string>();
+    items.forEach((item, index) => {
+      if (itemIds.has(item.itemId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Admission batch item ids must be unique.",
+          path: [index, "itemId"]
+        });
+      }
+      itemIds.add(item.itemId);
+      if (runIds.has(item.runId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Admission batch run ids must be unique.",
+          path: [index, "runId"]
+        });
+      }
+      runIds.add(item.runId);
+    });
+  })
+}).strict();
+
+export const WorkstreamAdmissionBatchSchema = WorkstreamAdmissionBatchInputSchema.extend({
+  createdAt: z.string().datetime(),
+  contentDigest: Sha256DigestSchema
+}).strict();
+
+export const WorkstreamAdmissionResultStatusSchema = z.enum([
+  "created",
+  "idempotent_replay",
+  "follow_up_queued",
+  "needs_human_decision",
+  "rejected"
+]);
+
+export const WorkstreamAdmissionBatchItemResultSchema = z.object({
+  itemId: z.string().min(1),
+  index: NonNegativeIntegerSchema,
+  runId: z.string().min(1),
+  status: WorkstreamAdmissionResultStatusSchema,
+  statusCode: z.number().int().min(100).max(599).optional(),
+  reasonCode: z.string().min(1).optional(),
+  admittedRunId: z.string().min(1).optional(),
+  followUpRequestId: z.string().min(1).optional(),
+  humanEscalationId: z.string().min(1).optional()
+}).strict();
+
+function admissionItemResultsEqual(
+  left: z.infer<typeof WorkstreamAdmissionBatchItemResultSchema>,
+  right: z.infer<typeof WorkstreamAdmissionBatchItemResultSchema>
+): boolean {
+  return left.itemId === right.itemId
+    && left.index === right.index
+    && left.runId === right.runId
+    && left.status === right.status
+    && left.statusCode === right.statusCode
+    && left.reasonCode === right.reasonCode
+    && left.admittedRunId === right.admittedRunId
+    && left.followUpRequestId === right.followUpRequestId
+    && left.humanEscalationId === right.humanEscalationId;
+}
+
+export const WorkstreamAdmissionQuietExceptionSchema = z.object({
+  itemId: z.string().min(1),
+  index: NonNegativeIntegerSchema,
+  runId: z.string().min(1),
+  status: z.enum(["needs_human_decision", "rejected"]),
+  reasonCode: z.string().min(1).optional()
+}).strict();
+
+export const WorkstreamAdmissionQuietSummarySchema = z.object({
+  totalItems: NonNegativeIntegerSchema,
+  createdCount: NonNegativeIntegerSchema,
+  idempotentReplayCount: NonNegativeIntegerSchema,
+  followUpQueuedCount: NonNegativeIntegerSchema,
+  needsHumanDecisionCount: NonNegativeIntegerSchema,
+  rejectedCount: NonNegativeIntegerSchema,
+  exceptionCount: NonNegativeIntegerSchema,
+  exceptions: z.array(WorkstreamAdmissionQuietExceptionSchema).max(10),
+  omittedExceptionCount: NonNegativeIntegerSchema
+}).strict().superRefine((summary, ctx) => {
+  const counted = summary.createdCount
+    + summary.idempotentReplayCount
+    + summary.followUpQueuedCount
+    + summary.needsHumanDecisionCount
+    + summary.rejectedCount;
+  if (counted !== summary.totalItems) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Admission result counts must equal totalItems." });
+  }
+  if (summary.exceptionCount !== summary.needsHumanDecisionCount + summary.rejectedCount) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "exceptionCount must include all exceptional outcomes." });
+  }
+  if (summary.exceptions.length > summary.exceptionCount) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Exception samples cannot exceed exceptionCount." });
+  }
+  if (summary.omittedExceptionCount !== summary.exceptionCount - summary.exceptions.length) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "omittedExceptionCount must describe unsampled exceptions." });
+  }
+});
+
+export const WorkstreamAdmissionBatchResultSchema = z.object({
+  batchId: z.string().min(1),
+  workstreamId: z.string().min(1),
+  inputDigest: Sha256DigestSchema,
+  results: z.array(WorkstreamAdmissionBatchItemResultSchema).max(1_000),
+  summary: WorkstreamAdmissionQuietSummarySchema,
+  completedAt: z.string().datetime()
+}).strict().superRefine((result, ctx) => {
+  if (result.results.length !== result.summary.totalItems) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Result count must equal summary totalItems.", path: ["results"] });
+  }
+  const itemIds = new Set(result.results.map((item) => item.itemId));
+  if (itemIds.size !== result.results.length) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Admission result item ids must be unique.", path: ["results"] });
+  }
+  const indices = new Set(result.results.map((item) => item.index));
+  if (indices.size !== result.results.length) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Admission result indices must be unique.", path: ["results"] });
+  }
+  const counts = {
+    createdCount: result.results.filter((item) => item.status === "created").length,
+    idempotentReplayCount: result.results.filter((item) => item.status === "idempotent_replay").length,
+    followUpQueuedCount: result.results.filter((item) => item.status === "follow_up_queued").length,
+    needsHumanDecisionCount: result.results.filter((item) => item.status === "needs_human_decision").length,
+    rejectedCount: result.results.filter((item) => item.status === "rejected").length
+  };
+  for (const [field, count] of Object.entries(counts)) {
+    if (result.summary[field as keyof typeof counts] !== count) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${field} must match the corresponding admission results.`,
+        path: ["summary", field]
+      });
+    }
+  }
+});
+
+export const WorkstreamAdmissionBatchProgressItemSchema = z.object({
+  itemId: z.string().min(1),
+  index: NonNegativeIntegerSchema,
+  runId: z.string().min(1),
+  workThreadId: z.string().min(1),
+  status: z.enum(["pending", "processing", "completed"]),
+  result: WorkstreamAdmissionBatchItemResultSchema.optional()
+}).strict().superRefine((item, ctx) => {
+  if ((item.status === "completed") !== Boolean(item.result)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Only completed items carry a durable result.", path: ["result"] });
+  }
+});
+
+export const WorkstreamAdmissionBatchReceiptSchema = z.object({
+  batch: WorkstreamAdmissionBatchSchema,
+  status: z.enum(["processing", "completed"]),
+  items: z.array(WorkstreamAdmissionBatchProgressItemSchema).min(1).max(1_000),
+  result: WorkstreamAdmissionBatchResultSchema.optional(),
+  updatedAt: z.string().datetime(),
+  completedAt: z.string().datetime().optional()
+}).strict().superRefine((receipt, ctx) => {
+  if (receipt.items.length !== receipt.batch.items.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Receipt progress must cover every durable batch item.",
+      path: ["items"]
+    });
+  }
+  receipt.items.forEach((item, index) => {
+    const batchItem = receipt.batch.items[index];
+    if (
+      !batchItem
+      || item.index !== index
+      || item.itemId !== batchItem.itemId
+      || item.runId !== batchItem.runId
+      || item.workThreadId !== batchItem.workThreadId
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Receipt progress item identity must match the durable batch item at the same index.",
+        path: ["items", index]
+      });
+    }
+  });
+  if (receipt.result) {
+    if (
+      receipt.result.batchId !== receipt.batch.id
+      || receipt.result.workstreamId !== receipt.batch.workstreamId
+      || receipt.result.inputDigest !== receipt.batch.contentDigest
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Receipt result must describe the same durable batch and input digest.",
+        path: ["result"]
+      });
+    }
+    if (receipt.result.summary.totalItems !== receipt.items.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Receipt result must cover every batch item.",
+        path: ["result", "summary", "totalItems"]
+      });
+    }
+    receipt.result.results.forEach((resultItem, index) => {
+      const progressItem = receipt.items[index];
+      if (
+        !progressItem
+        || resultItem.index !== index
+        || resultItem.itemId !== progressItem.itemId
+        || resultItem.runId !== progressItem.runId
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Receipt result item identity must match progress at the same index.",
+          path: ["result", "results", index]
+        });
+      } else if (!progressItem.result || !admissionItemResultsEqual(resultItem, progressItem.result)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Receipt result item must match the complete durable progress result at the same index.",
+          path: ["result", "results", index]
+        });
+      }
+    });
+  }
+  if (receipt.status === "completed") {
+    if (!receipt.result || !receipt.completedAt || receipt.items.some((item) => item.status !== "completed")) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A completed batch receipt requires all item results and completion metadata." });
+    }
+  } else if (receipt.result || receipt.completedAt) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A processing batch receipt cannot carry final completion metadata." });
+  }
+});
+
+export const WorkstreamLocalityMetricsSchema = z.object({
+  local: NonNegativeIntegerSchema,
+  private: NonNegativeIntegerSchema,
+  hosted: NonNegativeIntegerSchema,
+  unknown: NonNegativeIntegerSchema
+}).strict();
+
+export const WorkstreamMetricsSchema = z.object({
+  workstreamId: z.string().min(1),
+  workThreadCount: NonNegativeIntegerSchema,
+  acceptedWorkThreadCount: NonNegativeIntegerSchema,
+  runCount: NonNegativeIntegerSchema,
+  queuedRunCount: NonNegativeIntegerSchema,
+  activeRunCount: NonNegativeIntegerSchema,
+  needsHumanRunCount: NonNegativeIntegerSchema,
+  terminalRunCount: NonNegativeIntegerSchema,
+  failedRunCount: NonNegativeIntegerSchema,
+  budgetBlockedRunCount: NonNegativeIntegerSchema,
+  exceptionCount: NonNegativeIntegerSchema,
+  totalAttempts: NonNegativeIntegerSchema,
+  attemptsPerRunExceededCount: NonNegativeIntegerSchema,
+  totalCostUnits: NonNegativeIntegerSchema,
+  attemptsByLocality: WorkstreamLocalityMetricsSchema
+}).strict().superRefine((metrics, ctx) => {
+  if (metrics.acceptedWorkThreadCount > metrics.workThreadCount) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "acceptedWorkThreadCount cannot exceed workThreadCount.", path: ["acceptedWorkThreadCount"] });
+  }
+  if (metrics.attemptsPerRunExceededCount > metrics.runCount) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "attemptsPerRunExceededCount cannot exceed runCount.", path: ["attemptsPerRunExceededCount"] });
+  }
+  const localityAttempts = metrics.attemptsByLocality.local
+    + metrics.attemptsByLocality.private
+    + metrics.attemptsByLocality.hosted
+    + metrics.attemptsByLocality.unknown;
+  if (localityAttempts !== metrics.totalAttempts) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Locality attempt counts must equal totalAttempts.", path: ["attemptsByLocality"] });
+  }
+  const categorizedRuns = metrics.queuedRunCount
+    + metrics.activeRunCount
+    + metrics.needsHumanRunCount
+    + metrics.terminalRunCount;
+  if (categorizedRuns !== metrics.runCount) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Run status counts must equal runCount." });
+  }
+  if (metrics.budgetBlockedRunCount > metrics.runCount) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "budgetBlockedRunCount cannot exceed runCount.", path: ["budgetBlockedRunCount"] });
+  }
+  if (metrics.failedRunCount > metrics.terminalRunCount) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "failedRunCount cannot exceed terminalRunCount.", path: ["failedRunCount"] });
+  }
+});
+
+export const WorkstreamBudgetViolationCodeSchema = z.enum([
+  "concurrency_budget_exceeded",
+  "attempt_budget_exceeded",
+  "cost_budget_exceeded",
+  "cost_accounting_mismatch",
+  "locality_budget_exceeded",
+  "budget_blocked_runs"
+]);
+
+export const WorkstreamBudgetViolationSchema = z.object({
+  code: WorkstreamBudgetViolationCodeSchema,
+  message: z.string().min(1),
+  actual: NonNegativeIntegerSchema,
+  limit: NonNegativeIntegerSchema.optional(),
+  locality: RunnerLocalitySchema.optional()
+}).strict();
+
+export const WorkstreamEvaluationInputSchema = z.object({
+  recipe: FactoryRecipeSnapshotSchema,
+  workstream: WorkstreamSchema,
+  metrics: WorkstreamMetricsSchema,
+  evaluatedAt: z.string().datetime()
+}).strict();
+
+export const WorkstreamEvaluationSchema = z.object({
+  workstreamId: z.string().min(1),
+  recipeId: z.string().min(1),
+  recipeVersion: z.number().int().positive(),
+  status: z.enum(["healthy", "attention_required", "blocked"]),
+  inputDigest: Sha256DigestSchema,
+  evaluatedAt: z.string().datetime(),
+  acceptedWorkThreadCount: NonNegativeIntegerSchema,
+  violations: z.array(WorkstreamBudgetViolationSchema)
+}).strict();
+
+export type FactoryRecipeBudget = z.infer<typeof FactoryRecipeBudgetSchema>;
+export type FactoryRecipeSnapshotInput = z.infer<typeof FactoryRecipeSnapshotInputSchema>;
+export type FactoryRecipeSnapshot = z.infer<typeof FactoryRecipeSnapshotSchema>;
+export type WorkstreamMember = z.infer<typeof WorkstreamMemberSchema>;
+export type WorkstreamInput = z.infer<typeof WorkstreamInputSchema>;
+export type Workstream = z.infer<typeof WorkstreamSchema>;
+export type WorkstreamAdmissionBatchItem = z.infer<typeof WorkstreamAdmissionBatchItemSchema>;
+export type WorkstreamAdmissionBatchInput = z.infer<typeof WorkstreamAdmissionBatchInputSchema>;
+export type WorkstreamAdmissionBatch = z.infer<typeof WorkstreamAdmissionBatchSchema>;
+export type WorkstreamAdmissionResultStatus = z.infer<typeof WorkstreamAdmissionResultStatusSchema>;
+export type WorkstreamAdmissionBatchItemResult = z.infer<typeof WorkstreamAdmissionBatchItemResultSchema>;
+export type WorkstreamAdmissionQuietSummary = z.infer<typeof WorkstreamAdmissionQuietSummarySchema>;
+export type WorkstreamAdmissionBatchResult = z.infer<typeof WorkstreamAdmissionBatchResultSchema>;
+export type WorkstreamAdmissionBatchProgressItem = z.infer<typeof WorkstreamAdmissionBatchProgressItemSchema>;
+export type WorkstreamAdmissionBatchReceipt = z.infer<typeof WorkstreamAdmissionBatchReceiptSchema>;
+export type WorkstreamMetrics = z.infer<typeof WorkstreamMetricsSchema>;
+export type WorkstreamBudgetViolation = z.infer<typeof WorkstreamBudgetViolationSchema>;
+export type WorkstreamEvaluationInput = z.infer<typeof WorkstreamEvaluationInputSchema>;
+export type WorkstreamEvaluation = z.infer<typeof WorkstreamEvaluationSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./action.js";
 export * from "./capability.js";
 export * from "./credential-safety.js";
+export * from "./factory.js";
 export * from "./channel-protocol.js";
 export * from "./integration-protocol.js";
 export * from "./json-schema.js";

--- a/packages/core/src/json-schema.ts
+++ b/packages/core/src/json-schema.ts
@@ -71,6 +71,16 @@ import {
   RunnerDirectoryEntrySchema,
   RunnerRegistrationInputSchema
 } from "./routing.js";
+import {
+  FactoryRecipeSnapshotInputSchema,
+  FactoryRecipeSnapshotSchema,
+  WorkstreamAdmissionBatchInputSchema,
+  WorkstreamAdmissionBatchReceiptSchema,
+  WorkstreamEvaluationSchema,
+  WorkstreamInputSchema,
+  WorkstreamMetricsSchema,
+  WorkstreamSchema
+} from "./factory.js";
 
 export const OpenTagJsonSchemas = {
   OpenTagEvent: zodToJsonSchema(OpenTagEventSchema, "OpenTagEvent"),
@@ -136,5 +146,13 @@ export const OpenTagJsonSchemas = {
   RunnerRegistration: zodToJsonSchema(RunnerRegistrationInputSchema, "RunnerRegistration"),
   RunnerDirectoryEntry: zodToJsonSchema(RunnerDirectoryEntrySchema, "RunnerDirectoryEntry"),
   RoutingDecision: zodToJsonSchema(RoutingDecisionSchema, "RoutingDecision"),
-  AcceptedCompletionMetrics: zodToJsonSchema(AcceptedCompletionMetricsSchema, "AcceptedCompletionMetrics")
+  AcceptedCompletionMetrics: zodToJsonSchema(AcceptedCompletionMetricsSchema, "AcceptedCompletionMetrics"),
+  FactoryRecipeSnapshotInput: zodToJsonSchema(FactoryRecipeSnapshotInputSchema, "FactoryRecipeSnapshotInput"),
+  FactoryRecipeSnapshot: zodToJsonSchema(FactoryRecipeSnapshotSchema, "FactoryRecipeSnapshot"),
+  WorkstreamInput: zodToJsonSchema(WorkstreamInputSchema, "WorkstreamInput"),
+  Workstream: zodToJsonSchema(WorkstreamSchema, "Workstream"),
+  WorkstreamAdmissionBatchInput: zodToJsonSchema(WorkstreamAdmissionBatchInputSchema, "WorkstreamAdmissionBatchInput"),
+  WorkstreamAdmissionBatchReceipt: zodToJsonSchema(WorkstreamAdmissionBatchReceiptSchema, "WorkstreamAdmissionBatchReceipt"),
+  WorkstreamMetrics: zodToJsonSchema(WorkstreamMetricsSchema, "WorkstreamMetrics"),
+  WorkstreamEvaluation: zodToJsonSchema(WorkstreamEvaluationSchema, "WorkstreamEvaluation")
 } as const;

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -502,6 +502,8 @@ export const FollowUpRequestSchema = z.object({
   sourceEventId: z.string().min(1),
   conversationKey: z.string().min(1),
   activeRunId: z.string().min(1).optional(),
+  workstreamId: z.string().min(1).optional(),
+  admissionBatchId: z.string().min(1).optional(),
   event: z.lazy(() => OpenTagEventSchema),
     decision: RunAdmissionDecisionSchema,
     accessProfileSnapshot: AgentAccessProfileSnapshotSchema.optional(),
@@ -512,6 +514,13 @@ export const FollowUpRequestSchema = z.object({
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime()
 }).superRefine((value, ctx) => {
+  if (value.admissionBatchId && !value.workstreamId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Follow-up batch attribution requires a workstream.",
+      path: ["admissionBatchId"]
+    });
+  }
   if (Boolean(value.accessProfileSnapshot) !== Boolean(value.policySnapshotProvenance)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/packages/core/test/factory.test.ts
+++ b/packages/core/test/factory.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import {
+  FactoryRecipeBudgetSchema,
+  FactoryRecipeSnapshotInputSchema,
+  WorkstreamAdmissionBatchInputSchema,
+  WorkstreamAdmissionBatchReceiptSchema,
+  WorkstreamAdmissionBatchResultSchema,
+  WorkstreamAdmissionBatchSchema,
+  WorkstreamAdmissionQuietSummarySchema,
+  WorkstreamInputSchema,
+  WorkstreamMetricsSchema
+} from "../src/factory.js";
+
+describe("factory contracts", () => {
+  const budgets = {
+    maxConcurrentRuns: 4,
+    maxAttemptsPerRun: 3,
+    maxCostUnits: 100,
+    costUnitsPerAttempt: 5,
+    allowedLocalities: ["local", "private"] as const
+  };
+
+  it("keeps recipe request fields strict and server-owned fields out of input", () => {
+    expect(FactoryRecipeSnapshotInputSchema.parse({
+      id: "recipe_default",
+      version: 1,
+      name: "Default",
+      budgets
+    })).toMatchObject({ version: 1 });
+    expect(() => FactoryRecipeSnapshotInputSchema.parse({
+      id: "recipe_default",
+      version: 1,
+      name: "Default",
+      budgets,
+      createdAt: "2026-07-26T00:00:00.000Z"
+    })).toThrow();
+    expect(() => FactoryRecipeBudgetSchema.parse({ ...budgets, maxConcurrentRuns: 0 })).toThrow();
+    expect(() => FactoryRecipeBudgetSchema.parse({ ...budgets, maxCostUnits: 4, costUnitsPerAttempt: 5 })).toThrow(/cannot exceed/u);
+    expect(() => FactoryRecipeBudgetSchema.parse({ ...budgets, allowedLocalities: ["local", "local"] })).toThrow(/unique/u);
+    expect(() => FactoryRecipeBudgetSchema.parse({ ...budgets, unknown: true })).toThrow();
+  });
+
+  it("accepts only unique WorkThread members", () => {
+    const input = {
+      id: "workstream_1",
+      recipeId: "recipe_default",
+      recipeVersion: 1,
+      name: "Release",
+      members: [
+        { kind: "work_thread" as const, workThreadId: "thread_1" },
+        { kind: "work_thread" as const, workThreadId: "thread_2" }
+      ]
+    };
+    expect(WorkstreamInputSchema.parse(input).members).toHaveLength(2);
+    expect(() => WorkstreamInputSchema.parse({ ...input, members: [] })).toThrow();
+    expect(() => WorkstreamInputSchema.parse({ ...input, members: [input.members[0], input.members[0]] })).toThrow(/unique/u);
+    expect(() => WorkstreamInputSchema.parse({
+      ...input,
+      members: [{ kind: "work_item", workItemReference: {} }]
+    })).toThrow();
+  });
+
+  it("requires stable unique batch item and run identities with a bounded exception summary", () => {
+    const event = {
+      id: "event_1",
+      source: "github",
+      sourceEventId: "event_1",
+      receivedAt: "2026-07-26T00:00:00.000Z",
+      actor: { provider: "github", providerUserId: "actor_1" },
+      target: { mention: "@opentag", agentId: "opentag" },
+      command: { rawText: "Please fix the release.", intent: "fix", args: {} },
+      context: [],
+      permissions: [],
+      callback: { provider: "github", uri: "https://api.github.test/issues/1/comments" },
+      metadata: {}
+    };
+    const first = { itemId: "item_1", runId: "run_1", workThreadId: "thread_1", event };
+    expect(WorkstreamAdmissionBatchInputSchema.parse({
+      id: "batch_1",
+      workstreamId: "workstream_1",
+      items: [first]
+    }).items).toHaveLength(1);
+    expect(() => WorkstreamAdmissionBatchInputSchema.parse({
+      id: "batch_1",
+      workstreamId: "workstream_1",
+      items: [first, { ...first, itemId: "item_2" }]
+    })).toThrow(/run ids must be unique/u);
+
+    expect(WorkstreamAdmissionQuietSummarySchema.parse({
+      totalItems: 12,
+      createdCount: 0,
+      idempotentReplayCount: 0,
+      followUpQueuedCount: 0,
+      needsHumanDecisionCount: 12,
+      rejectedCount: 0,
+      exceptionCount: 12,
+      exceptions: Array.from({ length: 10 }, (_, index) => ({
+        itemId: `item_${index}`,
+        index,
+        runId: `run_${index}`,
+        status: "needs_human_decision" as const
+      })),
+      omittedExceptionCount: 2
+    }).omittedExceptionCount).toBe(2);
+  });
+
+  it("binds durable batch receipts to their batch, progress, and final result", () => {
+    const event = {
+      id: "event_receipt",
+      source: "github",
+      sourceEventId: "event_receipt",
+      receivedAt: "2026-07-26T00:00:00.000Z",
+      actor: { provider: "github", providerUserId: "actor_1" },
+      target: { mention: "@opentag", agentId: "opentag" },
+      command: { rawText: "Please fix the release.", intent: "fix", args: {} },
+      context: [],
+      permissions: [],
+      callback: { provider: "github", uri: "https://api.github.test/issues/1/comments" },
+      metadata: {}
+    };
+    const digest = `sha256:${"a".repeat(64)}`;
+    const completedAt = "2026-07-26T00:01:00.000Z";
+    const batch = WorkstreamAdmissionBatchSchema.parse({
+      id: "batch_receipt",
+      workstreamId: "workstream_1",
+      items: [{ itemId: "item_1", runId: "run_1", workThreadId: "thread_1", event }],
+      createdAt: "2026-07-26T00:00:00.000Z",
+      contentDigest: digest
+    });
+    const itemResult = {
+      itemId: "item_1",
+      index: 0,
+      runId: "run_1",
+      status: "created" as const,
+      statusCode: 201,
+      admittedRunId: "run_1"
+    };
+    const summary = {
+      totalItems: 1,
+      createdCount: 1,
+      idempotentReplayCount: 0,
+      followUpQueuedCount: 0,
+      needsHumanDecisionCount: 0,
+      rejectedCount: 0,
+      exceptionCount: 0,
+      exceptions: [],
+      omittedExceptionCount: 0
+    };
+    const result = WorkstreamAdmissionBatchResultSchema.parse({
+      batchId: batch.id,
+      workstreamId: batch.workstreamId,
+      inputDigest: batch.contentDigest,
+      results: [itemResult],
+      summary,
+      completedAt
+    });
+    const receipt = {
+      batch,
+      status: "completed" as const,
+      items: [{
+        itemId: "item_1",
+        index: 0,
+        runId: "run_1",
+        workThreadId: "thread_1",
+        status: "completed" as const,
+        result: itemResult
+      }],
+      result,
+      updatedAt: completedAt,
+      completedAt
+    };
+
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse(receipt).success).toBe(true);
+    expect(WorkstreamAdmissionBatchResultSchema.safeParse({ ...result, results: [] }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchResultSchema.safeParse({
+      ...result,
+      results: [itemResult, { ...itemResult, itemId: "item_2", runId: "run_2" }],
+      summary: { ...summary, totalItems: 2, createdCount: 2 }
+    }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchResultSchema.safeParse({
+      ...result,
+      results: [{ ...itemResult, status: "rejected", statusCode: 409, admittedRunId: undefined }]
+    }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({ ...receipt, result: undefined }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({ ...receipt, completedAt: undefined }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({
+      ...receipt,
+      items: [{ ...receipt.items[0], result: undefined }]
+    }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({ ...receipt, status: "processing" }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({
+      ...receipt,
+      result: { ...result, batchId: "batch_other" }
+    }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({
+      ...receipt,
+      result: { ...result, workstreamId: "workstream_other" }
+    }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({
+      ...receipt,
+      result: { ...result, inputDigest: `sha256:${"b".repeat(64)}` }
+    }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({
+      ...receipt,
+      items: [{ ...receipt.items[0], runId: "run_other" }]
+    }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({
+      ...receipt,
+      result: { ...result, results: [{ ...itemResult, runId: "run_other" }] }
+    }).success).toBe(false);
+    expect(WorkstreamAdmissionBatchReceiptSchema.safeParse({
+      ...receipt,
+      result: {
+        ...result,
+        results: [{ ...itemResult, status: "rejected", statusCode: 409, admittedRunId: undefined }],
+        summary: { ...summary, createdCount: 0, rejectedCount: 1, exceptionCount: 1, omittedExceptionCount: 1 }
+      }
+    }).success).toBe(false);
+  });
+
+  it("validates WorkThread authority, run breakdown, cost, and locality dimensions", () => {
+    const metrics = {
+      workstreamId: "workstream_1",
+      workThreadCount: 2,
+      acceptedWorkThreadCount: 1,
+      runCount: 3,
+      queuedRunCount: 1,
+      activeRunCount: 1,
+      needsHumanRunCount: 0,
+      terminalRunCount: 1,
+      failedRunCount: 0,
+      budgetBlockedRunCount: 0,
+      exceptionCount: 0,
+      totalAttempts: 2,
+      attemptsPerRunExceededCount: 0,
+      totalCostUnits: 10,
+      attemptsByLocality: { local: 2, private: 0, hosted: 0, unknown: 0 }
+    };
+    expect(WorkstreamMetricsSchema.parse(metrics).acceptedWorkThreadCount).toBe(1);
+    expect(() => WorkstreamMetricsSchema.parse({ ...metrics, acceptedWorkThreadCount: 3 })).toThrow(/workThreadCount/u);
+    expect(() => WorkstreamMetricsSchema.parse({ ...metrics, queuedRunCount: 2 })).toThrow(/Run status counts/u);
+    expect(() => WorkstreamMetricsSchema.parse({ ...metrics, attemptsByLocality: { local: 1, private: 0, hosted: 0, unknown: 0 } })).toThrow(/totalAttempts/u);
+  });
+});

--- a/packages/core/test/json-schema.test.ts
+++ b/packages/core/test/json-schema.test.ts
@@ -38,5 +38,13 @@ describe("OpenTagJsonSchemas", () => {
     expect(OpenTagJsonSchemas.RunnerDirectoryEntry).toHaveProperty("definitions.RunnerDirectoryEntry");
     expect(OpenTagJsonSchemas.RoutingDecision).toHaveProperty("definitions.RoutingDecision");
     expect(OpenTagJsonSchemas.AcceptedCompletionMetrics).toHaveProperty("definitions.AcceptedCompletionMetrics");
+    expect(OpenTagJsonSchemas.FactoryRecipeSnapshotInput).toHaveProperty("definitions.FactoryRecipeSnapshotInput");
+    expect(OpenTagJsonSchemas.FactoryRecipeSnapshot).toHaveProperty("definitions.FactoryRecipeSnapshot");
+    expect(OpenTagJsonSchemas.WorkstreamInput).toHaveProperty("definitions.WorkstreamInput");
+    expect(OpenTagJsonSchemas.Workstream).toHaveProperty("definitions.Workstream");
+    expect(OpenTagJsonSchemas.WorkstreamAdmissionBatchInput).toHaveProperty("definitions.WorkstreamAdmissionBatchInput");
+    expect(OpenTagJsonSchemas.WorkstreamAdmissionBatchReceipt).toHaveProperty("definitions.WorkstreamAdmissionBatchReceipt");
+    expect(OpenTagJsonSchemas.WorkstreamMetrics).toHaveProperty("definitions.WorkstreamMetrics");
+    expect(OpenTagJsonSchemas.WorkstreamEvaluation).toHaveProperty("definitions.WorkstreamEvaluation");
   });
 });

--- a/packages/dispatcher/README.md
+++ b/packages/dispatcher/README.md
@@ -45,6 +45,13 @@ export const dispatcher = createDispatcherApp({
 
 The app exposes `/healthz` and `/v1/*` dispatcher endpoints for runners, Project Target bindings, generic channel bindings, Slack compatibility bindings, runs, progress, heartbeats, completion, and audit event lookup.
 
+Factory-mode callers can additionally create immutable recipe snapshots and
+WorkThread-only workstreams, submit replay-safe workstream batches, inspect a
+durable batch receipt, and read workstream metrics/evaluation. Every batch item
+uses the same managed-channel ownership and Run admission path as `/v1/runs`;
+routine per-item source-thread acknowledgements are suppressed in favor of one
+bounded exception summary.
+
 When `pairingToken` is set, every `/v1/*` endpoint requires:
 
 ```text

--- a/packages/dispatcher/src/admission.ts
+++ b/packages/dispatcher/src/admission.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import {
   AgentAccessProfileSnapshotSchema,
   conversationKeysFromEvent,
@@ -17,6 +16,7 @@ import {
   type RunAdmissionReasonCode
 } from "@opentag/core";
 import { type FollowUpRequest, type RepoBinding, type createOpenTagRepository } from "@opentag/store";
+import { sha256Digest } from "./digest.js";
 
 type Repository = ReturnType<typeof createOpenTagRepository>;
 
@@ -42,6 +42,8 @@ export type AgentAccessProfileCheck = (input: AgentAccessProfileCheckInput) => P
 export type AdmitRunInput = {
   requestId: string;
   event: OpenTagEvent;
+  workstreamId?: string;
+  admissionBatchId?: string;
 };
 
 export type AdmitRunResult =
@@ -196,21 +198,6 @@ function admissionDecision(input: {
 
 async function defaultAgentAccessProfileCheck(): Promise<AgentAccessProfileCheckResult> {
   return { allowed: true };
-}
-
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
-  if (value && typeof value === "object") {
-    return `{${Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-      .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
-}
-
-function sha256Digest(value: unknown): string {
-  return `sha256:${createHash("sha256").update(stableJson(value)).digest("hex")}`;
 }
 
 function defaultAdmissionSnapshots(input: {
@@ -470,6 +457,8 @@ export function createAdmissionRuntime(input: {
           event: request.event,
           decision,
           activeRunId: activeRun.run.id,
+          ...(request.workstreamId ? { workstreamId: request.workstreamId } : {}),
+          ...(request.admissionBatchId ? { admissionBatchId: request.admissionBatchId } : {}),
           ...snapshots,
           routingPolicy
         });

--- a/packages/dispatcher/src/digest.ts
+++ b/packages/dispatcher/src/digest.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => compareCodeUnits(left, right))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function sha256Digest(value: unknown): string {
+  return `sha256:${createHash("sha256").update(stableJson(value)).digest("hex")}`;
+}

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -40,6 +40,16 @@ import {
   createAdapterMutationCompilerRegistry,
   OpenTagEventSchema,
   OpenTagRunResultSchema,
+  FactoryRecipeSnapshotSchema,
+  FactoryRecipeSnapshotInputSchema,
+  WorkstreamAdmissionBatchInputSchema,
+  WorkstreamAdmissionBatchItemResultSchema,
+  WorkstreamAdmissionBatchReceiptSchema,
+  WorkstreamAdmissionBatchResultSchema,
+  WorkstreamAdmissionBatchSchema,
+  WorkstreamMetricsSchema,
+  WorkstreamInputSchema,
+  WorkstreamSchema,
   PolicyRuleSchema,
   PolicyScopeSchema,
   RunnerRegistrationRequestSchema,
@@ -52,6 +62,7 @@ import {
   readRequestTextWithLimit,
   shouldDeliverSourceReceipt
 } from "@opentag/core";
+import { evaluateWorkstream } from "@opentag/governance";
 import {
   applyGitHubIssueMutationOperation,
   createGitHubIssueMutationCompiler,
@@ -321,6 +332,7 @@ function createDispatcherRateLimitMiddleware(options: DispatcherRateLimitOptions
   };
 }
 import { createAdmissionRuntime, sourceRepoIsPublic, type AgentAccessProfileCheck } from "./admission.js";
+import { sha256Digest } from "./digest.js";
 import { createDefaultCallbackPresentation, type CallbackPresentation, type LarkRenderLocale } from "./presentation.js";
 import {
   createDispatcherCompletionGovernance,
@@ -2882,6 +2894,45 @@ export function createDispatcherApp(input: {
   const sqlite = new Database(input.databasePath);
   migrateSchema(sqlite);
   const repo = createOpenTagRepository(drizzle(sqlite));
+  const workstreamBatchLeaseSeconds = 300;
+  const workstreamBatchHeartbeatMs = Math.floor(workstreamBatchLeaseSeconds * 1_000 / 3);
+
+  async function withWorkstreamAdmissionLease<T>(lease: {
+    batchId: string;
+    itemId: string;
+    leaseOwner: string;
+  }, task: () => Promise<T>): Promise<T> {
+    let renewalFailure: Error | undefined;
+    let renewalChain = Promise.resolve();
+    const renew = async () => {
+      if (renewalFailure) return;
+      const renewed = await repo.renewWorkstreamAdmissionBatchLease({
+        ...lease,
+        leaseSeconds: workstreamBatchLeaseSeconds
+      });
+      if (renewed.outcome !== "renewed") {
+        throw new Error(
+          `Workstream batch item ${lease.itemId} lease could not be renewed: ${renewed.outcome}.`
+        );
+      }
+    };
+    const scheduleRenewal = () => {
+      renewalChain = renewalChain.then(renew).catch((error: unknown) => {
+        renewalFailure = error instanceof Error ? error : new Error(String(error));
+      });
+    };
+    const heartbeat = globalThis.setInterval(scheduleRenewal, workstreamBatchHeartbeatMs);
+    try {
+      const result = await task();
+      await renewalChain;
+      if (renewalFailure) throw renewalFailure;
+      await renew();
+      return result;
+    } finally {
+      globalThis.clearInterval(heartbeat);
+      await renewalChain;
+    }
+  }
   const completionGovernance = createDispatcherCompletionGovernance({
     repo,
     policies: input.completionPolicies ?? [],
@@ -3229,6 +3280,7 @@ export function createDispatcherApp(input: {
     type: string;
     severity?: "info" | "warn" | "error" | undefined;
     subject?: string | undefined;
+    idempotencyKey?: string | undefined;
     payload?: Record<string, unknown> | undefined;
     createdAt?: string | undefined;
   }) => {
@@ -3236,6 +3288,7 @@ export function createDispatcherApp(input: {
       type: input.type,
       ...(input.severity ? { severity: input.severity } : {}),
       ...(input.subject ? { subject: input.subject } : {}),
+      ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
       ...(input.payload ? { payload: input.payload } : {}),
       ...(input.createdAt ? { createdAt: input.createdAt } : {})
     });
@@ -3244,6 +3297,7 @@ export function createDispatcherApp(input: {
     requestId: string;
     event: OpenTagEvent;
     decision: import("@opentag/core").RunAdmissionDecision;
+    deliverSourceCallback?: boolean;
   }): Promise<{ escalation?: HumanEscalation; resolutionUnavailableReason?: string }> {
     const protocol = protocolRunFieldsFromEvent(inputValue.event, inputValue.decision.decidedAt);
     if (!protocol.thread) {
@@ -3287,7 +3341,11 @@ export function createDispatcherApp(input: {
       openedAt: inputValue.decision.decidedAt
     });
     const opened = await repo.openHumanEscalation({ escalation });
-    if (opened.created && presentation.shouldDeliverStatusUpdate(inputValue.event.callback.provider)) {
+    if (
+      inputValue.deliverSourceCallback !== false
+      && opened.created
+      && presentation.shouldDeliverStatusUpdate(inputValue.event.callback.provider)
+    ) {
       const semantic = presentation.runStatusPresentation({
         runId: inputValue.requestId,
         state: "waiting_for_human",
@@ -3313,6 +3371,231 @@ export function createDispatcherApp(input: {
       });
     }
     return { escalation: opened.escalation };
+  }
+
+  type RunAdmissionHttpResult = {
+    body: Record<string, unknown>;
+    status: 200 | 201 | 202 | 403;
+    batchStatus: "created" | "idempotent_replay" | "follow_up_queued" | "needs_human_decision" | "rejected";
+    reasonCode?: string;
+    admittedRunId?: string;
+    followUpRequestId?: string;
+    humanEscalationId?: string;
+  };
+
+  async function admitAndCreateRun(inputValue: {
+    runId: string;
+    event: OpenTagEvent;
+    channelPrincipal?: ChannelPrincipalIdentity;
+    quiet?: boolean;
+    workstreamId?: string;
+    admissionBatchId?: string;
+  }): Promise<RunAdmissionHttpResult> {
+    let ownershipVerified = false;
+    try {
+      ownershipVerified = await managedChannelOwnershipVerified({
+        repo,
+        event: inputValue.event,
+        ...(inputValue.channelPrincipal ? { principal: inputValue.channelPrincipal } : {})
+      });
+    } catch (error) {
+      if (!(error instanceof ChannelBindingCorruptionError)) throw error;
+      await recordControlPlaneEvent({
+        type: "admission.managed_channel_binding_corrupt",
+        severity: "error",
+        subject: inputValue.runId,
+        payload: {
+          runId: inputValue.runId,
+          source: inputValue.event.source,
+          sourceEventId: inputValue.event.sourceEventId
+        }
+      });
+      return {
+        body: { error: "managed_channel_binding_corrupt" },
+        status: 403,
+        batchStatus: "rejected",
+        reasonCode: "managed_channel_binding_corrupt"
+      };
+    }
+    if (!ownershipVerified) {
+      await recordControlPlaneEvent({
+        type: "admission.managed_channel_ownership_unverified",
+        severity: "warn",
+        subject: inputValue.runId,
+        payload: {
+          runId: inputValue.runId,
+          source: inputValue.event.source,
+          sourceEventId: inputValue.event.sourceEventId
+        }
+      });
+      return {
+        body: { error: "managed_channel_ownership_unverified" },
+        status: 403,
+        batchStatus: "rejected",
+        reasonCode: "managed_channel_ownership_unverified"
+      };
+    }
+
+    const admitted = await admission.admitRun({
+      requestId: inputValue.runId,
+      event: inputValue.event,
+      ...(inputValue.workstreamId ? { workstreamId: inputValue.workstreamId } : {}),
+      ...(inputValue.admissionBatchId ? { admissionBatchId: inputValue.admissionBatchId } : {})
+    });
+    if (admitted.outcome === "needs_human_decision") {
+      const projectTarget = projectTargetRefFromEvent(inputValue.event);
+      await recordControlPlaneEvent({
+        type: "admission.needs_human_decision",
+        severity: ["repo_context_missing", "repo_not_bound"].includes(admitted.decision.reasonCode) ? "warn" : "info",
+        subject: inputValue.runId,
+        payload: {
+          runId: inputValue.runId,
+          decision: admitted.decision,
+          source: inputValue.event.source,
+          sourceEventId: inputValue.event.sourceEventId,
+          projectTarget: projectTarget ? `${projectTarget.provider}:${projectTarget.owner}/${projectTarget.repo}` : null
+        }
+      });
+      const humanDecision = await structureAdmissionHumanDecision({
+        requestId: inputValue.runId,
+        event: inputValue.event,
+        decision: admitted.decision,
+        deliverSourceCallback: !inputValue.quiet
+      });
+      return {
+        body: { decision: admitted.decision, ...humanDecision },
+        status: 202,
+        batchStatus: "needs_human_decision",
+        reasonCode: admitted.decision.reasonCode,
+        ...(humanDecision.escalation ? { humanEscalationId: humanDecision.escalation.id } : {})
+      };
+    }
+
+    if (admitted.outcome === "drop_duplicate") {
+      const replay = await repo.createRun({
+        id: inputValue.runId,
+        event: inputValue.event,
+        ...(inputValue.workstreamId ? { workstreamId: inputValue.workstreamId } : {}),
+        ...(inputValue.admissionBatchId ? { admissionBatchId: inputValue.admissionBatchId } : {})
+      });
+      const decision = replay.created ? admitted.decision : replay.replayDecision;
+      return {
+        body: { decision, run: replay.run, idempotentReplay: true },
+        status: 200,
+        batchStatus: "idempotent_replay",
+        admittedRunId: replay.run.id
+      };
+    }
+
+    if (admitted.outcome === "follow_up_queued") {
+      const event = admitted.followUpRequest.event;
+      const activeRunId = admitted.followUpRequest.activeRunId;
+      if (
+        !inputValue.quiet
+        && activeRunId
+        && shouldDeliverRunStatusUpdate(presentation, { provider: event.callback.provider, state: "queued" })
+      ) {
+        const queuedPresentation = presentation.runStatusPresentation({
+          runId: activeRunId,
+          state: "queued",
+          message: `Queued follow-up ${admitted.followUpRequest.id} behind the active run.`,
+          nextAction: "Wait for the active run final reply, send another follow-up to queue more context, or request cancellation with /stop.",
+          detailVisibility: "source_thread"
+        });
+        const queued = presentation.render({
+          provider: event.callback.provider,
+          ...larkRenderLocaleRenderOption(event),
+          presentation: queuedPresentation
+        });
+        await deliverAndAudit({
+          repo,
+          sink: callbackSink,
+          retry: callbackRetry,
+          message: {
+            runId: activeRunId,
+            kind: "progress",
+            provider: event.callback.provider,
+            uri: event.callback.uri,
+            body: queued.body,
+            ...(event.target.agentId ? { agentId: event.target.agentId } : {}),
+            ...(event.callback.threadKey ? { threadKey: event.callback.threadKey } : {}),
+            ...(queued.blocks?.length ? { blocks: queued.blocks } : {}),
+            ...(queued.rich ? { rich: queued.rich } : {}),
+            statusMessageKey: `${activeRunId}:status`
+          }
+        });
+      }
+      return {
+        body: { decision: admitted.decision, followUpRequest: admitted.followUpRequest },
+        status: 202,
+        batchStatus: "follow_up_queued",
+        followUpRequestId: admitted.followUpRequest.id,
+        ...(activeRunId ? { admittedRunId: activeRunId } : {})
+      };
+    }
+
+    const createdRun = await repo.createRun({
+      id: inputValue.runId,
+      event: inputValue.event,
+      accessProfileSnapshot: admitted.accessProfileSnapshot,
+      policySnapshotProvenance: admitted.policySnapshotProvenance,
+      routingPolicy: admitted.routingPolicy,
+      ...(inputValue.workstreamId ? { workstreamId: inputValue.workstreamId } : {}),
+      ...(inputValue.admissionBatchId ? { admissionBatchId: inputValue.admissionBatchId } : {})
+    });
+    if (!createdRun.created) {
+      return {
+        body: { decision: createdRun.replayDecision, run: createdRun.run, idempotentReplay: true },
+        status: 200,
+        batchStatus: "idempotent_replay",
+        admittedRunId: createdRun.run.id
+      };
+    }
+    const { run } = createdRun;
+    if (!inputValue.quiet) {
+      const sourceReceiptDelivery = await deliverSourceReceiptBestEffort({
+        repo,
+        sink: sourceReceiptSink,
+        receipt: {
+          runId: run.id,
+          provider: inputValue.event.callback.provider,
+          state: "received",
+          event: inputValue.event,
+          ...(inputValue.event.target.agentId ? { agentId: inputValue.event.target.agentId } : {})
+        }
+      });
+      if (sourceReceiptDelivery.delivered) scheduleDelayedLarkStatusCard({ run, event: inputValue.event });
+      const shouldDeliverAcknowledgement =
+        presentation.shouldDeliverAcknowledgement(inputValue.event.callback.provider)
+        || (shouldDeliverSourceReceipt(inputValue.event.callback.provider) && !sourceReceiptDelivery.delivered);
+      if (shouldDeliverAcknowledgement) {
+        const acknowledgementPresentation = presentation.acknowledgementPresentation({ runId: run.id });
+        const acknowledgement = presentation.render({
+          provider: inputValue.event.callback.provider,
+          ...larkRenderLocaleRenderOption(inputValue.event),
+          presentation: acknowledgementPresentation
+        });
+        const statusMessageKey = lifecycleStatusMessageKey({ provider: inputValue.event.callback.provider, runId: run.id });
+        await deliverAndAudit({
+          repo,
+          sink: callbackSink,
+          retry: callbackRetry,
+          message: {
+            runId: run.id,
+            kind: "acknowledgement",
+            provider: inputValue.event.callback.provider,
+            uri: inputValue.event.callback.uri,
+            body: acknowledgement.body,
+            ...(inputValue.event.target.agentId ? { agentId: inputValue.event.target.agentId } : {}),
+            ...(inputValue.event.callback.threadKey ? { threadKey: inputValue.event.callback.threadKey } : {}),
+            ...(statusMessageKey ? { statusMessageKey } : {}),
+            ...(acknowledgement.blocks?.length ? { blocks: acknowledgement.blocks } : {}),
+            ...(acknowledgement.rich ? { rich: acknowledgement.rich } : {})
+          }
+        });
+      }
+    }
+    return { body: { decision: admitted.decision, run }, status: 201, batchStatus: "created", admittedRunId: run.id };
   }
   const sourceThreadControl = createSourceThreadControlHandler({
     repo,
@@ -4636,164 +4919,313 @@ export function createDispatcherApp(input: {
     return c.json({ binding });
   });
 
+  app.post("/v1/factory-recipes", async (c) => {
+    const recipe = await parseDispatcherBody(c, FactoryRecipeSnapshotInputSchema);
+    const outcome = await repo.createFactoryRecipeSnapshot({
+      id: recipe.id,
+      version: recipe.version,
+      recipe
+    });
+    if (outcome.outcome === "conflict") return c.json({ error: "factory_recipe_conflict" }, 409);
+    return c.json({ recipe: FactoryRecipeSnapshotSchema.parse({
+      ...outcome.recipeSnapshot.recipe,
+      createdAt: outcome.recipeSnapshot.createdAt,
+      contentDigest: outcome.recipeSnapshot.contentDigest
+    }) }, outcome.outcome === "created" ? 201 : 200);
+  });
+
+  app.get("/v1/factory-recipes/:id/versions/:version", async (c) => {
+    const version = Number(c.req.param("version"));
+    if (!Number.isInteger(version) || version < 1) return c.json({ error: "invalid_factory_recipe_version" }, 400);
+    const stored = await repo.getFactoryRecipeSnapshot({ id: c.req.param("id"), version });
+    if (!stored) return c.json({ error: "factory_recipe_not_found" }, 404);
+    return c.json({ recipe: FactoryRecipeSnapshotSchema.parse({
+      ...stored.recipe,
+      createdAt: stored.createdAt,
+      contentDigest: stored.contentDigest
+    }) });
+  });
+
+  app.post("/v1/workstreams", async (c) => {
+    const workstream = await parseDispatcherBody(c, WorkstreamInputSchema);
+    const outcome = await repo.createFactoryWorkstream({
+      id: workstream.id,
+      recipeId: workstream.recipeId,
+      recipeVersion: workstream.recipeVersion,
+      workstream,
+      workThreadIds: workstream.members.map((member) => member.workThreadId)
+    });
+    if (outcome.outcome === "recipe_not_found") return c.json({ error: "factory_recipe_not_found" }, 404);
+    if (outcome.outcome === "work_thread_not_found") {
+      return c.json({ error: "work_thread_not_found", workThreadId: outcome.workThreadId }, 404);
+    }
+    if (outcome.outcome === "conflict") return c.json({ error: "workstream_conflict" }, 409);
+    const stored = outcome.workstream;
+    if (!stored) throw new Error(`Workstream ${workstream.id} was not returned after ${outcome.outcome}.`);
+    return c.json({ workstream: WorkstreamSchema.parse({
+      ...stored.workstream,
+      createdAt: stored.createdAt,
+      contentDigest: stored.contentDigest
+    }) }, outcome.outcome === "created" ? 201 : 200);
+  });
+
+  app.get("/v1/workstreams/:id", async (c) => {
+    const stored = await repo.getFactoryWorkstream({ id: c.req.param("id") });
+    if (!stored) return c.json({ error: "workstream_not_found" }, 404);
+    return c.json({ workstream: WorkstreamSchema.parse({
+      ...stored.workstream,
+      createdAt: stored.createdAt,
+      contentDigest: stored.contentDigest
+    }) });
+  });
+
+  async function emitWorkstreamBatchSummary(resultValue: z.infer<typeof WorkstreamAdmissionBatchResultSchema>): Promise<void> {
+    await recordControlPlaneEvent({
+      type: "workstream.batch.exceptions",
+      severity: resultValue.summary.exceptionCount > 0 ? "warn" : "info",
+      subject: resultValue.workstreamId,
+      idempotencyKey: `workstream.batch.exceptions:${resultValue.batchId}`,
+      payload: {
+        workstreamId: resultValue.workstreamId,
+        inputDigest: resultValue.inputDigest,
+        summary: resultValue.summary
+      }
+    });
+  }
+
+  function workstreamBatchReceipt(stored: Awaited<ReturnType<typeof repo.getWorkstreamAdmissionBatch>>) {
+    if (!stored) throw new Error("Cannot project a missing workstream admission batch.");
+    return WorkstreamAdmissionBatchReceiptSchema.parse({
+      batch: WorkstreamAdmissionBatchSchema.parse({
+        ...WorkstreamAdmissionBatchInputSchema.parse(stored.request),
+        createdAt: stored.createdAt,
+        contentDigest: stored.requestDigest
+      }),
+      status: stored.status,
+      items: stored.items.map((item) => ({
+        itemId: item.itemId,
+        index: item.ordinal,
+        runId: item.runId,
+        workThreadId: item.workThreadId,
+        status: item.status,
+        ...(item.result ? { result: WorkstreamAdmissionBatchItemResultSchema.parse(item.result) } : {})
+      })),
+      ...(stored.result ? { result: WorkstreamAdmissionBatchResultSchema.parse(stored.result) } : {}),
+      updatedAt: stored.updatedAt,
+      ...(stored.completedAt ? { completedAt: stored.completedAt } : {})
+    });
+  }
+
+  app.post("/v1/workstream-batches", async (c) => {
+    const batch = await parseDispatcherBody(c, WorkstreamAdmissionBatchInputSchema);
+    const inputDigest = sha256Digest(batch);
+    const leaseOwner = `dispatcher_${randomUUID()}`;
+    const existedBeforeAdmission = Boolean(await repo.getWorkstreamAdmissionBatch({ id: batch.id }));
+    const started = await repo.beginWorkstreamAdmissionBatch({
+      id: batch.id,
+      workstreamId: batch.workstreamId,
+      requestDigest: inputDigest,
+      request: batch,
+      items: batch.items,
+      leaseOwner,
+      leaseSeconds: workstreamBatchLeaseSeconds
+    });
+    if (started.outcome === "conflict") return c.json({ error: "workstream_batch_conflict" }, 409);
+    if (started.outcome === "workstream_not_found") return c.json({ error: "workstream_not_found" }, 404);
+    if (started.outcome === "invalid_member") {
+      return c.json({ error: "workstream_member_mismatch", workThreadId: started.workThreadId }, 409);
+    }
+    if (!started.batch) throw new Error(`Workstream batch ${batch.id} did not return its durable state.`);
+    if (started.outcome === "in_progress") {
+      return c.json({ receipt: workstreamBatchReceipt(started.batch) }, 200);
+    }
+    if (started.outcome === "replay") {
+      const durableResult = WorkstreamAdmissionBatchResultSchema.parse(started.batch.result);
+      await emitWorkstreamBatchSummary(durableResult);
+      return c.json({ receipt: workstreamBatchReceipt(started.batch) }, 200);
+    }
+
+    const channelPrincipal = channelPrincipalFromRequest(c.req.raw, channelPrincipals);
+    const results: z.infer<typeof WorkstreamAdmissionBatchResultSchema>["results"] = [];
+    for (const durableItem of started.batch.items) {
+      if (durableItem.status === "completed") {
+        results.push(WorkstreamAdmissionBatchItemResultSchema.parse(durableItem.result));
+        continue;
+      }
+      const claimed = await repo.claimWorkstreamAdmissionBatchItem({
+        batchId: batch.id,
+        itemId: durableItem.itemId,
+        leaseOwner,
+        leaseSeconds: workstreamBatchLeaseSeconds
+      });
+      if (claimed.outcome === "completed" && claimed.item?.result) {
+        results.push(WorkstreamAdmissionBatchItemResultSchema.parse(claimed.item.result));
+        continue;
+      }
+      if (claimed.outcome !== "claimed" || !claimed.item) {
+        throw new Error(`Workstream batch item ${durableItem.itemId} could not be claimed: ${claimed.outcome}.`);
+      }
+
+      const item = claimed.item;
+      const eventThreadId = protocolRunFieldsFromEvent(item.event, item.event.receivedAt).thread?.id;
+      const durableThread = await repo.getWorkThread({ workThreadId: item.workThreadId });
+      const itemResult = await withWorkstreamAdmissionLease({
+        batchId: batch.id,
+        itemId: item.itemId,
+        leaseOwner
+      }, async (): Promise<z.infer<typeof WorkstreamAdmissionBatchResultSchema>["results"][number]> => {
+        if (!durableThread || eventThreadId !== item.workThreadId) {
+          return {
+            itemId: item.itemId,
+            index: item.ordinal,
+            runId: item.runId,
+            status: "rejected",
+            statusCode: 409,
+            reasonCode: !durableThread ? "work_thread_not_found" : "event_work_thread_mismatch"
+          };
+        }
+        try {
+          const admissionResult = await admitAndCreateRun({
+            runId: item.runId,
+            event: item.event,
+            quiet: true,
+            workstreamId: batch.workstreamId,
+            admissionBatchId: batch.id,
+            ...(channelPrincipal ? { channelPrincipal } : {})
+          });
+          return {
+            itemId: item.itemId,
+            index: item.ordinal,
+            runId: item.runId,
+            status: admissionResult.batchStatus,
+            statusCode: admissionResult.status,
+            ...(admissionResult.reasonCode ? { reasonCode: admissionResult.reasonCode } : {}),
+            ...(admissionResult.admittedRunId ? { admittedRunId: admissionResult.admittedRunId } : {}),
+            ...(admissionResult.followUpRequestId ? { followUpRequestId: admissionResult.followUpRequestId } : {}),
+            ...(admissionResult.humanEscalationId ? { humanEscalationId: admissionResult.humanEscalationId } : {})
+          };
+        } catch (error) {
+          const reasonCode = error instanceof Error && error.message.startsWith("FACTORY_")
+            ? error.message.toLowerCase()
+            : null;
+          if (!reasonCode) throw error;
+          return {
+            itemId: item.itemId,
+            index: item.ordinal,
+            runId: item.runId,
+            status: "rejected",
+            statusCode: 409,
+            reasonCode
+          };
+        }
+      });
+      const completed = await repo.completeWorkstreamAdmissionBatchItem({
+        batchId: batch.id,
+        itemId: item.itemId,
+        leaseOwner,
+        result: itemResult
+      });
+      if (completed.outcome !== "completed" && completed.outcome !== "duplicate") {
+        throw new Error(`Workstream batch item ${item.itemId} could not be completed: ${completed.outcome}.`);
+      }
+      results.push(itemResult);
+    }
+
+    results.sort((left, right) => left.index - right.index);
+    const exceptions = results.filter((item) => item.status === "needs_human_decision" || item.status === "rejected");
+    const summary = {
+      totalItems: results.length,
+      createdCount: results.filter((item) => item.status === "created").length,
+      idempotentReplayCount: results.filter((item) => item.status === "idempotent_replay").length,
+      followUpQueuedCount: results.filter((item) => item.status === "follow_up_queued").length,
+      needsHumanDecisionCount: results.filter((item) => item.status === "needs_human_decision").length,
+      rejectedCount: results.filter((item) => item.status === "rejected").length,
+      exceptionCount: exceptions.length,
+      exceptions: exceptions.slice(0, 10).map((item) => ({
+        itemId: item.itemId,
+        index: item.index,
+        runId: item.runId,
+        status: item.status as "needs_human_decision" | "rejected",
+        ...(item.reasonCode ? { reasonCode: item.reasonCode } : {})
+      })),
+      omittedExceptionCount: Math.max(0, exceptions.length - 10)
+    };
+    const result = WorkstreamAdmissionBatchResultSchema.parse({
+      batchId: batch.id,
+      workstreamId: batch.workstreamId,
+      inputDigest,
+      results,
+      summary,
+      completedAt: new Date().toISOString()
+    });
+    const finalLease = await repo.renewWorkstreamAdmissionBatchLease({
+      batchId: batch.id,
+      leaseOwner,
+      leaseSeconds: workstreamBatchLeaseSeconds
+    });
+    if (finalLease.outcome !== "renewed") {
+      throw new Error(`Workstream batch ${batch.id} lease could not be renewed before finalization: ${finalLease.outcome}.`);
+    }
+    const finalized = await repo.finalizeWorkstreamAdmissionBatch({ id: batch.id, leaseOwner, result });
+    if (finalized.outcome === "replay" && finalized.batch?.result) {
+      const durableResult = WorkstreamAdmissionBatchResultSchema.parse(finalized.batch.result);
+      await emitWorkstreamBatchSummary(durableResult);
+      return c.json({ receipt: workstreamBatchReceipt(finalized.batch) }, 200);
+    }
+    if (finalized.outcome !== "completed") {
+      throw new Error(`Workstream batch ${batch.id} could not be finalized: ${finalized.outcome}.`);
+    }
+    await emitWorkstreamBatchSummary(result);
+    if (!finalized.batch) throw new Error(`Workstream batch ${batch.id} finalized without durable state.`);
+    return c.json({ receipt: workstreamBatchReceipt(finalized.batch) }, existedBeforeAdmission ? 200 : 201);
+  });
+
+  app.get("/v1/workstream-batches/:id", async (c) => {
+    const batch = await repo.getWorkstreamAdmissionBatch({ id: c.req.param("id") });
+    if (!batch) return c.json({ error: "workstream_batch_not_found" }, 404);
+    return c.json({ receipt: workstreamBatchReceipt(batch) });
+  });
+
+  app.get("/v1/workstreams/:id/metrics", async (c) => {
+    const metrics = await repo.getWorkstreamMetrics({ workstreamId: c.req.param("id") });
+    if (!metrics) return c.json({ error: "workstream_not_found" }, 404);
+    return c.json({ metrics: WorkstreamMetricsSchema.parse(metrics) });
+  });
+
+  app.get("/v1/workstreams/:id/evaluation", async (c) => {
+    const storedWorkstream = await repo.getFactoryWorkstream({ id: c.req.param("id") });
+    if (!storedWorkstream) return c.json({ error: "workstream_not_found" }, 404);
+    const workstream = WorkstreamSchema.parse({
+      ...storedWorkstream.workstream,
+      createdAt: storedWorkstream.createdAt,
+      contentDigest: storedWorkstream.contentDigest
+    });
+    const storedRecipe = await repo.getFactoryRecipeSnapshot({ id: workstream.recipeId, version: workstream.recipeVersion });
+    if (!storedRecipe) return c.json({ error: "factory_recipe_not_found" }, 404);
+    const metrics = await repo.getWorkstreamMetrics({ workstreamId: workstream.id });
+    if (!metrics) return c.json({ error: "workstream_not_found" }, 404);
+    const evaluation = evaluateWorkstream({
+      recipe: FactoryRecipeSnapshotSchema.parse({
+        ...storedRecipe.recipe,
+        createdAt: storedRecipe.createdAt,
+        contentDigest: storedRecipe.contentDigest
+      }),
+      workstream,
+      metrics: WorkstreamMetricsSchema.parse(metrics),
+      evaluatedAt: input.completionNow?.() ?? new Date().toISOString()
+    });
+    return c.json({ evaluation });
+  });
+
   app.post("/v1/runs", async (c) => {
     const parsed = await parseDispatcherBody(c, CreateRunSchema);
     const channelPrincipal = channelPrincipalFromRequest(c.req.raw, channelPrincipals);
-    let ownershipVerified = false;
-    try {
-      ownershipVerified = await managedChannelOwnershipVerified({
-        repo,
-        event: parsed.event,
-        ...(channelPrincipal ? { principal: channelPrincipal } : {})
-      });
-    } catch (error) {
-      if (!(error instanceof ChannelBindingCorruptionError)) throw error;
-      await recordControlPlaneEvent({
-        type: "admission.managed_channel_binding_corrupt",
-        severity: "error",
-        subject: parsed.runId,
-        payload: { runId: parsed.runId, source: parsed.event.source, sourceEventId: parsed.event.sourceEventId }
-      });
-      return c.json({ error: "managed_channel_binding_corrupt" }, 403);
-    }
-    if (!ownershipVerified) {
-      await recordControlPlaneEvent({
-        type: "admission.managed_channel_ownership_unverified",
-        severity: "warn",
-        subject: parsed.runId,
-        payload: { runId: parsed.runId, source: parsed.event.source, sourceEventId: parsed.event.sourceEventId }
-      });
-      return c.json({ error: "managed_channel_ownership_unverified" }, 403);
-    }
-    const admitted = await admission.admitRun({ requestId: parsed.runId, event: parsed.event });
-
-    if (admitted.outcome === "needs_human_decision") {
-      const projectTarget = projectTargetRefFromEvent(parsed.event);
-      await recordControlPlaneEvent({
-        type: "admission.needs_human_decision",
-        severity: ["repo_context_missing", "repo_not_bound"].includes(admitted.decision.reasonCode) ? "warn" : "info",
-        subject: parsed.runId,
-        payload: {
-          runId: parsed.runId,
-          decision: admitted.decision,
-          source: parsed.event.source,
-          sourceEventId: parsed.event.sourceEventId,
-          projectTarget: projectTarget ? `${projectTarget.provider}:${projectTarget.owner}/${projectTarget.repo}` : null
-        }
-      });
-      const humanDecision = await structureAdmissionHumanDecision({
-        requestId: parsed.runId,
-        event: parsed.event,
-        decision: admitted.decision
-      });
-      return c.json({ decision: admitted.decision, ...humanDecision }, 202);
-    }
-
-    if (admitted.outcome === "drop_duplicate") {
-      const replay = await repo.createRun({ id: parsed.runId, event: parsed.event });
-      const decision = replay.created ? admitted.decision : replay.replayDecision;
-      return c.json({ decision, run: replay.run, idempotentReplay: true }, 200);
-    }
-
-    if (admitted.outcome === "follow_up_queued") {
-      const event = admitted.followUpRequest.event;
-      const activeRunId = admitted.followUpRequest.activeRunId;
-      if (activeRunId && shouldDeliverRunStatusUpdate(presentation, { provider: event.callback.provider, state: "queued" })) {
-        const queuedPresentation = presentation.runStatusPresentation({
-          runId: activeRunId,
-          state: "queued",
-          message: `Queued follow-up ${admitted.followUpRequest.id} behind the active run.`,
-          nextAction: "Wait for the active run final reply, send another follow-up to queue more context, or request cancellation with /stop.",
-          detailVisibility: "source_thread"
-        });
-        const queued = presentation.render({
-          provider: event.callback.provider,
-          ...larkRenderLocaleRenderOption(event),
-          presentation: queuedPresentation
-        });
-        await deliverAndAudit({
-          repo,
-          sink: callbackSink,
-          retry: callbackRetry,
-          message: {
-            runId: activeRunId,
-            kind: "progress",
-            provider: event.callback.provider,
-            uri: event.callback.uri,
-            body: queued.body,
-            ...(event.target.agentId ? { agentId: event.target.agentId } : {}),
-            ...(event.callback.threadKey ? { threadKey: event.callback.threadKey } : {}),
-            ...(queued.blocks?.length ? { blocks: queued.blocks } : {}),
-            ...(queued.rich ? { rich: queued.rich } : {}),
-            statusMessageKey: `${activeRunId}:status`
-          }
-        });
-      }
-      return c.json({ decision: admitted.decision, followUpRequest: admitted.followUpRequest }, 202);
-    }
-
-    const createdRun = await repo.createRun({
-      id: parsed.runId,
+    const result = await admitAndCreateRun({
+      runId: parsed.runId,
       event: parsed.event,
-      accessProfileSnapshot: admitted.accessProfileSnapshot,
-      policySnapshotProvenance: admitted.policySnapshotProvenance,
-      routingPolicy: admitted.routingPolicy
+      ...(channelPrincipal ? { channelPrincipal } : {})
     });
-    if (!createdRun.created) {
-      return c.json(
-        {
-          decision: createdRun.replayDecision,
-          run: createdRun.run,
-          idempotentReplay: true
-        },
-        200
-      );
-    }
-    const { run } = createdRun;
-    const sourceReceiptDelivery = await deliverSourceReceiptBestEffort({
-      repo,
-      sink: sourceReceiptSink,
-      receipt: {
-        runId: run.id,
-        provider: parsed.event.callback.provider,
-        state: "received",
-        event: parsed.event,
-        ...(parsed.event.target.agentId ? { agentId: parsed.event.target.agentId } : {})
-      }
-    });
-    if (sourceReceiptDelivery.delivered) {
-      scheduleDelayedLarkStatusCard({ run, event: parsed.event });
-    }
-    const shouldDeliverAcknowledgement =
-      presentation.shouldDeliverAcknowledgement(parsed.event.callback.provider) ||
-      (shouldDeliverSourceReceipt(parsed.event.callback.provider) && !sourceReceiptDelivery.delivered);
-    if (shouldDeliverAcknowledgement) {
-      const acknowledgementPresentation = presentation.acknowledgementPresentation({ runId: run.id });
-      const acknowledgement = presentation.render({
-        provider: parsed.event.callback.provider,
-        ...larkRenderLocaleRenderOption(parsed.event),
-        presentation: acknowledgementPresentation
-      });
-      const statusMessageKey = lifecycleStatusMessageKey({ provider: parsed.event.callback.provider, runId: run.id });
-      await deliverAndAudit({
-        repo,
-        sink: callbackSink,
-        retry: callbackRetry,
-        message: {
-          runId: run.id,
-          kind: "acknowledgement",
-          provider: parsed.event.callback.provider,
-          uri: parsed.event.callback.uri,
-          body: acknowledgement.body,
-          ...(parsed.event.target.agentId ? { agentId: parsed.event.target.agentId } : {}),
-          ...(parsed.event.callback.threadKey ? { threadKey: parsed.event.callback.threadKey } : {}),
-          ...(statusMessageKey ? { statusMessageKey } : {}),
-          ...(acknowledgement.blocks?.length ? { blocks: acknowledgement.blocks } : {}),
-          ...(acknowledgement.rich ? { rich: acknowledgement.rich } : {})
-        }
-      });
-    }
-    return c.json({ decision: admitted.decision, run }, 201);
+    return c.json(result.body, result.status);
   });
 
   app.post("/v1/thread-actions", async (c) => {

--- a/packages/dispatcher/test/digest.test.ts
+++ b/packages/dispatcher/test/digest.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { sha256Digest } from "../src/digest.js";
+
+describe("dispatcher durable digests", () => {
+  it("uses stable code-unit ordering across hosts", () => {
+    expect(sha256Digest({ z: 1, "ä": 2, a: 3, "😀": 4 })).toBe(
+      "sha256:fb215dbd6cdd5ce98f4e77b27ba82bf88b6376d244e0dbc9323c496101653081"
+    );
+  });
+});

--- a/packages/dispatcher/test/workstream-batches.test.ts
+++ b/packages/dispatcher/test/workstream-batches.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { createDispatcherApp, type CallbackMessage, type SourceReceipt } from "../src/server.js";
+
+const event = {
+  id: "evt_seed",
+  source: "github",
+  sourceEventId: "comment_seed",
+  receivedAt: "2026-07-26T00:00:00.000Z",
+  actor: { provider: "github", providerUserId: "42", handle: "octocat", writeAccess: true },
+  target: { mention: "@opentag", agentId: "opentag" },
+  command: { rawText: "fix this", intent: "fix", args: {} },
+  context: [{ provider: "github", kind: "issue", uri: "https://github.com/acme/demo/issues/1", visibility: "public" }],
+  workItem: {
+    provider: "github",
+    kind: "issue",
+    externalId: "acme/demo#1",
+    uri: "https://github.com/acme/demo/issues/1",
+    ownerContainer: { provider: "github", id: "acme/demo", uri: "https://github.com/acme/demo" }
+  },
+  permissions: [{ scope: "issue:comment", reason: "reply to source thread" }],
+  callback: { provider: "github", uri: "https://api.github.com/repos/acme/demo/issues/1/comments" },
+  metadata: { repoProvider: "github", owner: "acme", repo: "demo" }
+} as const;
+
+function post(body: unknown) {
+  return { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) };
+}
+
+async function factorySetup(input: {
+  callbackMessages?: CallbackMessage[];
+  sourceReceipts?: SourceReceipt[];
+  agentAccessProfileCheck?: Parameters<typeof createDispatcherApp>[0]["agentAccessProfileCheck"];
+  completionNow?: Parameters<typeof createDispatcherApp>[0]["completionNow"];
+  databasePath?: string;
+} = {}) {
+  const app = createDispatcherApp({
+    databasePath: input.databasePath ?? ":memory:",
+    callbackSink: { async deliver(message) { input.callbackMessages?.push(message); } },
+    sourceReceiptSink: { async deliver(receipt) { input.sourceReceipts?.push(receipt); return { delivered: true }; } },
+    ...(input.agentAccessProfileCheck ? { agentAccessProfileCheck: input.agentAccessProfileCheck } : {}),
+    ...(input.completionNow ? { completionNow: input.completionNow } : {})
+  });
+  expect((await app.request("/v1/runners", post({ runnerId: "runner_1", name: "Local Runner" }))).status).toBe(201);
+  expect((await app.request("/v1/repo-bindings", post({
+    provider: "github",
+    owner: "acme",
+    repo: "demo",
+    runnerId: "runner_1",
+    workspacePath: "/tmp/acme-demo",
+    defaultExecutor: "echo",
+    allowedActors: ["octocat"]
+  }))).status).toBe(201);
+  const seedResponse = await app.request("/v1/runs", post({ runId: "run_seed", event }));
+  expect(seedResponse.status).toBe(201);
+  const seed = await seedResponse.json() as { run: { thread: { id: string } } };
+  expect((await app.request("/v1/runs/run_seed/cancel", post({ reason: "factory setup" }))).status).toBe(200);
+
+  const recipe = {
+    id: "recipe_default",
+    version: 1,
+    name: "Default workstream",
+    budgets: {
+      maxConcurrentRuns: 2,
+      maxAttemptsPerRun: 3,
+      maxCostUnits: 20,
+      costUnitsPerAttempt: 1,
+      allowedLocalities: ["local", "private", "hosted"]
+    }
+  };
+  expect((await app.request("/v1/factory-recipes", post(recipe))).status).toBe(201);
+  const workstream = {
+    id: "workstream_default",
+    recipeId: recipe.id,
+    recipeVersion: recipe.version,
+    name: "Default workstream",
+    members: [{ kind: "work_thread", workThreadId: seed.run.thread.id }]
+  };
+  expect((await app.request("/v1/workstreams", post(workstream))).status).toBe(201);
+  return { app, recipe, workstream, workThreadId: seed.run.thread.id };
+}
+
+describe("workstream batch admission", () => {
+  it("keeps single-run behavior and admits an ordered quiet replay-safe batch", async () => {
+    const callbackMessages: CallbackMessage[] = [];
+    const sourceReceipts: SourceReceipt[] = [];
+    const { app, workThreadId } = await factorySetup({ callbackMessages, sourceReceipts });
+    callbackMessages.length = 0;
+    sourceReceipts.length = 0;
+
+    const batch = {
+      id: "batch_1",
+      workstreamId: "workstream_default",
+      items: [{
+        itemId: "item_1",
+        runId: "run_batch_1",
+        workThreadId,
+        event: { ...event, id: "evt_batch_1", sourceEventId: "comment_batch_1", receivedAt: "2026-07-26T00:01:00.000Z" }
+      }]
+    };
+    const admitted = await app.request("/v1/workstream-batches", post(batch));
+    expect(admitted.status).toBe(201);
+    const responseBody = await admitted.json() as { receipt: { result: unknown } };
+    expect(responseBody.receipt).toMatchObject({
+      status: "completed",
+      batch: { id: "batch_1", workstreamId: "workstream_default" },
+      items: [{ itemId: "item_1", index: 0, runId: "run_batch_1", status: "completed" }],
+      result: {
+        batchId: "batch_1",
+        workstreamId: "workstream_default",
+        results: [{ itemId: "item_1", index: 0, runId: "run_batch_1", admittedRunId: "run_batch_1", status: "created" }],
+        summary: { totalItems: 1, createdCount: 1, exceptionCount: 0, exceptions: [], omittedExceptionCount: 0 }
+      }
+    });
+    expect(callbackMessages).toEqual([]);
+    expect(sourceReceipts).toEqual([]);
+
+    const replay = await app.request("/v1/workstream-batches", post(batch));
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toEqual(responseBody);
+    const durable = await app.request("/v1/workstream-batches/batch_1");
+    await expect(durable.json()).resolves.toEqual(responseBody);
+
+    const conflicting = await app.request("/v1/workstream-batches", post({
+      ...batch,
+      items: [{ ...batch.items[0], event: { ...batch.items[0].event, command: { ...batch.items[0].event.command, rawText: "different" } } }]
+    }));
+    expect(conflicting.status).toBe(409);
+    await expect(conflicting.json()).resolves.toEqual({ error: "workstream_batch_conflict" });
+
+    expect((await app.request("/v1/workstreams/workstream_default/metrics")).status).toBe(200);
+    expect((await app.request("/v1/workstreams/workstream_default/evaluation")).status).toBe(200);
+    const audit = await app.request("/v1/control-plane-events?type=workstream.batch.exceptions");
+    const auditBody = await audit.json() as { events: unknown[] };
+    expect(auditBody.events).toHaveLength(1);
+  });
+
+  it("rejects strict bodies and work-thread membership mismatches", async () => {
+    const { app, workThreadId } = await factorySetup();
+    const invalid = await app.request("/v1/workstream-batches", post({
+      id: "batch_extra",
+      workstreamId: "workstream_default",
+      items: [{ itemId: "item_extra", runId: "run_extra", workThreadId, event }],
+      extra: true
+    }));
+    expect(invalid.status).toBe(400);
+
+    const mismatch = await app.request("/v1/workstream-batches", post({
+      id: "batch_mismatch",
+      workstreamId: "workstream_default",
+      items: [{ itemId: "item_mismatch", runId: "run_mismatch", workThreadId: "thread_missing", event }]
+    }));
+    expect(mismatch.status).toBe(409);
+    await expect(mismatch.json()).resolves.toEqual({ error: "workstream_member_mismatch", workThreadId: "thread_missing" });
+  });
+
+  it("preserves factory attribution when a queued batch follow-up is promoted", async () => {
+    const { app, workThreadId } = await factorySetup();
+    expect((await app.request("/v1/runs", post({
+      runId: "run_active_before_batch",
+      event: {
+        ...event,
+        id: "evt_active_before_batch",
+        sourceEventId: "comment_active_before_batch",
+        receivedAt: "2026-07-26T00:01:00.000Z"
+      }
+    }))).status).toBe(201);
+    expect((await app.request("/v1/runners/runner_1/claim", { method: "POST" })).status).toBe(200);
+    const batch = {
+      id: "batch_follow_up",
+      workstreamId: "workstream_default",
+      items: [{
+        itemId: "item_follow_up",
+        runId: "follow_up_batch_queued",
+        workThreadId,
+        event: {
+          ...event,
+          id: "evt_batch_follow_up",
+          sourceEventId: "comment_batch_follow_up",
+          receivedAt: "2026-07-26T00:03:00.000Z"
+        }
+      }]
+    };
+
+    const admitted = await app.request("/v1/workstream-batches", post(batch));
+    expect(admitted.status).toBe(201);
+    await expect(admitted.json()).resolves.toMatchObject({
+      receipt: {
+        result: {
+          results: [
+            { itemId: "item_follow_up", status: "follow_up_queued", followUpRequestId: "follow_up_batch_queued" }
+          ]
+        }
+      }
+    });
+
+    const queued = await app.request("/v1/follow-up-requests/follow_up_batch_queued");
+    await expect(queued.json()).resolves.toMatchObject({
+      followUpRequest: {
+        id: "follow_up_batch_queued",
+        workstreamId: "workstream_default",
+        admissionBatchId: "batch_follow_up"
+      }
+    });
+
+    const promoted = await app.request("/v1/follow-up-requests/follow_up_batch_queued/create-run", post({
+      runId: "run_promoted_from_batch"
+    }));
+    expect(promoted.status).toBe(201);
+    await expect(promoted.json()).resolves.toMatchObject({
+      run: { id: "run_promoted_from_batch", parentRunId: "run_active_before_batch" }
+    });
+
+    const metrics = await app.request("/v1/workstreams/workstream_default/metrics");
+    await expect(metrics.json()).resolves.toMatchObject({ metrics: { runCount: 1 } });
+  });
+
+  it("keeps needs-human decisions durable and bounds the quiet exception summary", async () => {
+    let deny = false;
+    const callbackMessages: CallbackMessage[] = [];
+    const sourceReceipts: SourceReceipt[] = [];
+    const { app, workThreadId } = await factorySetup({
+      callbackMessages,
+      sourceReceipts,
+      agentAccessProfileCheck: async () => deny
+        ? { allowed: false, reason: "access denied", reasonCode: "agent_access_profile_denied" }
+        : { allowed: true }
+    });
+    callbackMessages.length = 0;
+    sourceReceipts.length = 0;
+    deny = true;
+
+    const items = Array.from({ length: 12 }, (_, index) => ({
+      itemId: `item_denied_${index}`,
+      runId: `run_denied_${index}`,
+      workThreadId,
+      event: {
+        ...event,
+        id: `evt_denied_${index}`,
+        sourceEventId: `comment_denied_${index}`,
+        receivedAt: `2026-07-26T00:${String(index + 1).padStart(2, "0")}:00.000Z`
+      }
+    }));
+    const response = await app.request("/v1/workstream-batches", post({
+      id: "batch_denied",
+      workstreamId: "workstream_default",
+      items
+    }));
+    expect(response.status).toBe(201);
+    const body = await response.json() as {
+      receipt: { result: { results: Array<{ status: string; humanEscalationId?: string }>; summary: Record<string, unknown> } };
+    };
+    expect(body.receipt.result.summary).toMatchObject({
+      totalItems: 12,
+      needsHumanDecisionCount: 12,
+      exceptionCount: 12,
+      omittedExceptionCount: 2,
+      exceptions: expect.arrayContaining([expect.objectContaining({ status: "needs_human_decision" })])
+    });
+    expect((body.receipt.result.summary["exceptions"] as unknown[])).toHaveLength(10);
+    expect(body.receipt.result.results).toHaveLength(12);
+    expect(body.receipt.result.results.every((item) => item.status === "needs_human_decision" && item.humanEscalationId)).toBe(true);
+    expect(callbackMessages).toEqual([]);
+    expect(sourceReceipts).toEqual([]);
+  });
+
+  it("renews the batch and current item leases during a slow admission", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "opentag-workstream-heartbeat-"));
+    const databasePath = join(directory, "dispatcher.sqlite");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-26T00:00:00.000Z"));
+    let delayAdmission = false;
+    let releaseAdmission: (() => void) | undefined;
+    let signalAdmissionStarted: (() => void) | undefined;
+    const admissionStarted = new Promise<void>((resolve) => {
+      signalAdmissionStarted = resolve;
+    });
+    const admissionRelease = new Promise<void>((resolve) => {
+      releaseAdmission = resolve;
+    });
+    try {
+      const { app, workThreadId } = await factorySetup({
+        databasePath,
+        agentAccessProfileCheck: async () => {
+          if (delayAdmission) {
+            signalAdmissionStarted?.();
+            await admissionRelease;
+          }
+          return { allowed: true };
+        }
+      });
+      delayAdmission = true;
+      const batch = {
+        id: "batch_heartbeat",
+        workstreamId: "workstream_default",
+        items: [{
+          itemId: "item_heartbeat",
+          runId: "run_heartbeat",
+          workThreadId,
+          event: {
+            ...event,
+            id: "evt_heartbeat",
+            sourceEventId: "comment_heartbeat",
+            receivedAt: "2026-07-26T00:01:00.000Z"
+          }
+        }]
+      };
+
+      const admission = app.request("/v1/workstream-batches", post(batch));
+      await admissionStarted;
+      await vi.advanceTimersByTimeAsync(301_000);
+
+      const competingDispatcher = createDispatcherApp({ databasePath });
+      const competing = await competingDispatcher.request("/v1/workstream-batches", post(batch));
+      expect(competing.status).toBe(200);
+      await expect(competing.json()).resolves.toMatchObject({
+        receipt: {
+          status: "processing",
+          items: [{ itemId: "item_heartbeat", status: "processing" }]
+        }
+      });
+
+      releaseAdmission?.();
+      const completed = await admission;
+      expect(completed.status).toBe(201);
+      await expect(completed.json()).resolves.toMatchObject({
+        receipt: { status: "completed", result: { batchId: "batch_heartbeat" } }
+      });
+    } finally {
+      vi.useRealTimers();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("resumes an expired processing item without creating a second run", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "opentag-workstream-batch-"));
+    const databasePath = join(directory, "dispatcher.sqlite");
+    try {
+      const { app, workThreadId } = await factorySetup({ databasePath });
+      const batch = {
+        id: "batch_resume",
+        workstreamId: "workstream_default",
+        items: [{
+          itemId: "item_resume",
+          runId: "run_resume",
+          workThreadId,
+          event: { ...event, id: "evt_resume", sourceEventId: "comment_resume", receivedAt: "2026-07-26T00:20:00.000Z" }
+        }]
+      };
+      expect((await app.request("/v1/workstream-batches", post(batch))).status).toBe(201);
+
+      const sqlite = new Database(databasePath);
+      try {
+        sqlite.prepare(`UPDATE workstream_admission_batches
+          SET status = 'processing', lease_owner = 'live_dispatcher', lease_expires_at = '2999-01-01T00:00:00.000Z',
+              result_json = NULL, completed_at = NULL
+          WHERE id = ?`).run(batch.id);
+      } finally {
+        sqlite.close();
+      }
+      const activeLease = await app.request("/v1/workstream-batches", post(batch));
+      expect(activeLease.status).toBe(200);
+      await expect(activeLease.json()).resolves.toMatchObject({
+        receipt: { batch: { id: "batch_resume" }, status: "processing" }
+      });
+
+      const expiredSqlite = new Database(databasePath);
+      try {
+        expiredSqlite.prepare(`UPDATE workstream_admission_batches
+          SET lease_owner = 'dead_dispatcher', lease_expires_at = '2000-01-01T00:00:00.000Z'
+          WHERE id = ?`).run(batch.id);
+        expiredSqlite.prepare(`UPDATE workstream_admission_batch_items
+          SET status = 'processing', lease_owner = 'dead_dispatcher', lease_expires_at = '2000-01-01T00:00:00.000Z',
+              result_json = NULL, completed_at = NULL
+          WHERE batch_id = ? AND item_id = ?`).run(batch.id, "item_resume");
+      } finally {
+        expiredSqlite.close();
+      }
+
+      const resumed = await app.request("/v1/workstream-batches", post(batch));
+      expect(resumed.status).toBe(200);
+      await expect(resumed.json()).resolves.toMatchObject({
+        receipt: {
+          status: "completed",
+          result: {
+            results: [{
+              itemId: "item_resume",
+              runId: "run_resume",
+              admittedRunId: "run_resume",
+              status: "idempotent_replay"
+            }]
+          }
+        }
+      });
+      const metrics = await app.request("/v1/workstreams/workstream_default/metrics");
+      await expect(metrics.json()).resolves.toMatchObject({ metrics: { runCount: 1 } });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("reconstructs the same durable receipt and deterministic evaluation after restart", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "opentag-workstream-replay-"));
+    const databasePath = join(directory, "dispatcher.sqlite");
+    const completionNow = () => "2026-07-26T00:30:00.000Z";
+    try {
+      const { app, workThreadId } = await factorySetup({ databasePath, completionNow });
+      const batch = {
+        id: "batch_restart_replay",
+        workstreamId: "workstream_default",
+        items: [{
+          itemId: "item_restart_replay",
+          runId: "run_restart_replay",
+          workThreadId,
+          event: {
+            ...event,
+            id: "evt_restart_replay",
+            sourceEventId: "comment_restart_replay",
+            receivedAt: "2026-07-26T00:29:00.000Z"
+          }
+        }]
+      };
+      expect((await app.request("/v1/workstream-batches", post(batch))).status).toBe(201);
+      const beforeReceipt = await (await app.request("/v1/workstream-batches/batch_restart_replay")).json();
+      const beforeEvaluation = await (await app.request("/v1/workstreams/workstream_default/evaluation")).json();
+
+      const recovered = createDispatcherApp({ databasePath, completionNow });
+      const afterReceipt = await (await recovered.request("/v1/workstream-batches/batch_restart_replay")).json();
+      const afterEvaluation = await (await recovered.request("/v1/workstreams/workstream_default/evaluation")).json();
+
+      expect(afterReceipt).toEqual(beforeReceipt);
+      expect(afterEvaluation).toEqual(beforeEvaluation);
+      await expect(recovered.request("/v1/workstream-batches", post(batch)).then((response) => response.json()))
+        .resolves.toEqual(beforeReceipt);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -4,6 +4,10 @@ Deterministic execution governance for OpenTag work loops.
 
 This package owns the Phase 1 completion predicate and its small command/query orchestration surface. It keeps executor success separate from evidence-backed work completion.
 
+It also owns pure, deterministic routing and factory-workstream evaluation.
+Persistence, batch processing, Attempt leasing, and operator presentation remain
+outside this package.
+
 ## Install
 
 ```bash
@@ -33,6 +37,18 @@ bounded partition so explicitly selected runners remain reachable.
 Routing does not use executor self-reported success or accepted-completion
 metrics to bypass policy. Those metrics are an operator-facing evaluation
 signal until an explicit, reviewable ranking policy is introduced.
+
+## Workstream evaluation
+
+`evaluateWorkstream` evaluates one immutable recipe snapshot, its WorkThread-only
+workstream, and metrics derived from durable Runs, fenced Attempts, and current
+CompletionAssessments. It returns a canonical input digest and one of
+`healthy`, `attention_required`, or `blocked`.
+
+Concurrency, per-Run attempts, fixed abstract cost units, and immutable Attempt
+locality are fail-closed budget signals. Cost units are capacity accounting, not
+currency. The function has no provider calls and cannot update a live
+CompletionAssessment.
 
 ## Responsibilities
 

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -2,3 +2,4 @@ export * from "./evaluate.js";
 export * from "./governance.js";
 export * from "./routing.js";
 export * from "./types.js";
+export * from "./workstream.js";

--- a/packages/governance/src/routing.ts
+++ b/packages/governance/src/routing.ts
@@ -26,6 +26,7 @@ export type RoutingEvaluationInput = {
   access: {
     allowedRunnerIds?: string[];
     allowedExecutorIds?: string[];
+    allowedLocalities?: RunnerLocality[];
     locality?: RoutingLocalityRequirement;
     unresolvedConnectionRefs: boolean;
   };
@@ -129,6 +130,13 @@ export function evaluateRouting(input: RoutingEvaluationInput): RoutingDecision 
         reasons.push({ code: "runner_locality_mismatch", message: "Runner locality does not satisfy the captured access profile." });
       } else if (runner) {
         reasons.push({ code: "runner_locality_satisfied", message: "Runner locality satisfies the captured access profile." });
+      }
+
+      if (runner && input.access.allowedLocalities !== undefined && !input.access.allowedLocalities.includes(runner.locality)) {
+        eligible = false;
+        reasons.push({ code: "runner_locality_not_allowed_by_factory_recipe", message: "Factory recipe does not allow this runner locality." });
+      } else if (runner && input.access.allowedLocalities !== undefined) {
+        reasons.push({ code: "runner_locality_allowed_by_factory_recipe", message: "Factory recipe allows this runner locality." });
       }
 
       if (input.access.allowedExecutorIds !== undefined && !input.access.allowedExecutorIds.includes(executorId)) {

--- a/packages/governance/src/workstream.ts
+++ b/packages/governance/src/workstream.ts
@@ -1,0 +1,139 @@
+import { createHash } from "node:crypto";
+import {
+  WorkstreamEvaluationInputSchema,
+  WorkstreamEvaluationSchema,
+  type RunnerLocality,
+  type WorkstreamBudgetViolation,
+  type WorkstreamEvaluation,
+  type WorkstreamEvaluationInput
+} from "@opentag/core";
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => compareCodeUnits(left, right))
+        .map(([key, child]) => [key, canonicalize(child)])
+    );
+  }
+  return value;
+}
+
+function normalizedInput(input: WorkstreamEvaluationInput): WorkstreamEvaluationInput {
+  return {
+    ...input,
+    recipe: {
+      ...input.recipe,
+      budgets: {
+        ...input.recipe.budgets,
+        allowedLocalities: [...input.recipe.budgets.allowedLocalities].sort(compareCodeUnits)
+      }
+    },
+    workstream: {
+      ...input.workstream,
+      members: [...input.workstream.members].sort((left, right) => compareCodeUnits(left.workThreadId, right.workThreadId))
+    }
+  };
+}
+
+export function workstreamInputDigest(inputValue: WorkstreamEvaluationInput): string {
+  const input = WorkstreamEvaluationInputSchema.parse(inputValue);
+  const normalized = normalizedInput(input);
+  return `sha256:${createHash("sha256").update(JSON.stringify(canonicalize(normalized))).digest("hex")}`;
+}
+
+export function evaluateWorkstream(inputValue: WorkstreamEvaluationInput): WorkstreamEvaluation {
+  const input = WorkstreamEvaluationInputSchema.parse(inputValue);
+  if (input.recipe.id !== input.workstream.recipeId || input.recipe.version !== input.workstream.recipeVersion) {
+    throw new Error("Workstream recipe reference does not match the evaluated recipe snapshot.");
+  }
+  if (input.metrics.workstreamId !== input.workstream.id) {
+    throw new Error("Workstream metrics do not belong to the evaluated workstream.");
+  }
+
+  const violations: WorkstreamBudgetViolation[] = [];
+  const budgets = input.recipe.budgets;
+  const metrics = input.metrics;
+
+  if (metrics.activeRunCount > budgets.maxConcurrentRuns) {
+    violations.push({
+      code: "concurrency_budget_exceeded",
+      message: "Active runs exceed the recipe concurrency budget.",
+      actual: metrics.activeRunCount,
+      limit: budgets.maxConcurrentRuns
+    });
+  }
+  if (metrics.attemptsPerRunExceededCount > 0) {
+    violations.push({
+      code: "attempt_budget_exceeded",
+      message: "One or more runs exceed the recipe attempt budget.",
+      actual: metrics.attemptsPerRunExceededCount,
+      limit: budgets.maxAttemptsPerRun
+    });
+  }
+  if (metrics.budgetBlockedRunCount > 0) {
+    violations.push({
+      code: "budget_blocked_runs",
+      message: "One or more runs are blocked by a recipe budget.",
+      actual: metrics.budgetBlockedRunCount
+    });
+  }
+
+  const observedCostUnits = metrics.totalAttempts * budgets.costUnitsPerAttempt;
+  if (metrics.totalCostUnits !== observedCostUnits) {
+    violations.push({
+      code: "cost_accounting_mismatch",
+      message: "Reported cost units do not match the recipe cost per attempt.",
+      actual: metrics.totalCostUnits,
+      limit: observedCostUnits
+    });
+  }
+  if (observedCostUnits > budgets.maxCostUnits) {
+    violations.push({
+      code: "cost_budget_exceeded",
+      message: "Observed attempt cost exceeds the recipe cost budget.",
+      actual: observedCostUnits,
+      limit: budgets.maxCostUnits
+    });
+  }
+
+  const allowedLocalities = new Set<RunnerLocality>(budgets.allowedLocalities);
+  (Object.entries(metrics.attemptsByLocality) as Array<[RunnerLocality | "unknown", number]>).forEach(([locality, count]) => {
+    if (locality === "unknown" && count > 0) {
+      violations.push({
+        code: "locality_budget_exceeded",
+        message: "One or more attempts have no immutable locality snapshot.",
+        actual: count
+      });
+      return;
+    }
+    if (locality !== "unknown" && count > 0 && !allowedLocalities.has(locality)) {
+      violations.push({
+        code: "locality_budget_exceeded",
+        message: `Attempts ran in disallowed locality: ${locality}.`,
+        actual: count,
+        locality
+      });
+    }
+  });
+
+  violations.sort((left, right) =>
+    compareCodeUnits(left.code, right.code) || compareCodeUnits(left.locality ?? "", right.locality ?? "")
+  );
+
+  return WorkstreamEvaluationSchema.parse({
+    workstreamId: input.workstream.id,
+    recipeId: input.recipe.id,
+    recipeVersion: input.recipe.version,
+    status: violations.length > 0 ? "blocked" : metrics.exceptionCount > 0 ? "attention_required" : "healthy",
+    inputDigest: workstreamInputDigest(input),
+    evaluatedAt: input.evaluatedAt,
+    acceptedWorkThreadCount: metrics.acceptedWorkThreadCount,
+    violations
+  });
+}

--- a/packages/governance/test/routing.test.ts
+++ b/packages/governance/test/routing.test.ts
@@ -110,6 +110,25 @@ describe("evaluateRouting", () => {
     expect(decision).not.toHaveProperty("selected");
   });
 
+  it("treats factory recipe locality as an additional hard routing constraint", () => {
+    const decision = evaluateRouting({
+      runId: "run_factory_locality",
+      runnerIds: ["runner-hosted", "runner-local"],
+      executorIds: ["codex"],
+      runners: [
+        runner({ runnerId: "runner-hosted", locality: "hosted" }),
+        runner({ runnerId: "runner-local", locality: "local" })
+      ],
+      access: { allowedLocalities: ["local"], unresolvedConnectionRefs: false },
+      decidedAt
+    });
+    expect(decision.selected).toMatchObject({ runnerId: "runner-local" });
+    expect(decision.candidates[0]).toMatchObject({
+      eligible: false,
+      reasons: expect.arrayContaining([expect.objectContaining({ code: "runner_locality_not_allowed_by_factory_recipe" })])
+    });
+  });
+
   it("derives a stable decision id independently of evaluation time", () => {
     const input = {
       runId: "run_stable",

--- a/packages/governance/test/workstream.test.ts
+++ b/packages/governance/test/workstream.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { WorkstreamEvaluationInput } from "@opentag/core";
+import { evaluateWorkstream, workstreamInputDigest } from "../src/workstream.js";
+
+const digest = `sha256:${"a".repeat(64)}`;
+
+function baseInput(): WorkstreamEvaluationInput {
+  return {
+    recipe: {
+      id: "recipe_1",
+      version: 1,
+      name: "Release",
+      budgets: {
+        maxConcurrentRuns: 2,
+        maxAttemptsPerRun: 3,
+        maxCostUnits: 20,
+        costUnitsPerAttempt: 5,
+        allowedLocalities: ["local", "private"]
+      },
+      createdAt: "2026-07-26T00:00:00.000Z",
+      contentDigest: digest
+    },
+    workstream: {
+      id: "workstream_1",
+      recipeId: "recipe_1",
+      recipeVersion: 1,
+      name: "Release",
+      members: [
+        { kind: "work_thread", workThreadId: "thread_1" },
+        { kind: "work_thread", workThreadId: "thread_2" }
+      ],
+      createdAt: "2026-07-26T00:00:00.000Z",
+      contentDigest: digest
+    },
+    metrics: {
+      workstreamId: "workstream_1",
+      workThreadCount: 2,
+      acceptedWorkThreadCount: 1,
+      runCount: 2,
+      queuedRunCount: 0,
+      activeRunCount: 1,
+      needsHumanRunCount: 0,
+      terminalRunCount: 1,
+      failedRunCount: 0,
+      budgetBlockedRunCount: 0,
+      exceptionCount: 0,
+      totalAttempts: 2,
+      attemptsPerRunExceededCount: 0,
+      totalCostUnits: 10,
+      attemptsByLocality: { local: 1, private: 1, hosted: 0, unknown: 0 }
+    },
+    evaluatedAt: "2026-07-26T01:00:00.000Z"
+  };
+}
+
+describe("evaluateWorkstream", () => {
+  it("is deterministic and independent of set-like input ordering", () => {
+    const input = baseInput();
+    const reordered = {
+      ...input,
+      recipe: {
+        ...input.recipe,
+        budgets: { ...input.recipe.budgets, allowedLocalities: ["private", "local"] as const }
+      },
+      workstream: { ...input.workstream, members: [...input.workstream.members].reverse() }
+    };
+    expect(workstreamInputDigest(input)).toBe(workstreamInputDigest(reordered));
+    expect(evaluateWorkstream(input)).toEqual(evaluateWorkstream(reordered));
+    expect(evaluateWorkstream(input)).toMatchObject({ status: "healthy", acceptedWorkThreadCount: 1 });
+  });
+
+  it.each([
+    ["concurrency_budget_exceeded", (input: WorkstreamEvaluationInput) => ({ ...input, metrics: { ...input.metrics, activeRunCount: 2, queuedRunCount: 0, terminalRunCount: 0 }, recipe: { ...input.recipe, budgets: { ...input.recipe.budgets, maxConcurrentRuns: 1 } } })],
+    ["attempt_budget_exceeded", (input: WorkstreamEvaluationInput) => ({ ...input, metrics: { ...input.metrics, attemptsPerRunExceededCount: 1 } })],
+    ["cost_budget_exceeded", (input: WorkstreamEvaluationInput) => ({ ...input, recipe: { ...input.recipe, budgets: { ...input.recipe.budgets, maxCostUnits: 9 } } })],
+    ["cost_accounting_mismatch", (input: WorkstreamEvaluationInput) => ({ ...input, metrics: { ...input.metrics, totalCostUnits: 9 } })],
+    ["locality_budget_exceeded", (input: WorkstreamEvaluationInput) => ({ ...input, metrics: { ...input.metrics, attemptsByLocality: { local: 1, private: 0, hosted: 1, unknown: 0 } } })],
+    ["locality_budget_exceeded", (input: WorkstreamEvaluationInput) => ({ ...input, metrics: { ...input.metrics, attemptsByLocality: { local: 1, private: 0, hosted: 0, unknown: 1 } } })],
+    ["budget_blocked_runs", (input: WorkstreamEvaluationInput) => ({ ...input, metrics: { ...input.metrics, budgetBlockedRunCount: 1 } })]
+  ] as const)("fails closed for %s", (code, mutate) => {
+    const evaluation = evaluateWorkstream(mutate(baseInput()));
+    expect(evaluation.status).toBe("blocked");
+    expect(evaluation.violations.map((violation) => violation.code)).toContain(code);
+  });
+
+  it("uses ordinary exceptions only as an attention signal", () => {
+    const input = baseInput();
+    const evaluation = evaluateWorkstream({ ...input, metrics: { ...input.metrics, exceptionCount: 1 } });
+    expect(evaluation).toMatchObject({ status: "attention_required", violations: [] });
+  });
+});

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -13,7 +13,7 @@ pnpm add @opentag/store
 ## Exports
 
 - `migrateSchema`: creates or updates the SQLite schema.
-- `createOpenTagRepository`: repository API for runners, bindings, runs, leases, progress, completion, and audit events.
+- `createOpenTagRepository`: repository API for runners, bindings, runs, leases, progress, completion, factory recipes/workstreams, replay-safe batch receipts, and audit events.
 - Drizzle table definitions from `schema.ts`.
 - Types such as `ClaimedOpenTagRun`, `OpenTagAuditEvent`, `RepoBinding`, `ChannelBinding`, and `SlackChannelBinding`.
 

--- a/packages/store/src/canonical-json.ts
+++ b/packages/store/src/canonical-json.ts
@@ -1,0 +1,21 @@
+import { createHash } from "node:crypto";
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => compareCodeUnits(left, right))
+        .map(([key, child]) => [key, canonicalize(child)])
+    );
+  }
+  return value;
+}
+
+export function canonicalSha256Json(value: unknown): string {
+  return `sha256:${createHash("sha256").update(JSON.stringify(canonicalize(value))).digest("hex")}`;
+}

--- a/packages/store/src/repository.ts
+++ b/packages/store/src/repository.ts
@@ -30,6 +30,7 @@ import {
   grantMatchesAction,
   containsCredentialLikeData,
   FollowUpRequestSchema,
+  FactoryRecipeSnapshotInputSchema,
   FrozenRoutingPolicySchema,
   isCredentialFieldName,
   redactCredentialLikeData,
@@ -49,6 +50,8 @@ import {
   HumanEscalationSchema,
   VerificationEvidenceSchema,
   WorkThreadSchema,
+  WorkstreamAdmissionBatchInputSchema,
+  WorkstreamInputSchema,
   type ApprovalDecision,
   type AgentAccessProfileSnapshot,
   type ActorIdentity,
@@ -65,6 +68,7 @@ import {
   type CompletionContract,
   type CompletionWaiver,
   type FrozenRoutingPolicy,
+  type FactoryRecipeSnapshotInput,
   type HumanEscalation,
   type MutationIntentActionability,
   type OpenTagEvent,
@@ -85,12 +89,14 @@ import {
   type RunnerRegistrationInput,
   type SuggestedChangesSnapshot,
   type VerificationEvidence,
-  type WorkThread
+  type WorkThread,
+  type WorkstreamInput
 } from "@opentag/core";
 import { evaluateRouting } from "@opentag/governance";
 import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, lt, lte, notExists, or, sql } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { alias } from "drizzle-orm/sqlite-core";
+import { canonicalSha256Json } from "./canonical-json.js";
 import {
   applyPlans,
   attempts,
@@ -102,6 +108,9 @@ import {
   completionContracts,
   completionWaivers,
   controlPlaneEvents,
+  factoryRecipeSnapshots,
+  factoryWorkstreamMembers,
+  factoryWorkstreams,
   governanceEvents,
   humanEscalations,
   linearOAuthInstallStates,
@@ -117,7 +126,9 @@ import {
   runs,
   suggestedChanges,
   verificationEvidenceRecords,
-  workThreads
+  workThreads,
+  workstreamAdmissionBatchItems,
+  workstreamAdmissionBatches
 } from "./schema.js";
 
 export type OpenTagRunWithEvent = {
@@ -385,6 +396,8 @@ export type FollowUpRequest = {
   sourceEventId: string;
   conversationKey: string;
   activeRunId?: string;
+  workstreamId?: string;
+  admissionBatchId?: string;
   event: OpenTagEvent;
   decision: RunAdmissionDecision;
   accessProfileSnapshot?: AgentAccessProfileSnapshot;
@@ -428,6 +441,72 @@ export type OpenTagAggregateMetrics = {
   childRunCount: number;
   applyOutcomeCounts: ApplyOutcomeCounts;
   staleIntentCount: number;
+};
+
+export type StoredFactoryRecipeSnapshot = {
+  id: string;
+  version: number;
+  recipe: FactoryRecipeSnapshotInput;
+  contentDigest: string;
+  createdAt: string;
+};
+
+export type StoredFactoryWorkstream = {
+  id: string;
+  recipeId: string;
+  recipeVersion: number;
+  workstream: WorkstreamInput;
+  contentDigest: string;
+  workThreadIds: string[];
+  createdAt: string;
+};
+
+export type WorkstreamAdmissionBatchItem = {
+  itemId: string;
+  ordinal: number;
+  runId: string;
+  workThreadId: string;
+  event: OpenTagEvent;
+  status: "pending" | "processing" | "completed";
+  leaseOwner?: string;
+  leaseExpiresAt?: string;
+  result?: unknown;
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+};
+
+export type WorkstreamAdmissionBatch = {
+  id: string;
+  workstreamId: string;
+  requestDigest: string;
+  request: unknown;
+  status: "processing" | "completed";
+  leaseOwner?: string;
+  leaseExpiresAt?: string;
+  result?: unknown;
+  items: WorkstreamAdmissionBatchItem[];
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+};
+
+export type WorkstreamMetrics = {
+  workstreamId: string;
+  workThreadCount: number;
+  acceptedWorkThreadCount: number;
+  runCount: number;
+  queuedRunCount: number;
+  activeRunCount: number;
+  terminalRunCount: number;
+  failedRunCount: number;
+  needsHumanRunCount: number;
+  budgetBlockedRunCount: number;
+  totalAttempts: number;
+  attemptsPerRunExceededCount: number;
+  totalCostUnits: number;
+  attemptsByLocality: { local: number; private: number; hosted: number; unknown: number };
+  exceptionCount: number;
 };
 
 export type AttemptMutationConflict = "stale_attempt";
@@ -518,6 +597,68 @@ function mergeWorkThreadAnchors(current: DurableWorkThread, incoming: WorkThread
 function workThreadFromRow(row: typeof workThreads.$inferSelect): DurableWorkThread {
   const thread = WorkThreadSchema.parse(JSON.parse(row.threadJson));
   return { ...thread, id: row.id };
+}
+
+function factoryRecipeSnapshotFromRow(row: typeof factoryRecipeSnapshots.$inferSelect): StoredFactoryRecipeSnapshot {
+  return {
+    id: row.id,
+    version: row.version,
+    recipe: FactoryRecipeSnapshotInputSchema.parse(JSON.parse(row.recipeJson)),
+    contentDigest: row.contentDigest,
+    createdAt: row.createdAt
+  };
+}
+
+function factoryWorkstreamFromRows(
+  row: typeof factoryWorkstreams.$inferSelect,
+  members: Array<Pick<typeof factoryWorkstreamMembers.$inferSelect, "workThreadId">>
+): StoredFactoryWorkstream {
+  return {
+    id: row.id,
+    recipeId: row.recipeId,
+    recipeVersion: row.recipeVersion,
+    workstream: WorkstreamInputSchema.parse(JSON.parse(row.workstreamJson)),
+    contentDigest: row.contentDigest,
+    workThreadIds: members.map((member) => member.workThreadId).sort(),
+    createdAt: row.createdAt
+  };
+}
+
+function admissionBatchItemFromRow(row: typeof workstreamAdmissionBatchItems.$inferSelect): WorkstreamAdmissionBatchItem {
+  return {
+    itemId: row.itemId,
+    ordinal: row.ordinal,
+    runId: row.runId,
+    workThreadId: row.workThreadId,
+    event: OpenTagEventSchema.parse(JSON.parse(row.eventJson)),
+    status: row.status as WorkstreamAdmissionBatchItem["status"],
+    ...(row.leaseOwner ? { leaseOwner: row.leaseOwner } : {}),
+    ...(row.leaseExpiresAt ? { leaseExpiresAt: row.leaseExpiresAt } : {}),
+    ...(row.resultJson ? { result: JSON.parse(row.resultJson) as unknown } : {}),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    ...(row.completedAt ? { completedAt: row.completedAt } : {})
+  };
+}
+
+function admissionBatchFromRows(
+  row: typeof workstreamAdmissionBatches.$inferSelect,
+  items: Array<typeof workstreamAdmissionBatchItems.$inferSelect>
+): WorkstreamAdmissionBatch {
+  return {
+    id: row.id,
+    workstreamId: row.workstreamId,
+    requestDigest: row.requestDigest,
+    request: JSON.parse(row.requestJson) as unknown,
+    status: row.status as WorkstreamAdmissionBatch["status"],
+    ...(row.leaseOwner ? { leaseOwner: row.leaseOwner } : {}),
+    ...(row.leaseExpiresAt ? { leaseExpiresAt: row.leaseExpiresAt } : {}),
+    ...(row.resultJson ? { result: JSON.parse(row.resultJson) as unknown } : {}),
+    items: items.sort((left, right) => left.ordinal - right.ordinal).map(admissionBatchItemFromRow),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    ...(row.completedAt ? { completedAt: row.completedAt } : {})
+  };
 }
 
 function completionContractFromRow(row: typeof completionContracts.$inferSelect): CompletionContract {
@@ -647,6 +788,62 @@ function stableActionJson(value: unknown): string {
       .join(",")}}`;
   }
   return JSON.stringify(value);
+}
+
+type CurrentAssessmentAuthorityRow = {
+  assessmentId: string;
+  threadId: string;
+  persistedThreadId: string;
+  assessmentJson: string;
+  waiverId: string | null;
+  waiverWorkThreadId: string | null;
+  waiverContractId: string | null;
+  waiverContractVersion: number | null;
+  waiverCycle: number | null;
+  waiverContentDigest: string | null;
+  waiverJson: string | null;
+};
+
+function currentAssessmentIsAccepted(row: CurrentAssessmentAuthorityRow, evaluatedAt: string): boolean {
+  try {
+    const assessment = CompletionAssessmentSchema.parse(JSON.parse(row.assessmentJson));
+    if (
+      assessment.id !== row.assessmentId
+      || assessment.workThreadId !== row.threadId
+      || row.persistedThreadId !== row.threadId
+    ) {
+      return false;
+    }
+    if (assessment.state === "satisfied") return assessment.evidenceBacked;
+    if (assessment.state !== "waived" || !assessment.evidenceBacked || !assessment.waiver) return false;
+
+    const waiver = assessment.waiver;
+    if (
+      !row.waiverJson
+      || row.waiverId !== waiver.id
+      || row.waiverWorkThreadId !== row.threadId
+      || row.waiverContractId !== assessment.contractId
+      || row.waiverContractVersion !== assessment.contractVersion
+      || row.waiverCycle !== assessment.cycle
+      || waiver.waivedAt > evaluatedAt
+      || (waiver.expiresAt !== undefined && waiver.expiresAt <= evaluatedAt)
+      || (waiver.runId !== undefined && waiver.runId !== assessment.triggeredByRunId)
+    ) {
+      return false;
+    }
+    const persistedWaiver = CompletionWaiverSchema.parse(JSON.parse(row.waiverJson));
+    const { id: _id, ...semanticWaiver } = waiver;
+    const expectedDigest = `sha256:${sha256(stableActionJson(semanticWaiver))}`;
+    const waivedGateIds = assessment.gateResults
+      .filter((gate) => gate.state === "waived")
+      .map((gate) => gate.gateId);
+    return row.waiverContentDigest === expectedDigest
+      && JSON.stringify(persistedWaiver) === JSON.stringify(waiver)
+      && waivedGateIds.length > 0
+      && waivedGateIds.every((gateId) => waiver.gateIds.includes(gateId));
+  } catch {
+    return false;
+  }
 }
 
 const SAFE_RECEIPT_METADATA_KEYS = new Set([
@@ -875,6 +1072,8 @@ function followUpRequestFromRow(row: typeof followUpRequests.$inferSelect): Foll
     sourceEventId: row.sourceEventId,
     conversationKey: row.conversationKey,
     ...(row.activeRunId ? { activeRunId: row.activeRunId } : {}),
+    ...(row.workstreamId ? { workstreamId: row.workstreamId } : {}),
+    ...(row.admissionBatchId ? { admissionBatchId: row.admissionBatchId } : {}),
     event: OpenTagEventSchema.parse(JSON.parse(row.eventJson)),
     decision: RunAdmissionDecisionSchema.parse(JSON.parse(row.decisionJson)),
     ...(row.accessProfileSnapshotJson
@@ -1734,6 +1933,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
     now: Date;
     snapshot: RoutingDirectorySnapshot;
     event?: OpenTagEvent;
+    allowedLocalities?: Array<"local" | "private" | "hosted">;
   }): RoutingDecision {
     const event = input.event ?? OpenTagEventSchema.parse(JSON.parse(input.runRow.eventJson));
     const accessProfile = input.runRow.accessProfileSnapshotJson
@@ -1820,6 +2020,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           ? { allowedExecutorIds: accessProfile.constraints.allowedExecutorIds }
           : {}),
         ...(accessProfile?.constraints.locality ? { locality: accessProfile.constraints.locality } : {}),
+        ...(input.allowedLocalities ? { allowedLocalities: input.allowedLocalities } : {}),
         unresolvedConnectionRefs: Boolean(accessProfile?.connectionRefs.length)
       },
       decidedAt: input.now.toISOString()
@@ -1849,19 +2050,30 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       activeRunId: input.runRow.id,
       eventId: input.event.id
     });
-    await appendRunEvent({
-      runId: input.runRow.id,
-      type: "admission.decided",
-      payload: replayDecision,
-      visibility: "audit",
-      importance: "normal",
-      message: replayDecision.reason,
-      createdAt: input.createdAt
-    });
-    await appendRunEvent({
-      runId: input.runRow.id,
-      type: "run.create_idempotent_replay",
-      payload: {
+    const replayIdentity = {
+      requestedRunId: input.requestedRunId,
+      replayKind: input.replayKind,
+      sourceDeliveryId: input.sourceDeliveryId ?? null,
+      eventId: input.event.id
+    };
+    await db.insert(runEvents).values([
+      {
+        ...runEventValues({
+          runId: input.runRow.id,
+          type: "admission.decided",
+          payload: replayDecision,
+          visibility: "audit",
+          importance: "normal",
+          message: replayDecision.reason,
+          createdAt: input.createdAt
+        }),
+        progressIdempotencyDigest: sha256Json({ kind: "create_run_replay_admission", ...replayIdentity })
+      },
+      {
+        ...runEventValues({
+          runId: input.runRow.id,
+          type: "run.create_idempotent_replay",
+          payload: {
         requestedRunId: input.requestedRunId,
         eventId: input.event.id,
         replayKey:
@@ -1874,11 +2086,14 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           admissionDecision: replayDecision,
           expectedRunnerId: input.expectedRunnerId
         })
-      },
-      visibility: "audit",
-      importance: "low",
-      createdAt: input.createdAt
-    });
+          },
+          visibility: "audit",
+          importance: "low",
+          createdAt: input.createdAt
+        }),
+        progressIdempotencyDigest: sha256Json({ kind: "create_run_replay", ...replayIdentity })
+      }
+    ]).onConflictDoNothing().run();
     return {
       run: runFromRow(input.runRow),
       created: false,
@@ -2088,6 +2303,327 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
 
   return {
     appendRunEvent,
+
+    async getFactoryRecipeSnapshot(input: { id: string; version: number }): Promise<StoredFactoryRecipeSnapshot | null> {
+      const row = await db.select().from(factoryRecipeSnapshots)
+        .where(and(eq(factoryRecipeSnapshots.id, input.id), eq(factoryRecipeSnapshots.version, input.version))).limit(1).get();
+      return row ? factoryRecipeSnapshotFromRow(row) : null;
+    },
+
+    async createFactoryRecipeSnapshot(input: {
+      id: string;
+      version: number;
+      recipe: FactoryRecipeSnapshotInput;
+      contentDigest?: string;
+      createdAt?: string;
+    }): Promise<{ outcome: "created" | "existing"; recipeSnapshot: StoredFactoryRecipeSnapshot } | { outcome: "conflict"; recipeSnapshot: StoredFactoryRecipeSnapshot }> {
+      const recipe = FactoryRecipeSnapshotInputSchema.parse(input.recipe);
+      if (recipe.id !== input.id || recipe.version !== input.version) throw new Error("FACTORY_RECIPE_IDENTITY_MISMATCH");
+      const recipeJson = JSON.stringify(recipe);
+      const contentDigest = sha256Json(recipe);
+      if (input.contentDigest && input.contentDigest !== contentDigest) throw new Error("FACTORY_RECIPE_CONTENT_DIGEST_MISMATCH");
+      const createdAt = input.createdAt ?? nowIso();
+      return db.transaction((tx) => {
+        const existing = tx.select().from(factoryRecipeSnapshots)
+          .where(and(eq(factoryRecipeSnapshots.id, input.id), eq(factoryRecipeSnapshots.version, input.version))).limit(1).get();
+        if (existing) {
+          return { outcome: existing.contentDigest === contentDigest ? "existing" as const : "conflict" as const, recipeSnapshot: factoryRecipeSnapshotFromRow(existing) };
+        }
+        tx.insert(factoryRecipeSnapshots).values({ id: input.id, version: input.version, recipeJson, contentDigest, createdAt }).run();
+        return { outcome: "created" as const, recipeSnapshot: { id: input.id, version: input.version, recipe, contentDigest, createdAt } };
+      });
+    },
+
+    async getFactoryWorkstream(input: { id: string }): Promise<StoredFactoryWorkstream | null> {
+      const row = await db.select().from(factoryWorkstreams).where(eq(factoryWorkstreams.id, input.id)).limit(1).get();
+      if (!row) return null;
+      const members = await db.select({ workThreadId: factoryWorkstreamMembers.workThreadId }).from(factoryWorkstreamMembers)
+        .where(eq(factoryWorkstreamMembers.workstreamId, input.id)).orderBy(asc(factoryWorkstreamMembers.workThreadId));
+      return factoryWorkstreamFromRows(row, members);
+    },
+
+    async createFactoryWorkstream(input: {
+      id: string;
+      recipeId: string;
+      recipeVersion: number;
+      workstream: Partial<WorkstreamInput> & { name: string };
+      workThreadIds: string[];
+      contentDigest?: string;
+      createdAt?: string;
+    }): Promise<{ outcome: "created" | "existing"; workstream: StoredFactoryWorkstream } | { outcome: "conflict" | "recipe_not_found" | "work_thread_not_found"; workstream?: StoredFactoryWorkstream; workThreadId?: string }> {
+      const normalizedWorkThreadIds = [...new Set(input.workThreadIds)].sort();
+      if (normalizedWorkThreadIds.length === 0) return { outcome: "work_thread_not_found" as const };
+      const candidateWorkstream = input.workstream as Record<string, unknown>;
+      const workstream = WorkstreamInputSchema.parse({
+        ...candidateWorkstream,
+        id: input.id,
+        recipeId: input.recipeId,
+        recipeVersion: input.recipeVersion,
+        members: normalizedWorkThreadIds.map((workThreadId) => ({ kind: "work_thread", workThreadId }))
+      });
+      const workstreamJson = JSON.stringify(workstream);
+      const contentDigest = sha256Json(workstream);
+      if (input.contentDigest && input.contentDigest !== contentDigest) throw new Error("FACTORY_WORKSTREAM_CONTENT_DIGEST_MISMATCH");
+      const createdAt = input.createdAt ?? nowIso();
+      return db.transaction((tx) => {
+        const existing = tx.select().from(factoryWorkstreams).where(eq(factoryWorkstreams.id, input.id)).limit(1).get();
+        if (existing) {
+          const members = tx.select({ workThreadId: factoryWorkstreamMembers.workThreadId }).from(factoryWorkstreamMembers)
+            .where(eq(factoryWorkstreamMembers.workstreamId, input.id)).orderBy(asc(factoryWorkstreamMembers.workThreadId)).all();
+          const stored = factoryWorkstreamFromRows(existing, members);
+          return { outcome: existing.contentDigest === contentDigest ? "existing" as const : "conflict" as const, workstream: stored };
+        }
+        const recipe = tx.select({ id: factoryRecipeSnapshots.id }).from(factoryRecipeSnapshots)
+          .where(and(eq(factoryRecipeSnapshots.id, input.recipeId), eq(factoryRecipeSnapshots.version, input.recipeVersion))).limit(1).get();
+        if (!recipe) return { outcome: "recipe_not_found" as const };
+        for (const workThreadId of normalizedWorkThreadIds) {
+          const thread = tx.select({ id: workThreads.id }).from(workThreads).where(eq(workThreads.id, workThreadId)).limit(1).get();
+          if (!thread) return { outcome: "work_thread_not_found" as const, workThreadId };
+        }
+        tx.insert(factoryWorkstreams).values({ id: input.id, recipeId: input.recipeId, recipeVersion: input.recipeVersion, workstreamJson, contentDigest, createdAt }).run();
+        if (normalizedWorkThreadIds.length > 0) tx.insert(factoryWorkstreamMembers).values(normalizedWorkThreadIds.map((workThreadId) => ({ workstreamId: input.id, workThreadId, createdAt }))).run();
+        return { outcome: "created" as const, workstream: { id: input.id, recipeId: input.recipeId, recipeVersion: input.recipeVersion, workstream, contentDigest, workThreadIds: normalizedWorkThreadIds, createdAt } };
+      });
+    },
+
+    async getWorkstreamAdmissionBatch(input: { id: string }): Promise<WorkstreamAdmissionBatch | null> {
+      const row = await db.select().from(workstreamAdmissionBatches).where(eq(workstreamAdmissionBatches.id, input.id)).limit(1).get();
+      if (!row) return null;
+      const items = await db.select().from(workstreamAdmissionBatchItems).where(eq(workstreamAdmissionBatchItems.batchId, input.id)).orderBy(asc(workstreamAdmissionBatchItems.ordinal));
+      return admissionBatchFromRows(row, items);
+    },
+
+    async beginWorkstreamAdmissionBatch(input: {
+      id: string;
+      workstreamId: string;
+      requestDigest: string;
+      request: unknown;
+      items: Array<{ itemId: string; runId: string; workThreadId: string; event: OpenTagEvent }>;
+      leaseOwner: string;
+      leaseSeconds: number;
+      now?: Date;
+    }): Promise<{ outcome: "acquired" | "in_progress" | "replay" | "conflict" | "workstream_not_found" | "invalid_member"; batch?: WorkstreamAdmissionBatch; workThreadId?: string }> {
+      const now = input.now ?? new Date();
+      const at = now.toISOString();
+      const leaseExpiresAt = new Date(now.getTime() + input.leaseSeconds * 1000).toISOString();
+      const request = WorkstreamAdmissionBatchInputSchema.parse(input.request);
+      if (request.id !== input.id || request.workstreamId !== input.workstreamId) throw new Error("FACTORY_BATCH_REQUEST_IDENTITY_MISMATCH");
+      const suppliedItems = input.items.map((item) => ({ ...item, event: OpenTagEventSchema.parse(item.event) }));
+      if (canonicalSha256Json(request.items) !== canonicalSha256Json(suppliedItems)) throw new Error("FACTORY_BATCH_REQUEST_ITEMS_MISMATCH");
+      const requestDigest = canonicalSha256Json(request);
+      if (requestDigest !== input.requestDigest) throw new Error("FACTORY_BATCH_REQUEST_DIGEST_MISMATCH");
+      return db.transaction((tx) => {
+        const existing = tx.select().from(workstreamAdmissionBatches).where(eq(workstreamAdmissionBatches.id, input.id)).limit(1).get();
+        if (existing) {
+          const items = tx.select().from(workstreamAdmissionBatchItems).where(eq(workstreamAdmissionBatchItems.batchId, input.id)).orderBy(asc(workstreamAdmissionBatchItems.ordinal)).all();
+          const batch = admissionBatchFromRows(existing, items);
+          if (existing.requestDigest !== requestDigest) return { outcome: "conflict" as const, batch };
+          if (existing.status === "completed") return { outcome: "replay" as const, batch };
+          if (existing.leaseOwner !== input.leaseOwner && existing.leaseExpiresAt && existing.leaseExpiresAt > at) return { outcome: "in_progress" as const, batch };
+          tx.update(workstreamAdmissionBatches).set({ leaseOwner: input.leaseOwner, leaseExpiresAt, updatedAt: at }).where(eq(workstreamAdmissionBatches.id, input.id)).run();
+          return { outcome: "acquired" as const, batch: admissionBatchFromRows({ ...existing, leaseOwner: input.leaseOwner, leaseExpiresAt, updatedAt: at }, items) };
+        }
+        const workstream = tx.select({ id: factoryWorkstreams.id }).from(factoryWorkstreams).where(eq(factoryWorkstreams.id, input.workstreamId)).limit(1).get();
+        if (!workstream) return { outcome: "workstream_not_found" as const };
+        const itemIds = new Set<string>();
+        const runIds = new Set<string>();
+        for (const item of input.items) {
+          if (itemIds.has(item.itemId) || runIds.has(item.runId)) return { outcome: "conflict" as const };
+          itemIds.add(item.itemId); runIds.add(item.runId);
+          const member = tx.select({ workThreadId: factoryWorkstreamMembers.workThreadId }).from(factoryWorkstreamMembers)
+            .where(and(eq(factoryWorkstreamMembers.workstreamId, input.workstreamId), eq(factoryWorkstreamMembers.workThreadId, item.workThreadId))).limit(1).get();
+          if (!member) return { outcome: "invalid_member" as const, workThreadId: item.workThreadId };
+        }
+        tx.insert(workstreamAdmissionBatches).values({ id: input.id, workstreamId: input.workstreamId, requestDigest, requestJson: JSON.stringify(request), status: "processing", leaseOwner: input.leaseOwner, leaseExpiresAt, createdAt: at, updatedAt: at }).run();
+        if (input.items.length > 0) tx.insert(workstreamAdmissionBatchItems).values(input.items.map((item, ordinal) => ({ batchId: input.id, itemId: item.itemId, ordinal, runId: item.runId, workThreadId: item.workThreadId, eventJson: JSON.stringify(OpenTagEventSchema.parse(item.event)), status: "pending", createdAt: at, updatedAt: at }))).run();
+        const row = tx.select().from(workstreamAdmissionBatches).where(eq(workstreamAdmissionBatches.id, input.id)).get()!;
+        const items = tx.select().from(workstreamAdmissionBatchItems).where(eq(workstreamAdmissionBatchItems.batchId, input.id)).orderBy(asc(workstreamAdmissionBatchItems.ordinal)).all();
+        return { outcome: "acquired" as const, batch: admissionBatchFromRows(row, items) };
+      });
+    },
+
+    async claimWorkstreamAdmissionBatchItem(input: { batchId: string; itemId: string; leaseOwner: string; leaseSeconds: number; now?: Date }): Promise<{ outcome: "claimed" | "in_progress" | "completed" | "not_found" | "batch_lease_lost"; item?: WorkstreamAdmissionBatchItem }> {
+      const now = input.now ?? new Date();
+      const at = now.toISOString();
+      const leaseExpiresAt = new Date(now.getTime() + input.leaseSeconds * 1000).toISOString();
+      return db.transaction((tx) => {
+        const batch = tx.select().from(workstreamAdmissionBatches).where(eq(workstreamAdmissionBatches.id, input.batchId)).limit(1).get();
+        if (!batch) return { outcome: "not_found" as const };
+        if (batch.status === "completed") return { outcome: "completed" as const };
+        if (batch.leaseOwner !== input.leaseOwner || (batch.leaseExpiresAt !== null && batch.leaseExpiresAt <= at)) return { outcome: "batch_lease_lost" as const };
+        const item = tx.select().from(workstreamAdmissionBatchItems).where(and(eq(workstreamAdmissionBatchItems.batchId, input.batchId), eq(workstreamAdmissionBatchItems.itemId, input.itemId))).limit(1).get();
+        if (!item) return { outcome: "not_found" as const };
+        tx.update(workstreamAdmissionBatches).set({ leaseExpiresAt, updatedAt: at })
+          .where(eq(workstreamAdmissionBatches.id, input.batchId)).run();
+        if (item.status === "completed") return { outcome: "completed" as const, item: admissionBatchItemFromRow(item) };
+        if (item.status === "processing" && item.leaseOwner !== input.leaseOwner && item.leaseExpiresAt && item.leaseExpiresAt > at) return { outcome: "in_progress" as const, item: admissionBatchItemFromRow(item) };
+        tx.update(workstreamAdmissionBatchItems).set({ status: "processing", leaseOwner: input.leaseOwner, leaseExpiresAt, updatedAt: at })
+          .where(and(eq(workstreamAdmissionBatchItems.batchId, input.batchId), eq(workstreamAdmissionBatchItems.itemId, input.itemId))).run();
+        return { outcome: "claimed" as const, item: admissionBatchItemFromRow({ ...item, status: "processing", leaseOwner: input.leaseOwner, leaseExpiresAt, updatedAt: at }) };
+      });
+    },
+
+    async renewWorkstreamAdmissionBatchLease(input: {
+      batchId: string;
+      itemId?: string;
+      leaseOwner: string;
+      leaseSeconds: number;
+      now?: Date;
+    }): Promise<{ outcome: "renewed" | "completed" | "stale_lease" | "not_found" }> {
+      const now = input.now ?? new Date();
+      const at = now.toISOString();
+      const leaseExpiresAt = new Date(now.getTime() + input.leaseSeconds * 1000).toISOString();
+      return db.transaction((tx) => {
+        const batch = tx.select().from(workstreamAdmissionBatches)
+          .where(eq(workstreamAdmissionBatches.id, input.batchId)).limit(1).get();
+        if (!batch) return { outcome: "not_found" as const };
+        if (batch.status === "completed") return { outcome: "completed" as const };
+        if (
+          batch.leaseOwner !== input.leaseOwner
+          || batch.leaseExpiresAt === null
+          || batch.leaseExpiresAt <= at
+        ) {
+          return { outcome: "stale_lease" as const };
+        }
+        if (input.itemId) {
+          const item = tx.select().from(workstreamAdmissionBatchItems).where(and(
+            eq(workstreamAdmissionBatchItems.batchId, input.batchId),
+            eq(workstreamAdmissionBatchItems.itemId, input.itemId)
+          )).limit(1).get();
+          if (!item) return { outcome: "not_found" as const };
+          if (
+            item.status !== "processing"
+            || item.leaseOwner !== input.leaseOwner
+            || item.leaseExpiresAt === null
+            || item.leaseExpiresAt <= at
+          ) {
+            return { outcome: item.status === "completed" ? "completed" as const : "stale_lease" as const };
+          }
+          tx.update(workstreamAdmissionBatchItems).set({ leaseExpiresAt, updatedAt: at }).where(and(
+            eq(workstreamAdmissionBatchItems.batchId, input.batchId),
+            eq(workstreamAdmissionBatchItems.itemId, input.itemId)
+          )).run();
+        }
+        tx.update(workstreamAdmissionBatches).set({ leaseExpiresAt, updatedAt: at })
+          .where(eq(workstreamAdmissionBatches.id, input.batchId)).run();
+        return { outcome: "renewed" as const };
+      });
+    },
+
+    async completeWorkstreamAdmissionBatchItem(input: { batchId: string; itemId: string; leaseOwner: string; result: unknown; now?: Date }): Promise<{ outcome: "completed" | "duplicate" | "stale_lease" | "not_found"; item?: WorkstreamAdmissionBatchItem }> {
+      const at = (input.now ?? new Date()).toISOString();
+      const resultJson = JSON.stringify(input.result);
+      return db.transaction((tx) => {
+        const batch = tx.select().from(workstreamAdmissionBatches).where(eq(workstreamAdmissionBatches.id, input.batchId)).limit(1).get();
+        if (!batch) return { outcome: "not_found" as const };
+        if (batch.status !== "processing" || batch.leaseOwner !== input.leaseOwner || (batch.leaseExpiresAt !== null && batch.leaseExpiresAt <= at)) {
+          return { outcome: "stale_lease" as const };
+        }
+        const item = tx.select().from(workstreamAdmissionBatchItems).where(and(eq(workstreamAdmissionBatchItems.batchId, input.batchId), eq(workstreamAdmissionBatchItems.itemId, input.itemId))).limit(1).get();
+        if (!item) return { outcome: "not_found" as const };
+        if (item.status === "completed") return { outcome: item.resultJson === resultJson ? "duplicate" as const : "stale_lease" as const, item: admissionBatchItemFromRow(item) };
+        if (item.status !== "processing" || item.leaseOwner !== input.leaseOwner || (item.leaseExpiresAt !== null && item.leaseExpiresAt <= at)) return { outcome: "stale_lease" as const, item: admissionBatchItemFromRow(item) };
+        tx.update(workstreamAdmissionBatchItems).set({ status: "completed", resultJson, leaseOwner: null, leaseExpiresAt: null, completedAt: at, updatedAt: at })
+          .where(and(eq(workstreamAdmissionBatchItems.batchId, input.batchId), eq(workstreamAdmissionBatchItems.itemId, input.itemId))).run();
+        return { outcome: "completed" as const, item: admissionBatchItemFromRow({ ...item, status: "completed", resultJson, leaseOwner: null, leaseExpiresAt: null, completedAt: at, updatedAt: at }) };
+      });
+    },
+
+    async finalizeWorkstreamAdmissionBatch(input: { id: string; leaseOwner: string; result: unknown; now?: Date }): Promise<{ outcome: "completed" | "replay" | "incomplete" | "stale_lease" | "not_found"; batch?: WorkstreamAdmissionBatch }> {
+      const at = (input.now ?? new Date()).toISOString();
+      const resultJson = JSON.stringify(input.result);
+      return db.transaction((tx) => {
+        const row = tx.select().from(workstreamAdmissionBatches).where(eq(workstreamAdmissionBatches.id, input.id)).limit(1).get();
+        if (!row) return { outcome: "not_found" as const };
+        const items = tx.select().from(workstreamAdmissionBatchItems).where(eq(workstreamAdmissionBatchItems.batchId, input.id)).orderBy(asc(workstreamAdmissionBatchItems.ordinal)).all();
+        if (row.status === "completed") return { outcome: "replay" as const, batch: admissionBatchFromRows(row, items) };
+        if (row.leaseOwner !== input.leaseOwner || (row.leaseExpiresAt !== null && row.leaseExpiresAt <= at)) return { outcome: "stale_lease" as const, batch: admissionBatchFromRows(row, items) };
+        if (items.some((item) => item.status !== "completed")) return { outcome: "incomplete" as const, batch: admissionBatchFromRows(row, items) };
+        tx.update(workstreamAdmissionBatches).set({ status: "completed", resultJson, leaseOwner: null, leaseExpiresAt: null, completedAt: at, updatedAt: at }).where(eq(workstreamAdmissionBatches.id, input.id)).run();
+        return { outcome: "completed" as const, batch: admissionBatchFromRows({ ...row, status: "completed", resultJson, leaseOwner: null, leaseExpiresAt: null, completedAt: at, updatedAt: at }, items) };
+      });
+    },
+
+    async getWorkstreamMetrics(input: { workstreamId: string }): Promise<WorkstreamMetrics | null> {
+      const workstream = await db.select().from(factoryWorkstreams).where(eq(factoryWorkstreams.id, input.workstreamId)).limit(1).get();
+      if (!workstream) return null;
+      const recipe = await db.select().from(factoryRecipeSnapshots).where(and(eq(factoryRecipeSnapshots.id, workstream.recipeId), eq(factoryRecipeSnapshots.version, workstream.recipeVersion))).limit(1).get();
+      let recipeValue: FactoryRecipeSnapshotInput;
+      try {
+        recipeValue = FactoryRecipeSnapshotInputSchema.parse(recipe ? JSON.parse(recipe.recipeJson) : null);
+      } catch {
+        throw new Error("FACTORY_RECIPE_AUTHORITY_MISSING_OR_INVALID");
+      }
+      const costUnitsPerAttempt = recipeValue.budgets.costUnitsPerAttempt;
+      const memberRows = await db.select({ workThreadId: factoryWorkstreamMembers.workThreadId }).from(factoryWorkstreamMembers).where(eq(factoryWorkstreamMembers.workstreamId, input.workstreamId));
+      const currentAssessmentRows = memberRows.length > 0 ? await db.select({
+        threadId: workThreads.id,
+        assessmentId: completionAssessments.id,
+        persistedThreadId: completionAssessments.workThreadId,
+        assessmentJson: completionAssessments.assessmentJson,
+        waiverId: completionWaivers.id,
+        waiverWorkThreadId: completionWaivers.workThreadId,
+        waiverContractId: completionWaivers.contractId,
+        waiverContractVersion: completionWaivers.contractVersion,
+        waiverCycle: completionWaivers.cycle,
+        waiverContentDigest: completionWaivers.contentDigest,
+        waiverJson: completionWaivers.waiverJson
+      })
+        .from(factoryWorkstreamMembers)
+        .innerJoin(workThreads, eq(workThreads.id, factoryWorkstreamMembers.workThreadId))
+        .innerJoin(completionAssessments, eq(completionAssessments.id, workThreads.currentAssessmentId))
+        .leftJoin(completionWaivers, eq(
+          completionWaivers.id,
+          sql<string | null>`CASE WHEN json_valid(${completionAssessments.assessmentJson}) THEN json_extract(${completionAssessments.assessmentJson}, '$.waiver.id') ELSE NULL END`
+        ))
+        .where(eq(factoryWorkstreamMembers.workstreamId, input.workstreamId)) : [];
+      const evaluatedAt = nowIso();
+      const acceptedWorkThreadCount = currentAssessmentRows.filter((row) =>
+        currentAssessmentIsAccepted(row, evaluatedAt)
+      ).length;
+      const runRows = await db.select().from(runs).where(eq(runs.workstreamId, input.workstreamId));
+      const attemptRows = runRows.length > 0 ? await db.select({
+        runId: attempts.runId,
+        runnerLocality: attempts.runnerLocality
+      }).from(attempts)
+        .innerJoin(runs, eq(runs.id, attempts.runId))
+        .where(eq(runs.workstreamId, input.workstreamId)) : [];
+      const blockedEvents = runRows.length > 0 ? await db.select({
+        runId: runEvents.runId,
+        payloadJson: runEvents.payloadJson
+      }).from(runEvents)
+        .innerJoin(runs, eq(runs.id, runEvents.runId))
+        .where(and(eq(runs.workstreamId, input.workstreamId), eq(runEvents.type, "factory.budget_blocked"))) : [];
+      const currentlyNeedsHuman = new Set(runRows.filter((run) => run.status === "needs_approval").map((run) => run.id));
+      const blockedRunIds = new Set(blockedEvents.filter((row) => currentlyNeedsHuman.has(row.runId)).map((row) => row.runId));
+      const localityCounts = { local: 0, private: 0, hosted: 0, unknown: 0 };
+      const attemptCountByRun = new Map<string, number>();
+      for (const attempt of attemptRows) {
+        attemptCountByRun.set(attempt.runId, (attemptCountByRun.get(attempt.runId) ?? 0) + 1);
+        const locality = attempt.runnerLocality;
+        if (locality === "local" || locality === "private" || locality === "hosted") localityCounts[locality] += 1;
+        else localityCounts.unknown += 1;
+      }
+      const terminal = new Set(["succeeded", "failed", "cancelled", "interrupted", "timed_out"]);
+      return {
+        workstreamId: input.workstreamId,
+        workThreadCount: memberRows.length,
+        acceptedWorkThreadCount,
+        runCount: runRows.length,
+        queuedRunCount: runRows.filter((run) => run.status === "queued").length,
+        activeRunCount: runRows.filter((run) => ["assigned", "running"].includes(run.status)).length,
+        terminalRunCount: runRows.filter((run) => terminal.has(run.status)).length,
+        failedRunCount: runRows.filter((run) => ["failed", "interrupted", "timed_out"].includes(run.status)).length,
+        needsHumanRunCount: runRows.filter((run) => run.status === "needs_approval").length,
+        budgetBlockedRunCount: blockedRunIds.size,
+        totalAttempts: attemptRows.length,
+        attemptsPerRunExceededCount: [...attemptCountByRun.values()]
+          .filter((count) => count > recipeValue.budgets.maxAttemptsPerRun).length,
+        totalCostUnits: attemptRows.length * costUnitsPerAttempt,
+        attemptsByLocality: localityCounts,
+        exceptionCount: runRows.filter((run) => run.status === "needs_approval" || ["failed", "interrupted", "timed_out"].includes(run.status)).length
+      };
+    },
 
     upsertWorkThread: upsertWorkThreadRecord,
 
@@ -3063,6 +3599,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       event: OpenTagEvent;
       decision: RunAdmissionDecision;
       activeRunId?: string;
+      workstreamId?: string;
+      admissionBatchId?: string;
       accessProfileSnapshot?: AgentAccessProfileSnapshot;
       policySnapshotProvenance?: PolicySnapshotProvenance;
       routingPolicy?: FrozenRoutingPolicy;
@@ -3078,6 +3616,9 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const routingPolicy = input.routingPolicy
         ? FrozenRoutingPolicySchema.parse(input.routingPolicy)
         : undefined;
+      if (input.admissionBatchId && !input.workstreamId) {
+        throw new Error("Follow-up batch attribution requires a workstream.");
+      }
       if (Boolean(accessProfileSnapshot) !== Boolean(policySnapshotProvenance)) {
         throw new Error("Follow-up access and policy snapshots must be captured together.");
       }
@@ -3093,6 +3634,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           sourceEventId: event.id,
           conversationKey,
           activeRunId: input.activeRunId ?? null,
+          workstreamId: input.workstreamId ?? null,
+          admissionBatchId: input.admissionBatchId ?? null,
           eventJson: JSON.stringify(event),
           decisionJson: JSON.stringify(decision),
           accessProfileSnapshotJson: accessProfileSnapshot ? JSON.stringify(accessProfileSnapshot) : null,
@@ -3108,6 +3651,12 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         const existing = await db.select().from(followUpRequests).where(eq(followUpRequests.sourceEventId, event.id)).limit(1).get();
         if (!existing) {
           throw new Error(`Follow-up request already exists for event ${event.id}, but it could not be loaded`);
+        }
+        if (
+          existing.workstreamId !== (input.workstreamId ?? null)
+          || existing.admissionBatchId !== (input.admissionBatchId ?? null)
+        ) {
+          throw new Error("FACTORY_FOLLOW_UP_ATTRIBUTION_CONFLICT");
         }
         return { followUpRequest: followUpRequestFromRow(existing), created: false };
       }
@@ -3159,7 +3708,12 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           ...(followUp.accessProfileSnapshot ? { accessProfileSnapshot: followUp.accessProfileSnapshot } : {}),
           ...(followUp.policySnapshotProvenance ? { policySnapshotProvenance: followUp.policySnapshotProvenance } : {}),
           ...(followUp.routingPolicy ? { routingPolicy: followUp.routingPolicy } : {}),
-          ...(followUp.activeRunId ? { parentRunId: followUp.activeRunId } : {})
+          ...(followUp.activeRunId ? { parentRunId: followUp.activeRunId } : {}),
+          ...(followUp.workstreamId ? { workstreamId: followUp.workstreamId } : {}),
+          ...(followUp.admissionBatchId ? {
+            admissionBatchId: followUp.admissionBatchId,
+            admissionItemRunId: followUp.id
+          } : {})
         });
         if (!created) {
           throw new Error(`Run already exists for follow-up request ${input.followUpRequestId}.`);
@@ -3675,6 +4229,9 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       triggeredByAction?: ActionHint;
       sourceProposalId?: string;
       sourceApplyPlanId?: string;
+      workstreamId?: string;
+      admissionBatchId?: string;
+      admissionItemRunId?: string;
     }): Promise<CreateRunResult> {
       const event = OpenTagEventSchema.parse(input.event);
       const accessProfileSnapshot = input.accessProfileSnapshot
@@ -3698,6 +4255,24 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       const durableThread = protocolFields.thread
         ? (await upsertWorkThreadRecord({ thread: protocolFields.thread, recordedAt: createdAt })).thread
         : undefined;
+      if (input.workstreamId) {
+        if (!durableThread) throw new Error("FACTORY_ATTRIBUTION_REQUIRES_WORK_THREAD");
+        const member = await db.select({ workThreadId: factoryWorkstreamMembers.workThreadId }).from(factoryWorkstreamMembers)
+          .where(and(eq(factoryWorkstreamMembers.workstreamId, input.workstreamId), eq(factoryWorkstreamMembers.workThreadId, durableThread.id))).limit(1).get();
+        if (!member) throw new Error("FACTORY_WORKSTREAM_MEMBERSHIP_MISMATCH");
+      }
+      if (input.admissionBatchId) {
+        if (!input.workstreamId || !durableThread) throw new Error("FACTORY_BATCH_ATTRIBUTION_REQUIRES_WORKSTREAM");
+        const item = await db.select({ runId: workstreamAdmissionBatchItems.runId }).from(workstreamAdmissionBatchItems)
+          .innerJoin(workstreamAdmissionBatches, eq(workstreamAdmissionBatches.id, workstreamAdmissionBatchItems.batchId))
+          .where(and(
+            eq(workstreamAdmissionBatchItems.batchId, input.admissionBatchId),
+            eq(workstreamAdmissionBatchItems.runId, input.admissionItemRunId ?? input.id),
+            eq(workstreamAdmissionBatchItems.workThreadId, durableThread.id),
+            eq(workstreamAdmissionBatches.workstreamId, input.workstreamId)
+          )).limit(1).get();
+        if (!item) throw new Error("FACTORY_ADMISSION_BATCH_ATTRIBUTION_MISMATCH");
+      }
       const repoKey = projectTargetRefFromEvent(event);
       const routingBinding = routingPolicy ? null : await repoBindingForProjectTarget(repoKey);
       const expectedRunnerId = routingPolicy?.runnerIds?.[0] ?? routingBinding?.runnerId ?? null;
@@ -3723,6 +4298,40 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         runnerIds: frozenRunnerIds,
         executorIds: frozenExecutorIds
       });
+      const reconcileReplayFactoryAttribution = (existingRunId: string): void => {
+        if (!input.workstreamId && !input.admissionBatchId) return;
+        db.transaction((tx) => {
+          const current = tx.select().from(runs).where(eq(runs.id, existingRunId)).limit(1).get();
+          if (!current) throw new Error("FACTORY_REPLAY_RUN_NOT_FOUND");
+          if (!durableThread || current.workThreadId !== durableThread.id) throw new Error("FACTORY_REPLAY_WORK_THREAD_MISMATCH");
+          if (current.workstreamId && current.workstreamId !== input.workstreamId) throw new Error("FACTORY_REPLAY_WORKSTREAM_CONFLICT");
+          if (current.admissionBatchId && current.admissionBatchId !== input.admissionBatchId) throw new Error("FACTORY_REPLAY_ADMISSION_BATCH_CONFLICT");
+          const shouldAttachWorkstream = Boolean(input.workstreamId && !current.workstreamId);
+          const shouldAttachBatch = Boolean(input.admissionBatchId && !current.admissionBatchId);
+          if (!shouldAttachWorkstream && !shouldAttachBatch) return;
+          const updated = tx.update(runs).set({
+            ...(shouldAttachWorkstream ? { workstreamId: input.workstreamId! } : {}),
+            ...(shouldAttachBatch ? { admissionBatchId: input.admissionBatchId! } : {}),
+            updatedAt: createdAt
+          }).where(and(
+            eq(runs.id, existingRunId),
+            ...(shouldAttachWorkstream ? [isNull(runs.workstreamId)] : []),
+            ...(shouldAttachBatch ? [isNull(runs.admissionBatchId)] : [])
+          )).run();
+          if (updated.changes !== 1) throw new Error("FACTORY_REPLAY_ATTRIBUTION_CAS_CONFLICT");
+          tx.insert(runEvents).values({
+            ...runEventValues({
+              runId: existingRunId,
+              type: "factory.attribution_attached",
+              payload: { workstreamId: input.workstreamId, admissionBatchId: input.admissionBatchId },
+              visibility: "audit",
+              importance: "normal",
+              createdAt
+            }),
+            progressIdempotencyDigest: sha256Json({ kind: "factory_attribution", workstreamId: input.workstreamId, admissionBatchId: input.admissionBatchId })
+          }).onConflictDoNothing({ target: [runEvents.runId, runEvents.progressIdempotencyDigest] }).run();
+        });
+      };
       const sourceDeliveryId = sourceDeliveryIdFromEvent(event);
       if (sourceDeliveryId) {
         const existingDelivery = await db
@@ -3734,6 +4343,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         if (existingDelivery) {
           const existingByDelivery = await db.select().from(runs).where(eq(runs.id, existingDelivery.runId)).limit(1).get();
           if (existingByDelivery) {
+            reconcileReplayFactoryAttribution(existingByDelivery.id);
             return recordCreateRunReplay({
               runRow: existingByDelivery,
               requestedRunId: input.id,
@@ -3747,9 +4357,15 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           }
         }
       }
-      const insertResult = await db
-        .insert(runs)
-        .values({
+      const createDecision = RunAdmissionDecisionSchema.parse({
+        action: "start",
+        reason: "Source event accepted and ready to create a run.",
+        reasonCode: "new_event",
+        decidedAt: createdAt,
+        eventId: event.id
+      });
+      const insertResult = db.transaction((tx) => {
+        const inserted = tx.insert(runs).values({
         id: input.id,
         eventId: event.id,
         status: "queued",
@@ -3765,6 +4381,8 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         repoOwner: repoKey?.owner ?? null,
         repoName: repoKey?.repo ?? null,
         workThreadId: durableThread?.id ?? null,
+        workstreamId: input.workstreamId ?? null,
+        admissionBatchId: input.admissionBatchId ?? null,
         conversationKey: conversationKeyFromEvent(event),
         routingPolicyJson: JSON.stringify(capturedRoutingPolicy),
         routingRunnerIdsJson: frozenRunnerIds === null ? null : JSON.stringify(frozenRunnerIds),
@@ -3772,13 +4390,37 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
         routingRejectionsJson: "[]",
         createdAt,
         updatedAt: createdAt
-        })
-        .onConflictDoNothing({ target: runs.eventId });
+        }).onConflictDoNothing({ target: runs.eventId }).run();
+        if (inserted.changes === 0) return inserted;
+        if (sourceDeliveryId) {
+          tx.insert(sourceDeliveries).values({ source: event.source, deliveryId: sourceDeliveryId, runId: input.id, eventId: event.id, createdAt })
+            .onConflictDoNothing({ target: [sourceDeliveries.source, sourceDeliveries.deliveryId] }).run();
+        }
+        const baseEvents: Array<typeof runEvents.$inferInsert> = [
+          runEventValues({ runId: input.id, type: "admission.decided", payload: createDecision, visibility: "audit", importance: "normal", message: createDecision.reason, createdAt }),
+          runEventValues({ runId: input.id, type: "run.created", payload: { eventId: event.id, provenance: runProvenance({ event, projectTarget: repoKey, admissionDecision: createDecision, expectedRunnerId }) }, visibility: "audit", importance: "low", createdAt }),
+          runEventValues({ runId: input.id, type: "context_packet.generated", payload: { contextPacket: protocolFields.contextPacket, ...(durableThread ? { thread: durableThread } : {}) }, visibility: "audit", importance: "normal", message: protocolFields.contextPacket.summary, createdAt })
+        ];
+        if (accessProfileSnapshot && policySnapshotProvenance) {
+          baseEvents.push(runEventValues({
+            runId: input.id,
+            type: "agent_access_profile.captured",
+            payload: { accessProfileSnapshotId: accessProfileSnapshot.id, policySnapshotId: policySnapshotProvenance.id, requestedBy: accessProfileSnapshot.requestedBy, agentPrincipal: accessProfileSnapshot.agentPrincipal, projectTargets: accessProfileSnapshot.projectTargets },
+            visibility: "audit",
+            importance: "high",
+            message: "Attributed agent access and policy snapshots captured at admission.",
+            createdAt
+          }));
+        }
+        tx.insert(runEvents).values(baseEvents).run();
+        return inserted;
+      });
       if (insertResult.changes === 0) {
         const existingBySourceEvent = await db.select().from(runs).where(eq(runs.eventId, event.id)).limit(1).get();
         if (!existingBySourceEvent) {
           throw new Error(`Run already exists for event ${event.id}, but it could not be loaded`);
         }
+        reconcileReplayFactoryAttribution(existingBySourceEvent.id);
         return recordCreateRunReplay({
           runRow: existingBySourceEvent,
           requestedRunId: input.id,
@@ -3787,79 +4429,6 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           expectedRunnerId,
           replayKind: "source_event",
           sourceDeliveryId,
-          createdAt
-        });
-      }
-      const createDecision = RunAdmissionDecisionSchema.parse({
-        action: "start",
-        reason: "Source event accepted and ready to create a run.",
-        reasonCode: "new_event",
-        decidedAt: createdAt,
-        eventId: event.id
-      });
-      if (sourceDeliveryId) {
-        await db
-          .insert(sourceDeliveries)
-          .values({
-            source: event.source,
-            deliveryId: sourceDeliveryId,
-            runId: input.id,
-            eventId: event.id,
-            createdAt
-          })
-          .onConflictDoNothing({ target: [sourceDeliveries.source, sourceDeliveries.deliveryId] });
-      }
-      await appendRunEvent({
-        runId: input.id,
-        type: "admission.decided",
-        payload: createDecision,
-        visibility: "audit",
-        importance: "normal",
-        message: createDecision.reason,
-        createdAt
-      });
-      await appendRunEvent({
-        runId: input.id,
-        type: "run.created",
-        payload: {
-          eventId: event.id,
-          provenance: runProvenance({
-            event,
-            projectTarget: repoKey,
-            admissionDecision: createDecision,
-            expectedRunnerId
-          })
-        },
-        visibility: "audit",
-        importance: "low",
-        createdAt
-      });
-      await appendRunEvent({
-        runId: input.id,
-        type: "context_packet.generated",
-        payload: {
-          contextPacket: protocolFields.contextPacket,
-          ...(durableThread ? { thread: durableThread } : {})
-        },
-        visibility: "audit",
-        importance: "normal",
-        message: protocolFields.contextPacket.summary,
-        createdAt
-      });
-      if (accessProfileSnapshot && policySnapshotProvenance) {
-        await appendRunEvent({
-          runId: input.id,
-          type: "agent_access_profile.captured",
-          payload: {
-            accessProfileSnapshotId: accessProfileSnapshot.id,
-            policySnapshotId: policySnapshotProvenance.id,
-            requestedBy: accessProfileSnapshot.requestedBy,
-            agentPrincipal: accessProfileSnapshot.agentPrincipal,
-            projectTargets: accessProfileSnapshot.projectTargets
-          },
-          visibility: "audit",
-          importance: "high",
-          message: "Attributed agent access and policy snapshots captured at admission.",
           createdAt
         });
       }
@@ -4268,11 +4837,62 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
                 directory: snapshot.directory.filter((entry) => candidateRunnerIds.has(entry.runnerId))
               }
             : snapshot;
+          const factoryBudget = candidate.workstreamId
+            ? (() => {
+                const row = tx.select({ recipeJson: factoryRecipeSnapshots.recipeJson }).from(factoryWorkstreams)
+                  .innerJoin(factoryRecipeSnapshots, and(
+                    eq(factoryRecipeSnapshots.id, factoryWorkstreams.recipeId),
+                    eq(factoryRecipeSnapshots.version, factoryWorkstreams.recipeVersion)
+                  )).where(eq(factoryWorkstreams.id, candidate.workstreamId!)).limit(1).get();
+                if (!row) return null;
+                try {
+                  const parsed = FactoryRecipeSnapshotInputSchema.safeParse(JSON.parse(row.recipeJson));
+                  return parsed.success ? parsed.data.budgets : null;
+                } catch {
+                  return null;
+                }
+              })()
+            : undefined;
+          if (candidate.workstreamId && !factoryBudget) {
+            const blockedAt = now.toISOString();
+            const invariantKey = `factory-recipe-authority:${candidate.workstreamId}`;
+            tx.insert(runEvents).values({
+              ...runEventValues({
+                runId: candidate.id,
+                type: "factory.invariant_blocked",
+                payload: { workstreamId: candidate.workstreamId, invariant: "authoritative_recipe_snapshot_missing_or_invalid" },
+                visibility: "audit",
+                importance: "blocking",
+                message: "Factory claim is blocked because its authoritative recipe snapshot is missing or invalid.",
+                createdAt: blockedAt
+              }),
+              progressIdempotencyDigest: sha256Json({ kind: invariantKey, runId: candidate.id })
+            }).onConflictDoNothing({ target: [runEvents.runId, runEvents.progressIdempotencyDigest] }).run();
+            tx.insert(controlPlaneEvents).values({
+              type: "factory.invariant_blocked",
+              severity: "error",
+              subject: candidate.workstreamId,
+              idempotencyKey: `${invariantKey}:${candidate.id}`,
+              payloadJson: JSON.stringify({
+                workstreamId: candidate.workstreamId,
+                runId: candidate.id,
+                invariant: "authoritative_recipe_snapshot_missing_or_invalid"
+              }),
+              createdAt: blockedAt
+            }).onConflictDoNothing({ target: controlPlaneEvents.idempotencyKey }).run();
+            continue;
+          }
+          if (candidate.workstreamId && factoryBudget?.maxConcurrentRuns !== undefined) {
+            const active = tx.select({ count: sql<number>`count(*)` }).from(runs)
+              .where(and(eq(runs.workstreamId, candidate.workstreamId), inArray(runs.status, ["assigned", "running"]))).get()?.count ?? 0;
+            if (active >= factoryBudget.maxConcurrentRuns) continue;
+          }
           const routingDecision = routingDecisionForRun({
             runRow: candidate,
             now,
             snapshot: candidateSnapshot,
-            event: eventForQueuedRun(candidate)
+            event: eventForQueuedRun(candidate),
+            ...(factoryBudget?.allowedLocalities ? { allowedLocalities: factoryBudget.allowedLocalities } : {})
           });
           const latest = latestRoutingEventByRun.get(candidate.id);
           const previous = latest ? RoutingDecisionSchema.safeParse(JSON.parse(latest.payloadJson)) : undefined;
@@ -4297,6 +4917,49 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
           const previousAttempt = tx.select({ number: attempts.number }).from(attempts)
             .where(eq(attempts.runId, candidate.id)).orderBy(desc(attempts.number)).limit(1).get();
           const number = (previousAttempt?.number ?? 0) + 1;
+          if (candidate.workstreamId) {
+            const budget = factoryBudget!;
+            const workstreamAttempts = tx.select({ count: sql<number>`count(*)` }).from(attempts)
+              .innerJoin(runs, eq(runs.id, attempts.runId)).where(eq(runs.workstreamId, candidate.workstreamId)).get()?.count ?? 0;
+            const costUnitsPerAttempt = budget.costUnitsPerAttempt ?? 0;
+            const nextCostUnits = (workstreamAttempts + 1) * costUnitsPerAttempt;
+            const runnerLocality = selectedRunner?.locality ?? "unknown";
+            const violation = budget.maxAttemptsPerRun !== undefined && number > budget.maxAttemptsPerRun
+                ? { code: "max_attempts_per_run", observed: number, limit: budget.maxAttemptsPerRun }
+                : budget.maxCostUnits !== undefined && nextCostUnits > budget.maxCostUnits
+                  ? { code: "max_cost_units", observed: nextCostUnits, limit: budget.maxCostUnits }
+                  : null;
+            if (violation) {
+              const blockedAt = now.toISOString();
+              const blocked = tx.update(runs).set({ status: "needs_approval", currentRoutingDecisionId: null, updatedAt: blockedAt })
+                .where(and(eq(runs.id, candidate.id), eq(runs.status, "queued"))).run();
+              if (blocked.changes === 1) {
+                const dedupeDigest = sha256Json({ kind: "factory_budget", workstreamId: candidate.workstreamId, code: violation.code });
+                tx.insert(runEvents).values({
+                  ...runEventValues({
+                    runId: candidate.id,
+                    type: "factory.budget_blocked",
+                    payload: { workstreamId: candidate.workstreamId, violation, runnerId: input.runnerId, runnerLocality },
+                    visibility: "audit",
+                    importance: "blocking",
+                    message: `Factory workstream budget blocked this attempt: ${violation.code}.`,
+                    createdAt: blockedAt
+                  }),
+                  progressIdempotencyDigest: dedupeDigest
+                }).onConflictDoNothing({ target: [runEvents.runId, runEvents.progressIdempotencyDigest] }).run();
+                if (candidate.workThreadId) {
+                  tx.insert(governanceEvents).values({
+                    workThreadId: candidate.workThreadId,
+                    type: "factory.budget_blocked",
+                    subjectId: candidate.id,
+                    payloadJson: JSON.stringify({ workstreamId: candidate.workstreamId, violation }),
+                    createdAt: blockedAt
+                  }).run();
+                }
+              }
+              continue;
+            }
+          }
           const updateResult = tx.update(runs).set({
             status: "assigned",
             assignedRunnerId: input.runnerId,
@@ -4316,6 +4979,7 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
             runId: candidate.id,
             number,
             runnerId: input.runnerId,
+            runnerLocality: selectedRunner?.locality ?? null,
             selectedExecutorId: authoritativeExecutorId,
             routingDecisionId: routingDecision.id,
             fencingToken,
@@ -6155,16 +6819,19 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
       type: string;
       severity?: ControlPlaneEventSeverity;
       subject?: string;
+      idempotencyKey?: string;
       payload?: unknown;
       createdAt?: string;
-    }): Promise<void> {
-      await db.insert(controlPlaneEvents).values({
+    }): Promise<"recorded" | "duplicate"> {
+      const inserted = await db.insert(controlPlaneEvents).values({
         type: input.type,
         severity: input.severity ?? "info",
         subject: input.subject ?? null,
+        idempotencyKey: input.idempotencyKey ?? null,
         payloadJson: JSON.stringify(input.payload ?? {}),
         createdAt: input.createdAt ?? nowIso()
-      });
+      }).onConflictDoNothing({ target: controlPlaneEvents.idempotencyKey });
+      return inserted.changes === 1 ? "recorded" : "duplicate";
     },
 
     async listControlPlaneEvents(input: { limit?: number; type?: string; severity?: ControlPlaneEventSeverity } = {}): Promise<ControlPlaneEvent[]> {
@@ -6495,27 +7162,28 @@ export function createOpenTagRepository(db: BetterSQLite3Database) {
 
     async getAcceptedCompletionMetrics(): Promise<AcceptedCompletionMetrics> {
       const currentAssessmentRows = await db.select({
-        id: completionAssessments.id,
+        assessmentId: completionAssessments.id,
         threadId: workThreads.id,
         persistedThreadId: completionAssessments.workThreadId,
-        assessmentJson: completionAssessments.assessmentJson
+        assessmentJson: completionAssessments.assessmentJson,
+        waiverId: completionWaivers.id,
+        waiverWorkThreadId: completionWaivers.workThreadId,
+        waiverContractId: completionWaivers.contractId,
+        waiverContractVersion: completionWaivers.contractVersion,
+        waiverCycle: completionWaivers.cycle,
+        waiverContentDigest: completionWaivers.contentDigest,
+        waiverJson: completionWaivers.waiverJson
       }).from(workThreads)
-        .innerJoin(completionAssessments, eq(completionAssessments.id, workThreads.currentAssessmentId));
+        .innerJoin(completionAssessments, eq(completionAssessments.id, workThreads.currentAssessmentId))
+        .leftJoin(completionWaivers, eq(
+          completionWaivers.id,
+          sql<string | null>`CASE WHEN json_valid(${completionAssessments.assessmentJson}) THEN json_extract(${completionAssessments.assessmentJson}, '$.waiver.id') ELSE NULL END`
+        ));
+      const evaluatedAt = nowIso();
       const acceptedAssessmentRefs = currentAssessmentRows.flatMap((assessment) => {
-        try {
-          const parsed = CompletionAssessmentSchema.safeParse(JSON.parse(assessment.assessmentJson));
-          return parsed.success && (
-            parsed.data.state === "waived"
-            || (parsed.data.state === "satisfied" && parsed.data.evidenceBacked)
-          )
-            && parsed.data.id === assessment.id
-            && parsed.data.workThreadId === assessment.threadId
-            && assessment.persistedThreadId === assessment.threadId
-            ? [{ assessmentId: assessment.id, workThreadId: assessment.threadId }]
-            : [];
-        } catch {
-          return [];
-        }
+        return currentAssessmentIsAccepted(assessment, evaluatedAt)
+          ? [{ assessmentId: assessment.assessmentId, workThreadId: assessment.threadId }]
+          : [];
       });
       type AggregateRow = {
         dimension: "total" | "runner" | "executor";

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -22,6 +22,8 @@ export const runs = sqliteTable(
     repoOwner: text("repo_owner"),
     repoName: text("repo_name"),
     workThreadId: text("work_thread_id"),
+    workstreamId: text("workstream_id"),
+    admissionBatchId: text("admission_batch_id"),
     conversationKey: text("conversation_key"),
     leasedAt: text("leased_at"),
     leaseExpiresAt: text("lease_expires_at"),
@@ -43,6 +45,8 @@ export const runs = sqliteTable(
     repoIdx: index("runs_repo_idx").on(table.repoProvider, table.repoOwner, table.repoName),
     workThreadIdx: index("runs_work_thread_idx").on(table.workThreadId),
     workThreadAuthorityIdx: index("runs_work_thread_authority_idx").on(table.workThreadId, table.createdAt, table.id),
+    workstreamIdx: index("runs_workstream_idx").on(table.workstreamId, table.status),
+    admissionBatchIdx: index("runs_admission_batch_idx").on(table.admissionBatchId),
     conversationIdx: index("runs_conversation_idx").on(table.conversationKey)
   })
 );
@@ -54,6 +58,7 @@ export const attempts = sqliteTable(
     runId: text("run_id").notNull(),
     number: integer("number").notNull(),
     runnerId: text("runner_id").notNull(),
+    runnerLocality: text("runner_locality"),
     selectedExecutorId: text("selected_executor_id"),
     routingDecisionId: text("routing_decision_id"),
     fencingToken: text("fencing_token").notNull(),
@@ -80,6 +85,8 @@ export const followUpRequests = sqliteTable(
     sourceEventId: text("source_event_id").notNull(),
     conversationKey: text("conversation_key").notNull(),
     activeRunId: text("active_run_id"),
+    workstreamId: text("workstream_id"),
+    admissionBatchId: text("admission_batch_id"),
     eventJson: text("event_json").notNull(),
     decisionJson: text("decision_json").notNull(),
     accessProfileSnapshotJson: text("access_profile_snapshot_json"),
@@ -141,12 +148,94 @@ export const controlPlaneEvents = sqliteTable(
     type: text("type").notNull(),
     severity: text("severity").notNull(),
     subject: text("subject"),
+    idempotencyKey: text("idempotency_key"),
     payloadJson: text("payload_json").notNull(),
     createdAt: text("created_at").notNull()
   },
   (table) => ({
     typeIdx: index("control_plane_events_type_idx").on(table.type),
-    severityIdx: index("control_plane_events_severity_idx").on(table.severity)
+    severityIdx: index("control_plane_events_severity_idx").on(table.severity),
+    idempotencyIdx: uniqueIndex("control_plane_events_idempotency_key_idx").on(table.idempotencyKey)
+  })
+);
+
+export const factoryRecipeSnapshots = sqliteTable(
+  "factory_recipe_snapshots",
+  {
+    id: text("id").notNull(),
+    version: integer("version").notNull(),
+    recipeJson: text("recipe_json").notNull(),
+    contentDigest: text("content_digest").notNull(),
+    createdAt: text("created_at").notNull()
+  },
+  (table) => ({ pk: primaryKey({ columns: [table.id, table.version] }) })
+);
+
+export const factoryWorkstreams = sqliteTable(
+  "factory_workstreams",
+  {
+    id: text("id").primaryKey(),
+    recipeId: text("recipe_id").notNull(),
+    recipeVersion: integer("recipe_version").notNull(),
+    workstreamJson: text("workstream_json").notNull(),
+    contentDigest: text("content_digest").notNull(),
+    createdAt: text("created_at").notNull()
+  },
+  (table) => ({ recipeIdx: index("factory_workstreams_recipe_idx").on(table.recipeId, table.recipeVersion) })
+);
+
+export const factoryWorkstreamMembers = sqliteTable(
+  "factory_workstream_members",
+  {
+    workstreamId: text("workstream_id").notNull(),
+    workThreadId: text("work_thread_id").notNull(),
+    createdAt: text("created_at").notNull()
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.workstreamId, table.workThreadId] }),
+    threadIdx: index("factory_workstream_members_thread_idx").on(table.workThreadId)
+  })
+);
+
+export const workstreamAdmissionBatches = sqliteTable(
+  "workstream_admission_batches",
+  {
+    id: text("id").primaryKey(),
+    workstreamId: text("workstream_id").notNull(),
+    requestDigest: text("request_digest").notNull(),
+    requestJson: text("request_json").notNull(),
+    status: text("status").notNull(),
+    leaseOwner: text("lease_owner"),
+    leaseExpiresAt: text("lease_expires_at"),
+    resultJson: text("result_json"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    completedAt: text("completed_at")
+  },
+  (table) => ({ workstreamStatusIdx: index("workstream_admission_batches_workstream_status_idx").on(table.workstreamId, table.status) })
+);
+
+export const workstreamAdmissionBatchItems = sqliteTable(
+  "workstream_admission_batch_items",
+  {
+    batchId: text("batch_id").notNull(),
+    itemId: text("item_id").notNull(),
+    ordinal: integer("ordinal").notNull(),
+    runId: text("run_id").notNull(),
+    workThreadId: text("work_thread_id").notNull(),
+    eventJson: text("event_json").notNull(),
+    status: text("status").notNull(),
+    leaseOwner: text("lease_owner"),
+    leaseExpiresAt: text("lease_expires_at"),
+    resultJson: text("result_json"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    completedAt: text("completed_at")
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.batchId, table.itemId] }),
+    ordinalIdx: uniqueIndex("workstream_admission_batch_items_ordinal_idx").on(table.batchId, table.ordinal),
+    statusIdx: index("workstream_admission_batch_items_status_idx").on(table.batchId, table.status)
   })
 );
 
@@ -698,6 +787,98 @@ function migrateHumanEscalationAccessIdentitySchema(sqlite: Database.Database): 
   })();
 }
 
+function migrateFactoryWorkstreamSchema(sqlite: Database.Database): void {
+  const migrationId = "2026-07-26-factory-workstreams-v1";
+  const applied = sqlite.prepare("SELECT id FROM opentag_schema_migrations WHERE id = ?").get(migrationId);
+  if (applied) return;
+  sqlite.transaction(() => {
+    const runColumns = sqlite.prepare("PRAGMA table_info(runs)").all() as { name: string }[];
+    const runColumnNames = new Set(runColumns.map((column) => column.name));
+    if (!runColumnNames.has("workstream_id")) sqlite.exec("ALTER TABLE runs ADD COLUMN workstream_id TEXT");
+    if (!runColumnNames.has("admission_batch_id")) sqlite.exec("ALTER TABLE runs ADD COLUMN admission_batch_id TEXT");
+    const attemptColumns = sqlite.prepare("PRAGMA table_info(attempts)").all() as { name: string }[];
+    if (!attemptColumns.some((column) => column.name === "runner_locality")) {
+      sqlite.exec("ALTER TABLE attempts ADD COLUMN runner_locality TEXT");
+    }
+    const followUpColumns = sqlite.prepare("PRAGMA table_info(follow_up_requests)").all() as { name: string }[];
+    const followUpColumnNames = new Set(followUpColumns.map((column) => column.name));
+    if (!followUpColumnNames.has("workstream_id")) sqlite.exec("ALTER TABLE follow_up_requests ADD COLUMN workstream_id TEXT");
+    if (!followUpColumnNames.has("admission_batch_id")) sqlite.exec("ALTER TABLE follow_up_requests ADD COLUMN admission_batch_id TEXT");
+    sqlite.exec(`
+      CREATE INDEX IF NOT EXISTS runs_workstream_idx ON runs(workstream_id, status);
+      CREATE INDEX IF NOT EXISTS runs_admission_batch_idx ON runs(admission_batch_id);
+
+      CREATE TABLE IF NOT EXISTS factory_recipe_snapshots (
+        id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        recipe_json TEXT NOT NULL,
+        content_digest TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (id, version)
+      );
+      CREATE TABLE IF NOT EXISTS factory_workstreams (
+        id TEXT PRIMARY KEY,
+        recipe_id TEXT NOT NULL,
+        recipe_version INTEGER NOT NULL,
+        workstream_json TEXT NOT NULL,
+        content_digest TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS factory_workstreams_recipe_idx
+        ON factory_workstreams(recipe_id, recipe_version);
+      CREATE TABLE IF NOT EXISTS factory_workstream_members (
+        workstream_id TEXT NOT NULL,
+        work_thread_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (workstream_id, work_thread_id)
+      );
+      CREATE INDEX IF NOT EXISTS factory_workstream_members_thread_idx
+        ON factory_workstream_members(work_thread_id);
+      CREATE TABLE IF NOT EXISTS workstream_admission_batches (
+        id TEXT PRIMARY KEY,
+        workstream_id TEXT NOT NULL,
+        request_digest TEXT NOT NULL,
+        request_json TEXT NOT NULL,
+        status TEXT NOT NULL,
+        lease_owner TEXT,
+        lease_expires_at TEXT,
+        result_json TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        completed_at TEXT
+      );
+      CREATE INDEX IF NOT EXISTS workstream_admission_batches_workstream_status_idx
+        ON workstream_admission_batches(workstream_id, status);
+      CREATE TABLE IF NOT EXISTS workstream_admission_batch_items (
+        batch_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        ordinal INTEGER NOT NULL,
+        run_id TEXT NOT NULL,
+        work_thread_id TEXT NOT NULL,
+        event_json TEXT NOT NULL,
+        status TEXT NOT NULL,
+        lease_owner TEXT,
+        lease_expires_at TEXT,
+        result_json TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        completed_at TEXT,
+        PRIMARY KEY (batch_id, item_id)
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS workstream_admission_batch_items_ordinal_idx
+        ON workstream_admission_batch_items(batch_id, ordinal);
+      CREATE INDEX IF NOT EXISTS workstream_admission_batch_items_status_idx
+        ON workstream_admission_batch_items(batch_id, status);
+    `);
+    const controlPlaneColumns = sqlite.prepare("PRAGMA table_info(control_plane_events)").all() as { name: string }[];
+    if (!controlPlaneColumns.some((column) => column.name === "idempotency_key")) {
+      sqlite.exec("ALTER TABLE control_plane_events ADD COLUMN idempotency_key TEXT");
+    }
+    sqlite.exec("CREATE UNIQUE INDEX IF NOT EXISTS control_plane_events_idempotency_key_idx ON control_plane_events(idempotency_key)");
+    sqlite.prepare("INSERT INTO opentag_schema_migrations (id, applied_at) VALUES (?, ?)").run(migrationId, new Date().toISOString());
+  })();
+}
+
 export function migrateSchema(sqlite: Database.Database): void {
   sqlite.exec(`
     CREATE TABLE IF NOT EXISTS runs (
@@ -954,6 +1135,8 @@ export function migrateSchema(sqlite: Database.Database): void {
       source_event_id TEXT NOT NULL,
       conversation_key TEXT NOT NULL,
       active_run_id TEXT,
+      workstream_id TEXT,
+      admission_batch_id TEXT,
       event_json TEXT NOT NULL,
       decision_json TEXT NOT NULL,
       access_profile_snapshot_json TEXT,
@@ -1292,4 +1475,5 @@ export function migrateSchema(sqlite: Database.Database): void {
   migrateCompletionGovernanceSchema(sqlite);
   migrateCompletionWaiverSchema(sqlite);
   migrateHumanEscalationAccessIdentitySchema(sqlite);
+  migrateFactoryWorkstreamSchema(sqlite);
 }

--- a/packages/store/test/factory-workstreams.test.ts
+++ b/packages/store/test/factory-workstreams.test.ts
@@ -1,0 +1,328 @@
+import Database from "better-sqlite3";
+import { WorkstreamAdmissionBatchInputSchema } from "@opentag/core";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { canonicalSha256Json } from "../src/canonical-json.js";
+import { createOpenTagRepository } from "../src/repository.js";
+import { migrateSchema } from "../src/schema.js";
+
+function fixture() {
+  const sqlite = new Database(":memory:");
+  migrateSchema(sqlite);
+  return { sqlite, repo: createOpenTagRepository(drizzle(sqlite)) };
+}
+
+function event(id: string) {
+  return {
+    id: `event-${id}`,
+    source: "github" as const,
+    sourceEventId: `comment-${id}`,
+    receivedAt: "2026-07-26T00:00:00.000Z",
+    actor: { provider: "github" as const, providerUserId: "42", handle: "octocat" },
+    target: { mention: "@opentag", agentId: "opentag" },
+    command: { rawText: "fix", intent: "fix" as const, args: {} },
+    context: [{ provider: "github" as const, kind: "issue" as const, uri: "https://github.com/acme/demo/issues/42", visibility: "public" as const }],
+    workItem: { provider: "github" as const, kind: "issue" as const, externalId: "acme/demo#42", uri: "https://github.com/acme/demo/issues/42", ownerContainer: { provider: "github" as const, id: "acme/demo", uri: "https://github.com/acme/demo" } },
+    thread: { provider: "github" as const, kind: "issue_comment" as const, externalId: "comment-root", uri: "https://github.com/acme/demo/issues/42#issuecomment-root", threadKey: "acme/demo#42" },
+    permissions: [{ scope: "issue:comment", reason: "reply" }],
+    callback: { provider: "github" as const, uri: "https://api.github.com/repos/acme/demo/issues/42/comments" },
+    metadata: { owner: "acme", repo: "demo", issueNumber: 42 }
+  };
+}
+
+async function setupFactory() {
+  const { sqlite, repo } = fixture();
+  const run = await repo.createRun({ id: "seed-run", event: event("seed") });
+  const workThreadId = run.run.thread?.id;
+  if (!workThreadId) throw new Error("expected WorkThread");
+  const recipe = { id: "recipe", version: 1, name: "bounded", budgets: { maxConcurrentRuns: 1, maxAttemptsPerRun: 1, maxCostUnits: 1, costUnitsPerAttempt: 1, allowedLocalities: ["local"] } };
+  await repo.createFactoryRecipeSnapshot({ id: "recipe", version: 1, recipe });
+  await repo.createFactoryWorkstream({ id: "workstream", recipeId: "recipe", recipeVersion: 1, workstream: { id: "workstream", name: "one" }, workThreadIds: [workThreadId] });
+  return { sqlite, repo, workThreadId };
+}
+
+describe("factory workstream persistence", () => {
+  it("uses a stable code-unit canonical digest for durable replay identity", () => {
+    expect(canonicalSha256Json({ z: 1, "ä": 2, a: 3, "😀": 4 })).toBe(
+      "sha256:fb215dbd6cdd5ce98f4e77b27ba82bf88b6376d244e0dbc9323c496101653081"
+    );
+  });
+
+  it("migrates a pre-Phase-4 database idempotently without losing legacy runs or follow-ups", async () => {
+    const sqlite = new Database(":memory:");
+    migrateSchema(sqlite);
+    const legacyRepo = createOpenTagRepository(drizzle(sqlite));
+    const legacyEvent = event("legacy-migration");
+    await legacyRepo.createRun({ id: "legacy-run", event: legacyEvent });
+    await legacyRepo.createFollowUpRequest({
+      id: "legacy-follow-up",
+      event: event("legacy-follow-up"),
+      activeRunId: "legacy-run",
+      decision: {
+        action: "queue_follow_up",
+        reason: "Legacy follow-up remains queued.",
+        reasonCode: "active_run_same_thread",
+        decidedAt: "2026-07-26T00:00:00.000Z",
+        activeRunId: "legacy-run",
+        eventId: "event-legacy-follow-up"
+      }
+    });
+
+    sqlite.exec(`
+      DROP INDEX IF EXISTS runs_workstream_idx;
+      DROP INDEX IF EXISTS runs_admission_batch_idx;
+      DROP INDEX IF EXISTS control_plane_events_idempotency_key_idx;
+      DROP TABLE IF EXISTS workstream_admission_batch_items;
+      DROP TABLE IF EXISTS workstream_admission_batches;
+      DROP TABLE IF EXISTS factory_workstream_members;
+      DROP TABLE IF EXISTS factory_workstreams;
+      DROP TABLE IF EXISTS factory_recipe_snapshots;
+      ALTER TABLE runs DROP COLUMN workstream_id;
+      ALTER TABLE runs DROP COLUMN admission_batch_id;
+      ALTER TABLE attempts DROP COLUMN runner_locality;
+      ALTER TABLE control_plane_events DROP COLUMN idempotency_key;
+      ALTER TABLE follow_up_requests DROP COLUMN workstream_id;
+      ALTER TABLE follow_up_requests DROP COLUMN admission_batch_id;
+      DELETE FROM opentag_schema_migrations WHERE id = '2026-07-26-factory-workstreams-v1';
+    `);
+
+    migrateSchema(sqlite);
+    migrateSchema(sqlite);
+    const migratedRepo = createOpenTagRepository(drizzle(sqlite));
+    await expect(migratedRepo.getRun({ runId: "legacy-run" })).resolves.toMatchObject({ run: { id: "legacy-run" } });
+    await expect(migratedRepo.getFollowUpRequest({ id: "legacy-follow-up" })).resolves.toMatchObject({
+      id: "legacy-follow-up",
+      status: "queued"
+    });
+    const table = sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get("factory_workstreams");
+    expect(table).toEqual({ name: "factory_workstreams" });
+    const runColumns = sqlite.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;
+    expect(runColumns.map((column) => column.name)).toEqual(expect.arrayContaining(["workstream_id", "admission_batch_id"]));
+    const followUpColumns = sqlite.prepare("PRAGMA table_info(follow_up_requests)").all() as Array<{ name: string }>;
+    expect(followUpColumns.map((column) => column.name)).toEqual(expect.arrayContaining(["workstream_id", "admission_batch_id"]));
+  });
+
+  it("keeps recipe and workstream snapshots immutable", async () => {
+    const { repo } = await setupFactory();
+    await expect(repo.createFactoryRecipeSnapshot({ id: "recipe", version: 1, recipe: { id: "recipe", version: 1, name: "changed", budgets: { maxConcurrentRuns: 1, maxAttemptsPerRun: 1, maxCostUnits: 1, costUnitsPerAttempt: 1, allowedLocalities: ["local"] } } })).resolves.toMatchObject({ outcome: "conflict" });
+    await expect(repo.createFactoryWorkstream({ id: "workstream", recipeId: "recipe", recipeVersion: 1, workstream: { id: "workstream", name: "changed" }, workThreadIds: ["missing"] })).resolves.toMatchObject({ outcome: "conflict" });
+  });
+
+  it("resumes expired batches, fences items, and replays completed results", async () => {
+    const { repo, workThreadId } = await setupFactory();
+    const items = [{ itemId: "item", runId: "run", workThreadId, event: event("batch") }];
+    const request = { id: "batch", workstreamId: "workstream", items };
+    const input = { id: "batch", workstreamId: "workstream", requestDigest: canonicalSha256Json(WorkstreamAdmissionBatchInputSchema.parse(request)), request, items, leaseOwner: "owner-a", leaseSeconds: 1, now: new Date("2026-07-26T00:00:00.000Z") };
+    await expect(repo.beginWorkstreamAdmissionBatch(input)).resolves.toMatchObject({ outcome: "acquired" });
+    await expect(repo.beginWorkstreamAdmissionBatch({ ...input, leaseOwner: "owner-b", now: new Date("2026-07-26T00:00:00.500Z") })).resolves.toMatchObject({ outcome: "in_progress" });
+    await expect(repo.beginWorkstreamAdmissionBatch({ ...input, leaseOwner: "owner-b", leaseSeconds: 60, now: new Date("2026-07-26T00:00:02.000Z") })).resolves.toMatchObject({ outcome: "acquired" });
+    await expect(repo.claimWorkstreamAdmissionBatchItem({ batchId: "batch", itemId: "item", leaseOwner: "owner-b", leaseSeconds: 60, now: new Date("2026-07-26T00:00:02.000Z") })).resolves.toMatchObject({ outcome: "claimed" });
+    await expect(repo.renewWorkstreamAdmissionBatchLease({ batchId: "batch", itemId: "item", leaseOwner: "owner-a", leaseSeconds: 60, now: new Date("2026-07-26T00:00:50.000Z") })).resolves.toMatchObject({ outcome: "stale_lease" });
+    await expect(repo.renewWorkstreamAdmissionBatchLease({ batchId: "batch", itemId: "item", leaseOwner: "owner-b", leaseSeconds: 60, now: new Date("2026-07-26T00:00:50.000Z") })).resolves.toMatchObject({ outcome: "renewed" });
+    await expect(repo.beginWorkstreamAdmissionBatch({ ...input, leaseOwner: "owner-c", leaseSeconds: 60, now: new Date("2026-07-26T00:01:03.000Z") })).resolves.toMatchObject({ outcome: "in_progress" });
+    await expect(repo.completeWorkstreamAdmissionBatchItem({ batchId: "batch", itemId: "item", leaseOwner: "owner-a", result: { status: "created" }, now: new Date("2026-07-26T00:01:03.000Z") })).resolves.toMatchObject({ outcome: "stale_lease" });
+    await expect(repo.completeWorkstreamAdmissionBatchItem({ batchId: "batch", itemId: "item", leaseOwner: "owner-b", result: { status: "created" }, now: new Date("2026-07-26T00:01:03.000Z") })).resolves.toMatchObject({ outcome: "completed" });
+    await expect(repo.finalizeWorkstreamAdmissionBatch({ id: "batch", leaseOwner: "owner-b", result: { totalItems: 1 }, now: new Date("2026-07-26T00:01:03.000Z") })).resolves.toMatchObject({ outcome: "completed" });
+    await expect(repo.beginWorkstreamAdmissionBatch({ ...input, leaseOwner: "owner-c", now: new Date("2026-07-26T00:02:00.000Z") })).resolves.toMatchObject({ outcome: "replay", batch: { result: { totalItems: 1 } } });
+  });
+
+  it("attributes runs and atomically blocks a second attempt at the recipe budget", async () => {
+    const { sqlite, repo } = await setupFactory();
+    sqlite.prepare("DELETE FROM runs WHERE id = ?").run("seed-run");
+    await repo.registerRunner({ runnerId: "runner", name: "runner", locality: "local" });
+    await repo.createRepoBinding({ provider: "github", owner: "acme", repo: "demo", runnerId: "runner", defaultExecutor: "codex" });
+    const run = await repo.createRun({ id: "factory-run", event: event("factory"), workstreamId: "workstream" });
+    expect(run.created).toBe(true);
+    await expect(repo.claimNextRun({ runnerId: "runner", leaseSeconds: 0 })).resolves.toMatchObject({ run: { id: "factory-run" } });
+    await expect(repo.claimNextRun({ runnerId: "runner", leaseSeconds: 60 })).resolves.toBeNull();
+    await expect(repo.getRun({ runId: "factory-run" })).resolves.toMatchObject({ run: { status: "needs_approval" } });
+    await expect(repo.getWorkstreamMetrics({ workstreamId: "workstream" })).resolves.toMatchObject({
+      workThreadCount: 1,
+      runCount: 1,
+      needsHumanRunCount: 1,
+      budgetBlockedRunCount: 1,
+      totalAttempts: 1,
+      attemptsPerRunExceededCount: 0,
+      totalCostUnits: 1,
+      attemptsByLocality: { local: 1, private: 0, hosted: 0, unknown: 0 }
+    });
+  });
+
+  it("derives lifetime metrics without binding every historical run id", async () => {
+    const { sqlite, repo } = await setupFactory();
+    sqlite.exec(`
+      WITH RECURSIVE sequence(value) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT value + 1 FROM sequence WHERE value < 33000
+      )
+      INSERT INTO runs (
+        id, event_id, status, event_json, workstream_id,
+        routing_rejections_json, created_at, updated_at
+      )
+      SELECT
+        'historical-run-' || value,
+        'historical-event-' || value,
+        'queued',
+        '{}',
+        'workstream',
+        '[]',
+        '2026-07-26T00:00:00.000Z',
+        '2026-07-26T00:00:00.000Z'
+      FROM sequence;
+    `);
+
+    await expect(repo.getWorkstreamMetrics({ workstreamId: "workstream" })).resolves.toMatchObject({
+      runCount: 33_000,
+      queuedRunCount: 33_000,
+      totalAttempts: 0,
+      budgetBlockedRunCount: 0
+    });
+  });
+
+  it("fails closed and audits once when an attributed claim loses recipe authority", async () => {
+    const { sqlite, repo } = await setupFactory();
+    sqlite.prepare("DELETE FROM runs WHERE id = ?").run("seed-run");
+    await repo.registerRunner({ runnerId: "runner", name: "runner", locality: "local" });
+    await repo.createRepoBinding({ provider: "github", owner: "acme", repo: "demo", runnerId: "runner", defaultExecutor: "codex" });
+    await repo.createRun({ id: "factory-corrupt-recipe", event: event("corrupt-recipe"), workstreamId: "workstream" });
+    sqlite.prepare("DELETE FROM factory_recipe_snapshots WHERE id = ? AND version = ?").run("recipe", 1);
+
+    await expect(repo.claimNextRun({ runnerId: "runner", leaseSeconds: 60 })).resolves.toBeNull();
+    await expect(repo.claimNextRun({ runnerId: "runner", leaseSeconds: 60 })).resolves.toBeNull();
+    await expect(repo.getRun({ runId: "factory-corrupt-recipe" })).resolves.toMatchObject({ run: { status: "queued" } });
+    expect(sqlite.prepare("SELECT count(*) AS count FROM attempts WHERE run_id = ?").get("factory-corrupt-recipe")).toEqual({ count: 0 });
+    expect((await repo.listRunEvents({ runId: "factory-corrupt-recipe" })).filter((entry) => entry.type === "factory.invariant_blocked")).toHaveLength(1);
+    expect(sqlite.prepare("SELECT count(*) AS count FROM control_plane_events WHERE type = ? AND subject = ?").get("factory.invariant_blocked", "workstream")).toEqual({ count: 1 });
+  });
+
+  it("publishes a new run only with its complete base audit and keeps replay audit bounded", async () => {
+    const { sqlite, repo } = fixture();
+    const source = { ...event("atomic"), metadata: { ...event("atomic").metadata, deliveryId: "delivery-atomic" } };
+    await repo.createRun({ id: "atomic-run", event: source });
+    await repo.createRun({ id: "atomic-retry", event: source });
+    await repo.createRun({ id: "atomic-retry", event: source });
+    const events = await repo.listRunEvents({ runId: "atomic-run" });
+    expect(events.filter((entry) => entry.type === "run.created")).toHaveLength(1);
+    expect(events.filter((entry) => entry.type === "context_packet.generated")).toHaveLength(1);
+    expect(events.filter((entry) => entry.type === "admission.decided" && (entry.payload as { reasonCode?: string }).reasonCode === "new_event")).toHaveLength(1);
+    expect(events.filter((entry) => entry.type === "run.create_idempotent_replay")).toHaveLength(1);
+    expect(sqlite.prepare("SELECT count(*) AS count FROM source_deliveries WHERE run_id = ?").get("atomic-run")).toEqual({ count: 1 });
+  });
+
+  it("treats concurrency as transient capacity and leaves the next run queued without blocking audit", async () => {
+    const { sqlite, repo } = await setupFactory();
+    sqlite.prepare("DELETE FROM runs WHERE id = ?").run("seed-run");
+    await repo.registerRunner({ runnerId: "runner", name: "runner", locality: "local" });
+    await repo.createRepoBinding({ provider: "github", owner: "acme", repo: "demo", runnerId: "runner", defaultExecutor: "codex" });
+    await repo.createRun({ id: "run-one", event: event("one"), workstreamId: "workstream" });
+    await repo.createRun({ id: "run-two", event: event("two"), workstreamId: "workstream" });
+    await expect(repo.claimNextRun({ runnerId: "runner", leaseSeconds: 60 })).resolves.toMatchObject({ run: { id: "run-one" } });
+    await expect(repo.claimNextRun({ runnerId: "runner", leaseSeconds: 60 })).resolves.toBeNull();
+    await expect(repo.getRun({ runId: "run-two" })).resolves.toMatchObject({ run: { status: "queued" } });
+    expect((await repo.listRunEvents({ runId: "run-two" })).some((entry) => entry.type === "factory.budget_blocked")).toBe(false);
+  });
+
+  it("counts accepted WorkThreads only from the current assessment authority", async () => {
+    const { sqlite, repo, workThreadId } = await setupFactory();
+    const assessment = (id: string, sequence: number, state: "satisfied" | "pending", evidenceBacked: boolean) => ({
+      id,
+      workThreadId,
+      contractId: "contract",
+      contractVersion: 1,
+      cycle: 1,
+      sequence,
+      ...(sequence > 1 ? { supersedesAssessmentId: "assessment-accepted" } : {}),
+      inputDigest: `sha256:${String(sequence).repeat(64)}`,
+      targetBindings: [],
+      state,
+      evidenceBacked,
+      gateResults: [{ gateId: "checks", state: state === "satisfied" ? "passed" : "missing", evidenceIds: state === "satisfied" ? ["evidence"] : [], reasonCode: state === "satisfied" ? "verification_passed" : "verification_missing", reason: "authority", evaluatedAt: "2026-07-26T00:00:00.000Z" }],
+      assessedAt: "2026-07-26T00:00:00.000Z",
+      assessedBy: "opentag"
+    });
+    const accepted = assessment("assessment-accepted", 1, "satisfied", true);
+    const pending = assessment("assessment-pending", 2, "pending", false);
+    const insert = sqlite.prepare(`INSERT INTO completion_assessments (id, work_thread_id, contract_id, contract_version, cycle, sequence, supersedes_assessment_id, input_digest, state, assessment_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+    insert.run(accepted.id, workThreadId, "contract", 1, 1, 1, null, accepted.inputDigest, accepted.state, JSON.stringify(accepted), accepted.assessedAt);
+    insert.run(pending.id, workThreadId, "contract", 1, 1, 2, "assessment-accepted", pending.inputDigest, pending.state, JSON.stringify(pending), pending.assessedAt);
+    sqlite.prepare("UPDATE work_threads SET current_assessment_id = ? WHERE id = ?").run("assessment-pending", workThreadId);
+    await expect(repo.getWorkstreamMetrics({ workstreamId: "workstream" })).resolves.toMatchObject({ acceptedWorkThreadCount: 0 });
+    sqlite.prepare("UPDATE work_threads SET current_assessment_id = ? WHERE id = ?").run("assessment-accepted", workThreadId);
+    await expect(repo.getWorkstreamMetrics({ workstreamId: "workstream" })).resolves.toMatchObject({ acceptedWorkThreadCount: 1 });
+  });
+
+  it("counts only current unexpired persisted waiver authority", async () => {
+    const { sqlite, repo, workThreadId } = await setupFactory();
+    await repo.recordCompletionContract({
+      contract: {
+        id: "contract-waiver",
+        version: 1,
+        workThreadId,
+        cycle: 1,
+        mode: "governed",
+        targetSelectors: [],
+        resolvedFrom: [{ scope: "work_context_owner_container", ref: "github:acme/demo", version: "1" }],
+        gates: [{ id: "acceptance", kind: "human_acceptance", requiredRole: "repo_owner" }],
+        maxAutomaticRetries: 0,
+        onSatisfied: "report_only",
+        createdAt: "2026-07-26T00:00:00.000Z"
+      }
+    });
+    const waiver = (id: string, expiresAt: string) => ({
+      id,
+      contractId: "contract-waiver",
+      contractVersion: 1,
+      cycle: 1,
+      actor: { provider: "github" as const, providerUserId: "owner-1", handle: "repo-owner" },
+      reason: "The owner explicitly accepted this bounded exception.",
+      scope: "selected_gates" as const,
+      policyScope: "work_context_owner_container" as const,
+      gateIds: ["acceptance"],
+      waivedAt: "2026-07-26T00:01:00.000Z",
+      expiresAt
+    });
+    const acceptedWaiver = waiver("waiver-active", "2999-01-01T00:00:00.000Z");
+    const expiredWaiver = waiver("waiver-expired", "2000-01-01T00:00:00.000Z");
+    await repo.recordCompletionWaiver({ waiver: acceptedWaiver });
+    await repo.recordCompletionWaiver({ waiver: expiredWaiver });
+
+    const assessment = (id: string, sequence: number, attributedWaiver: typeof acceptedWaiver) => ({
+      id,
+      workThreadId,
+      contractId: "contract-waiver",
+      contractVersion: 1,
+      cycle: 1,
+      sequence,
+      ...(sequence > 1 ? { supersedesAssessmentId: "assessment-waiver-active" } : {}),
+      inputDigest: `sha256:${String(sequence).repeat(64)}`,
+      targetBindings: [],
+      state: "waived",
+      evidenceBacked: true,
+      gateResults: [{
+        gateId: "acceptance",
+        state: "waived",
+        evidenceIds: [],
+        reasonCode: "gate_waived",
+        reason: "The gate is covered by an attributed waiver.",
+        evaluatedAt: "2026-07-26T00:01:00.000Z"
+      }],
+      assessedAt: "2026-07-26T00:01:00.000Z",
+      assessedBy: "human",
+      acceptedAt: "2026-07-26T00:01:00.000Z",
+      waiver: attributedWaiver
+    });
+    const active = assessment("assessment-waiver-active", 1, acceptedWaiver);
+    const expired = assessment("assessment-waiver-expired", 2, expiredWaiver);
+    const insert = sqlite.prepare(`INSERT INTO completion_assessments
+      (id, work_thread_id, contract_id, contract_version, cycle, sequence, supersedes_assessment_id, input_digest, state, assessment_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+    insert.run(active.id, workThreadId, active.contractId, active.contractVersion, active.cycle, active.sequence, null, active.inputDigest, active.state, JSON.stringify(active), active.assessedAt);
+    insert.run(expired.id, workThreadId, expired.contractId, expired.contractVersion, expired.cycle, expired.sequence, expired.supersedesAssessmentId, expired.inputDigest, expired.state, JSON.stringify(expired), expired.assessedAt);
+
+    sqlite.prepare("UPDATE work_threads SET current_assessment_id = ? WHERE id = ?").run(active.id, workThreadId);
+    await expect(repo.getWorkstreamMetrics({ workstreamId: "workstream" })).resolves.toMatchObject({ acceptedWorkThreadCount: 1 });
+    sqlite.prepare("UPDATE work_threads SET current_assessment_id = ? WHERE id = ?").run(expired.id, workThreadId);
+    await expect(repo.getWorkstreamMetrics({ workstreamId: "workstream" })).resolves.toMatchObject({ acceptedWorkThreadCount: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

- add immutable recipe snapshots and WorkThread-only workstreams
- admit replay-safe quiet batches through the existing governance and admission path
- enforce claim-time concurrency, attempt, cost-unit, and locality budgets
- expose durable receipts, metrics, evaluation, SDK APIs, and CLI workstream status
- preserve follow-up attribution and current completion and waiver authority

## Safety and compatibility

- additive, restart-safe migration keeps legacy runs and follow-ups readable
- exact batch replay returns the durable receipt; conflicting content fails closed
- missing or invalid recipe authority never claims unbudgeted work
- no DAG, operator console, adaptive routing, or provider billing model
- package versions remain 0.7.0; this PR does not publish npm packages

## Verification

- full workspace lint passed
- full workspace build passed
- 135 test files and 1,772 tests passed
- focused migration, replay, fencing, waiver, follow-up attribution, and restart tests passed
- independent final verification and code review approved with no remaining findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workstream status reporting with human-readable and JSON output.
  * Added factory recipe/workstream APIs, including durable batch admission, metrics, and evaluation.
  * Enabled replay-safe workstream batch receipts with deterministic behavior and recovery.
  * Introduced deterministic workstream evaluation with budget checks, locality-aware routing, and canonical input digests.
* **Documentation**
  * Expanded CLI and documentation with new Phase 4A/workstream behavior guidance and replay instructions.
* **Bug Fixes**
  * Improved idempotency, completion authority enforcement, atomic budgeting/locality admission rules, and lease/retry correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->