### PR TITLE
feat(factory): prove provider-live GitHub acceptance

### DIFF
--- a/docs/live-e2e-smoke-harness.md
+++ b/docs/live-e2e-smoke-harness.md
@@ -24,6 +24,7 @@ Current cases:
 | `factory-conformance` | No | File-backed recipe/workstream/batch loop with restart replay, bounded exceptions, authoritative accepted outcomes, and Echo plus local ACP executor paths |
 | `openclaw-acp` | Yes | Strict OpenClaw hard-cancellation probe plus worktree cwd, scratch cwd, and fresh-session checks through the generic ACP host |
 | `github-webhook-live` | Yes | Real GitHub repository webhook, local CLI stack, current-head required check, merged PR, durable satisfied assessment, and restart-safe final receipt |
+| `github-factory-live` | Yes | Real external GitHub source thread admitted through a recipe/workstream batch, local execution, PR/check/merge, authoritative accepted metrics, restart replay, and deduplicated source receipt |
 | `github-cli-live` | Yes | Real GitHub issue callback using dispatcher-assisted run creation |
 | `slack-local-live` | Yes | Real Slack callback using dispatcher-assisted run creation |
 | `slack-ui-live` | Yes | Real Slack source-thread mention or button flow through Socket Mode or Events API |
@@ -37,6 +38,8 @@ environment variables, then prints what would run.
 
 ```bash
 corepack pnpm smoke:live -- --case github-webhook-live --dry-run
+OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture \
+corepack pnpm smoke:live -- --case github-factory-live --dry-run
 corepack pnpm smoke:live -- --case slack-ui-live --dry-run --allow-missing
 ```
 
@@ -75,8 +78,8 @@ corepack pnpm smoke:live -- \
 
 ```bash
 corepack pnpm smoke:live -- \
-  --case github-webhook-live \
-  --report .omx/live-e2e/github-webhook-live.json
+  --case github-factory-live \
+  --report .omx/live-e2e/github-factory-live-harness.json
 ```
 
 3. Inspect the provider thread and local status:
@@ -124,6 +127,64 @@ observation.
 Use `github-webhook-live` for the real source-control completion loop and
 `builtin-acp` for provider-backed executor readiness. No DAG scheduler or
 operator console is part of this case.
+
+### GitHub Factory Acceptance
+
+`github-factory-live` sets `OPENTAG_GH_LIVE_FACTORY=true` on the existing real
+GitHub harness. It deliberately creates the GitHub issue and source request
+before installing the temporary OpenTag webhook. The comment therefore remains
+a real, externally durable planning instruction without also creating an
+unattributed direct Run. OpenTag fetches that comment, normalizes it through the
+GitHub adapter, ensures its canonical WorkThread, and submits the same event as
+one item in an immutable recipe-owned workstream batch.
+
+The case then uses the normal runtime and provider path. A local fenced Attempt
+changes an isolated worktree, OpenTag creates a real pull request, a required
+status is recorded for the exact current head, and completion remains pending
+until GitHub reports the merge. The source thread must receive exactly one
+provider-verified completion receipt. The harness restarts against the same
+database, submits the identical batch again, and requires both the durable
+receipt and authoritative workstream metrics to remain byte-equivalent.
+
+The sanitized acceptance report is generated from retained provider and store
+observations. It is rejected instead of written when any required relationship
+is missing or contradictory. Its proof matrix is:
+
+| Claim | Retained authority |
+| --- | --- |
+| External planning source | GitHub issue URL, mention URL, issue/comment/event identifiers |
+| Factory admission | Canonical WorkThread, immutable recipe/workstream digests, durable batch digest and admitted Run identity |
+| Local execution | Run snapshots plus latest fenced Attempt runner, executor, locality, and terminal status |
+| PR and check | GitHub PR identity/state and required status tied to the PR head SHA |
+| Accepted completion | Completion snapshots before evidence, after the check, after merge, and after restart |
+| Accepted metrics | Workstream metrics proving terminal Runs remain `1` while accepted WorkThreads advance `0 -> 1` |
+| Restart recovery | Exact batch receipt replay, byte-equivalent satisfied assessment and metrics, and unchanged source-receipt identity, body digest, and count |
+
+Run the provider/governance proof with the deterministic local ACP writer:
+
+```bash
+OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture \
+OPENTAG_GH_LIVE_REPORT=.omx/live-e2e/github-factory-live.json \
+corepack pnpm smoke:live -- --case github-factory-live
+```
+
+This proves the real GitHub, local runtime, factory admission, and governance
+chain. It does not claim model-provider readiness; run `builtin-acp` separately
+for that. GitHub remains the planning and source-control authority. This case
+adds neither a dependency DAG nor an operator console.
+
+The first Phase 5 live acceptance passed on 2026-07-27 against
+[`amplifthq/opentag-test` issue #77](https://github.com/amplifthq/opentag-test/issues/77)
+and [pull request #78](https://github.com/amplifthq/opentag-test/pull/78).
+The PR head `3a65b9788bf26c2e26401ba688c176d0c0c3d239` carried the successful
+`opentag-phase1-live` status and was merged as
+`3eb6d9a354b6a7140cf396f371aba444cec409d2`. The retained report
+`.omx/live-e2e/github-factory-live-phase5.json` records one terminal local
+Attempt, accepted WorkThreads advancing from zero to one after provider
+evidence, unchanged post-restart metrics, exact batch replay, and one unchanged
+provider-verified source receipt. The GitHub issue deliberately remains open:
+OpenTag accepted the governed delivery outcome but did not mutate the external
+planning system's business status.
 
 ## Case Notes
 
@@ -197,7 +258,8 @@ credential-isolation parts of the full conformance checklist.
 
 ### GitHub Repository Webhook
 
-`github-webhook-live` wraps `scripts/dev/run-github-webhook-live-test.sh`.
+`github-webhook-live` and `github-factory-live` wrap
+`scripts/dev/run-github-webhook-live-test.sh`.
 It requires:
 
 - `gh` authenticated as a user with admin or maintain access to

--- a/docs/live-e2e-smoke-harness.md
+++ b/docs/live-e2e-smoke-harness.md
@@ -173,7 +173,8 @@ chain. It does not claim model-provider readiness; run `builtin-acp` separately
 for that. GitHub remains the planning and source-control authority. This case
 adds neither a dependency DAG nor an operator console.
 
-The first Phase 5 live acceptance passed on 2026-07-27 against
+The first Phase 5 live acceptance passed on 2026-07-26 UTC
+(2026-07-27 Asia/Shanghai) against
 [`amplifthq/opentag-test` issue #77](https://github.com/amplifthq/opentag-test/issues/77)
 and [pull request #78](https://github.com/amplifthq/opentag-test/pull/78).
 The PR head `3a65b9788bf26c2e26401ba688c176d0c0c3d239` carried the successful

--- a/docs/software-factory-control-plane.md
+++ b/docs/software-factory-control-plane.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft architecture proposal, updated 2026-07-25.
+Active architecture and phased delivery record, updated 2026-07-27.
 
 This document defines the proposed product and architecture direction for
 OpenTag as an open control plane for governed software factories. It builds on
@@ -1442,6 +1442,57 @@ The deterministic conformance case is implementation and runtime evidence. It
 does not replace the separate provider-live GitHub loop required below for a
 public factory-control-plane claim. Phase 4B does not add dependency edges, a
 DAG scheduler, mutable workstream planning state, or an operator console.
+
+#### Phase 5 implementation boundary — provider-live factory acceptance
+
+Phase 5 proves one externally planned factory loop without expanding OpenTag
+into a backlog or workflow product:
+
+- a real GitHub issue and issue comment remain the canonical work request and
+  source conversation;
+- a pairing-authorized ensure command derives and persists the canonical
+  WorkThread from the normalized external event without creating a seed Run;
+- an immutable recipe and WorkThread-only workstream admit that event through
+  one durable batch;
+- the normal local daemon claims a fenced Attempt, writes an isolated worktree,
+  and creates a real pull request;
+- GitHub provides the current-head required-check and merge facts; executor
+  success alone cannot satisfy completion;
+- accepted-outcome metrics advance only from the authoritative current
+  CompletionAssessment for the WorkThread;
+- closing and reopening the stack preserves satisfied completion, exact batch
+  replay, accepted metrics, and source-thread receipt deduplication.
+
+The acceptance report is fail-closed: it is derived from retained GitHub
+objects, durable Run/Attempt rows, batch receipts, assessment snapshots, and
+workstream metrics. A stale check head, premature accepted metric, changed
+restart receipt, missing execution snapshot, or duplicate final callback makes
+the case fail rather than producing a positive assertion.
+
+Phase 5 adds no dependency edges, DAG scheduler, mutable planning state, or
+operator console. Recipe JSON identifies governance and budget policy; GitHub
+continues to own prioritization, discussion, and business status. See
+[Live E2E Smoke Harness](./live-e2e-smoke-harness.md#github-factory-acceptance)
+for the command and evidence contract.
+
+Acceptance receipt, 2026-07-27:
+
+- external source: [`amplifthq/opentag-test` issue #77](https://github.com/amplifthq/opentag-test/issues/77)
+  and its durable `@opentag run` comment;
+- governed change: [pull request #78](https://github.com/amplifthq/opentag-test/pull/78),
+  required status bound to head `3a65b9788bf26c2e26401ba688c176d0c0c3d239`,
+  merged as `3eb6d9a354b6a7140cf396f371aba444cec409d2`;
+- runtime authority: one factory-attributed succeeded Run and one succeeded
+  fenced local ACP Attempt;
+- completion authority: terminal Runs remained one while accepted WorkThreads
+  advanced `0 -> 1` only after provider-verified merge evidence;
+- recovery authority: restart preserved the satisfied assessment and metrics,
+  returned the exact durable batch receipt, and did not duplicate the single
+  final source-thread completion receipt.
+
+The source issue remains open. That is intentional evidence that accepted
+OpenTag completion does not silently overwrite the external planning system's
+business status.
 
 ## Compatibility and migration
 

--- a/docs/software-factory-control-plane.md
+++ b/docs/software-factory-control-plane.md
@@ -1475,7 +1475,7 @@ continues to own prioritization, discussion, and business status. See
 [Live E2E Smoke Harness](./live-e2e-smoke-harness.md#github-factory-acceptance)
 for the command and evidence contract.
 
-Acceptance receipt, 2026-07-27:
+Acceptance receipt, 2026-07-26 UTC (2026-07-27 Asia/Shanghai):
 
 - external source: [`amplifthq/opentag-test` issue #77](https://github.com/amplifthq/opentag-test/issues/77)
   and its durable `@opentag run` comment;

--- a/packages/cli/src/factory.ts
+++ b/packages/cli/src/factory.ts
@@ -2,9 +2,11 @@ import { readFile } from "node:fs/promises";
 import { createOpenTagClient, type OpenTagClient } from "@opentag/client";
 import {
   FactoryRecipeSnapshotInputSchema,
+  OpenTagEventSchema,
   WorkstreamAdmissionBatchInputSchema,
   WorkstreamInputSchema,
   type FactoryRecipeSnapshot,
+  type WorkThread,
   type Workstream,
   type WorkstreamAdmissionBatchReceipt
 } from "@opentag/core";
@@ -14,7 +16,13 @@ import {
   type OpenTagCliConfig
 } from "./config.js";
 
-type FactoryAction = "created" | "retrieved" | "submitted";
+type FactoryAction = "created" | "ensured" | "retrieved" | "submitted";
+
+export type FactoryWorkThreadEnsureOptions = {
+  config?: string;
+  input?: string;
+  json?: boolean;
+};
 
 export type FactoryRecipeCreateOptions = {
   config?: string;
@@ -55,6 +63,7 @@ export type FactoryBatchGetOptions = {
 
 type FactoryCommandResult =
   | { recipe: FactoryRecipeSnapshot }
+  | { workThread: WorkThread & { id: string }; created: boolean }
   | { workstream: Workstream }
   | { receipt: WorkstreamAdmissionBatchReceipt };
 
@@ -115,7 +124,7 @@ async function loadJsonInput(inputPath: string | undefined, dependencies: Factor
 function factoryClient(config: OpenTagCliConfig, fetchImpl?: typeof fetch): OpenTagClient {
   const pairingToken = config.daemon.pairingToken?.trim();
   if (!pairingToken) {
-    throw new Error("Factory operations require daemon.pairingToken; a runner token cannot authorize recipe or workstream admission.");
+    throw new Error("Factory operations require daemon.pairingToken; a runner token cannot authorize WorkThread, recipe, or workstream admission.");
   }
   return createOpenTagClient({
     dispatcherUrl: config.daemon.dispatcherUrl,
@@ -133,6 +142,15 @@ export async function createFactoryRecipeFromConfig(input: {
   return factoryClient(input.config, input.fetchImpl).createFactoryRecipeSnapshot(
     FactoryRecipeSnapshotInputSchema.parse(document)
   );
+}
+
+export async function ensureFactoryWorkThreadFromConfig(input: {
+  config: OpenTagCliConfig;
+  inputPath: string;
+  fetchImpl?: typeof fetch;
+} & FactoryInputDependencies): Promise<{ workThread: WorkThread & { id: string }; created: boolean }> {
+  const document = await loadJsonInput(input.inputPath, input);
+  return factoryClient(input.config, input.fetchImpl).ensureWorkThread(OpenTagEventSchema.parse(document));
 }
 
 export async function getFactoryRecipeFromConfig(input: {
@@ -188,6 +206,14 @@ export function formatFactoryCommandOutput(
   options: { action: FactoryAction; json?: boolean }
 ): string {
   if (options.json) return JSON.stringify(result, null, 2);
+  if ("workThread" in result) {
+    return [
+      `Factory work thread ${options.action}: ${result.workThread.id} (${result.created ? "created" : "already existed"})`,
+      `Source: ${result.workThread.workItemReference.provider}`,
+      `External work item: ${result.workThread.workItemReference.externalId}`,
+      `Anchors: ${1 + (result.workThread.secondaryAnchors?.length ?? 0)}`
+    ].join("\n");
+  }
   if ("recipe" in result) {
     return [
       `Factory recipe ${options.action}: ${result.recipe.id} v${result.recipe.version}`,
@@ -239,6 +265,21 @@ export async function runFactoryRecipeCreateCommand(
     ...(dependencies.stdin ? { stdin: dependencies.stdin } : {})
   });
   (dependencies.logger ?? console).log(formatFactoryCommandOutput(result, { action: "created", json: options.json ?? false }));
+}
+
+export async function runFactoryWorkThreadEnsureCommand(
+  options: FactoryWorkThreadEnsureOptions,
+  dependencies: FactoryCommandDependencies = {}
+): Promise<void> {
+  const { config } = commandConfig(options.config);
+  const result = await ensureFactoryWorkThreadFromConfig({
+    config,
+    inputPath: nonEmpty(options.input, "--input"),
+    ...(dependencies.fetchImpl ? { fetchImpl: dependencies.fetchImpl } : {}),
+    ...(dependencies.readText ? { readText: dependencies.readText } : {}),
+    ...(dependencies.stdin ? { stdin: dependencies.stdin } : {})
+  });
+  (dependencies.logger ?? console).log(formatFactoryCommandOutput(result, { action: "ensured", json: options.json ?? false }));
 }
 
 export async function runFactoryRecipeGetCommand(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import {
   runFactoryBatchSubmitCommand,
   runFactoryRecipeCreateCommand,
   runFactoryRecipeGetCommand,
+  runFactoryWorkThreadEnsureCommand,
   runFactoryWorkstreamCreateCommand,
   runFactoryWorkstreamGetCommand
 } from "./factory.js";
@@ -181,6 +182,16 @@ program
   .action(runCliAction(runCancelCommand));
 
 const factoryCommand = program.command("factory").description("Operate recipe-driven software factory workstreams");
+
+const factoryWorkThreadCommand = factoryCommand.command("work-thread").description("Ensure external work threads are available to factory workstreams");
+
+factoryWorkThreadCommand
+  .command("ensure")
+  .description("Ensure a durable WorkThread from a normalized OpenTag event")
+  .option("--config <path>", "Config file path")
+  .requiredOption("--input <path>", "Normalized OpenTag event JSON file path, or - for stdin")
+  .option("--json", "Print the structured dispatcher response as JSON")
+  .action(runCliAction(runFactoryWorkThreadEnsureCommand));
 
 const factoryRecipeCommand = factoryCommand.command("recipe").description("Create or inspect immutable factory recipes");
 

--- a/packages/cli/test/factory.test.ts
+++ b/packages/cli/test/factory.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createFactoryRecipeFromConfig,
   createFactoryWorkstreamFromConfig,
+  ensureFactoryWorkThreadFromConfig,
   formatFactoryCommandOutput,
   getFactoryBatchFromConfig,
   getFactoryRecipeFromConfig,
@@ -147,6 +148,46 @@ function responseFor(url: string): unknown {
 }
 
 describe("OpenTag factory CLI", () => {
+  it("ensures an external WorkThread from stdin and reports an idempotent replay", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const workThread = {
+      id: "thread_github_acme/demo#1_comment_1",
+      workItemReference: {
+        provider: "github",
+        kind: "issue",
+        externalId: "acme/demo#1",
+        uri: "https://github.com/acme/demo/issues/1"
+      },
+      primaryAnchor: {
+        provider: "github",
+        kind: "github_thread",
+        externalId: event.callback.uri,
+        uri: event.callback.uri,
+        controlPlane: true,
+        canApprove: true
+      }
+    };
+    const normalizedEvent = { ...event, workItem: workThread.workItemReference };
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Response.json({ workThread, created: false });
+    }) as unknown as typeof fetch;
+
+    const result = await ensureFactoryWorkThreadFromConfig({
+      config: config(),
+      inputPath: "-",
+      stdin: Readable.from([JSON.stringify(normalizedEvent)]),
+      fetchImpl
+    });
+
+    expect(result).toEqual({ workThread, created: false });
+    expect(requests[0]?.url).toBe("https://relay.example/v1/work-threads/ensure");
+    expect(JSON.parse(String(requests[0]?.init?.body))).toEqual(normalizedEvent);
+    expect(formatFactoryCommandOutput(result, { action: "ensured" })).toContain(
+      "Factory work thread ensured: thread_github_acme/demo#1_comment_1 (already existed)"
+    );
+  });
+
   it("creates a recipe from a JSON file with pairing-scoped factory authority", async () => {
     const path = join(tempDir(), "recipe.json");
     writeFileSync(path, JSON.stringify(recipeInput));

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -21,6 +21,7 @@ import {
   WorkstreamMetricsSchema,
   WorkstreamInputSchema,
   WorkstreamSchema,
+  WorkThreadSchema,
   type ActorIdentity,
   type Action,
   type ActionPermissionRequest,
@@ -57,7 +58,8 @@ import {
   type WorkstreamAdmissionBatchReceipt,
   type WorkstreamEvaluation,
   type WorkstreamInput,
-  type WorkstreamMetrics
+  type WorkstreamMetrics,
+  type WorkThread
 } from "@opentag/core";
 
 export type {
@@ -301,6 +303,13 @@ export type CreateRunInput = {
   event: OpenTagEvent;
 };
 
+export type EnsuredWorkThread = WorkThread & { id: string };
+
+export type EnsureWorkThreadResult = {
+  workThread: EnsuredWorkThread;
+  created: boolean;
+};
+
 export type CreateRunResult =
   | {
       outcome: "run_created";
@@ -501,6 +510,7 @@ export type OpenTagClient = {
   unbindChannel(input: { provider: string; accountId: string; conversationId: string }): Promise<void>;
   bindSlackChannel(input: SlackChannelBindingInput): Promise<void>;
   getSlackChannelBinding(input: { teamId: string; channelId: string }): Promise<{ binding: SlackChannelBindingInput }>;
+  ensureWorkThread(input: OpenTagEvent): Promise<EnsureWorkThreadResult>;
   createFactoryRecipeSnapshot(input: FactoryRecipeSnapshotInput): Promise<{ recipe: FactoryRecipeSnapshot }>;
   getFactoryRecipeSnapshot(input: { id: string; version: number }): Promise<{ recipe: FactoryRecipeSnapshot }>;
   createWorkstream(input: WorkstreamInput): Promise<{ workstream: Workstream }>;
@@ -933,6 +943,22 @@ export function createOpenTagClient(options: OpenTagClientOptions): OpenTagClien
       });
       await assertOk(response, "getSlackChannelBinding");
       return (await response.json()) as { binding: SlackChannelBindingInput };
+    },
+
+    async ensureWorkThread(input) {
+      const event = OpenTagEventSchema.parse(input);
+      const response = await fetchImpl(`${baseUrl}/v1/work-threads/ensure`, {
+        method: "POST",
+        headers: jsonHeaders(options.pairingToken),
+        body: JSON.stringify(event)
+      });
+      await assertOk(response, "ensureWorkThread");
+      const body = (await response.json()) as { workThread?: unknown; created?: unknown };
+      const workThread = WorkThreadSchema.parse(body.workThread);
+      if (!workThread.id || typeof body.created !== "boolean") {
+        throw new Error("ensureWorkThread returned an invalid response.");
+      }
+      return { workThread: { ...workThread, id: workThread.id }, created: body.created };
     },
 
     async createFactoryRecipeSnapshot(input) {

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -98,6 +98,53 @@ function completionExplanationFixture() {
 }
 
 describe("@opentag/client", () => {
+  it("ensures a durable WorkThread from a normalized event with pairing authorization", async () => {
+    const requests: Array<{ url: string; method: string; headers: Headers; body?: unknown }> = [];
+    const normalizedEvent = {
+      ...event,
+      workItem: {
+        provider: "github",
+        kind: "issue",
+        externalId: "acme/demo#1",
+        uri: "https://github.com/acme/demo/issues/1"
+      }
+    };
+    const workThread = {
+      id: "thread_github_acme/demo#1_comment_1",
+      workItemReference: normalizedEvent.workItem,
+      primaryAnchor: {
+        provider: "github",
+        kind: "github_thread",
+        externalId: normalizedEvent.callback.uri,
+        uri: normalizedEvent.callback.uri,
+        controlPlane: true,
+        canApprove: true
+      }
+    };
+    const client = createOpenTagClient({
+      dispatcherUrl: "http://dispatcher.test",
+      pairingToken: "pairing_token",
+      fetchImpl: async (url, init) => {
+        requests.push({
+          url: String(url),
+          method: init?.method ?? "GET",
+          headers: new Headers(init?.headers),
+          ...(init?.body ? { body: JSON.parse(String(init.body)) } : {})
+        });
+        return jsonResponse({ workThread, created: true }, 201);
+      }
+    });
+
+    await expect(client.ensureWorkThread(normalizedEvent)).resolves.toEqual({ workThread, created: true });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      url: "http://dispatcher.test/v1/work-threads/ensure",
+      method: "POST",
+      body: normalizedEvent
+    });
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer pairing_token");
+  });
+
   it("uses the additive factory workstream API routes and parses their contracts", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const digest = `sha256:${"a".repeat(64)}`;

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -50,6 +50,7 @@ import {
   WorkstreamMetricsSchema,
   WorkstreamInputSchema,
   WorkstreamSchema,
+  WorkThreadSchema,
   PolicyRuleSchema,
   PolicyScopeSchema,
   RunnerRegistrationRequestSchema,
@@ -4922,6 +4923,17 @@ export function createDispatcherApp(input: {
     });
     if (!binding) return c.json({ error: "slack_channel_binding_not_found" }, 404);
     return c.json({ binding });
+  });
+
+  app.post("/v1/work-threads/ensure", async (c) => {
+    const event = await parseDispatcherBody(c, OpenTagEventSchema);
+    const thread = protocolRunFieldsFromEvent(event, event.receivedAt).thread;
+    if (!thread) return c.json({ error: "work_thread_required" }, 422);
+    const outcome = await repo.upsertWorkThread({ thread, recordedAt: event.receivedAt });
+    return c.json({
+      workThread: WorkThreadSchema.parse(outcome.thread),
+      created: outcome.created
+    }, outcome.created ? 201 : 200);
   });
 
   app.post("/v1/factory-recipes", async (c) => {

--- a/packages/dispatcher/test/github-factory-acceptance.test.ts
+++ b/packages/dispatcher/test/github-factory-acceptance.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGitHubFactoryAcceptanceReport,
+  normalizeGitHubFactorySourceEvent,
+  type GitHubFactoryAcceptanceEvidence
+} from "../../../scripts/test/github-factory-acceptance.js";
+
+const digest = `sha256:${"a".repeat(64)}`;
+
+function completion(state: string, requiredChecks: string, merge: string) {
+  return {
+    completion: state,
+    currentAssessment: {
+      id: "assessment_live_42",
+      inputDigest: digest,
+      state,
+      targetBindings: [
+        {
+          key: "primary_change",
+          provider: "github",
+          resourceRef: "github:amplifthq/opentag-test:pull_request:7",
+          resourceVersion: "abc123"
+        }
+      ],
+      gateResults: [
+        { gateId: "required_checks", state: requiredChecks },
+        { gateId: "merge", state: merge }
+      ]
+    }
+  };
+}
+
+function workstreamMetrics(acceptedWorkThreadCount: number) {
+  return {
+    metrics: {
+      workstreamId: "workstream_live_42",
+      workThreadCount: 1,
+      acceptedWorkThreadCount,
+      runCount: 1,
+      queuedRunCount: 0,
+      activeRunCount: 0,
+      needsHumanRunCount: 0,
+      terminalRunCount: 1,
+      failedRunCount: 0,
+      budgetBlockedRunCount: 0,
+      exceptionCount: 0,
+      totalAttempts: 1,
+      attemptsPerRunExceededCount: 0,
+      totalCostUnits: 1,
+      attemptsByLocality: { local: 1, private: 0, hosted: 0, unknown: 0 }
+    }
+  };
+}
+
+function receipt() {
+  return {
+    receipt: {
+      batch: { id: "batch_live_42", contentDigest: digest },
+      status: "completed",
+      result: {
+        results: [{ itemId: "item_live_42", status: "created", admittedRunId: "run_live_42" }]
+      }
+    }
+  };
+}
+
+function evidence(): GitHubFactoryAcceptanceEvidence {
+  return {
+    recordedAt: "2026-07-27T00:00:00.000Z",
+    repository: "amplifthq/opentag-test",
+    runtimeSource: "source_checkout",
+    source: {
+      issueUrl: "https://github.com/amplifthq/opentag-test/issues/42",
+      mentionUrl: "https://github.com/amplifthq/opentag-test/issues/42#issuecomment-100",
+      issueNumber: 42,
+      issueState: "OPEN",
+      commentId: "100",
+      eventId: "evt_github_comment_100"
+    },
+    factory: {
+      workThreadId: "thread_live_42",
+      recipe: { id: "recipe_live_42", version: 1, contentDigest: digest },
+      workstream: { id: "workstream_live_42", contentDigest: digest },
+      batch: {
+        id: "batch_live_42",
+        inputDigest: digest,
+        initialReceipt: receipt(),
+        replayedReceipt: receipt()
+      }
+    },
+    run: {
+      id: "run_live_42",
+      status: "succeeded",
+      workThreadId: "thread_live_42",
+      workstreamId: "workstream_live_42",
+      admissionBatchId: "batch_live_42",
+      contextPacketCaptured: true,
+      accessProfileCaptured: true,
+      policyProvenanceCaptured: true
+    },
+    attempt: {
+      id: "attempt_live_42",
+      runnerId: "runner_live",
+      executorId: "phase1-fixture",
+      locality: "local",
+      status: "succeeded",
+      hasFencingToken: true
+    },
+    pullRequest: {
+      number: 7,
+      state: "MERGED",
+      url: "https://github.com/amplifthq/opentag-test/pull/7",
+      headRefOid: "abc123",
+      mergedAt: "2026-07-27T00:10:00.000Z",
+      mergeCommit: { oid: "def456" }
+    },
+    requiredCheck: {
+      context: "opentag-phase5-live",
+      headSha: "abc123",
+      state: "success",
+      targetUrl: "https://github.com/amplifthq/opentag-test/pull/7"
+    },
+    completion: {
+      afterExecutorSuccess: completion("pending", "missing", "missing"),
+      afterRequiredCheck: completion("pending", "passed", "missing"),
+      afterMerge: completion("satisfied", "passed", "passed"),
+      afterRestart: completion("satisfied", "passed", "passed")
+    },
+    metrics: {
+      beforeProviderEvidence: workstreamMetrics(0),
+      afterMerge: workstreamMetrics(1),
+      afterRestart: workstreamMetrics(1)
+    },
+    assessmentCount: 3,
+    sourceReceipt: {
+      matchedPhrase: "provider-verified completion requirements are satisfied",
+      beforeRestart: {
+        id: "200",
+        url: "https://github.com/amplifthq/opentag-test/issues/42#issuecomment-200",
+        bodyDigest: digest
+      },
+      afterRestart: {
+        id: "200",
+        url: "https://github.com/amplifthq/opentag-test/issues/42#issuecomment-200",
+        bodyDigest: digest
+      },
+      countBeforeRestart: 1,
+      countAfterRestart: 1
+    }
+  };
+}
+
+describe("GitHub factory live acceptance report", () => {
+  it("normalizes one real-source-shaped issue comment into a factory admission event", () => {
+    const event = normalizeGitHubFactorySourceEvent({
+      id: "100",
+      commentBody: "@opentag run Update README.md",
+      commentUrl: "https://github.com/amplifthq/opentag-test/issues/42#issuecomment-100",
+      apiCommentsUrl: "https://api.github.com/repos/amplifthq/opentag-test/issues/42/comments",
+      issueUrl: "https://github.com/amplifthq/opentag-test/issues/42",
+      issueNumber: 42,
+      owner: "amplifthq",
+      repo: "opentag-test",
+      actorId: 7,
+      actorLogin: "operator",
+      authorAssociation: "MEMBER",
+      actorWriteAccess: true,
+      private: false,
+      receivedAt: "2026-07-27T00:00:00.000Z"
+    });
+
+    expect(event).toMatchObject({
+      id: "evt_github_comment_100",
+      source: "github",
+      sourceEventId: "100",
+      command: { intent: "run", args: { prompt: "Update README.md" } },
+      workItem: { externalId: "amplifthq/opentag-test#42" },
+      callback: { threadKey: "amplifthq/opentag-test#42" }
+    });
+  });
+
+  it("derives the public factory proof only from consistent observed evidence", () => {
+    const report = buildGitHubFactoryAcceptanceReport(evidence());
+
+    expect(report).toMatchObject({
+      schemaVersion: 1,
+      case: "github-factory-live",
+      factory: {
+        workThreadId: "thread_live_42",
+        batch: { admittedRunId: "run_live_42", restartReplayMatched: true }
+      },
+      metrics: {
+        beforeProviderEvidence: { metrics: { terminalRunCount: 1, acceptedWorkThreadCount: 0 } },
+        afterMerge: { metrics: { terminalRunCount: 1, acceptedWorkThreadCount: 1 } }
+      },
+      excludedScope: ["dag", "operator_console"]
+    });
+    expect(Object.values(report.assertions)).toEqual(expect.arrayContaining([true]));
+    expect(JSON.stringify(report)).not.toContain("fencingToken");
+  });
+
+  it("rejects a required check that is not bound to the pull request head", () => {
+    const input = evidence();
+    input.requiredCheck.headSha = "stale-head";
+
+    expect(() => buildGitHubFactoryAcceptanceReport(input)).toThrow(/required check is not bound to the PR head/u);
+  });
+
+  it("rejects a proof that changed the external planning issue state", () => {
+    const input = evidence();
+    input.source.issueState = "CLOSED";
+
+    expect(() => buildGitHubFactoryAcceptanceReport(input)).toThrow(/mutated the external planning issue state/u);
+  });
+
+  it("rejects accepted metrics that advance before provider-verified completion", () => {
+    const input = evidence();
+    input.metrics.beforeProviderEvidence = workstreamMetrics(1);
+
+    expect(() => buildGitHubFactoryAcceptanceReport(input)).toThrow(/accepted outcome did not advance 0 -> 1/u);
+  });
+
+  it("rejects a restart that changes the durable batch receipt or completion assessment", () => {
+    const changedReceipt = evidence();
+    changedReceipt.factory.batch.replayedReceipt = {
+      ...changedReceipt.factory.batch.replayedReceipt,
+      unexpected: true
+    };
+    expect(() => buildGitHubFactoryAcceptanceReport(changedReceipt)).toThrow(/restart replay changed the durable batch receipt/u);
+
+    const changedAssessment = evidence();
+    changedAssessment.completion.afterRestart.currentAssessment = {
+      ...changedAssessment.completion.afterRestart.currentAssessment as object,
+      id: "assessment_replaced_after_restart"
+    };
+    expect(() => buildGitHubFactoryAcceptanceReport(changedAssessment)).toThrow(/restart changed the durable satisfied completion assessment/u);
+  });
+
+  it("rejects a replaced or duplicated final source receipt after restart", () => {
+    const replacedReceipt = evidence();
+    replacedReceipt.sourceReceipt.afterRestart = {
+      ...replacedReceipt.sourceReceipt.afterRestart,
+      id: "201"
+    };
+    expect(() => buildGitHubFactoryAcceptanceReport(replacedReceipt)).toThrow(/restart changed or replaced the final source-thread receipt/u);
+
+    const duplicateReceipt = evidence();
+    duplicateReceipt.sourceReceipt.countAfterRestart = 2;
+    expect(() => buildGitHubFactoryAcceptanceReport(duplicateReceipt)).toThrow(/expected exactly one provider-verified source-thread receipt after restart/u);
+  });
+});

--- a/packages/dispatcher/test/github-factory-acceptance.test.ts
+++ b/packages/dispatcher/test/github-factory-acceptance.test.ts
@@ -195,7 +195,7 @@ describe("GitHub factory live acceptance report", () => {
       },
       excludedScope: ["dag", "operator_console"]
     });
-    expect(Object.values(report.assertions)).toEqual(expect.arrayContaining([true]));
+    expect(Object.values(report.assertions).every((value) => value === true)).toBe(true);
     expect(JSON.stringify(report)).not.toContain("fencingToken");
   });
 

--- a/packages/dispatcher/test/server.test.ts
+++ b/packages/dispatcher/test/server.test.ts
@@ -615,6 +615,71 @@ describe("dispatcher API", () => {
     expect(JSON.stringify(events)).not.toContain("pair_test");
   });
 
+  it("ensures one durable WorkThread from normalized external events and merges new anchors", async () => {
+    const app = createDispatcherApp({
+      databasePath: ":memory:",
+      pairingToken: "pair_test",
+      runnerToken: "runner_test"
+    });
+
+    const runnerScoped = await app.request(
+      "/v1/work-threads/ensure",
+      authorizedJsonRequest(validEvent, "runner_test")
+    );
+    expect(runnerScoped.status).toBe(401);
+    await expect(runnerScoped.json()).resolves.toMatchObject({
+      error: "unauthorized",
+      reason: "invalid_pairing_token"
+    });
+
+    const first = await app.request(
+      "/v1/work-threads/ensure",
+      authorizedJsonRequest(validEvent, "pair_test")
+    );
+    expect(first.status).toBe(201);
+    const firstBody = await first.json() as { workThread: { id: string }; created: boolean };
+    expect(firstBody).toMatchObject({
+      created: true,
+      workThread: {
+        id: expect.any(String),
+        workItemReference: { provider: "github", externalId: "acme/demo#1" }
+      }
+    });
+
+    const replay = await app.request(
+      "/v1/work-threads/ensure",
+      authorizedJsonRequest({
+        ...validEvent,
+        id: "evt_2",
+        sourceEventId: "comment_2",
+        callback: {
+          ...validEvent.callback,
+          uri: "https://api.github.com/repos/acme/demo/issues/1/comments/2",
+          threadKey: "acme/demo#1/comment-2"
+        }
+      }, "pair_test")
+    );
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      created: false,
+      workThread: {
+        id: firstBody.workThread.id,
+        secondaryAnchors: [expect.objectContaining({ externalId: "acme/demo#1/comment-2" })]
+      }
+    });
+  });
+
+  it("rejects normalized events that cannot derive a durable WorkThread", async () => {
+    const app = createDispatcherApp({ databasePath: ":memory:", pairingToken: "pair_test" });
+    const response = await app.request(
+      "/v1/work-threads/ensure",
+      authorizedJsonRequest({ ...validEvent, workItem: undefined }, "pair_test")
+    );
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({ error: "work_thread_required" });
+  });
+
   it("allows runner-operator auth to prune source delivery replay keys and audit metrics", async () => {
     const app = createDispatcherApp({ databasePath: ":memory:", pairingToken: "pair_test", runnerToken: "runner_test" });
     const body = {

--- a/scripts/dev/run-github-webhook-live-test.sh
+++ b/scripts/dev/run-github-webhook-live-test.sh
@@ -35,6 +35,10 @@ Helpful env:
                                      verifies restart-safe completion.
   OPENTAG_GH_LIVE_REQUIRED_CHECK  required commit-status context, default
                                      opentag-phase1-live
+  OPENTAG_GH_LIVE_FACTORY         true/false, default false. Routes one real
+                                     GitHub issue comment through WorkThread
+                                     ensure, recipe, workstream, and durable
+                                     batch admission before local execution.
   OPENTAG_GH_LIVE_REPORT          optional structured evidence JSON path
   OPENTAG_GH_LIVE_CLI_BIN         optional installed `opentag` executable;
                                      defaults to the source CLI through tsx
@@ -70,6 +74,7 @@ fi
 : "${OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN:=false}"
 : "${OPENTAG_GH_LIVE_STRICT_COMPLETION:=true}"
 : "${OPENTAG_GH_LIVE_REQUIRED_CHECK:=opentag-phase1-live}"
+: "${OPENTAG_GH_LIVE_FACTORY:=false}"
 
 cd "$ROOT_DIR"
 
@@ -87,6 +92,17 @@ PR_NUMBER=""
 PR_HEAD_SHA=""
 COMPLETION_PAYLOAD=""
 REPORT_PATH=""
+MENTION_URL=""
+COMMENT_ID=""
+EVENT_ID=""
+EVENT_PATH=""
+WORK_THREAD_ID=""
+RECIPE_ID=""
+WORKSTREAM_ID=""
+BATCH_ID=""
+BATCH_INPUT_DIGEST=""
+INITIAL_BATCH_RECEIPT_PATH=""
+REPLAYED_BATCH_RECEIPT_PATH=""
 
 bool_true() {
   case "${1:-}" in
@@ -174,7 +190,12 @@ if [[ "$PERMISSION" != "ADMIN" && "$PERMISSION" != "MAINTAIN" ]]; then
 fi
 GITHUB_TOKEN="$(gh auth token)"
 export GITHUB_TOKEN
-export OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN OPENTAG_GH_LIVE_STRICT_COMPLETION OPENTAG_GH_LIVE_REQUIRED_CHECK
+export OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN OPENTAG_GH_LIVE_STRICT_COMPLETION OPENTAG_GH_LIVE_REQUIRED_CHECK OPENTAG_GH_LIVE_FACTORY
+
+if bool_true "$OPENTAG_GH_LIVE_FACTORY" && ! bool_true "$OPENTAG_GH_LIVE_STRICT_COMPLETION"; then
+  echo "Factory acceptance requires OPENTAG_GH_LIVE_STRICT_COMPLETION=true." >&2
+  exit 1
+fi
 
 if bool_true "$OPENTAG_GH_LIVE_STRICT_COMPLETION"; then
   if [[ "$OPENTAG_GH_LIVE_EXECUTOR" == "echo" ]]; then
@@ -339,6 +360,27 @@ summary = {
 }
 print("Run metrics:", json.dumps(summary, sort_keys=True))
 PY
+}
+
+run_cli() {
+  if [[ -n "${OPENTAG_GH_LIVE_CLI_BIN:-}" ]]; then
+    "$OPENTAG_GH_LIVE_CLI_BIN" "$@"
+  else
+    NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../packages/cli/src/index.ts "$@"
+  fi
+}
+
+run_factory_acceptance_tool() {
+  NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/github-factory-acceptance.ts "$@"
+}
+
+capture_workstream_metrics() {
+  local output_path="$1"
+  curl -fsS \
+    -H "authorization: Bearer $OPENTAG_PAIRING_TOKEN" \
+    -o "$output_path" \
+    "http://localhost:${OPENTAG_DISPATCHER_PORT}/v1/workstreams/${WORKSTREAM_ID}/metrics"
+  chmod 600 "$output_path"
 }
 
 completion_payload() {
@@ -624,6 +666,64 @@ fi
 PUBLIC_URL="${PUBLIC_URL%/}"
 public_ingress_probe "$PUBLIC_URL"
 
+if bool_true "$OPENTAG_GH_LIVE_FACTORY"; then
+  ISSUE_URL="$(gh issue create --repo "${OWNER}/${REPO}" \
+    --title "OpenTag GitHub factory live acceptance" \
+    --body "External planning source for one recipe-driven OpenTag factory acceptance loop. OpenTag will retain governance authority without creating an internal DAG or operator console.")"
+  ISSUE_NUMBER="${ISSUE_URL##*/}"
+  echo "Created external planning issue: $ISSUE_URL"
+
+  MENTION_BODY="@opentag run ${OPENTAG_GH_LIVE_COMMAND}"
+  echo "Posting the external source-thread request before installing the temporary OpenTag webhook..."
+  MENTION_URL="$(gh issue comment "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --body "$MENTION_BODY")"
+  COMMENT_ID="${MENTION_URL##*issuecomment-}"
+  if [[ -z "$COMMENT_ID" || "$COMMENT_ID" == "$MENTION_URL" ]]; then
+    echo "Could not derive the GitHub comment id from: $MENTION_URL" >&2
+    exit 1
+  fi
+  echo "Source mention: $MENTION_URL"
+
+  SOURCE_COMMENT_PATH="$TMP_ROOT/source-comment.json"
+  SOURCE_EVENT_INPUT_PATH="$TMP_ROOT/source-event-input.json"
+  EVENT_PATH="$TMP_ROOT/source-event.json"
+  gh api "repos/${OWNER}/${REPO}/issues/comments/${COMMENT_ID}" >"$SOURCE_COMMENT_PATH"
+  REPOSITORY_PRIVATE="$(gh api "repos/${OWNER}/${REPO}" --jq '.private')"
+  python3 - "$SOURCE_COMMENT_PATH" "$SOURCE_EVENT_INPUT_PATH" "$ISSUE_URL" "$ISSUE_NUMBER" "$OWNER" "$REPO" "$REPOSITORY_PRIVATE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+comment_path, output_path, issue_url, issue_number, owner, repo, private = sys.argv[1:]
+comment = json.loads(Path(comment_path).read_text(encoding="utf-8"))
+payload = {
+    "id": str(comment["id"]),
+    "commentBody": comment["body"],
+    "commentUrl": comment["html_url"],
+    "apiCommentsUrl": f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/comments",
+    "issueUrl": issue_url,
+    "issueNumber": int(issue_number),
+    "owner": owner,
+    "repo": repo,
+    "actorId": int(comment["user"]["id"]),
+    "actorLogin": comment["user"]["login"],
+    "authorAssociation": comment.get("author_association"),
+    "actorWriteAccess": True,
+    "private": private.lower() == "true",
+    "receivedAt": comment["created_at"],
+}
+Path(output_path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+Path(output_path).chmod(0o600)
+PY
+  run_factory_acceptance_tool event "$SOURCE_EVENT_INPUT_PATH" "$EVENT_PATH"
+  EVENT_ID="$(python3 - "$EVENT_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+print(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["id"])
+PY
+)"
+fi
+
 echo "Creating temporary GitHub repository webhook for ${OWNER}/${REPO}"
 HOOK_ID="$(
   python3 - <<PY | gh api "repos/${OWNER}/${REPO}/hooks" --method POST --input - --jq '.id'
@@ -643,36 +743,136 @@ PY
 )"
 echo "Temporary webhook id: $HOOK_ID"
 
-ISSUE_URL="$(gh issue create --repo "${OWNER}/${REPO}" \
-  --title "OpenTag GitHub webhook live test" \
-  --body "Temporary issue for validating OpenTag repository webhook -> local agent -> GitHub source-thread action receipts.")"
-ISSUE_NUMBER="${ISSUE_URL##*/}"
-echo "Created issue: $ISSUE_URL"
-
-WAIT_STARTED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-MENTION_BODY="@opentag run ${OPENTAG_GH_LIVE_COMMAND}"
-echo "Posting mention comment through GitHub..."
-MENTION_URL="$(gh issue comment "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --body "$MENTION_BODY")"
-echo "Mention comment: $MENTION_URL"
-
 RUN_ID=""
-ISSUE_SQL="$(sql_escape "$ISSUE_NUMBER")"
-STARTED_SQL="$(sql_escape "$WAIT_STARTED_AT")"
-deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
-while (( SECONDS < deadline )); do
-  RUN_ID="$(
-    sqlite_one "select id from runs where json_extract(event_json, '$.source') = 'github' and json_extract(event_json, '$.metadata.issueNumber') = $ISSUE_SQL and created_at >= '$STARTED_SQL' order by created_at desc limit 1;"
-  )"
-  if [[ -n "$RUN_ID" ]]; then
-    break
+if bool_true "$OPENTAG_GH_LIVE_FACTORY"; then
+  WORK_THREAD_RESPONSE_PATH="$TMP_ROOT/work-thread.json"
+  RECIPE_INPUT_PATH="$TMP_ROOT/recipe-input.json"
+  RECIPE_RESPONSE_PATH="$TMP_ROOT/recipe.json"
+  WORKSTREAM_INPUT_PATH="$TMP_ROOT/workstream-input.json"
+  WORKSTREAM_RESPONSE_PATH="$TMP_ROOT/workstream.json"
+  BATCH_INPUT_PATH="$TMP_ROOT/batch-input.json"
+  INITIAL_BATCH_RECEIPT_PATH="$TMP_ROOT/batch-initial.json"
+  RECIPE_ID="recipe_github_live_${COMMENT_ID}"
+  WORKSTREAM_ID="workstream_github_live_${COMMENT_ID}"
+  BATCH_ID="batch_github_live_${COMMENT_ID}"
+  RUN_ID="run_github_live_${COMMENT_ID}"
+
+  run_cli factory work-thread ensure --config "$CONFIG_PATH" --input "$EVENT_PATH" --json >"$WORK_THREAD_RESPONSE_PATH"
+  WORK_THREAD_ID="$(python3 - "$WORK_THREAD_RESPONSE_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+print(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["workThread"]["id"])
+PY
+)"
+
+  python3 - \
+    "$EVENT_PATH" "$RECIPE_INPUT_PATH" "$WORKSTREAM_INPUT_PATH" "$BATCH_INPUT_PATH" \
+    "$RECIPE_ID" "$WORKSTREAM_ID" "$BATCH_ID" "$RUN_ID" "$WORK_THREAD_ID" "$COMMENT_ID" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+(
+    event_path,
+    recipe_path,
+    workstream_path,
+    batch_path,
+    recipe_id,
+    workstream_id,
+    batch_id,
+    run_id,
+    work_thread_id,
+    comment_id,
+) = sys.argv[1:]
+event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+documents = {
+    recipe_path: {
+        "id": recipe_id,
+        "version": 1,
+        "name": "GitHub provider-live factory acceptance",
+        "budgets": {
+            "maxConcurrentRuns": 1,
+            "maxAttemptsPerRun": 3,
+            "maxCostUnits": 3,
+            "costUnitsPerAttempt": 1,
+            "allowedLocalities": ["local"],
+        },
+    },
+    workstream_path: {
+        "id": workstream_id,
+        "recipeId": recipe_id,
+        "recipeVersion": 1,
+        "name": "GitHub source thread factory acceptance",
+        "members": [{"kind": "work_thread", "workThreadId": work_thread_id}],
+    },
+    batch_path: {
+        "id": batch_id,
+        "workstreamId": workstream_id,
+        "items": [{
+            "itemId": f"item_github_live_{comment_id}",
+            "runId": run_id,
+            "workThreadId": work_thread_id,
+            "event": event,
+        }],
+    },
+}
+for path, document in documents.items():
+    target = Path(path)
+    target.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    target.chmod(0o600)
+PY
+
+  run_cli factory recipe create --config "$CONFIG_PATH" --input "$RECIPE_INPUT_PATH" --json >"$RECIPE_RESPONSE_PATH"
+  run_cli factory workstream create --config "$CONFIG_PATH" --input "$WORKSTREAM_INPUT_PATH" --json >"$WORKSTREAM_RESPONSE_PATH"
+  run_cli factory batch submit --config "$CONFIG_PATH" --input "$BATCH_INPUT_PATH" --json >"$INITIAL_BATCH_RECEIPT_PATH"
+  BATCH_INPUT_DIGEST="$(python3 - "$INITIAL_BATCH_RECEIPT_PATH" "$RUN_ID" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+receipt = payload["receipt"]
+result = receipt.get("result", {})
+items = result.get("results", [])
+if receipt.get("status") != "completed" or len(items) != 1:
+    raise SystemExit("Factory admission did not produce one completed result.")
+if items[0].get("status") != "created" or items[0].get("admittedRunId") != sys.argv[2]:
+    raise SystemExit(f"Factory admission did not create the intended Run: {items[0]}")
+print(receipt["batch"]["contentDigest"])
+PY
+)"
+  echo "Factory batch $BATCH_ID admitted attributed Run $RUN_ID for WorkThread $WORK_THREAD_ID."
+else
+  ISSUE_URL="$(gh issue create --repo "${OWNER}/${REPO}" \
+    --title "OpenTag GitHub webhook live test" \
+    --body "Temporary issue for validating OpenTag repository webhook -> local agent -> GitHub source-thread action receipts.")"
+  ISSUE_NUMBER="${ISSUE_URL##*/}"
+  echo "Created issue: $ISSUE_URL"
+
+  WAIT_STARTED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  MENTION_BODY="@opentag run ${OPENTAG_GH_LIVE_COMMAND}"
+  echo "Posting mention comment through GitHub..."
+  MENTION_URL="$(gh issue comment "$ISSUE_NUMBER" --repo "${OWNER}/${REPO}" --body "$MENTION_BODY")"
+  echo "Mention comment: $MENTION_URL"
+
+  ISSUE_SQL="$(sql_escape "$ISSUE_NUMBER")"
+  STARTED_SQL="$(sql_escape "$WAIT_STARTED_AT")"
+  deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    RUN_ID="$(
+      sqlite_one "select id from runs where json_extract(event_json, '$.source') = 'github' and json_extract(event_json, '$.metadata.issueNumber') = $ISSUE_SQL and created_at >= '$STARTED_SQL' order by created_at desc limit 1;"
+    )"
+    if [[ -n "$RUN_ID" ]]; then
+      break
+    fi
+    sleep 2
+  done
+  if [[ -z "$RUN_ID" ]]; then
+    echo "Timed out waiting for GitHub webhook-created run." >&2
+    exit 1
   fi
-  sleep 2
-done
-if [[ -z "$RUN_ID" ]]; then
-  echo "Timed out waiting for GitHub webhook-created run." >&2
-  exit 1
+  echo "Detected GitHub webhook-created run: $RUN_ID"
 fi
-echo "Detected GitHub webhook-created run: $RUN_ID"
 
 last_status=""
 deadline=$((SECONDS + OPENTAG_GH_LIVE_TIMEOUT_SECONDS))
@@ -696,6 +896,10 @@ if [[ "$status" != "succeeded" ]]; then
   exit 1
 fi
 print_metrics "$RUN_ID"
+if bool_true "$OPENTAG_GH_LIVE_FACTORY"; then
+  METRICS_BEFORE_PROVIDER_PATH="$TMP_ROOT/workstream-metrics-before-provider.json"
+  capture_workstream_metrics "$METRICS_BEFORE_PROVIDER_PATH"
+fi
 
 if bool_true "$OPENTAG_GH_LIVE_STRICT_COMPLETION"; then
   echo "Verifying executor success does not satisfy completion before provider evidence is complete..."
@@ -737,8 +941,11 @@ PY
     --method POST \
     -f state=success \
     -f context="$OPENTAG_GH_LIVE_REQUIRED_CHECK" \
-    -f description="OpenTag Phase 1 live completion acceptance" \
+    -f description="OpenTag provider-live completion acceptance" \
     -f target_url="$PR_URL" >/dev/null
+
+  REQUIRED_CHECKS_PATH="$TMP_ROOT/required-checks.json"
+  gh api "repos/${OWNER}/${REPO}/commits/${PR_HEAD_SHA}/status" >"$REQUIRED_CHECKS_PATH"
 
   wait_for_completion "$RUN_ID" "pending,unsatisfied" "required_checks" "passed"
   CHECKED_COMPLETION_PATH="$TMP_ROOT/completion-after-check.json"
@@ -756,6 +963,14 @@ PY
     >"$PR_INFO_PATH"
   wait_for_issue_comment "provider-verified completion requirements are satisfied"
   RECEIPTS_BEFORE_RESTART="$(completion_receipt_count)"
+  SOURCE_COMMENTS_PATH="$TMP_ROOT/source-comments-before-restart.json"
+  SOURCE_ISSUE_PATH="$TMP_ROOT/source-issue-after-completion.json"
+  gh api "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" >"$SOURCE_COMMENTS_PATH"
+  gh api "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}" >"$SOURCE_ISSUE_PATH"
+  if bool_true "$OPENTAG_GH_LIVE_FACTORY"; then
+    METRICS_AFTER_MERGE_PATH="$TMP_ROOT/workstream-metrics-after-merge.json"
+    capture_workstream_metrics "$METRICS_AFTER_MERGE_PATH"
+  fi
 
   echo "Restarting the CLI stack to verify durable satisfied completion and callback deduplication..."
   stop_cli_stack
@@ -777,17 +992,200 @@ PY
     echo "Restart emitted a duplicate provider-verified completion receipt ($RECEIPTS_BEFORE_RESTART -> $RECEIPTS_AFTER_RESTART)." >&2
     exit 1
   fi
+  SOURCE_COMMENTS_AFTER_RESTART_PATH="$TMP_ROOT/source-comments-after-restart.json"
+  gh api "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" >"$SOURCE_COMMENTS_AFTER_RESTART_PATH"
+  if bool_true "$OPENTAG_GH_LIVE_FACTORY"; then
+    METRICS_AFTER_RESTART_PATH="$TMP_ROOT/workstream-metrics-after-restart.json"
+    REPLAYED_BATCH_RECEIPT_PATH="$TMP_ROOT/batch-after-restart.json"
+    capture_workstream_metrics "$METRICS_AFTER_RESTART_PATH"
+    run_cli factory batch submit --config "$CONFIG_PATH" --input "$BATCH_INPUT_PATH" --json >"$REPLAYED_BATCH_RECEIPT_PATH"
+  fi
 
-  REPORT_PATH="${OPENTAG_GH_LIVE_REPORT:-$ROOT_DIR/.omx/live-e2e/github-completion-governance-$(date -u +%Y%m%dT%H%M%SZ).json}"
+  if bool_true "$OPENTAG_GH_LIVE_FACTORY"; then
+    REPORT_PATH="${OPENTAG_GH_LIVE_REPORT:-$ROOT_DIR/.omx/live-e2e/github-factory-live-$(date -u +%Y%m%dT%H%M%SZ).json}"
+  else
+    REPORT_PATH="${OPENTAG_GH_LIVE_REPORT:-$ROOT_DIR/.omx/live-e2e/github-completion-governance-$(date -u +%Y%m%dT%H%M%SZ).json}"
+  fi
+  if [[ "$REPORT_PATH" != /* ]]; then
+    REPORT_PATH="$ROOT_DIR/$REPORT_PATH"
+  fi
   mkdir -p "$(dirname "$REPORT_PATH")"
   ASSESSMENT_COUNT="$(sqlite_one "select count(*) from completion_assessments where work_thread_id = (select work_thread_id from runs where id = '$(sql_escape "$RUN_ID")');")"
   RUNTIME_SOURCE="source_checkout"
   if [[ -n "${OPENTAG_GH_LIVE_CLI_BIN:-}" ]]; then
     RUNTIME_SOURCE="registry_install"
   fi
-  python3 - \
-    "$REPORT_PATH" "$INITIAL_COMPLETION_PATH" "$CHECKED_COMPLETION_PATH" "$FINAL_COMPLETION_PATH" "$RESTARTED_COMPLETION_PATH" "$PR_INFO_PATH" \
-    "$OWNER/$REPO" "$ISSUE_URL" "$RUN_ID" "$OPENTAG_GH_LIVE_REQUIRED_CHECK" "$ASSESSMENT_COUNT" "$RECEIPTS_AFTER_RESTART" "$RUNTIME_SOURCE" <<'PY'
+  if bool_true "$OPENTAG_GH_LIVE_FACTORY"; then
+    RUN_EVIDENCE_PATH="$TMP_ROOT/run-evidence.json"
+    ATTEMPT_EVIDENCE_PATH="$TMP_ROOT/attempt-evidence.json"
+    EVIDENCE_INPUT_PATH="$TMP_ROOT/github-factory-evidence.json"
+    sqlite3 -json -cmd ".timeout 5000" "$DATABASE_PATH" \
+      "select id, status, work_thread_id as workThreadId, workstream_id as workstreamId, admission_batch_id as admissionBatchId, context_packet_json is not null as contextPacketCaptured, access_profile_snapshot_json is not null as accessProfileCaptured, policy_snapshot_provenance_json is not null as policyProvenanceCaptured from runs where id = '$(sql_escape "$RUN_ID")';" \
+      >"$RUN_EVIDENCE_PATH"
+    sqlite3 -json -cmd ".timeout 5000" "$DATABASE_PATH" \
+      "select a.id, a.runner_id as runnerId, coalesce(a.selected_executor_id, r.executor) as executorId, a.runner_locality as locality, a.status, length(a.fencing_token) > 0 as hasFencingToken from attempts a join runs r on r.id = a.run_id where a.run_id = '$(sql_escape "$RUN_ID")' order by a.number desc limit 1;" \
+      >"$ATTEMPT_EVIDENCE_PATH"
+    python3 - \
+      "$EVIDENCE_INPUT_PATH" "$INITIAL_COMPLETION_PATH" "$CHECKED_COMPLETION_PATH" "$FINAL_COMPLETION_PATH" "$RESTARTED_COMPLETION_PATH" \
+      "$PR_INFO_PATH" "$REQUIRED_CHECKS_PATH" "$RECIPE_RESPONSE_PATH" "$WORKSTREAM_RESPONSE_PATH" \
+      "$INITIAL_BATCH_RECEIPT_PATH" "$REPLAYED_BATCH_RECEIPT_PATH" "$RUN_EVIDENCE_PATH" "$ATTEMPT_EVIDENCE_PATH" \
+      "$METRICS_BEFORE_PROVIDER_PATH" "$METRICS_AFTER_MERGE_PATH" "$METRICS_AFTER_RESTART_PATH" "$SOURCE_COMMENTS_PATH" "$SOURCE_COMMENTS_AFTER_RESTART_PATH" "$SOURCE_ISSUE_PATH" \
+      "$OWNER/$REPO" "$ISSUE_URL" "$MENTION_URL" "$ISSUE_NUMBER" "$COMMENT_ID" "$EVENT_ID" "$WORK_THREAD_ID" \
+      "$RECIPE_ID" "$WORKSTREAM_ID" "$BATCH_ID" "$BATCH_INPUT_DIGEST" "$ASSESSMENT_COUNT" \
+      "$RECEIPTS_BEFORE_RESTART" "$RECEIPTS_AFTER_RESTART" "$RUNTIME_SOURCE" "$OPENTAG_GH_LIVE_REQUIRED_CHECK" <<'PY'
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+(
+    evidence_path,
+    initial_path,
+    checked_path,
+    final_path,
+    restarted_path,
+    pr_path,
+    required_checks_path,
+    recipe_path,
+    workstream_path,
+    initial_batch_path,
+    replayed_batch_path,
+    run_path,
+    attempt_path,
+    metrics_before_path,
+    metrics_merged_path,
+    metrics_restarted_path,
+    comments_before_restart_path,
+    comments_after_restart_path,
+    source_issue_path,
+    repository,
+    issue_url,
+    mention_url,
+    issue_number,
+    comment_id,
+    event_id,
+    work_thread_id,
+    recipe_id,
+    workstream_id,
+    batch_id,
+    batch_input_digest,
+    assessment_count,
+    receipts_before_restart,
+    receipts_after_restart,
+    runtime_source,
+    required_check_context,
+) = sys.argv[1:]
+
+def read(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+run_rows = read(run_path)
+attempt_rows = read(attempt_path)
+if len(run_rows) != 1 or len(attempt_rows) != 1:
+    raise SystemExit("Factory acceptance requires exactly one durable Run and latest Attempt.")
+run = run_rows[0]
+run["contextPacketCaptured"] = bool(run["contextPacketCaptured"])
+run["accessProfileCaptured"] = bool(run["accessProfileCaptured"])
+run["policyProvenanceCaptured"] = bool(run["policyProvenanceCaptured"])
+attempt = attempt_rows[0]
+attempt["hasFencingToken"] = bool(attempt["hasFencingToken"])
+
+combined_status = read(required_checks_path)
+statuses = [item for item in combined_status.get("statuses", []) if item.get("context") == required_check_context]
+if len(statuses) != 1:
+    raise SystemExit(f"Expected exactly one retained required status for {required_check_context}; observed {len(statuses)}.")
+required_check = statuses[0]
+required_check_head = combined_status.get("sha")
+
+phrase = "provider-verified completion requirements are satisfied"
+
+def receipt_observation(path, expected_count, phase):
+    receipts = [comment for comment in read(path) if phrase in (comment.get("body") or "")]
+    if len(receipts) != int(expected_count):
+        raise SystemExit(f"Retained source comments {phase} do not match the observed completion receipt count.")
+    if not receipts:
+        raise SystemExit(f"No provider-verified source-thread completion receipt was retained {phase}.")
+    receipt = receipts[-1]
+    body = receipt["body"]
+    return {
+        "id": str(receipt["id"]),
+        "url": receipt["html_url"],
+        "bodyDigest": f"sha256:{hashlib.sha256(body.encode('utf-8')).hexdigest()}",
+    }
+
+receipt_before_restart = receipt_observation(
+    comments_before_restart_path, receipts_before_restart, "before restart"
+)
+receipt_after_restart = receipt_observation(
+    comments_after_restart_path, receipts_after_restart, "after restart"
+)
+
+recipe = read(recipe_path)["recipe"]
+workstream = read(workstream_path)["workstream"]
+source_issue = read(source_issue_path)
+evidence = {
+    "recordedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "repository": repository,
+    "runtimeSource": runtime_source,
+    "source": {
+        "issueUrl": issue_url,
+        "mentionUrl": mention_url,
+        "issueNumber": int(issue_number),
+        "issueState": source_issue["state"].upper(),
+        "commentId": comment_id,
+        "eventId": event_id,
+    },
+    "factory": {
+        "workThreadId": work_thread_id,
+        "recipe": {"id": recipe_id, "version": 1, "contentDigest": recipe["contentDigest"]},
+        "workstream": {"id": workstream_id, "contentDigest": workstream["contentDigest"]},
+        "batch": {
+            "id": batch_id,
+            "inputDigest": batch_input_digest,
+            "initialReceipt": read(initial_batch_path),
+            "replayedReceipt": read(replayed_batch_path),
+        },
+    },
+    "run": run,
+    "attempt": attempt,
+    "pullRequest": read(pr_path),
+    "requiredCheck": {
+        "context": required_check["context"],
+        "headSha": required_check_head,
+        "state": required_check["state"],
+        **({"targetUrl": required_check["target_url"]} if required_check.get("target_url") else {}),
+    },
+    "completion": {
+        "afterExecutorSuccess": read(initial_path)["completion"],
+        "afterRequiredCheck": read(checked_path)["completion"],
+        "afterMerge": read(final_path)["completion"],
+        "afterRestart": read(restarted_path)["completion"],
+    },
+    "metrics": {
+        "beforeProviderEvidence": read(metrics_before_path),
+        "afterMerge": read(metrics_merged_path),
+        "afterRestart": read(metrics_restarted_path),
+    },
+    "assessmentCount": int(assessment_count),
+    "sourceReceipt": {
+        "matchedPhrase": phrase,
+        "beforeRestart": receipt_before_restart,
+        "afterRestart": receipt_after_restart,
+        "countBeforeRestart": int(receipts_before_restart),
+        "countAfterRestart": int(receipts_after_restart),
+    },
+}
+target = Path(evidence_path)
+target.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+target.chmod(0o600)
+PY
+    run_factory_acceptance_tool report "$EVIDENCE_INPUT_PATH" "$REPORT_PATH"
+    echo "Structured GitHub factory acceptance evidence: $REPORT_PATH"
+  else
+    python3 - \
+      "$REPORT_PATH" "$INITIAL_COMPLETION_PATH" "$CHECKED_COMPLETION_PATH" "$FINAL_COMPLETION_PATH" "$RESTARTED_COMPLETION_PATH" "$PR_INFO_PATH" \
+      "$OWNER/$REPO" "$ISSUE_URL" "$RUN_ID" "$OPENTAG_GH_LIVE_REQUIRED_CHECK" "$ASSESSMENT_COUNT" "$RECEIPTS_AFTER_RESTART" "$RUNTIME_SOURCE" <<'PY'
 import json
 import sys
 from datetime import datetime, timezone
@@ -830,18 +1228,12 @@ report = {
     },
     "assessmentCount": int(assessment_count),
     "providerVerifiedReceiptCount": int(receipt_count),
-    "assertions": {
-        "executorSuccessDidNotSatisfyCompletion": True,
-        "requiredCheckBoundToCurrentHead": True,
-        "requiredCheckDidNotBypassMerge": True,
-        "mergeSatisfiedContract": True,
-        "restartPreservedSatisfiedAssessment": True,
-        "restartDidNotDuplicateFinalReceipt": True,
-    },
 }
 Path(report_path).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+Path(report_path).chmod(0o600)
 PY
-  echo "Structured Phase 1 live evidence: $REPORT_PATH"
+    echo "Structured completion-governance evidence: $REPORT_PATH"
+  fi
 else
 echo "Recent issue comments after final receipt:"
 gh api "repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/comments?sort=created&direction=desc&per_page=4" \

--- a/scripts/test/github-factory-acceptance.ts
+++ b/scripts/test/github-factory-acceptance.ts
@@ -1,0 +1,350 @@
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+import { OpenTagEventSchema, type OpenTagEvent } from "../../packages/core/src/index.js";
+import { normalizeGitHubIssueComment, type GitHubIssueCommentInput } from "../../packages/github/src/index.js";
+
+type JsonObject = Record<string, unknown>;
+
+export type GitHubFactoryAcceptanceEvidence = {
+  recordedAt: string;
+  repository: string;
+  runtimeSource: "source_checkout" | "registry_install";
+  source: {
+    issueUrl: string;
+    mentionUrl: string;
+    issueNumber: number;
+    issueState: string;
+    commentId: string;
+    eventId: string;
+  };
+  factory: {
+    workThreadId: string;
+    recipe: { id: string; version: number; contentDigest: string };
+    workstream: { id: string; contentDigest: string };
+    batch: {
+      id: string;
+      inputDigest: string;
+      initialReceipt: JsonObject;
+      replayedReceipt: JsonObject;
+    };
+  };
+  run: {
+    id: string;
+    status: string;
+    workThreadId: string;
+    workstreamId: string;
+    admissionBatchId: string;
+    contextPacketCaptured: boolean;
+    accessProfileCaptured: boolean;
+    policyProvenanceCaptured: boolean;
+  };
+  attempt: {
+    id: string;
+    runnerId: string;
+    executorId: string;
+    locality: string;
+    status: string;
+    hasFencingToken: boolean;
+  };
+  pullRequest: {
+    number: number;
+    state: string;
+    url: string;
+    headRefOid: string;
+    mergedAt?: string;
+    mergeCommit?: { oid?: string } | null;
+  };
+  requiredCheck: {
+    context: string;
+    headSha: string;
+    state: string;
+    targetUrl?: string;
+  };
+  completion: {
+    afterExecutorSuccess: JsonObject;
+    afterRequiredCheck: JsonObject;
+    afterMerge: JsonObject;
+    afterRestart: JsonObject;
+  };
+  metrics: {
+    beforeProviderEvidence: JsonObject;
+    afterMerge: JsonObject;
+    afterRestart: JsonObject;
+  };
+  assessmentCount: number;
+  sourceReceipt: {
+    matchedPhrase: string;
+    beforeRestart: {
+      id: string;
+      url: string;
+      bodyDigest: string;
+    };
+    afterRestart: {
+      id: string;
+      url: string;
+      bodyDigest: string;
+    };
+    countBeforeRestart: number;
+    countAfterRestart: number;
+  };
+};
+
+export type GitHubFactoryAcceptanceReport = Omit<
+  GitHubFactoryAcceptanceEvidence,
+  "factory" | "completion" | "metrics"
+> & {
+  schemaVersion: 1;
+  case: "github-factory-live";
+  factory: Omit<GitHubFactoryAcceptanceEvidence["factory"], "batch"> & {
+    batch: Omit<GitHubFactoryAcceptanceEvidence["factory"]["batch"], "initialReceipt" | "replayedReceipt"> & {
+      status: string;
+      admittedRunId: string;
+      restartReplayMatched: true;
+    };
+  };
+  completion: GitHubFactoryAcceptanceEvidence["completion"];
+  metrics: GitHubFactoryAcceptanceEvidence["metrics"];
+  assertions: {
+    externalPlanningSystemRemainedAuthoritative: true;
+    factoryBatchCreatedAttributedRun: true;
+    localFencedAttemptCompleted: true;
+    executorSuccessDidNotSatisfyCompletion: true;
+    requiredCheckBoundToCurrentHead: true;
+    requiredCheckDidNotBypassMerge: true;
+    providerVerifiedMergeSatisfiedContract: true;
+    acceptedOutcomeAdvancedAuthoritatively: true;
+    restartPreservedSatisfiedAssessment: true;
+    restartPreservedWorkstreamMetrics: true;
+    restartReplayedExactBatchReceipt: true;
+    restartDidNotDuplicateFinalReceipt: true;
+  };
+  excludedScope: ["dag", "operator_console"];
+};
+
+function object(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as JsonObject;
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string.`);
+  return value;
+}
+
+function number(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a finite number.`);
+  return value;
+}
+
+function completionState(snapshot: JsonObject): string {
+  return string(snapshot["completion"], "completion state");
+}
+
+function currentAssessment(snapshot: JsonObject): JsonObject {
+  const assessment = object(snapshot["currentAssessment"], "current completion assessment");
+  string(assessment["id"], "current completion assessment id");
+  string(assessment["inputDigest"], "current completion assessment input digest");
+  string(assessment["state"], "current completion assessment state");
+  if (!Array.isArray(assessment["targetBindings"])) {
+    throw new Error("current completion assessment targetBindings must be an array.");
+  }
+  if (!Array.isArray(assessment["gateResults"])) {
+    throw new Error("current completion assessment gateResults must be an array.");
+  }
+  return assessment;
+}
+
+function gateState(snapshot: JsonObject, gateId: string): string | undefined {
+  const assessment = currentAssessment(snapshot);
+  const results = assessment["gateResults"];
+  if (!Array.isArray(results)) throw new Error("current completion assessment gateResults must be an array.");
+  for (const value of results) {
+    const gate = object(value, "completion gate result");
+    if (gate["gateId"] === gateId) return string(gate["state"], `${gateId} gate state`);
+  }
+  return undefined;
+}
+
+function receiptBody(receipt: JsonObject): JsonObject {
+  return object(receipt["receipt"] ?? receipt, "batch receipt");
+}
+
+function receiptAdmission(receipt: JsonObject): { status: string; admittedRunId: string; inputDigest: string } {
+  const body = receiptBody(receipt);
+  const batch = object(body["batch"], "batch receipt batch");
+  const result = object(body["result"], "batch receipt result");
+  const results = result["results"];
+  if (!Array.isArray(results) || results.length !== 1) {
+    throw new Error("GitHub factory acceptance requires exactly one batch result.");
+  }
+  const item = object(results[0], "batch admission result");
+  return {
+    status: string(item["status"], "batch admission status"),
+    admittedRunId: string(item["admittedRunId"], "batch admitted run id"),
+    inputDigest: string(batch["contentDigest"], "batch input digest")
+  };
+}
+
+function metrics(snapshot: JsonObject): JsonObject {
+  return object(snapshot["metrics"] ?? snapshot, "workstream metrics");
+}
+
+function metric(snapshot: JsonObject, field: string): number {
+  return number(metrics(snapshot)[field], `workstream metric ${field}`);
+}
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`GitHub factory acceptance failed: ${message}`);
+}
+
+export function normalizeGitHubFactorySourceEvent(input: GitHubIssueCommentInput): OpenTagEvent {
+  const event = normalizeGitHubIssueComment(input);
+  if (!event) throw new Error("GitHub factory source comment does not contain a valid @opentag command.");
+  return OpenTagEventSchema.parse(event);
+}
+
+export function buildGitHubFactoryAcceptanceReport(
+  evidence: GitHubFactoryAcceptanceEvidence
+): GitHubFactoryAcceptanceReport {
+  const admission = receiptAdmission(evidence.factory.batch.initialReceipt);
+  const replayAdmission = receiptAdmission(evidence.factory.batch.replayedReceipt);
+  const initialCompletion = completionState(evidence.completion.afterExecutorSuccess);
+  const checkedCompletion = completionState(evidence.completion.afterRequiredCheck);
+  const mergedCompletion = completionState(evidence.completion.afterMerge);
+  const restartedCompletion = completionState(evidence.completion.afterRestart);
+  const mergedAssessment = currentAssessment(evidence.completion.afterMerge);
+  const restartedAssessment = currentAssessment(evidence.completion.afterRestart);
+  const beforeTerminal = metric(evidence.metrics.beforeProviderEvidence, "terminalRunCount");
+  const beforeAccepted = metric(evidence.metrics.beforeProviderEvidence, "acceptedWorkThreadCount");
+  const mergedTerminal = metric(evidence.metrics.afterMerge, "terminalRunCount");
+  const mergedAccepted = metric(evidence.metrics.afterMerge, "acceptedWorkThreadCount");
+  const restartedTerminal = metric(evidence.metrics.afterRestart, "terminalRunCount");
+  const restartedAccepted = metric(evidence.metrics.afterRestart, "acceptedWorkThreadCount");
+
+  invariant(evidence.source.issueUrl.includes("github.com/"), "source work item is not a GitHub issue URL");
+  invariant(evidence.source.mentionUrl.includes("#issuecomment-"), "source mention is not a GitHub issue comment");
+  invariant(evidence.source.issueState.toUpperCase() === "OPEN", "factory acceptance mutated the external planning issue state");
+  invariant(evidence.source.commentId.length > 0 && evidence.source.eventId.length > 0, "source identities are missing");
+  invariant(evidence.factory.workThreadId === evidence.run.workThreadId, "Run is not attached to the factory WorkThread");
+  invariant(evidence.factory.workstream.id === evidence.run.workstreamId, "Run is not attributed to the workstream");
+  invariant(evidence.factory.batch.id === evidence.run.admissionBatchId, "Run is not attributed to the admission batch");
+  invariant(admission.status === "created", `batch admission status is ${admission.status}, expected created`);
+  invariant(admission.admittedRunId === evidence.run.id, "batch receipt does not identify the admitted Run");
+  invariant(admission.inputDigest === evidence.factory.batch.inputDigest, "batch receipt digest is not the retained input digest");
+  invariant(replayAdmission.admittedRunId === evidence.run.id, "replayed batch receipt points at a different Run");
+  invariant(isDeepStrictEqual(evidence.factory.batch.initialReceipt, evidence.factory.batch.replayedReceipt), "restart replay changed the durable batch receipt");
+  invariant(evidence.run.status === "succeeded", `Run status is ${evidence.run.status}, expected succeeded`);
+  invariant(evidence.run.contextPacketCaptured, "Run has no captured Context Packet");
+  invariant(evidence.run.accessProfileCaptured, "Run has no captured access-profile snapshot");
+  invariant(evidence.run.policyProvenanceCaptured, "Run has no captured policy provenance");
+  invariant(evidence.attempt.locality === "local", `Attempt locality is ${evidence.attempt.locality}, expected local`);
+  invariant(evidence.attempt.status === "succeeded", `Attempt status is ${evidence.attempt.status}, expected succeeded`);
+  invariant(evidence.attempt.hasFencingToken, "Attempt has no durable fencing token");
+  invariant(evidence.attempt.runnerId.length > 0 && evidence.attempt.executorId.length > 0, "Attempt attribution is incomplete");
+  invariant(initialCompletion !== "satisfied", "executor success satisfied completion before provider evidence");
+  invariant(checkedCompletion !== "satisfied", "required check bypassed the merge gate");
+  invariant(gateState(evidence.completion.afterRequiredCheck, "required_checks") === "passed", "required-check gate did not pass");
+  invariant(evidence.requiredCheck.headSha === evidence.pullRequest.headRefOid, "required check is not bound to the PR head");
+  invariant(evidence.requiredCheck.state === "success", `required check state is ${evidence.requiredCheck.state}`);
+  invariant(evidence.pullRequest.state.toUpperCase() === "MERGED" && Boolean(evidence.pullRequest.mergedAt), "pull request is not provider-verified merged");
+  invariant(mergedCompletion === "satisfied", "merge did not satisfy completion");
+  invariant(gateState(evidence.completion.afterMerge, "merge") === "passed", "merge gate did not pass");
+  invariant(restartedCompletion === "satisfied", "restart lost the satisfied completion state");
+  invariant(
+    isDeepStrictEqual(mergedAssessment, restartedAssessment),
+    "restart changed the durable satisfied completion assessment"
+  );
+  invariant(evidence.assessmentCount > 0, "no durable CompletionAssessment was recorded");
+  invariant(beforeTerminal === 1 && mergedTerminal === 1 && restartedTerminal === 1, "terminal Run authority changed across provider evidence or restart");
+  invariant(beforeAccepted === 0 && mergedAccepted === 1 && restartedAccepted === 1, "accepted outcome did not advance 0 -> 1 and remain authoritative");
+  invariant(isDeepStrictEqual(evidence.metrics.afterMerge, evidence.metrics.afterRestart), "restart changed authoritative workstream metrics");
+  invariant(evidence.sourceReceipt.matchedPhrase.length > 0, "source-thread completion receipt was not observed");
+  invariant(evidence.sourceReceipt.beforeRestart.bodyDigest.startsWith("sha256:"), "source-thread receipt digest is missing before restart");
+  invariant(evidence.sourceReceipt.afterRestart.bodyDigest.startsWith("sha256:"), "source-thread receipt digest is missing after restart");
+  invariant(evidence.sourceReceipt.countBeforeRestart === 1, "expected exactly one provider-verified source-thread receipt before restart");
+  invariant(evidence.sourceReceipt.countAfterRestart === 1, "expected exactly one provider-verified source-thread receipt after restart");
+  invariant(
+    isDeepStrictEqual(evidence.sourceReceipt.beforeRestart, evidence.sourceReceipt.afterRestart),
+    "restart changed or replaced the final source-thread receipt"
+  );
+
+  return {
+    schemaVersion: 1,
+    case: "github-factory-live",
+    recordedAt: evidence.recordedAt,
+    repository: evidence.repository,
+    runtimeSource: evidence.runtimeSource,
+    source: evidence.source,
+    factory: {
+      workThreadId: evidence.factory.workThreadId,
+      recipe: evidence.factory.recipe,
+      workstream: evidence.factory.workstream,
+      batch: {
+        id: evidence.factory.batch.id,
+        inputDigest: evidence.factory.batch.inputDigest,
+        status: admission.status,
+        admittedRunId: admission.admittedRunId,
+        restartReplayMatched: true
+      }
+    },
+    run: evidence.run,
+    attempt: evidence.attempt,
+    pullRequest: evidence.pullRequest,
+    requiredCheck: evidence.requiredCheck,
+    completion: evidence.completion,
+    metrics: evidence.metrics,
+    assessmentCount: evidence.assessmentCount,
+    sourceReceipt: evidence.sourceReceipt,
+    assertions: {
+      externalPlanningSystemRemainedAuthoritative: true,
+      factoryBatchCreatedAttributedRun: true,
+      localFencedAttemptCompleted: true,
+      executorSuccessDidNotSatisfyCompletion: true,
+      requiredCheckBoundToCurrentHead: true,
+      requiredCheckDidNotBypassMerge: true,
+      providerVerifiedMergeSatisfiedContract: true,
+      acceptedOutcomeAdvancedAuthoritatively: true,
+      restartPreservedSatisfiedAssessment: true,
+      restartPreservedWorkstreamMetrics: true,
+      restartReplayedExactBatchReceipt: true,
+      restartDidNotDuplicateFinalReceipt: true
+    },
+    excludedScope: ["dag", "operator_console"]
+  };
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}
+
+async function writePrivateJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+async function main(argv: string[]): Promise<void> {
+  const [command, inputPath, outputPath, ...rest] = argv;
+  if (rest.length > 0 || !inputPath || !outputPath || (command !== "event" && command !== "report")) {
+    throw new Error("Usage: github-factory-acceptance.ts <event|report> <input.json> <output.json>");
+  }
+
+  const input = await readJson(inputPath);
+  if (command === "event") {
+    await writePrivateJson(outputPath, normalizeGitHubFactorySourceEvent(input as GitHubIssueCommentInput));
+    return;
+  }
+  await writePrivateJson(outputPath, buildGitHubFactoryAcceptanceReport(input as GitHubFactoryAcceptanceEvidence));
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test/live-e2e-smoke.mjs
+++ b/scripts/test/live-e2e-smoke.mjs
@@ -101,6 +101,30 @@ const cases = [
     ]
   },
   {
+    id: "github-factory-live",
+    label: "Live GitHub recipe-driven factory acceptance",
+    live: true,
+    command: "OPENTAG_GH_LIVE_FACTORY=true scripts/dev/run-github-webhook-live-test.sh",
+    requiredCommands: [
+      "corepack",
+      "curl",
+      "gh",
+      "lsof",
+      "node",
+      "python3",
+      "sqlite3",
+      ...requiredCommandsForBuiltInAcpAgent(githubWebhookExecutor)
+    ],
+    optionalCommands: ["ngrok"],
+    notes: [
+      "Uses a real GitHub issue comment as the external planning source, then admits it through WorkThread ensure, an immutable recipe, a WorkThread-only workstream, and a durable batch.",
+      "Executes locally, creates and merges a real PR, verifies the required check against the current head, and requires provider-verified accepted completion.",
+      "Restarts the stack, replays the exact batch receipt, verifies the source-thread receipt is not duplicated, and proves accepted workstream metrics remain authoritative.",
+      "Set OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture to prove the GitHub/factory/governance chain with the deterministic local ACP worktree writer.",
+      "This case keeps planning external and explicitly excludes a DAG and operator console."
+    ]
+  },
+  {
     id: "github-cli-live",
     label: "Live GitHub dispatcher-assisted local executor smoke",
     live: true,


### PR DESCRIPTION
## Summary

- add a pairing-scoped, idempotent WorkThread ensure seam for normalized external source events
- extend the live GitHub harness to drive immutable recipe/workstream admission through the existing local runtime, pull request, required-check, merge, completion-governance, callback, restart, and metrics paths
- add a fail-closed acceptance report that verifies provider evidence against the PR head and requires byte-equivalent batch receipts, completion assessments, metrics, and source-receipt identity/content across restart
- record the Phase 5 provider-live acceptance boundary without adding a DAG, scheduler, planning UI, or operator console

## Provider-live acceptance

- external source: [GitHub issue #77](https://github.com/amplifthq/opentag-test/issues/77), which remains open
- source command: [issue comment 5084517470](https://github.com/amplifthq/opentag-test/issues/77#issuecomment-5084517470)
- governed change: [PR #78](https://github.com/amplifthq/opentag-test/pull/78)
- required status context: `opentag-phase1-live`, tied to head `3a65b9788bf26c2e26401ba688c176d0c0c3d239`
- provider merge commit: `3eb6d9a354b6a7140cf396f371aba444cec409d2`
- final source receipt: [issue comment 5084518723](https://github.com/amplifthq/opentag-test/issues/77#issuecomment-5084518723)
- authority progression: terminal Runs `1 -> 1 -> 1`; accepted WorkThreads `0 -> 1 -> 1`; final receipt count `1 -> 1`

The retained acceptance artifact reports `runtimeSource: source_checkout`. This PR proves the real GitHub integration and deterministic local ACP executor path; it does not claim registry-installed CLI or model-provider conformance.

## Verification

- `corepack pnpm test` — 137 files / 1,788 tests passed
- focused post-review suite — 4 files / 193 tests passed
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`
- `bash -n scripts/dev/run-github-webhook-live-test.sh`
- `git diff --check`
- `OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture OPENTAG_GH_LIVE_REPORT=.omx/live-e2e/github-factory-live-phase5.json corepack pnpm smoke:live -- --case github-factory-live`

## Boundaries

- GitHub remains the external planning and source-control authority.
- OpenTag owns admission, execution attribution, governed completion assessment, durable receipts, and accepted-outcome metrics.
- No dependency DAG, graph scheduler, internal backlog, planning console, or operator console is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WorkThread ensuring across client, dispatcher, and CLI (including `factory work-thread ensure` with JSON/stdin input).
  * Introduced `/v1/work-threads/ensure` to create or idempotently retrieve durable WorkThreads.
  * Added GitHub factory live smoke coverage and a GitHub factory acceptance report workflow.
* **Bug Fixes**
  * Enforcing of WorkThread presence now returns clear `422` errors for invalid inputs.
  * Ensuring is idempotent and preserves existing records on replay.
* **Documentation**
  * Expanded live smoke harness and control-plane docs with GitHub factory acceptance “fail-closed” rules.
* **Tests**
  * Added dispatcher, client, CLI, and GitHub factory acceptance test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->