### PR TITLE
feat: prove the Phase 4B software factory loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ OpenTag's CLI path is local-first.
 | `opentag service autostart enable` | Enable background service login autostart |
 | `opentag service autostart disable` | Disable background service login autostart |
 | `opentag status` | Show local config and runtime status; add `--run <run_id>`, `--channel provider:account/conversation`, or `--workstream <id>` for scoped detail |
+| `opentag factory ...` | Create or inspect immutable recipes and WorkThread-only workstreams, then submit or retrieve restart-safe admission batches from JSON |
 | `opentag cancel` | Request cancellation for a run or the active run in a source container |
 | `opentag completion escalations --run <run_id>` | List structured human escalations, audiences, options, expiry, and attribution for a run |
 | `opentag completion acknowledge --escalation <id> ...` | Attribute acknowledgement without resolving the blocking escalation |

--- a/docs/live-e2e-smoke-harness.md
+++ b/docs/live-e2e-smoke-harness.md
@@ -21,6 +21,7 @@ Current cases:
 | --- | --- | --- |
 | `protocol-runtime` | No | In-memory GitHub-shaped protocol smoke using dispatcher/client/store paths |
 | `slack-protocol` | No | In-memory Slack-shaped protocol smoke with quiet progress and Block Kit final callback |
+| `factory-conformance` | No | File-backed recipe/workstream/batch loop with restart replay, bounded exceptions, authoritative accepted outcomes, and Echo plus local ACP executor paths |
 | `openclaw-acp` | Yes | Strict OpenClaw hard-cancellation probe plus worktree cwd, scratch cwd, and fresh-session checks through the generic ACP host |
 | `github-webhook-live` | Yes | Real GitHub repository webhook, local CLI stack, current-head required check, merged PR, durable satisfied assessment, and restart-safe final receipt |
 | `github-cli-live` | Yes | Real GitHub issue callback using dispatcher-assisted run creation |
@@ -61,10 +62,13 @@ payloads.
 
 ## Recommended Sequence
 
-1. Run local protocol cases first:
+1. Run local protocol and factory conformance cases first:
 
 ```bash
-corepack pnpm smoke:live -- --case protocol-runtime --case slack-protocol
+corepack pnpm smoke:live -- \
+  --case protocol-runtime \
+  --case slack-protocol \
+  --case factory-conformance
 ```
 
 2. Run one live provider at a time with a report path:
@@ -85,6 +89,41 @@ The live pass is only credible when the source thread has a concise final
 callback, `opentag status --run` shows the Context Packet and Agent Work Ledger,
 artifacts exist, and provider-visible action receipts do not expose raw executor
 logs.
+
+### Factory Conformance
+
+`factory-conformance` wraps `corepack pnpm smoke:factory-conformance`. It uses a
+temporary file-backed database and the same public dispatcher client plus local
+daemon path used by an operator. One immutable recipe admits a quiet ordered
+batch into a WorkThread-only workstream, then the Echo executor and the local
+ACP fixture each complete one accepted work loop.
+
+The case closes and reopens the dispatcher against the same database before it
+replays the batch. It fails unless the replay returns the durable receipt,
+creates no duplicate work, and a changed payload is rejected as an idempotency
+conflict. A separate twelve-item exception batch must retain ten bounded
+exception samples, report two omitted samples, and produce no routine per-item
+source callback. Its accepted-outcome assertions use current
+CompletionAssessments and terminal Attempt executor attribution, not successful
+Run counts. The case first observes two terminal Runs and zero accepted
+outcomes, then submits deterministic current-head/check/merge snapshots through
+the authenticated public evidence-ingestion seam and requires the accepted
+counts to move to two without changing the terminal Run count.
+
+Set `OPENTAG_FACTORY_CONFORMANCE_REPORT` to retain its sanitized evidence:
+
+```bash
+OPENTAG_FACTORY_CONFORMANCE_REPORT=.omx/live-e2e/factory-conformance.json \
+corepack pnpm smoke:factory-conformance
+```
+
+This is deterministic runtime conformance, not a claim that a public source
+provider, model provider, pull request, required check, or merge was exercised;
+the GitHub-shaped evidence is a sanitized conformance input, not a provider API
+observation.
+Use `github-webhook-live` for the real source-control completion loop and
+`builtin-acp` for provider-backed executor readiness. No DAG scheduler or
+operator console is part of this case.
 
 ## Case Notes
 

--- a/docs/replay-harness.md
+++ b/docs/replay-harness.md
@@ -88,6 +88,28 @@ preserved, and accepted outcomes come only from the authoritative current
 CompletionAssessment. No provider API is called and the evaluation cannot
 write a CompletionAssessment.
 
+## Phase 4B Runtime Conformance
+
+The Phase 4A replay remains the narrow deterministic store/dispatcher contract.
+Phase 4B adds a process-level conformance case without replacing that coverage:
+
+```bash
+corepack pnpm smoke:factory-conformance
+```
+
+The conformance case opens a real loopback dispatcher over a file-backed
+database, operates the recipe, workstream, and batch APIs, runs two admitted
+items through the local daemon using Echo and a deterministic ACP fixture, then
+reopens the database and proves exact replay without duplicate work. It also
+locks the ten-sample exception bound and current-assessment authority for
+accepted-outcome metrics: successful terminal Runs remain unaccepted until
+deterministic verified evidence advances their current CompletionAssessments.
+
+This case is safe for ordinary CI because it has no provider credentials or
+external writes. It proves the live OpenTag runtime seams, not a public provider
+loop; the GitHub webhook smoke remains the separate external proof. Neither
+case introduces dependency scheduling, a DAG, or an operator console.
+
 ## Product Boundary
 
 Replay fixtures should reinforce OpenTag's boundary:

--- a/docs/software-factory-control-plane.md
+++ b/docs/software-factory-control-plane.md
@@ -1417,6 +1417,32 @@ dependency scheduling, adaptive routing, a planning UI, or an operator console.
 Its evaluation output is an immutable observation; it cannot update a live
 CompletionAssessment.
 
+#### Phase 4B implementation boundary
+
+Phase 4B closes the first recipe-driven runtime loop without widening OpenTag
+into a planning or workflow product:
+
+- a minimal CLI operates immutable recipes, WorkThread-only workstreams, and
+  durable admission batches from reviewable JSON inputs;
+- a file-backed conformance case drives the public dispatcher client and local
+  daemon through one recipe-owned batch;
+- two actual executor adapter paths complete admitted work: the in-process Echo
+  executor and a deterministic local ACP fixture;
+- closing and reopening the dispatcher against the same database preserves the
+  batch receipt, resumes or replays safely, and rejects a conflicting digest;
+- batch exceptions remain quiet and bounded to ten retained samples plus an
+  explicit omitted count;
+- factory outcome metrics are accepted only from the current authoritative
+  CompletionAssessment and attributed through the latest terminal fenced
+  Attempt's runner and executor; the conformance receipt records the transition
+  from two terminal Runs and zero accepted outcomes to two evidence-backed
+  accepted outcomes.
+
+The deterministic conformance case is implementation and runtime evidence. It
+does not replace the separate provider-live GitHub loop required below for a
+public factory-control-plane claim. Phase 4B does not add dependency edges, a
+DAG scheduler, mutable workstream planning state, or an operator console.
+
 ## Compatibility and migration
 
 1. Add schemas and tables without changing existing required fields.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "release:publish": "node scripts/release/publish-local.mjs",
     "opentag-dev": "node scripts/dev/install-opentag-dev.mjs",
     "smoke:governance": "node scripts/test/governance-matrix.mjs",
+    "smoke:factory-conformance": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/factory-conformance.ts",
     "smoke:acp-conformance": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/builtin-acp-conformance.ts",
     "smoke:live": "node scripts/test/live-e2e-smoke.mjs",
     "smoke:openclaw-acp-conformance": "NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/openclaw-acp-conformance.ts",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,6 +35,22 @@ For GitHub, GitLab, Linear, or Discord webhook deployments that use an already c
 
 `opentag status --workstream <workstream_id>` shows the workstream state and next action first, followed by recipe budgets, accepted outcomes, and bounded exception detail. Healthy workstreams stay quiet. Add `--json` to receive structured `workstream`, `recipe`, `metrics`, and `evaluation` objects for automation.
 
+The `factory` commands operate the recipe, workstream, and restart-safe admission-batch lifecycle through the configured dispatcher. Create and submit commands accept a complete JSON document from a file or from stdin with `--input -`. Every command supports `--json` for automation:
+
+```bash
+opentag factory recipe create --input recipe.json --json
+opentag factory recipe get --id recipe_release --version 1 --json
+opentag factory workstream create --input workstream.json --json
+opentag factory workstream get --id workstream_release --json
+opentag factory batch submit --input batch.json --json
+opentag factory batch get --id batch_release --json
+
+# The same create/submit input can be piped through stdin.
+cat batch.json | opentag factory batch submit --input - --json
+```
+
+The JSON documents use the public `FactoryRecipeSnapshotInput`, `WorkstreamInput`, and `WorkstreamAdmissionBatchInput` contracts. A workstream contains an explicit bounded set of existing WorkThread members; a batch contains ordered admission items for those members. These commands do not define a task graph or move project-management ownership into OpenTag.
+
 External local runtimes can report lifecycle hooks through the public [Hook Ingest Contract](../../docs/hook-ingest.md): `opentag ingest-template --format manifest` prints the manifest, and `opentag ingest` records audit-visible progress or terminal state through runner-scoped auth.
 
 ## Commands
@@ -47,6 +63,9 @@ opentag service stop
 opentag service status
 opentag service logs
 opentag status
+opentag factory recipe get --id <recipe_id> --version <version>
+opentag factory workstream get --id <workstream_id>
+opentag factory batch get --id <batch_id>
 opentag doctor
 opentag config path
 opentag config show

--- a/packages/cli/src/factory.ts
+++ b/packages/cli/src/factory.ts
@@ -1,0 +1,312 @@
+import { readFile } from "node:fs/promises";
+import { createOpenTagClient, type OpenTagClient } from "@opentag/client";
+import {
+  FactoryRecipeSnapshotInputSchema,
+  WorkstreamAdmissionBatchInputSchema,
+  WorkstreamInputSchema,
+  type FactoryRecipeSnapshot,
+  type Workstream,
+  type WorkstreamAdmissionBatchReceipt
+} from "@opentag/core";
+import {
+  defaultConfigPath,
+  readCliConfig,
+  type OpenTagCliConfig
+} from "./config.js";
+
+type FactoryAction = "created" | "retrieved" | "submitted";
+
+export type FactoryRecipeCreateOptions = {
+  config?: string;
+  input?: string;
+  json?: boolean;
+};
+
+export type FactoryRecipeGetOptions = {
+  config?: string;
+  id?: string;
+  version?: string | number;
+  json?: boolean;
+};
+
+export type FactoryWorkstreamCreateOptions = {
+  config?: string;
+  input?: string;
+  json?: boolean;
+};
+
+export type FactoryWorkstreamGetOptions = {
+  config?: string;
+  id?: string;
+  json?: boolean;
+};
+
+export type FactoryBatchSubmitOptions = {
+  config?: string;
+  input?: string;
+  json?: boolean;
+};
+
+export type FactoryBatchGetOptions = {
+  config?: string;
+  id?: string;
+  json?: boolean;
+};
+
+type FactoryCommandResult =
+  | { recipe: FactoryRecipeSnapshot }
+  | { workstream: Workstream }
+  | { receipt: WorkstreamAdmissionBatchReceipt };
+
+type FactoryInputDependencies = {
+  readText?(path: string): Promise<string>;
+  stdin?: AsyncIterable<string | Uint8Array>;
+};
+
+export type FactoryCommandDependencies = FactoryInputDependencies & {
+  fetchImpl?: typeof fetch;
+  logger?: Pick<typeof console, "log">;
+};
+
+function nonEmpty(value: string | undefined, label: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`${label} is required.`);
+  return trimmed;
+}
+
+function positiveInteger(value: string | number | undefined, label: string): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+async function readStdin(stdin: AsyncIterable<string | Uint8Array>): Promise<string> {
+  const decoder = new TextDecoder();
+  let text = "";
+  for await (const chunk of stdin) {
+    text += typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+async function loadJsonInput(inputPath: string | undefined, dependencies: FactoryInputDependencies): Promise<unknown> {
+  const path = nonEmpty(inputPath, "--input");
+  const source = path === "-" ? "stdin" : path;
+  let text: string;
+  try {
+    if (path === "-") {
+      text = await readStdin(dependencies.stdin ?? process.stdin);
+    } else {
+      text = await (dependencies.readText ?? ((filePath) => readFile(filePath, "utf8")))(path);
+    }
+  } catch (error) {
+    throw new Error(`Could not read factory JSON input from ${source}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new Error(`Factory input ${source} must contain valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function factoryClient(config: OpenTagCliConfig, fetchImpl?: typeof fetch): OpenTagClient {
+  const pairingToken = config.daemon.pairingToken?.trim();
+  if (!pairingToken) {
+    throw new Error("Factory operations require daemon.pairingToken; a runner token cannot authorize recipe or workstream admission.");
+  }
+  return createOpenTagClient({
+    dispatcherUrl: config.daemon.dispatcherUrl,
+    pairingToken,
+    ...(fetchImpl ? { fetchImpl } : {})
+  });
+}
+
+export async function createFactoryRecipeFromConfig(input: {
+  config: OpenTagCliConfig;
+  inputPath: string;
+  fetchImpl?: typeof fetch;
+} & FactoryInputDependencies): Promise<{ recipe: FactoryRecipeSnapshot }> {
+  const document = await loadJsonInput(input.inputPath, input);
+  return factoryClient(input.config, input.fetchImpl).createFactoryRecipeSnapshot(
+    FactoryRecipeSnapshotInputSchema.parse(document)
+  );
+}
+
+export async function getFactoryRecipeFromConfig(input: {
+  config: OpenTagCliConfig;
+  id: string;
+  version: string | number;
+  fetchImpl?: typeof fetch;
+}): Promise<{ recipe: FactoryRecipeSnapshot }> {
+  return factoryClient(input.config, input.fetchImpl).getFactoryRecipeSnapshot({
+    id: nonEmpty(input.id, "--id"),
+    version: positiveInteger(input.version, "--version")
+  });
+}
+
+export async function createFactoryWorkstreamFromConfig(input: {
+  config: OpenTagCliConfig;
+  inputPath: string;
+  fetchImpl?: typeof fetch;
+} & FactoryInputDependencies): Promise<{ workstream: Workstream }> {
+  const document = await loadJsonInput(input.inputPath, input);
+  return factoryClient(input.config, input.fetchImpl).createWorkstream(WorkstreamInputSchema.parse(document));
+}
+
+export async function getFactoryWorkstreamFromConfig(input: {
+  config: OpenTagCliConfig;
+  id: string;
+  fetchImpl?: typeof fetch;
+}): Promise<{ workstream: Workstream }> {
+  return factoryClient(input.config, input.fetchImpl).getWorkstream({ id: nonEmpty(input.id, "--id") });
+}
+
+export async function submitFactoryBatchFromConfig(input: {
+  config: OpenTagCliConfig;
+  inputPath: string;
+  fetchImpl?: typeof fetch;
+} & FactoryInputDependencies): Promise<{ receipt: WorkstreamAdmissionBatchReceipt }> {
+  const document = await loadJsonInput(input.inputPath, input);
+  return factoryClient(input.config, input.fetchImpl).createWorkstreamAdmissionBatch(
+    WorkstreamAdmissionBatchInputSchema.parse(document)
+  );
+}
+
+export async function getFactoryBatchFromConfig(input: {
+  config: OpenTagCliConfig;
+  id: string;
+  fetchImpl?: typeof fetch;
+}): Promise<{ receipt: WorkstreamAdmissionBatchReceipt }> {
+  return factoryClient(input.config, input.fetchImpl).getWorkstreamAdmissionBatch({ id: nonEmpty(input.id, "--id") });
+}
+
+export function formatFactoryCommandOutput(
+  result: FactoryCommandResult,
+  options: { action: FactoryAction; json?: boolean }
+): string {
+  if (options.json) return JSON.stringify(result, null, 2);
+  if ("recipe" in result) {
+    return [
+      `Factory recipe ${options.action}: ${result.recipe.id} v${result.recipe.version}`,
+      `Name: ${result.recipe.name}`,
+      `Digest: ${result.recipe.contentDigest}`
+    ].join("\n");
+  }
+  if ("workstream" in result) {
+    return [
+      `Factory workstream ${options.action}: ${result.workstream.id}`,
+      `Recipe: ${result.workstream.recipeId} v${result.workstream.recipeVersion}`,
+      `Members: ${result.workstream.members.length}`,
+      `Digest: ${result.workstream.contentDigest}`
+    ].join("\n");
+  }
+  const summary = result.receipt.result?.summary;
+  return [
+    `Admission batch ${options.action}: ${result.receipt.batch.id} (${result.receipt.status})`,
+    `Workstream: ${result.receipt.batch.workstreamId}`,
+    `Items: ${result.receipt.items.length}`,
+    ...(summary
+      ? [
+        `Created: ${summary.createdCount}`,
+        `Idempotent replays: ${summary.idempotentReplayCount}`,
+        `Follow-ups queued: ${summary.followUpQueuedCount}`,
+        `Needs human decision: ${summary.needsHumanDecisionCount}`,
+        `Rejected: ${summary.rejectedCount}`,
+        `Exceptions: ${summary.exceptionCount}${summary.omittedExceptionCount ? ` (${summary.omittedExceptionCount} omitted from samples)` : ""}`
+      ]
+      : [])
+  ].join("\n");
+}
+
+function commandConfig(configPath: string | undefined): { configPath: string; config: OpenTagCliConfig } {
+  const resolved = configPath ?? defaultConfigPath();
+  return { configPath: resolved, config: readCliConfig(resolved) };
+}
+
+export async function runFactoryRecipeCreateCommand(
+  options: FactoryRecipeCreateOptions,
+  dependencies: FactoryCommandDependencies = {}
+): Promise<void> {
+  const { config } = commandConfig(options.config);
+  const result = await createFactoryRecipeFromConfig({
+    config,
+    inputPath: nonEmpty(options.input, "--input"),
+    ...(dependencies.fetchImpl ? { fetchImpl: dependencies.fetchImpl } : {}),
+    ...(dependencies.readText ? { readText: dependencies.readText } : {}),
+    ...(dependencies.stdin ? { stdin: dependencies.stdin } : {})
+  });
+  (dependencies.logger ?? console).log(formatFactoryCommandOutput(result, { action: "created", json: options.json ?? false }));
+}
+
+export async function runFactoryRecipeGetCommand(
+  options: FactoryRecipeGetOptions,
+  dependencies: FactoryCommandDependencies = {}
+): Promise<void> {
+  const { config } = commandConfig(options.config);
+  const result = await getFactoryRecipeFromConfig({
+    config,
+    id: nonEmpty(options.id, "--id"),
+    version: positiveInteger(options.version, "--version"),
+    ...(dependencies.fetchImpl ? { fetchImpl: dependencies.fetchImpl } : {})
+  });
+  (dependencies.logger ?? console).log(formatFactoryCommandOutput(result, { action: "retrieved", json: options.json ?? false }));
+}
+
+export async function runFactoryWorkstreamCreateCommand(
+  options: FactoryWorkstreamCreateOptions,
+  dependencies: FactoryCommandDependencies = {}
+): Promise<void> {
+  const { config } = commandConfig(options.config);
+  const result = await createFactoryWorkstreamFromConfig({
+    config,
+    inputPath: nonEmpty(options.input, "--input"),
+    ...(dependencies.fetchImpl ? { fetchImpl: dependencies.fetchImpl } : {}),
+    ...(dependencies.readText ? { readText: dependencies.readText } : {}),
+    ...(dependencies.stdin ? { stdin: dependencies.stdin } : {})
+  });
+  (dependencies.logger ?? console).log(formatFactoryCommandOutput(result, { action: "created", json: options.json ?? false }));
+}
+
+export async function runFactoryWorkstreamGetCommand(
+  options: FactoryWorkstreamGetOptions,
+  dependencies: FactoryCommandDependencies = {}
+): Promise<void> {
+  const { config } = commandConfig(options.config);
+  const result = await getFactoryWorkstreamFromConfig({
+    config,
+    id: nonEmpty(options.id, "--id"),
+    ...(dependencies.fetchImpl ? { fetchImpl: dependencies.fetchImpl } : {})
+  });
+  (dependencies.logger ?? console).log(formatFactoryCommandOutput(result, { action: "retrieved", json: options.json ?? false }));
+}
+
+export async function runFactoryBatchSubmitCommand(
+  options: FactoryBatchSubmitOptions,
+  dependencies: FactoryCommandDependencies = {}
+): Promise<void> {
+  const { config } = commandConfig(options.config);
+  const result = await submitFactoryBatchFromConfig({
+    config,
+    inputPath: nonEmpty(options.input, "--input"),
+    ...(dependencies.fetchImpl ? { fetchImpl: dependencies.fetchImpl } : {}),
+    ...(dependencies.readText ? { readText: dependencies.readText } : {}),
+    ...(dependencies.stdin ? { stdin: dependencies.stdin } : {})
+  });
+  (dependencies.logger ?? console).log(formatFactoryCommandOutput(result, { action: "submitted", json: options.json ?? false }));
+}
+
+export async function runFactoryBatchGetCommand(
+  options: FactoryBatchGetOptions,
+  dependencies: FactoryCommandDependencies = {}
+): Promise<void> {
+  const { config } = commandConfig(options.config);
+  const result = await getFactoryBatchFromConfig({
+    config,
+    id: nonEmpty(options.id, "--id"),
+    ...(dependencies.fetchImpl ? { fetchImpl: dependencies.fetchImpl } : {})
+  });
+  (dependencies.logger ?? console).log(formatFactoryCommandOutput(result, { action: "retrieved", json: options.json ?? false }));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,14 @@ import {
   runCompletionWaiveCommand
 } from "./completion.js";
 import { runDoctorCommand } from "./doctor.js";
+import {
+  runFactoryBatchGetCommand,
+  runFactoryBatchSubmitCommand,
+  runFactoryRecipeCreateCommand,
+  runFactoryRecipeGetCommand,
+  runFactoryWorkstreamCreateCommand,
+  runFactoryWorkstreamGetCommand
+} from "./factory.js";
 import { runIngestCommand, runIngestTemplateCommand } from "./ingest.js";
 import { runMaintenancePruneSourceDeliveriesCommand } from "./maintenance.js";
 import { runPairCommand } from "./pair.js";
@@ -171,6 +179,63 @@ program
   .option("--reason <reason>", "Audit reason for cancellation")
   .option("--requested-by <actor>", "Audit actor requesting cancellation")
   .action(runCliAction(runCancelCommand));
+
+const factoryCommand = program.command("factory").description("Operate recipe-driven software factory workstreams");
+
+const factoryRecipeCommand = factoryCommand.command("recipe").description("Create or inspect immutable factory recipes");
+
+factoryRecipeCommand
+  .command("create")
+  .description("Create an immutable factory recipe from a JSON document")
+  .option("--config <path>", "Config file path")
+  .requiredOption("--input <path>", "Recipe JSON file path, or - for stdin")
+  .option("--json", "Print the structured dispatcher response as JSON")
+  .action(runCliAction(runFactoryRecipeCreateCommand));
+
+factoryRecipeCommand
+  .command("get")
+  .description("Get one immutable factory recipe version")
+  .option("--config <path>", "Config file path")
+  .requiredOption("--id <recipeId>", "Factory recipe id")
+  .requiredOption("--version <version>", "Positive recipe version")
+  .option("--json", "Print the structured dispatcher response as JSON")
+  .action(runCliAction(runFactoryRecipeGetCommand));
+
+const factoryWorkstreamCommand = factoryCommand.command("workstream").description("Create or inspect factory workstreams");
+
+factoryWorkstreamCommand
+  .command("create")
+  .description("Create a factory workstream from a JSON document")
+  .option("--config <path>", "Config file path")
+  .requiredOption("--input <path>", "Workstream JSON file path, or - for stdin")
+  .option("--json", "Print the structured dispatcher response as JSON")
+  .action(runCliAction(runFactoryWorkstreamCreateCommand));
+
+factoryWorkstreamCommand
+  .command("get")
+  .description("Get one factory workstream")
+  .option("--config <path>", "Config file path")
+  .requiredOption("--id <workstreamId>", "Factory workstream id")
+  .option("--json", "Print the structured dispatcher response as JSON")
+  .action(runCliAction(runFactoryWorkstreamGetCommand));
+
+const factoryBatchCommand = factoryCommand.command("batch").description("Submit or inspect restart-safe admission batches");
+
+factoryBatchCommand
+  .command("submit")
+  .description("Submit a workstream admission batch from a JSON document")
+  .option("--config <path>", "Config file path")
+  .requiredOption("--input <path>", "Admission batch JSON file path, or - for stdin")
+  .option("--json", "Print the structured dispatcher response as JSON")
+  .action(runCliAction(runFactoryBatchSubmitCommand));
+
+factoryBatchCommand
+  .command("get")
+  .description("Get one durable workstream admission batch receipt")
+  .option("--config <path>", "Config file path")
+  .requiredOption("--id <batchId>", "Admission batch id")
+  .option("--json", "Print the structured dispatcher response as JSON")
+  .action(runCliAction(runFactoryBatchGetCommand));
 
 const completionCommand = program.command("completion").description("Inspect or govern completion state");
 

--- a/packages/cli/test/factory.test.ts
+++ b/packages/cli/test/factory.test.ts
@@ -1,0 +1,302 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { createDispatcherApp } from "@opentag/dispatcher";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createFactoryRecipeFromConfig,
+  createFactoryWorkstreamFromConfig,
+  formatFactoryCommandOutput,
+  getFactoryBatchFromConfig,
+  getFactoryRecipeFromConfig,
+  getFactoryWorkstreamFromConfig,
+  submitFactoryBatchFromConfig
+} from "../src/factory.js";
+import { createSetupConfig } from "../src/setup.js";
+
+const digest = `sha256:${"a".repeat(64)}`;
+const createdAt = "2026-07-26T00:00:00.000Z";
+const completedAt = "2026-07-26T00:01:00.000Z";
+
+const recipeInput = {
+  id: "recipe_release",
+  version: 1,
+  name: "Release factory",
+  budgets: {
+    maxConcurrentRuns: 2,
+    maxAttemptsPerRun: 3,
+    maxCostUnits: 20,
+    costUnitsPerAttempt: 1,
+    allowedLocalities: ["local"]
+  }
+} as const;
+
+const recipe = { ...recipeInput, createdAt, contentDigest: digest };
+
+const workstreamInput = {
+  id: "workstream_release",
+  recipeId: recipe.id,
+  recipeVersion: recipe.version,
+  name: "Release factory",
+  members: [{ kind: "work_thread", workThreadId: "thread_1" }]
+} as const;
+
+const workstream = { ...workstreamInput, createdAt, contentDigest: digest };
+
+const event = {
+  id: "event_1",
+  source: "github",
+  sourceEventId: "event_1",
+  receivedAt: createdAt,
+  actor: { provider: "github", providerUserId: "actor_1" },
+  target: { mention: "@opentag", agentId: "opentag" },
+  command: { rawText: "Please fix the release.", intent: "fix", args: {} },
+  context: [],
+  permissions: [],
+  callback: { provider: "github", uri: "https://api.github.test/issues/1/comments" },
+  metadata: {}
+} as const;
+
+const batchInput = {
+  id: "batch_release",
+  workstreamId: workstream.id,
+  items: [{ itemId: "item_1", runId: "run_1", workThreadId: "thread_1", event }]
+} as const;
+
+const batchReceipt = {
+  batch: { ...batchInput, createdAt, contentDigest: digest },
+  status: "completed" as const,
+  items: [{
+    itemId: "item_1",
+    index: 0,
+    runId: "run_1",
+    workThreadId: "thread_1",
+    status: "completed" as const,
+    result: {
+      itemId: "item_1",
+      index: 0,
+      runId: "run_1",
+      status: "created" as const,
+      statusCode: 201,
+      admittedRunId: "run_1"
+    }
+  }],
+  result: {
+    batchId: batchInput.id,
+    workstreamId: workstream.id,
+    inputDigest: digest,
+    results: [{
+      itemId: "item_1",
+      index: 0,
+      runId: "run_1",
+      status: "created" as const,
+      statusCode: 201,
+      admittedRunId: "run_1"
+    }],
+    summary: {
+      totalItems: 1,
+      createdCount: 1,
+      idempotentReplayCount: 0,
+      followUpQueuedCount: 0,
+      needsHumanDecisionCount: 0,
+      rejectedCount: 0,
+      exceptionCount: 0,
+      exceptions: [],
+      omittedExceptionCount: 0
+    },
+    completedAt
+  },
+  updatedAt: completedAt,
+  completedAt
+};
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "opentag-cli-factory-test-"));
+}
+
+function config() {
+  const built = createSetupConfig({
+    language: "en",
+    platform: "github",
+    projectPath: tempDir(),
+    executor: "echo",
+    stateDirectory: join(tempDir(), "state"),
+    github: {
+      token: "ghp_token",
+      webhookSecret: "github_webhook_secret",
+      owner: "acme",
+      repo: "demo",
+      webhookPath: "/github/webhooks",
+      autoCreatePullRequest: false,
+      port: 3050
+    }
+  });
+  built.daemon.dispatcherUrl = "https://relay.example";
+  built.daemon.pairingToken = "legacy_pairing_token";
+  built.daemon.runnerToken = "runner_secret";
+  return built;
+}
+
+function responseFor(url: string): unknown {
+  if (url.includes("/v1/factory-recipes")) return { recipe };
+  if (url.includes("/v1/workstreams")) return { workstream };
+  if (url.includes("/v1/workstream-batches")) return { receipt: batchReceipt };
+  throw new Error(`Unexpected URL: ${url}`);
+}
+
+describe("OpenTag factory CLI", () => {
+  it("creates a recipe from a JSON file with pairing-scoped factory authority", async () => {
+    const path = join(tempDir(), "recipe.json");
+    writeFileSync(path, JSON.stringify(recipeInput));
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Response.json(responseFor(String(url)), { status: 201 });
+    }) as unknown as typeof fetch;
+
+    const result = await createFactoryRecipeFromConfig({
+      config: config(),
+      inputPath: path,
+      fetchImpl
+    });
+
+    expect(result).toEqual({ recipe });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://relay.example/v1/factory-recipes");
+    expect(requests[0]?.init?.headers).toMatchObject({
+      "content-type": "application/json",
+      authorization: "Bearer legacy_pairing_token"
+    });
+    expect(JSON.parse(String(requests[0]?.init?.body))).toEqual(recipeInput);
+  });
+
+  it("uses pairing authority against the dispatcher and never expands runner-token scope", async () => {
+    const configured = config();
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      pairingToken: configured.daemon.pairingToken,
+      runnerToken: configured.daemon.runnerToken
+    });
+    const fetchImpl = ((input: string | URL | Request, init?: RequestInit) => (
+      app.fetch(new Request(input, init))
+    )) as typeof fetch;
+
+    await expect(createFactoryRecipeFromConfig({
+      config: configured,
+      inputPath: "recipe.json",
+      readText: async () => JSON.stringify(recipeInput),
+      fetchImpl
+    })).resolves.toMatchObject({ recipe: { id: recipeInput.id, version: recipeInput.version } });
+
+    const runnerScoped = await app.request("/v1/factory-recipes", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${configured.daemon.runnerToken}`
+      },
+      body: JSON.stringify({ ...recipeInput, id: "recipe_runner_denied" })
+    });
+    expect(runnerScoped.status).toBe(401);
+    await expect(runnerScoped.json()).resolves.toMatchObject({
+      error: "unauthorized",
+      reason: "invalid_pairing_token"
+    });
+
+    const runnerToken = configured.daemon.runnerToken ?? "";
+    const revokedApp = createDispatcherApp({
+      databasePath: ":memory:",
+      pairingToken: configured.daemon.pairingToken,
+      runnerToken,
+      revokedRunnerTokenFingerprints: [createHash("sha256").update(runnerToken).digest("hex")]
+    });
+    const revokedRunner = await revokedApp.request("/v1/factory-recipes", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${runnerToken}`
+      },
+      body: JSON.stringify({ ...recipeInput, id: "recipe_revoked_runner_denied" })
+    });
+    expect(revokedRunner.status).toBe(401);
+    await expect(revokedRunner.json()).resolves.toMatchObject({
+      error: "unauthorized",
+      reason: "runner_token_revoked"
+    });
+  });
+
+  it("creates a workstream and submits a batch from stdin JSON", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Response.json(responseFor(String(url)), { status: 201 });
+    }) as unknown as typeof fetch;
+    const configured = config();
+
+    await createFactoryWorkstreamFromConfig({
+      config: configured,
+      inputPath: "-",
+      stdin: Readable.from([JSON.stringify(workstreamInput)]),
+      fetchImpl
+    });
+    await submitFactoryBatchFromConfig({
+      config: configured,
+      inputPath: "-",
+      stdin: Readable.from([JSON.stringify(batchInput)]),
+      fetchImpl
+    });
+
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://relay.example/v1/workstreams",
+      "https://relay.example/v1/workstream-batches"
+    ]);
+    expect(JSON.parse(String(requests[0]?.init?.body))).toEqual(workstreamInput);
+    expect(JSON.parse(String(requests[1]?.init?.body))).toEqual(batchInput);
+  });
+
+  it("gets recipes, workstreams, and batches with encoded identities", async () => {
+    const requests: string[] = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      requests.push(String(url));
+      return Response.json(responseFor(String(url)));
+    }) as unknown as typeof fetch;
+    const configured = config();
+
+    await getFactoryRecipeFromConfig({ config: configured, id: "release/candidate", version: "1", fetchImpl });
+    await getFactoryWorkstreamFromConfig({ config: configured, id: "release/candidate", fetchImpl });
+    await getFactoryBatchFromConfig({ config: configured, id: "release/candidate", fetchImpl });
+
+    expect(requests).toEqual([
+      "https://relay.example/v1/factory-recipes/release%2Fcandidate/versions/1",
+      "https://relay.example/v1/workstreams/release%2Fcandidate",
+      "https://relay.example/v1/workstream-batches/release%2Fcandidate"
+    ]);
+  });
+
+  it("rejects invalid input and invalid recipe versions before network access", async () => {
+    const path = join(tempDir(), "invalid.json");
+    writeFileSync(path, "{not-json");
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    await expect(createFactoryRecipeFromConfig({ config: config(), inputPath: path, fetchImpl })).rejects.toThrow(
+      "must contain valid JSON"
+    );
+    await expect(getFactoryRecipeFromConfig({ config: config(), id: "recipe_1", version: "0", fetchImpl })).rejects.toThrow(
+      "--version must be a positive integer"
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("prints structured JSON or concise operator-facing summaries", () => {
+    expect(formatFactoryCommandOutput({ recipe }, { json: true, action: "created" })).toBe(
+      JSON.stringify({ recipe }, null, 2)
+    );
+    expect(formatFactoryCommandOutput({ workstream }, { action: "retrieved" })).toContain(
+      "Factory workstream retrieved: workstream_release"
+    );
+    expect(formatFactoryCommandOutput({ receipt: batchReceipt }, { action: "submitted" })).toContain(
+      "Admission batch submitted: batch_release (completed)"
+    );
+  });
+});

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -2865,8 +2865,13 @@ function authorizeDispatcherRequest(input: {
   return runnerMatches || pairingMatches ? { ok: true } : { ok: false, reason: "invalid_dispatcher_token" };
 }
 
+export function openDispatcherDatabase(databasePath: string): InstanceType<typeof Database> {
+  return new Database(databasePath);
+}
+
 export function createDispatcherApp(input: {
   databasePath: string;
+  sqlite?: InstanceType<typeof Database>;
   callbackSink?: CallbackSink;
   sourceReceiptSink?: SourceReceiptSink;
   pairingToken?: string;
@@ -2891,7 +2896,7 @@ export function createDispatcherApp(input: {
   completionPolicies?: GitHubCompletionPolicy[];
   completionNow?: () => string;
 }) {
-  const sqlite = new Database(input.databasePath);
+  const sqlite = input.sqlite ?? openDispatcherDatabase(input.databasePath);
   migrateSchema(sqlite);
   const repo = createOpenTagRepository(drizzle(sqlite));
   const workstreamBatchLeaseSeconds = 300;

--- a/scripts/test/factory-conformance.ts
+++ b/scripts/test/factory-conformance.ts
@@ -10,6 +10,7 @@ import { createDispatcherClient, createOpenTagClient } from "../../packages/clie
 import type { OpenTagEvent, WorkstreamAdmissionBatchInput } from "../../packages/core/src/index.js";
 import {
   createDispatcherApp,
+  openDispatcherDatabase,
   type CallbackMessage,
   type GitHubCompletionPolicy,
   type SourceReceipt
@@ -148,8 +149,10 @@ async function startHarness(input: {
   callbackMessages: CallbackMessage[];
   sourceReceipts: SourceReceipt[];
 }): Promise<DispatcherHarness> {
+  const sqlite = openDispatcherDatabase(input.databasePath);
   const app = createDispatcherApp({
     databasePath: input.databasePath,
+    sqlite,
     pairingToken,
     completionPolicies: [completionPolicy],
     callbackSink: {
@@ -196,15 +199,23 @@ async function startHarness(input: {
   });
   const address = server.address();
   assert(address && typeof address !== "string", "Dispatcher must listen on a TCP port.");
+  let closed = false;
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
-    close() {
-      return new Promise<void>((resolvePromise, rejectPromise) => {
-        server.close((error?: Error) => {
-          if (error) rejectPromise(error);
-          else resolvePromise();
+    async close() {
+      if (closed) return;
+      closed = true;
+      try {
+        await new Promise<void>((resolvePromise, rejectPromise) => {
+          server.close((error?: Error) => {
+            if (error) rejectPromise(error);
+            else resolvePromise();
+          });
+          server.closeAllConnections();
         });
-      });
+      } finally {
+        sqlite.close();
+      }
     }
   };
 }

--- a/scripts/test/factory-conformance.ts
+++ b/scripts/test/factory-conformance.ts
@@ -1,0 +1,703 @@
+#!/usr/bin/env node
+import { strict as assert } from "node:assert";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createDispatcherClient, createOpenTagClient } from "../../packages/client/src/index.js";
+import type { OpenTagEvent, WorkstreamAdmissionBatchInput } from "../../packages/core/src/index.js";
+import {
+  createDispatcherApp,
+  type CallbackMessage,
+  type GitHubCompletionPolicy,
+  type SourceReceipt
+} from "../../packages/dispatcher/src/index.js";
+import { runOneDaemonIteration } from "../../packages/local-runtime/src/index.js";
+import {
+  createAcpAgentExecutor,
+  createEchoExecutor,
+  type ExecutorAdapter,
+  type ExecutorRunInput
+} from "../../packages/runner/src/index.js";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repositoryRoot = resolve(dirname(scriptPath), "../..");
+const acpFixture = resolve(repositoryRoot, "packages/runner/test/fixtures/acp-agent.mjs");
+const reportPath = process.env.OPENTAG_FACTORY_CONFORMANCE_REPORT?.trim();
+const pairingToken = "phase4b-conformance-token";
+const runnerId = "runner_phase4b_conformance";
+const repositoryOwner = "opentag-conformance";
+const repositoryName = "factory";
+const completionPolicy: GitHubCompletionPolicy = {
+  provider: "github",
+  owner: repositoryOwner,
+  repo: repositoryName,
+  requiredChecks: ["factory-conformance"],
+  baseBranch: "main",
+  requireMerge: true
+};
+
+type ExecutorObservation = {
+  executorId: string;
+  runId: string;
+  workspaceKind: ExecutorRunInput["workspace"]["kind"];
+  workspacePath: string;
+};
+
+type DispatcherHarness = {
+  baseUrl: string;
+  close(): Promise<void>;
+};
+
+function factoryEvent(input: {
+  lane: "echo" | "acp";
+  eventId: string;
+  sourceEventId: string;
+  receivedAt: string;
+  workItemExternalId?: string;
+}): OpenTagEvent {
+  const workItemExternalId = input.workItemExternalId ?? `ticket-${input.lane}`;
+  const issueNumber = input.lane === "echo" ? 1 : 2;
+  return {
+    id: input.eventId,
+    source: "github",
+    sourceEventId: input.sourceEventId,
+    receivedAt: input.receivedAt,
+    actor: {
+      provider: "github",
+      providerUserId: "phase4b-operator",
+      handle: "phase4b",
+      writeAccess: true
+    },
+    target: {
+      mention: "@opentag",
+      agentId: "opentag",
+      ...(input.lane === "acp" ? { executorHint: "custom" as const } : {})
+    },
+    command: {
+      rawText: `Run the deterministic Phase 4B ${input.lane} factory lane.`,
+      intent: "run",
+      args: { lane: input.lane }
+    },
+    context: [{
+      provider: "github",
+      kind: "issue",
+      uri: `https://github.com/${repositoryOwner}/${repositoryName}/issues/${issueNumber}`,
+      visibility: "public"
+    }],
+    workItem: {
+      provider: "github",
+      kind: "issue",
+      externalId: workItemExternalId,
+      uri: `https://github.com/${repositoryOwner}/${repositoryName}/issues/${issueNumber}`,
+      title: `Phase 4B ${input.lane} lane`,
+      ownerContainer: {
+        provider: "github",
+        id: `${repositoryOwner}/${repositoryName}`,
+        uri: `https://github.com/${repositoryOwner}/${repositoryName}`
+      }
+    },
+    permissions: input.lane === "acp"
+      ? [{
+          scope: "repo:write",
+          reason: "Allow the local ACP fixture to write its deterministic repository artifact."
+        }]
+      : [{
+          scope: "issue:comment",
+          reason: "Return the governed conformance result to its source thread."
+        }],
+    callback: {
+      provider: "github",
+      uri: `https://api.github.com/repos/${repositoryOwner}/${repositoryName}/issues/${issueNumber}/comments`,
+      threadKey: `${repositoryOwner}/${repositoryName}#${issueNumber}`
+    },
+    metadata: {
+      conformance: "phase4b",
+      lane: input.lane,
+      repoProvider: "github",
+      owner: repositoryOwner,
+      repo: repositoryName,
+      issueNumber
+    }
+  };
+}
+
+function observedExecutor(adapter: ExecutorAdapter, observations: ExecutorObservation[]): ExecutorAdapter {
+  return {
+    ...adapter,
+    async run(input, sink) {
+      observations.push({
+        executorId: adapter.id,
+        runId: input.runId,
+        workspaceKind: input.workspace.kind,
+        workspacePath: input.workspace.path
+      });
+      const result = await adapter.run(input, sink);
+      return {
+        ...result,
+        createdPullRequestUrl: `https://github.com/${repositoryOwner}/${repositoryName}/pull/${adapter.id === "echo" ? 101 : 102}`
+      };
+    }
+  };
+}
+
+async function startHarness(input: {
+  databasePath: string;
+  callbackMessages: CallbackMessage[];
+  sourceReceipts: SourceReceipt[];
+}): Promise<DispatcherHarness> {
+  const app = createDispatcherApp({
+    databasePath: input.databasePath,
+    pairingToken,
+    completionPolicies: [completionPolicy],
+    callbackSink: {
+      async deliver(message) {
+        input.callbackMessages.push(message);
+      }
+    },
+    sourceReceiptSink: {
+      async deliver(receipt) {
+        input.sourceReceipts.push(receipt);
+        return { delivered: true };
+      }
+    }
+  });
+  const server = createServer(async (request, response) => {
+    try {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      const address = server.address();
+      assert(address && typeof address !== "string", "Dispatcher must listen on a TCP port.");
+      const body = chunks.length ? Buffer.concat(chunks) : undefined;
+      const webResponse = await app.fetch(new Request(
+        `http://127.0.0.1:${address.port}${request.url ?? "/"}`,
+        {
+          method: request.method,
+          headers: new Headers(request.headers as Record<string, string>),
+          ...(body ? { body } : {})
+        }
+      ));
+      response.statusCode = webResponse.status;
+      webResponse.headers.forEach((value, key) => response.setHeader(key, value));
+      response.end(Buffer.from(await webResponse.arrayBuffer()));
+    } catch (error) {
+      response.statusCode = 500;
+      response.end(error instanceof Error ? error.message : String(error));
+    }
+  });
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", rejectPromise);
+      resolvePromise();
+    });
+  });
+  const address = server.address();
+  assert(address && typeof address !== "string", "Dispatcher must listen on a TCP port.");
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close() {
+      return new Promise<void>((resolvePromise, rejectPromise) => {
+        server.close((error?: Error) => {
+          if (error) rejectPromise(error);
+          else resolvePromise();
+        });
+      });
+    }
+  };
+}
+
+function initRepository(path: string): void {
+  mkdirSync(path, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: path, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "opentag@example.test"], { cwd: path });
+  execFileSync("git", ["config", "user.name", "OpenTag Conformance"], { cwd: path });
+  writeFileSync(join(path, "README.md"), "# Phase 4B factory conformance\n");
+  execFileSync("git", ["add", "README.md"], { cwd: path });
+  execFileSync("git", ["commit", "-m", "Initialize factory conformance fixture"], { cwd: path, stdio: "ignore" });
+}
+
+function findNamedFile(root: string, name: string): string | undefined {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const candidate = join(root, entry.name);
+    if (entry.isFile() && entry.name === name) return candidate;
+    if (entry.isDirectory()) {
+      const nested = findNamedFile(candidate, name);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
+}
+
+async function ingestAcceptedGitHubOutcome(
+  client: ReturnType<typeof createOpenTagClient>,
+  input: { deliveryId: string; pullRequestNumber: number; headSha: string; payloadDigestCharacter: string }
+): Promise<void> {
+  await client.ingestGitHubCompletionEvidence({
+    provider: "github",
+    deliveryId: input.deliveryId,
+    eventName: "pull_request",
+    repository: { owner: repositoryOwner, repo: repositoryName },
+    pullRequest: {
+      number: input.pullRequestNumber,
+      resourceRef: `github:${repositoryOwner}/${repositoryName}:pull_request:${input.pullRequestNumber}`,
+      headSha: input.headSha,
+      baseSha: "b".repeat(40),
+      baseBranch: "main",
+      state: "merged"
+    },
+    checks: { "factory-conformance": "passed" },
+    observedAt: "2026-07-26T01:05:00.000Z",
+    payloadDigest: `sha256:${input.payloadDigestCharacter.repeat(64)}`
+  });
+}
+
+function executorRegistration(adapter: ExecutorAdapter) {
+  assert(adapter.capability, `${adapter.id} must expose a typed capability contract.`);
+  return {
+    executorId: adapter.id,
+    capability: adapter.capability,
+    readiness: "ready" as const,
+    reason: "Deterministic conformance adapter is ready."
+  };
+}
+
+function requireCreatedWorkThread(
+  result: Awaited<ReturnType<ReturnType<typeof createOpenTagClient>["createRun"]>>,
+  expectedRunId: string
+): string {
+  assert.equal(result.outcome, "run_created", `${expectedRunId} must create a seed run.`);
+  assert.equal(result.run.id, expectedRunId);
+  assert(result.run.thread?.id, `${expectedRunId} must create a durable WorkThread.`);
+  return result.run.thread.id;
+}
+
+async function rawBatchRequest(baseUrl: string, batch: WorkstreamAdmissionBatchInput): Promise<Response> {
+  return fetch(`${baseUrl}/v1/workstream-batches`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${pairingToken}`
+    },
+    body: JSON.stringify(batch)
+  });
+}
+
+function writeReport(report: unknown): void {
+  const serialized = `${JSON.stringify(report, null, 2)}\n`;
+  if (reportPath) {
+    const absolute = resolve(repositoryRoot, reportPath);
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(absolute, serialized, { mode: 0o600 });
+    chmodSync(absolute, 0o600);
+  }
+  process.stdout.write(serialized);
+}
+
+async function main(): Promise<void> {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "opentag-factory-conformance-"));
+  const databasePath = join(fixtureRoot, "dispatcher.sqlite");
+  const scratchRoot = join(fixtureRoot, "scratch");
+  const checkoutPath = join(fixtureRoot, "repository");
+  const callbackMessages: CallbackMessage[] = [];
+  const sourceReceipts: SourceReceipt[] = [];
+  const observations: ExecutorObservation[] = [];
+  const echoExecutor = observedExecutor(createEchoExecutor(), observations);
+  const acpExecutor = observedExecutor(createAcpAgentExecutor({
+    id: "custom",
+    label: "Local ACP conformance fixture",
+    workspaceCwd: "required",
+    launch: {
+      command: process.execPath,
+      args: [acpFixture, "success"]
+    },
+    capabilities: {
+      supportsProfile: false,
+      supportsCancel: true
+    }
+  }), observations);
+  let firstHarness: DispatcherHarness | undefined;
+  let recoveredHarness: DispatcherHarness | undefined;
+
+  try {
+    initRepository(checkoutPath);
+    firstHarness = await startHarness({ databasePath, callbackMessages, sourceReceipts });
+    const firstClient = createOpenTagClient({ dispatcherUrl: firstHarness.baseUrl, pairingToken });
+    await firstClient.registerRunner({
+      runnerId,
+      name: "Phase 4B deterministic conformance runner",
+      locality: "local",
+      declaredState: "ready",
+      maxConcurrentRuns: 2,
+      executors: [executorRegistration(echoExecutor), executorRegistration(acpExecutor)]
+    });
+    await firstClient.bindRepository({
+      provider: "github",
+      owner: repositoryOwner,
+      repo: repositoryName,
+      runnerId,
+      workspacePath: checkoutPath,
+      defaultExecutor: "echo",
+      fallbackExecutorIds: ["custom"],
+      allowedActors: ["phase4b"]
+    });
+
+    const echoThreadId = requireCreatedWorkThread(await firstClient.createRun({
+      runId: "run_phase4b_seed_echo",
+      event: factoryEvent({
+        lane: "echo",
+        eventId: "evt_phase4b_seed_echo",
+        sourceEventId: "source_phase4b_seed_echo",
+        receivedAt: "2026-07-26T01:00:00.000Z"
+      })
+    }), "run_phase4b_seed_echo");
+    const acpThreadId = requireCreatedWorkThread(await firstClient.createRun({
+      runId: "run_phase4b_seed_acp",
+      event: factoryEvent({
+        lane: "acp",
+        eventId: "evt_phase4b_seed_acp",
+        sourceEventId: "source_phase4b_seed_acp",
+        receivedAt: "2026-07-26T01:00:01.000Z"
+      })
+    }), "run_phase4b_seed_acp");
+    await firstClient.cancelRun({ runId: "run_phase4b_seed_echo", reason: "Seeded durable WorkThread." });
+    await firstClient.cancelRun({ runId: "run_phase4b_seed_acp", reason: "Seeded durable WorkThread." });
+    callbackMessages.length = 0;
+    sourceReceipts.length = 0;
+
+    const { recipe } = await firstClient.createFactoryRecipeSnapshot({
+      id: "recipe_phase4b_conformance",
+      version: 1,
+      name: "Phase 4B deterministic factory loop",
+      budgets: {
+        maxConcurrentRuns: 2,
+        maxAttemptsPerRun: 2,
+        maxCostUnits: 4,
+        costUnitsPerAttempt: 1,
+        allowedLocalities: ["local"]
+      }
+    });
+    const { workstream } = await firstClient.createWorkstream({
+      id: "workstream_phase4b_conformance",
+      recipeId: recipe.id,
+      recipeVersion: recipe.version,
+      name: "Phase 4B two-executor loop",
+      members: [
+        { kind: "work_thread", workThreadId: echoThreadId },
+        { kind: "work_thread", workThreadId: acpThreadId }
+      ]
+    });
+    const acceptedBatch: WorkstreamAdmissionBatchInput = {
+      id: "batch_phase4b_accepted",
+      workstreamId: workstream.id,
+      items: [
+        {
+          itemId: "item_phase4b_echo",
+          runId: "run_phase4b_echo",
+          workThreadId: echoThreadId,
+          event: factoryEvent({
+            lane: "echo",
+            eventId: "evt_phase4b_echo",
+            sourceEventId: "source_phase4b_echo",
+            receivedAt: "2026-07-26T01:01:00.000Z"
+          })
+        },
+        {
+          itemId: "item_phase4b_acp",
+          runId: "run_phase4b_acp",
+          workThreadId: acpThreadId,
+          event: factoryEvent({
+            lane: "acp",
+            eventId: "evt_phase4b_acp",
+            sourceEventId: "source_phase4b_acp",
+            receivedAt: "2026-07-26T01:01:01.000Z"
+          })
+        }
+      ]
+    };
+    const { receipt: admittedReceipt } = await firstClient.createWorkstreamAdmissionBatch(acceptedBatch);
+    assert.equal(admittedReceipt.status, "completed");
+    assert.deepEqual(admittedReceipt.result?.summary, {
+      totalItems: 2,
+      createdCount: 2,
+      idempotentReplayCount: 0,
+      followUpQueuedCount: 0,
+      needsHumanDecisionCount: 0,
+      rejectedCount: 0,
+      exceptionCount: 0,
+      exceptions: [],
+      omittedExceptionCount: 0
+    });
+    assert.equal(callbackMessages.length, 0, "Batch admission must not emit routine callbacks.");
+    assert.equal(sourceReceipts.length, 0, "Batch admission must not emit routine source receipts.");
+
+    await firstHarness.close();
+    firstHarness = undefined;
+    recoveredHarness = await startHarness({ databasePath, callbackMessages, sourceReceipts });
+    const recoveredClient = createOpenTagClient({ dispatcherUrl: recoveredHarness.baseUrl, pairingToken });
+    const durableBeforeReplay = await recoveredClient.getWorkstreamAdmissionBatch({ id: acceptedBatch.id });
+    assert.deepEqual(durableBeforeReplay.receipt, admittedReceipt, "Restart must preserve the exact durable receipt.");
+    const replay = await recoveredClient.createWorkstreamAdmissionBatch(acceptedBatch);
+    assert.deepEqual(replay.receipt, admittedReceipt, "Exact replay after restart must return the same receipt.");
+    const conflictResponse = await rawBatchRequest(recoveredHarness.baseUrl, {
+      ...acceptedBatch,
+      items: acceptedBatch.items.map((item, index) => index === 0
+        ? {
+            ...item,
+            event: {
+              ...item.event,
+              command: { ...item.event.command, rawText: "Conflicting replay body." }
+            }
+          }
+        : item)
+    });
+    assert.equal(conflictResponse.status, 409, "Conflicting replay must fail with HTTP 409.");
+    assert.deepEqual(await conflictResponse.json(), { error: "workstream_batch_conflict" });
+
+    const daemonClient = createDispatcherClient({
+      dispatcherUrl: recoveredHarness.baseUrl,
+      runnerId,
+      pairingToken
+    });
+    const daemonInput = {
+      runnerId,
+      repositories: [{
+        provider: "github",
+        owner: repositoryOwner,
+        repo: repositoryName,
+        checkoutPath,
+        defaultExecutor: "echo",
+        fallbackExecutorIds: ["custom"],
+        baseBranch: "main",
+        pushRemote: "origin",
+        keepWorktree: "always" as const
+      }],
+      executors: { echo: echoExecutor, custom: acpExecutor },
+      scratchRoot,
+      keepScratch: "always" as const,
+      heartbeatIntervalMs: 0,
+      client: daemonClient
+    };
+    assert.equal(await runOneDaemonIteration(daemonInput), true, "First admitted run must execute.");
+    assert.equal(await runOneDaemonIteration(daemonInput), true, "Second admitted run must execute.");
+    assert.equal(await runOneDaemonIteration(daemonInput), false, "Durable replay must not create duplicate work.");
+    const executorIdsObserved = observations.map((entry) => entry.executorId).sort();
+    if (executorIdsObserved.length !== 2) {
+      const diagnostic = await recoveredClient.getRun({ runId: "run_phase4b_acp" });
+      const diagnosticEvents = await recoveredClient.listRunEvents({ runId: "run_phase4b_acp" });
+      assert.deepEqual(executorIdsObserved, ["custom", "echo"], JSON.stringify({ diagnostic, diagnosticEvents }));
+    }
+    assert.deepEqual(executorIdsObserved, ["custom", "echo"]);
+    assert(observations.every((entry) => entry.workspaceKind === "repository"));
+    const acpObservation = observations.find((entry) => entry.executorId === "custom");
+    assert(acpObservation, "The local ACP fixture adapter must execute.");
+    const acpFixtureArtifact = findNamedFile(checkoutPath, "acp-output.txt");
+    assert(acpFixtureArtifact, "The retained ACP worktree must contain the fixture artifact.");
+    assert.equal(
+      readFileSync(acpFixtureArtifact, "utf8"),
+      "created by the ACP fixture\n",
+      "The ACP path must be proven by its fixture artifact."
+    );
+
+    const { metrics: preEvidenceWorkstreamMetrics } = await recoveredClient.getWorkstreamMetrics({ id: workstream.id });
+    const { metrics: preEvidenceAcceptedMetrics } = await recoveredClient.getAcceptedCompletionMetrics();
+    assert.equal(preEvidenceWorkstreamMetrics.terminalRunCount, 2);
+    assert.equal(preEvidenceWorkstreamMetrics.acceptedWorkThreadCount, 0);
+    assert.equal(preEvidenceAcceptedMetrics.completedRuns, 2);
+    assert.equal(preEvidenceAcceptedMetrics.acceptedCompletions, 0);
+
+    await ingestAcceptedGitHubOutcome(recoveredClient, {
+      deliveryId: "delivery_phase4b_echo",
+      pullRequestNumber: 101,
+      headSha: "1".repeat(40),
+      payloadDigestCharacter: "c"
+    });
+    await ingestAcceptedGitHubOutcome(recoveredClient, {
+      deliveryId: "delivery_phase4b_acp",
+      pullRequestNumber: 102,
+      headSha: "2".repeat(40),
+      payloadDigestCharacter: "d"
+    });
+
+    const { metrics: workstreamMetrics } = await recoveredClient.getWorkstreamMetrics({ id: workstream.id });
+    const { evaluation } = await recoveredClient.getWorkstreamEvaluation({ id: workstream.id });
+    assert.equal(workstreamMetrics.runCount, 2);
+    assert.equal(workstreamMetrics.terminalRunCount, 2);
+    assert.equal(workstreamMetrics.totalAttempts, 2);
+    assert.equal(workstreamMetrics.acceptedWorkThreadCount, 2);
+    assert.equal(evaluation.status, "healthy");
+    assert.equal(evaluation.acceptedWorkThreadCount, 2);
+
+    const { metrics: acceptedMetrics } = await recoveredClient.getAcceptedCompletionMetrics();
+    assert.equal(acceptedMetrics.completedRuns, 2);
+    assert.equal(acceptedMetrics.acceptedCompletions, 2);
+    for (const executorId of ["echo", "custom"]) {
+      const segment = acceptedMetrics.byExecutor.find((entry) => entry.id === executorId);
+      assert(segment, `Accepted metrics must include executor '${executorId}'.`);
+      assert.deepEqual(segment, {
+        id: executorId,
+        completedRuns: 1,
+        acceptedCompletions: 1,
+        acceptanceRate: 1
+      });
+    }
+
+    const acceptedAuthorities = await Promise.all([
+      { runId: "run_phase4b_echo", workThreadId: echoThreadId, executorId: "echo" },
+      { runId: "run_phase4b_acp", workThreadId: acpThreadId, executorId: "custom" }
+    ].map(async (expected) => {
+      const [{ completion }, { run }, { events }] = await Promise.all([
+        recoveredClient.getCompletion({ runId: expected.runId }),
+        recoveredClient.getRun({ runId: expected.runId }),
+        recoveredClient.listRunEvents({ runId: expected.runId })
+      ]);
+      assert.equal(run.status, "succeeded", `${expected.runId} must be terminal and successful.`);
+      assert.equal(completion.completion, "satisfied");
+      assert.equal(completion.currentAssessment.state, "satisfied");
+      assert.equal(completion.currentAssessment.workThreadId, expected.workThreadId);
+      assert.equal(completion.currentAssessment.triggeredByRunId, expected.runId);
+      const claimedEvents = events.filter((event): event is {
+        type: string;
+        payload: { executorId?: unknown; attemptId?: unknown; attemptNumber?: unknown };
+      } => Boolean(event && typeof event === "object" && (event as { type?: unknown }).type === "run.claimed"));
+      const latestClaim = claimedEvents.at(-1);
+      assert(latestClaim, `${expected.runId} must expose its latest claimed Attempt in the public event stream.`);
+      assert.equal(latestClaim.payload.executorId, expected.executorId);
+      assert.equal(typeof latestClaim.payload.attemptId, "string");
+      assert.equal(latestClaim.payload.attemptNumber, 1);
+      return {
+        runId: expected.runId,
+        workThreadId: expected.workThreadId,
+        terminalStatus: run.status,
+        currentAssessmentId: completion.currentAssessment.id,
+        currentAssessmentState: completion.currentAssessment.state,
+        currentAssessmentTriggeredByRunId: completion.currentAssessment.triggeredByRunId,
+        latestAttemptId: latestClaim.payload.attemptId,
+        latestAttemptNumber: latestClaim.payload.attemptNumber,
+        latestAttemptExecutorId: latestClaim.payload.executorId
+      };
+    }));
+
+    const callbacksBeforeInvalidBatch = callbackMessages.length;
+    const sourceReceiptsBeforeInvalidBatch = sourceReceipts.length;
+    const invalidBatch: WorkstreamAdmissionBatchInput = {
+      id: "batch_phase4b_bounded_exceptions",
+      workstreamId: workstream.id,
+      items: Array.from({ length: 12 }, (_, index) => ({
+        itemId: `item_phase4b_invalid_${index}`,
+        runId: `run_phase4b_invalid_${index}`,
+        workThreadId: echoThreadId,
+        event: factoryEvent({
+          lane: "echo",
+          eventId: `evt_phase4b_invalid_${index}`,
+          sourceEventId: `source_phase4b_invalid_${index}`,
+          receivedAt: `2026-07-26T01:${String(index + 10).padStart(2, "0")}:00.000Z`,
+          workItemExternalId: `mismatched-ticket-${index}`
+        })
+      }))
+    };
+    const { receipt: invalidReceipt } = await recoveredClient.createWorkstreamAdmissionBatch(invalidBatch);
+    assert.equal(invalidReceipt.status, "completed");
+    assert.equal(invalidReceipt.result?.summary.totalItems, 12);
+    assert.equal(invalidReceipt.result?.summary.rejectedCount, 12);
+    assert.equal(invalidReceipt.result?.summary.exceptionCount, 12);
+    assert.equal(invalidReceipt.result?.summary.exceptions.length, 10);
+    assert.equal(invalidReceipt.result?.summary.omittedExceptionCount, 2);
+    assert(invalidReceipt.result?.summary.exceptions.every((entry) => (
+      entry.status === "rejected" && entry.reasonCode === "event_work_thread_mismatch"
+    )));
+    assert.equal(
+      callbackMessages.length - callbacksBeforeInvalidBatch,
+      0,
+      "Exceptional batch admission must remain quiet on source callbacks."
+    );
+    assert.equal(
+      sourceReceipts.length - sourceReceiptsBeforeInvalidBatch,
+      0,
+      "Exceptional batch admission must remain quiet on source receipts."
+    );
+
+    writeReport({
+      schemaVersion: 1,
+      proof: "opentag.phase4b.factory-conformance",
+      proofClass: "deterministic_runtime_conformance",
+      providerLive: false,
+      statement: "This report proves deterministic OpenTag runtime conformance; it is not provider-live public proof.",
+      providerEvidenceMode: "Deterministic GitHub snapshots were submitted through the authenticated public dispatcher ingestion seam.",
+      excludedScope: ["dag", "operator_console"],
+      recipe: {
+        id: recipe.id,
+        version: recipe.version,
+        contentDigest: recipe.contentDigest
+      },
+      workstream: {
+        id: workstream.id,
+        contentDigest: workstream.contentDigest,
+        workThreadCount: workstream.members.length
+      },
+      acceptedBatch: {
+        id: admittedReceipt.batch.id,
+        contentDigest: admittedReceipt.batch.contentDigest,
+        inputDigest: admittedReceipt.result?.inputDigest,
+        status: admittedReceipt.status,
+        createdCount: admittedReceipt.result?.summary.createdCount
+      },
+      restartSafety: {
+        dispatcherReopenedFromFileDatabase: true,
+        durableReceiptPreservedExactly: true,
+        exactReplayPreservedExactly: true,
+        conflictStatus: conflictResponse.status,
+        duplicateWorkClaimedAfterExecution: false
+      },
+      executorPaths: observations.map((entry) => ({
+        executorId: entry.executorId,
+        adapter: entry.executorId === "echo" ? "Echo Executor" : "Local ACP conformance fixture",
+        runId: entry.runId,
+        workspaceKind: entry.workspaceKind,
+        ...(entry.executorId === "custom" ? { fixtureArtifactObserved: true } : {})
+      })),
+      boundedExceptions: {
+        batchId: invalidReceipt.batch.id,
+        totalItems: invalidReceipt.result?.summary.totalItems,
+        exceptionCount: invalidReceipt.result?.summary.exceptionCount,
+        recordedExceptionCount: invalidReceipt.result?.summary.exceptions.length,
+        omittedExceptionCount: invalidReceipt.result?.summary.omittedExceptionCount,
+        callbackCount: callbackMessages.length - callbacksBeforeInvalidBatch,
+        sourceReceiptCount: sourceReceipts.length - sourceReceiptsBeforeInvalidBatch
+      },
+      authoritativeAcceptedOutcomes: acceptedMetrics,
+      acceptedOutcomeAuthorityTransition: {
+        beforeVerifiedEvidence: {
+          terminalRuns: preEvidenceWorkstreamMetrics.terminalRunCount,
+          acceptedWorkThreads: preEvidenceWorkstreamMetrics.acceptedWorkThreadCount,
+          completedRuns: preEvidenceAcceptedMetrics.completedRuns,
+          acceptedCompletions: preEvidenceAcceptedMetrics.acceptedCompletions
+        },
+        afterVerifiedEvidence: {
+          terminalRuns: workstreamMetrics.terminalRunCount,
+          acceptedWorkThreads: workstreamMetrics.acceptedWorkThreadCount,
+          completedRuns: acceptedMetrics.completedRuns,
+          acceptedCompletions: acceptedMetrics.acceptedCompletions
+        },
+        authorityRule: "Terminal Run success alone is not accepted; only current evidence-backed CompletionAssessments become accepted outcomes."
+      },
+      acceptedOutcomeAuthority: {
+        basis: "current CompletionAssessment joined to each WorkThread and the latest terminal Attempt attribution exposed by the public run event stream",
+        workThreads: acceptedAuthorities
+      },
+      workstreamMetrics,
+      workstreamEvaluation: evaluation
+    });
+  } finally {
+    if (firstHarness) await firstHarness.close().catch(() => undefined);
+    if (recoveredHarness) await recoveredHarness.close().catch(() => undefined);
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/test/live-e2e-smoke.mjs
+++ b/scripts/test/live-e2e-smoke.mjs
@@ -35,6 +35,18 @@ const cases = [
     requiredCommands: ["corepack"]
   },
   {
+    id: "factory-conformance",
+    label: "Restart-safe recipe factory conformance",
+    live: false,
+    command: "corepack pnpm smoke:factory-conformance",
+    requiredCommands: ["corepack", "git", "node"],
+    notes: [
+      "Runs one file-backed recipe/workstream/batch loop through the dispatcher and local daemon.",
+      "Exercises the Echo and deterministic local ACP fixture executor paths without provider credentials.",
+      "Proves durable replay, bounded batch exceptions, and current-assessment accepted-outcome attribution; it is not a provider-live public proof."
+    ]
+  },
+  {
     id: "builtin-acp",
     label: "Live built-in coding-agent ACP conformance",
     live: true,


### PR DESCRIPTION
## Summary

- add pairing-scoped CLI commands for immutable recipes, WorkThread-only workstreams, and restart-safe admission batches
- add one deterministic live factory conformance loop over a file-backed dispatcher, the local daemon, Echo, and a local ACP fixture
- register the proof in the live smoke harness and document the Phase 4B boundary without introducing a DAG or operator console

## Conformance evidence

- closes and reopens the dispatcher over the same SQLite database, preserves the exact durable receipt, accepts exact replay, rejects a changed digest with HTTP 409, and claims no duplicate work
- rejects a 12-item mismatch batch with 10 retained exception samples, 2 omitted samples, and zero callback or source-receipt emissions
- observes 2 terminal successful runs and 0 accepted outcomes before verified evidence, then 2 accepted outcomes after current evidence-backed CompletionAssessments without changing the terminal run count
- attributes exactly one accepted completion to Echo and one to the local ACP executor path
- keeps factory operations pairing-scoped; distinct and revoked runner tokens remain denied by the real dispatcher authorization path

This is deterministic OpenTag runtime conformance. It does not claim that a public source provider, model provider, pull request, required check, or merge was exercised.

## Verification

- `corepack pnpm test` — 136 files, 1778 tests passed
- `corepack pnpm typecheck` — passed
- `corepack pnpm lint` — passed; `@opentag/cli` lint rerun after the authority fix
- `corepack pnpm build` — passed
- `corepack pnpm smoke:live -- --case factory-conformance` — passed on the final conformance source
- independent code review — APPROVE, no remaining actionable findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `opentag factory` commands to create/retrieve recipes, workstreams, and restart-safe admission batches (JSON input or stdin).
  * Added a new smoke test, `smoke:factory-conformance`, and an additional `factory-conformance` case in the E2E harness.
* **Documentation**
  * Updated command reference and expanded conformance/replay documentation (Phase 4B runtime conformance and recommended smoke sequencing).
* **Tests**
  * Added CLI test coverage for validation, authorization, request routing, and output formatting.
  * Added end-to-end factory conformance verification including deterministic replay and bounded-exception handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->