### PR TITLE
chore(release): prepare OpenTag 0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Check deterministic factory conformance
+        run: pnpm smoke:factory-conformance
+
       - name: Check publication set consistency
         run: pnpm release:publication-set
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+No changes yet.
+
+## v0.8.0 - 2026-07-27
+
+OpenTag 0.8.0 completes the first provider-live, recipe-driven software-factory
+control loop on top of external planning systems. It adds access identity,
+bounded human escalation, deterministic runner placement, immutable factory
+recipes and WorkThread-only workstreams, restart-safe batch admission,
+authoritative accepted-outcome metrics, and a real GitHub-backed acceptance
+path. OpenTag still does not own backlog state, dependency DAGs, or an operator
+console; source systems own planning, Git owns changes, and provider evidence
+must satisfy completion gates.
+
 ### Added
 
 - Additive agent access-profile and policy-provenance snapshots that preserve
@@ -10,6 +23,25 @@
 - Structured human-escalation acknowledgement and resolution through the
   source thread, dispatcher API, TypeScript client, and CLI, including bounded
   options, audience, expiry, deduplication, and attributed audit events.
+- Explainable multi-runner routing contracts, deterministic governance
+  evaluation, durable routing snapshots, pairing-authenticated APIs, CLI status,
+  locality constraints, and frozen fallback decisions.
+- Immutable factory recipe snapshots, WorkThread-only workstreams, bounded
+  budgets, ordered durable admission batches, restart-safe lease recovery,
+  bounded exception summaries, workstream evaluation, and client/CLI control
+  surfaces.
+- Accepted-outcome metrics attributed only through the current authoritative
+  CompletionAssessment and the latest terminal fenced Attempt, including
+  runner and executor breakdowns without per-Run queries.
+- An idempotent WorkThread ensure command that derives canonical governance
+  identity from a normalized external event without creating a seed Run.
+- A deterministic factory conformance path covering Echo and local ACP executor
+  adapters, exact restart replay, conflicting digest rejection, bounded
+  exception handling, and authoritative metrics.
+- A real GitHub factory acceptance path from an external issue comment through
+  admission, local execution, pull request, current-head required status,
+  provider merge, accepted completion, source-thread receipt, restart recovery,
+  and workstream metrics.
 
 ### Changed
 
@@ -23,6 +55,56 @@
 - Human resolution is persisted as follow-up context; OpenTag no longer implies
   that a stopped executor can receive live input. Conflicting acknowledgement
   or resolution replays are rejected instead of rewriting history.
+- Attempt creation now enforces the immutable routing decision, selected runner,
+  executor placement, access profile, locality, attempt budget, concurrency
+  budget, and fencing authority in the same durable control path.
+- Factory batches persist every item before admission, process items in stable
+  order, keep routine per-item callbacks quiet, and return the exact durable
+  receipt for an idempotent replay after restart.
+- Workstream status now leads with state and next action, then accepted outcomes,
+  budget use, bounded exceptions, and historical run detail.
+- GitHub completion evidence remains bound to the current pull-request head;
+  executor success and a successful check cannot bypass the merge gate.
+- Provider compatibility checks, ACP readiness behavior, and the published
+  dependency graph were hardened, including updated Hono server and protobuf
+  runtime dependencies.
+- Registry-installed factory acceptance now fails closed unless the selected
+  CLI reports the target version and the clean npm lockfile binds the CLI,
+  installed GitHub source normalizer, and installed Core event schema to the
+  trusted public npm origin and sha512 integrity receipts; source normalization
+  and validation also run through those installed packages rather than workspace
+  product code.
+- npm `latest` promotion now preserves one non-overwritable pre-promotion
+  rollback snapshot across every partial-promotion retry, holds an atomic
+  cross-operator release lock, and aborts before replacing drifted registry tags.
+
+### Fixed
+
+- Completion-waiver time tests now use a stable clock boundary.
+- Human-escalation acknowledgement and resolution reject concurrent or
+  conflicting attempts without rewriting durable history.
+- Workstream metrics reject malformed, waived-without-authority, stale, or
+  cross-WorkThread assessments and retain latest-run authority at scale.
+- The factory acceptance report now rejects replaced assessments or edited,
+  replaced, or duplicated source receipts across restart.
+
+### Security
+
+- Expired or revoked access profiles fail closed before Attempt creation and
+  can open a durable security escalation for the governed WorkThread.
+- Runner and executor fallback cannot widen captured access or recipe locality.
+- Pairing credentials authorize factory administration; runner credentials
+  cannot invoke WorkThread, recipe, workstream, or batch control operations.
+
+### Release validation note
+
+The source-checkout provider-live proof completed against a real GitHub issue,
+pull request, current-head required status, merge, final source receipt, and
+restart recovery. Before promotion from npm `next` to `latest`, the exact
+registry-installed `@opentag/cli@0.8.0` candidate must repeat that factory loop
+and the coordinated registry, ACP, governance, privacy, package-audit, and live
+provider gates. This changelog does not claim those immutable registry artifacts
+have passed before publication.
 
 ## v0.7.0 - 2026-07-22
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ opentag-dev setup
 
 ## Packages
 
-Current public release: `v0.7.0`. The coordinated npm package family contains 16 public packages under the `@opentag` scope.
+Package source version: `v0.8.0`. npm dist-tags are authoritative for the currently published channel versions. The coordinated package family contains 16 public packages under the `@opentag` scope.
 
 | Package | Purpose |
 | --- | --- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -265,7 +265,7 @@ opentag-dev setup
 
 ## 软件包
 
-当前公开发布版本：`v0.7.0`。OpenTag 在 `@opentag` scope 下协调发布 16 个公开软件包。
+当前源码包版本：`v0.8.0`；npm dist-tag 是各发布通道当前公开版本的权威来源。OpenTag 在 `@opentag` scope 下协调发布 16 个公开软件包。
 
 | 包 | 用途 |
 | --- | --- |

--- a/docs/live-e2e-smoke-harness.md
+++ b/docs/live-e2e-smoke-harness.md
@@ -159,6 +159,7 @@ is missing or contradictory. Its proof matrix is:
 | Accepted completion | Completion snapshots before evidence, after the check, after merge, and after restart |
 | Accepted metrics | Workstream metrics proving terminal Runs remain `1` while accepted WorkThreads advance `0 -> 1` |
 | Restart recovery | Exact batch receipt replay, byte-equivalent satisfied assessment and metrics, and unchanged source-receipt identity, body digest, and count |
+| Registry artifact, when selected | Installed CLI, GitHub normalizer, and Core event-schema package versions, trusted public npm resolution, and npm lockfile sha512 integrity receipts |
 
 Run the provider/governance proof with the deterministic local ACP writer:
 
@@ -293,10 +294,30 @@ path with `OPENTAG_GH_LIVE_REPORT`. Set
 `OPENTAG_GH_LIVE_STRICT_COMPLETION=false` only when intentionally exercising
 the older optional `apply 1` compatibility flow.
 
-After publishing a candidate to npm `next`, install `@opentag/cli@0.7.0` into a
-fresh directory and set `OPENTAG_GH_LIVE_CLI_BIN` to that installation's
-`node_modules/.bin/opentag`. The same strict case then proves the immutable
-registry artifacts rather than the source checkout.
+After publishing a candidate to npm `next`, install `@opentag/cli@0.8.0` into a
+fresh directory by running the exact install from inside that directory:
+
+```bash
+smoke_root="$(mktemp -d)"
+(
+  set -euo pipefail
+
+  cd "$smoke_root"
+  npm init --yes >/dev/null
+  npm install --no-audit --no-fund @opentag/cli@0.8.0
+)
+```
+
+Then set `OPENTAG_GH_LIVE_CLI_BIN` to that installation's
+`node_modules/.bin/opentag` and
+`OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION=0.8.0`. The harness verifies the
+executable, package manifests, exact package-lock install paths, trusted public
+npm resolution, and integrity receipts before starting, then normalizes and
+validates the source comment through the installed `@opentag/github` and
+`@opentag/core` dependencies. npm verifies tarball bytes against SRI during
+installation; the harness retains the npm-generated lockfile receipts and does
+not independently download and hash the tarballs. The same strict case thus
+proves the immutable registry artifacts rather than workspace product code.
 
 ### Slack UI
 

--- a/docs/npm-release.md
+++ b/docs/npm-release.md
@@ -4,22 +4,21 @@ OpenTag npm packages are published manually from a clean local checkout until
 a trusted release pipeline exists. All public packages ship as one coordinated
 version.
 
-## Current release
+## Target release
 
 ```text
-0.7.0
+0.8.0
 ```
 
 The release is first published on the npm `next` dist-tag, tested from the
 registry, then promoted to `latest`. The exact commit that produced the npm
-artifacts must also receive the matching `v0.7.0` git tag and GitHub Release.
+artifacts must also receive the matching `v0.8.0` git tag and GitHub Release.
 
 The public release set contains 16 packages, including
-`@opentag/governance`. Established packages have a coordinated `0.6.0`
-release, while a newly introduced package may not have a previous `latest`
-target. Publishing `0.7.0` with `--tag next` must leave each package's existing
-`latest` pointer unchanged until the complete registry, ACP, governance, and
-live-platform gate passes.
+`@opentag/governance`. The complete family has a coordinated `0.7.0` release.
+Publishing `0.8.0` with `--tag next` must leave each package's existing
+`latest` pointer unchanged until the complete registry, ACP, governance,
+factory, and live-platform gate passes.
 
 ## Public package discovery and order
 
@@ -46,7 +45,7 @@ plan.
 ## Release gate
 
 Start from the intended release commit with a clean working tree. Confirm that
-all 16 public manifests use `0.7.0` and that the frozen lockfile is current,
+all 16 public manifests use `0.8.0` and that the frozen lockfile is current,
 then run the verification ladder in this order:
 
 ```bash
@@ -58,6 +57,7 @@ corepack pnpm typecheck
 corepack pnpm test
 corepack pnpm smoke:governance -- --all --report .omx/governance-matrix/all.json
 corepack pnpm smoke:privacy -- --allow-missing --report .omx/governance-matrix/privacy.json
+corepack pnpm smoke:factory-conformance
 OPENTAG_BUILTIN_ACP_AGENTS=hermes OPENTAG_HERMES_PROFILE=<profile> corepack pnpm smoke:acp-conformance
 OPENTAG_BUILTIN_ACP_AGENTS=openclaw OPENTAG_OPENCLAW_PROFILE=opentag-conformance corepack pnpm smoke:acp-conformance
 corepack pnpm release:check
@@ -106,17 +106,44 @@ provider identifiers.
 
 ## Publish the `next` canary
 
-Confirm npm access immediately before publishing:
+Capture the exact clean commit before any npm side effect, persist it as release
+authority, then confirm npm access and publish from that same commit:
 
 ```bash
-npm whoami
-npm org ls opentag
-corepack pnpm release:publish -- --tag next
+(
+  set -euo pipefail
+
+  test -z "$(git status --porcelain)"
+  release_state_dir=".omx/releases/0.8.0"
+  release_commit_file="$release_state_dir/release-commit-sha"
+  current_release_commit="$(git rev-parse HEAD)"
+  mkdir -p "$release_state_dir"
+  chmod 700 "$release_state_dir"
+  if [ -e "$release_commit_file" ]; then
+    test "$(<"$release_commit_file")" = "$current_release_commit"
+  else
+    release_commit_tmp="$(mktemp "$release_state_dir/release-commit-sha.XXXXXX")"
+    trap 'rm -f -- "$release_commit_tmp"' EXIT
+    chmod 600 "$release_commit_tmp"
+    printf '%s\n' "$current_release_commit" >"$release_commit_tmp"
+    mv -n "$release_commit_tmp" "$release_commit_file"
+    test ! -e "$release_commit_tmp"
+  fi
+  release_commit="$(<"$release_commit_file")"
+  test "$(git rev-parse HEAD)" = "$release_commit"
+
+  npm whoami
+  npm org ls opentag
+  corepack pnpm release:publish -- --tag next
+)
 ```
 
 The publish command uses the same automatic publication set and topological
 order as `release:check`. A coordinated release is incomplete until all 16
-packages exist at `0.7.0`; do not promote a partial package family.
+packages exist at `0.8.0`; do not promote a partial package family. Preserve
+the exact `release-commit-sha` file with the release record. Every later lock,
+tag, rollback, and release check reads that authority instead of recapturing
+the current `HEAD`.
 
 If npm asks for a two-factor one-time password, do not pass `--otp` by default
 for OpenTag releases. Refresh the local npm browser login, then rerun the normal
@@ -124,9 +151,10 @@ publish command:
 
 ```bash
 npm login --auth-type=web
-npm whoami
-corepack pnpm release:publish -- --tag next
 ```
+
+Then rerun the complete fail-fast publish block above. It refuses to publish if
+the clean checkout no longer matches the persisted release commit.
 
 If npm still requires a per-publish code after a fresh browser login, stop and
 continue from a trusted interactive terminal or adjust the npm account/session
@@ -140,13 +168,19 @@ registry:
 
 ```bash
 smoke_root="$(mktemp -d)"
-npm install --prefix "$smoke_root" --no-audit --no-fund @opentag/cli@0.7.0
-"$smoke_root/node_modules/.bin/opentag" --version
-"$smoke_root/node_modules/.bin/opentag" --help
-npm audit --prefix "$smoke_root" --omit=dev --audit-level=high
+(
+  set -euo pipefail
+
+  cd "$smoke_root"
+  npm init --yes >/dev/null
+  npm install --no-audit --no-fund @opentag/cli@0.8.0
+  test "$("$smoke_root/node_modules/.bin/opentag" --version)" = "0.8.0"
+  "$smoke_root/node_modules/.bin/opentag" --help
+  npm audit --prefix "$smoke_root" --omit=dev --audit-level=high
+)
 ```
 
-The version must be `0.7.0`. With isolated config and state directories, run
+The version must be `0.8.0`. With isolated config and state directories, run
 the setup, doctor, and foreground-start path for one platform that has real
 test credentials:
 
@@ -168,66 +202,283 @@ process after the receipt is visible. Record which platform was tested and the
 redacted evidence in the release notes; never record provider tokens, fencing
 tokens, raw ACP frames, or full private message IDs.
 
+For `0.8.0`, the required provider gate is the GitHub factory acceptance case,
+run with the registry-installed binary rather than the workspace CLI:
+
+```bash
+OPENTAG_GH_LIVE_CLI_BIN="$smoke_root/node_modules/.bin/opentag" \
+OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION=0.8.0 \
+OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture \
+OPENTAG_GH_LIVE_REPORT=.omx/live-e2e/github-factory-live-0.8.0.json \
+corepack pnpm smoke:live -- --case github-factory-live
+```
+
+The harness fails before starting the local stack unless the executable resolves
+to `@opentag/cli@0.8.0`, its `--version` output agrees, and the clean install's
+`package-lock.json` has an exact install-path entry with HTTPS registry
+resolution and sha512 integrity for `@opentag/cli`, the installed
+`@opentag/github` source normalizer, and the installed `@opentag/core` event
+schema. All three artifacts must resolve from `https://registry.npmjs.org`
+without URL credentials, queries, or fragments. Install from inside the fresh
+directory as shown above; do not use a detached `npm --prefix` invocation whose
+lockfile paths do not identify that installation exactly. npm verifies tarball
+bytes against the lockfile SRI value during installation; the harness retains
+that npm-generated receipt but does not independently redownload and hash the
+tarball. The source event is normalized and validated through those installed
+packages, not workspace source. The retained report must identify
+`runtimeSource: "registry_install"`, retain the sanitized
+package/version/registry/integrity receipt, and prove the same
+external-source, recipe admission, fenced local execution, current-head required
+status, provider merge, accepted completion, restart replay, source-receipt
+identity, and workstream metrics contract as the source-checkout acceptance. Do
+not promote `next` when that immutable registry path fails.
+
 Also verify every package and its canary tag before promotion:
 
 ```bash
-for manifest in packages/*/package.json; do
-  [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
-  package="$(jq -r '.name' "$manifest")"
-  test "$(npm view "$package@0.7.0" version)" = "0.7.0"
-  test "$(npm view "$package" dist-tags.next)" = "0.7.0"
-  npm view "$package" dist-tags --json
-done
+(
+  set -euo pipefail
+
+  test "$("$smoke_root/node_modules/.bin/opentag" --version)" = "0.8.0"
+  for manifest in packages/*/package.json; do
+    [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
+    package="$(jq -r '.name' "$manifest")"
+    test "$(npm view "$package@0.8.0" version)" = "0.8.0"
+    test "$(npm view "$package" dist-tags.next)" = "0.8.0"
+    npm view "$package" dist-tags --json
+  done
+)
 ```
 
 ## Promote the same artifacts to `latest`
 
-Promotion changes dist-tags only; it must not rebuild or republish. After all
-registry and live-platform checks pass, run the same command for every package.
-Repeating the dist-tag update is intentionally idempotent for every package:
+Promotion changes dist-tags only; it must not rebuild or republish. Before
+capturing rollback authority, acquire the repository-wide npm dist-tag lock.
+GitHub ref creation is atomic, so two release operators cannot both acquire the
+window:
 
 ```bash
-rollback_file="$(mktemp)"
-chmod 600 "$rollback_file"
-for manifest in packages/*/package.json; do
-  [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
-  package="$(jq -r '.name' "$manifest")"
-  previous_latest="$(npm view "$package" dist-tags.latest)"
-  printf '%s\t%s\n' "$package" "$previous_latest" >>"$rollback_file"
-done
+(
+  set -euo pipefail
 
-for manifest in packages/*/package.json; do
-  [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
-  package="$(jq -r '.name' "$manifest")"
-  npm dist-tag add "$package@0.7.0" latest
-done
+  release_state_dir=".omx/releases/0.8.0"
+  release_commit_file="$release_state_dir/release-commit-sha"
+  lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
+  test -f "$release_commit_file"
+  release_commit="$(<"$release_commit_file")"
+  test "$(git rev-parse HEAD)" = "$release_commit"
+  test -z "$(git status --porcelain)"
+  test ! -e "$lock_owner_file"
+  lock_nonce="$(openssl rand -hex 16)"
+  lock_owner="$(gh api user --jq '.login')"
+  release_tree="$(gh api "repos/amplifthq/opentag/git/commits/$release_commit" --jq '.tree.sha')"
+  lock_commit="$(gh api --method POST repos/amplifthq/opentag/git/commits \
+    -f message="OpenTag npm dist-tag lock release=$release_commit owner=$lock_owner nonce=$lock_nonce" \
+    -f tree="$release_tree" \
+    -f "parents[]=$release_commit" \
+    --jq '.sha')"
+  test "$(gh api "repos/amplifthq/opentag/git/commits/$lock_commit" --jq '.parents[0].sha')" = "$release_commit"
+  lock_owner_tmp="$(mktemp "$release_state_dir/npm-dist-tags.lock-sha.XXXXXX")"
+  trap 'rm -f -- "$lock_owner_tmp"' EXIT
+  chmod 600 "$lock_owner_tmp"
+  printf '%s\n' "$lock_commit" >"$lock_owner_tmp"
+  mv -n "$lock_owner_tmp" "$lock_owner_file"
+  test ! -e "$lock_owner_tmp"
+  if ! gh api --method POST repos/amplifthq/opentag/git/refs \
+    -f ref=refs/heads/release-lock/npm-dist-tags \
+    -f sha="$lock_commit"; then
+    rm -f -- "$lock_owner_file"
+    exit 1
+  fi
+  test "$(gh api repos/amplifthq/opentag/git/ref/heads/release-lock/npm-dist-tags --jq '.object.sha')" = "$(<"$lock_owner_file")"
+)
 ```
 
-Keep `rollback_file` until the release is complete. It records the actual
-pre-promotion `latest` target for each package, including an empty target for a
-package that did not previously have one.
+A failed ref creation means another promotion or rollback owns the window, or a
+previous operator left a stale lock. Stop. Inspect the referenced commit and
+coordinate with that operator before deciding whether the lock is stale; never
+delete it merely to make this command pass. The unique lock commit has the
+release commit as its parent and records an acquisition nonce and operator; its
+SHA is persisted in the protected release-state directory. A different
+operator on the same release commit therefore cannot accidentally pass the
+ownership checks. Keep the lock until the matching GitHub Release succeeds or
+rollback is fully verified.
+
+While holding that lock, create exactly one durable pre-promotion snapshot. The
+snapshot command refuses to overwrite an existing file so a partial-promotion
+retry cannot replace the original rollback authority:
+
+```bash
+(
+  set -euo pipefail
+
+  release_state_dir=".omx/releases/0.8.0"
+  release_commit_file="$release_state_dir/release-commit-sha"
+  lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
+  test -f "$release_commit_file"
+  release_commit="$(<"$release_commit_file")"
+  test "$(git rev-parse HEAD)" = "$release_commit"
+  test -f "$lock_owner_file"
+  lock_commit="$(<"$lock_owner_file")"
+  test "$(gh api repos/amplifthq/opentag/git/ref/heads/release-lock/npm-dist-tags --jq '.object.sha')" = "$lock_commit"
+  test "$(gh api "repos/amplifthq/opentag/git/commits/$lock_commit" --jq '.parents[0].sha')" = "$release_commit"
+  rollback_file="$release_state_dir/pre-promotion-latest.tsv"
+  mkdir -p "$release_state_dir"
+  chmod 700 "$release_state_dir"
+  test ! -e "$rollback_file"
+  snapshot_tmp="$(mktemp "$release_state_dir/pre-promotion-latest.XXXXXX")"
+  trap 'rm -f -- "$snapshot_tmp"' EXIT
+  chmod 600 "$snapshot_tmp"
+  for manifest in packages/*/package.json; do
+    [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
+    package="$(jq -r '.name' "$manifest")"
+    dist_tags_json="$(npm view "$package" dist-tags --json)"
+    previous_latest="$(jq -er '.latest | select(type == "string" and length > 0)' <<<"$dist_tags_json")"
+    test "$previous_latest" = "0.7.0"
+    printf '%s\t%s\n' "$package" "$previous_latest" >>"$snapshot_tmp"
+  done
+  test "$(wc -l <"$snapshot_tmp" | tr -d ' ')" = "16"
+  test "$(cut -f1 "$snapshot_tmp" | sort -u | wc -l | tr -d ' ')" = "16"
+  test "$(cut -f2 "$snapshot_tmp" | sort -u)" = "0.7.0"
+  mv -n "$snapshot_tmp" "$rollback_file"
+  test ! -e "$snapshot_tmp"
+)
+```
+
+Keep that exact file until the release is complete. It records the actual
+pre-promotion `latest` target for every package and fails unless the coordinated
+family is still on the known `0.7.0` baseline. A registry lookup failure or a
+missing/unexpected tag stops the release; it is never interpreted as rollback
+authority. Back the snapshot up outside the ephemeral shell session before
+changing any dist-tag.
+
+The following promotion loop is retryable. Every first attempt and retry must
+reuse the original `rollback_file`; never rerun the snapshot block after any
+package has been promoted:
+
+```bash
+(
+  set -euo pipefail
+
+  release_state_dir=".omx/releases/0.8.0"
+  release_commit_file="$release_state_dir/release-commit-sha"
+  lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
+  test -f "$release_commit_file"
+  release_commit="$(<"$release_commit_file")"
+  test "$(git rev-parse HEAD)" = "$release_commit"
+  test -f "$lock_owner_file"
+  lock_commit="$(<"$lock_owner_file")"
+  test "$(gh api repos/amplifthq/opentag/git/ref/heads/release-lock/npm-dist-tags --jq '.object.sha')" = "$lock_commit"
+  test "$(gh api "repos/amplifthq/opentag/git/commits/$lock_commit" --jq '.parents[0].sha')" = "$release_commit"
+  rollback_file=".omx/releases/0.8.0/pre-promotion-latest.tsv"
+  test -f "$rollback_file"
+  test "$(wc -l <"$rollback_file" | tr -d ' ')" = "16"
+  test "$(cut -f1 "$rollback_file" | sort -u | wc -l | tr -d ' ')" = "16"
+  test "$(cut -f2 "$rollback_file" | sort -u)" = "0.7.0"
+
+  for manifest in packages/*/package.json; do
+    [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
+    package="$(jq -r '.name' "$manifest")"
+    previous_latest="$(awk -F '\t' -v package="$package" '$1 == package { print $2 }' "$rollback_file")"
+    test "$previous_latest" = "0.7.0"
+    current_tags_json="$(npm view "$package" dist-tags --json)"
+    current_latest="$(jq -er '.latest | select(type == "string" and length > 0)' <<<"$current_tags_json")"
+    current_next="$(jq -er '.next | select(type == "string" and length > 0)' <<<"$current_tags_json")"
+    test "$current_next" = "0.8.0"
+    case "$current_latest" in
+      "$previous_latest") npm dist-tag add "$package@0.8.0" latest ;;
+      "0.8.0") ;;
+      *) echo "Refusing to replace drifted $package latest=$current_latest" >&2; exit 1 ;;
+    esac
+    test "$(npm view "$package" dist-tags.latest)" = "0.8.0"
+    test "$(npm view "$package" dist-tags.next)" = "0.8.0"
+  done
+)
+```
 
 Rerun the package loop from the registry-verification section and confirm both
-`next` and `latest` point at `0.7.0` for all 16 packages.
+`next` and `latest` point at `0.8.0` for all 16 packages.
 
 ## Create the matching source release
 
 Create the source tag from the exact clean commit used for `release:publish`.
-Copy the `v0.7.0` section of `CHANGELOG.md` into a temporary release-notes file,
+Copy the `v0.8.0` section of `CHANGELOG.md` into a temporary release-notes file,
 then run:
 
 ```bash
-git tag -a v0.7.0 -m "OpenTag v0.7.0"
-git push origin v0.7.0
-gh release create v0.7.0 \
-  --verify-tag \
-  --title "OpenTag v0.7.0" \
-  --notes-file /tmp/opentag-v0.7.0-release-notes.md
+(
+  set -euo pipefail
+
+  release_commit_file=".omx/releases/0.8.0/release-commit-sha"
+  test -f "$release_commit_file"
+  release_commit="$(<"$release_commit_file")"
+  test "$(git rev-parse HEAD)" = "$release_commit"
+  test -z "$(git status --porcelain)"
+
+  if git show-ref --verify --quiet refs/tags/v0.8.0; then
+    test "$(git cat-file -t refs/tags/v0.8.0)" = "tag"
+    test "$(git rev-parse 'v0.8.0^{}')" = "$release_commit"
+  else
+    git tag -a v0.8.0 "$release_commit" -m "OpenTag v0.8.0"
+  fi
+  test "$(git rev-parse 'v0.8.0^{}')" = "$release_commit"
+  git push origin v0.8.0
+  release_tag_ref="$(gh api repos/amplifthq/opentag/git/ref/tags/v0.8.0)"
+  test "$(jq -r '.object.type' <<<"$release_tag_ref")" = "tag"
+  release_tag_object="$(jq -r '.object.sha' <<<"$release_tag_ref")"
+  test "$(gh api "repos/amplifthq/opentag/git/tags/$release_tag_object" --jq '.object.sha')" = "$release_commit"
+  existing_release_state="$(gh api --paginate 'repos/amplifthq/opentag/releases?per_page=100' \
+    --jq '.[] | select(.tag_name == "v0.8.0") | [.tag_name, .draft, .prerelease, (.published_at != null)] | @tsv')"
+  case "$existing_release_state" in
+    "")
+      gh release create v0.8.0 \
+        --verify-tag \
+        --title "OpenTag v0.8.0" \
+        --notes-file /tmp/opentag-v0.8.0-release-notes.md
+      ;;
+    $'v0.8.0\tfalse\tfalse\ttrue') ;;
+    *) echo "Refusing conflicting draft, prerelease, unpublished, or duplicate v0.8.0 GitHub Release state" >&2; exit 1 ;;
+  esac
+  release_state="$(gh api repos/amplifthq/opentag/releases/tags/v0.8.0)"
+  test "$(jq -r '.tag_name' <<<"$release_state")" = "v0.8.0"
+  test "$(jq -r '.draft' <<<"$release_state")" = "false"
+  test "$(jq -r '.prerelease' <<<"$release_state")" = "false"
+  jq -er '.published_at | select(type == "string" and length > 0)' <<<"$release_state" >/dev/null
+)
 ```
+
+The tag/release block is retryable after partial success. It reuses an existing
+local tag only when it is annotated and peels to the persisted release commit;
+the pushed remote tag must also be annotated and target that commit. The
+paginated release lookup must succeed before an absent release is created, so a
+network or API failure is never misread as authoritative absence. An existing
+draft, prerelease, unpublished object, or duplicate match is conflicting state:
+stop and inspect it rather than treating it as the completed `v0.8.0` release.
 
 Verify that the GitHub Release tag resolves to the same commit that produced
 the npm tarballs. The release is not complete until npm, git, and GitHub all
-identify version `0.7.0`.
+identify version `0.8.0`. After that verification—or after a completed and
+verified rollback—release the exclusive window only when it still points at
+your release commit:
+
+```bash
+(
+  set -euo pipefail
+
+  release_state_dir=".omx/releases/0.8.0"
+  release_commit_file="$release_state_dir/release-commit-sha"
+  lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
+  test -f "$release_commit_file"
+  release_commit="$(<"$release_commit_file")"
+  test "$(git rev-parse HEAD)" = "$release_commit"
+  test -f "$lock_owner_file"
+  lock_commit="$(<"$lock_owner_file")"
+  test "$(gh api repos/amplifthq/opentag/git/ref/heads/release-lock/npm-dist-tags --jq '.object.sha')" = "$lock_commit"
+  test "$(gh api "repos/amplifthq/opentag/git/commits/$lock_commit" --jq '.parents[0].sha')" = "$release_commit"
+  gh api --method DELETE repos/amplifthq/opentag/git/refs/heads/release-lock/npm-dist-tags
+  rm -f -- "$lock_owner_file"
+)
+```
 
 ## Dist-tag rollback
 
@@ -236,24 +487,51 @@ Do not unpublish immutable package versions during rollback.
 - If canary validation fails before promotion, leave every package's previous
   `latest` tag unchanged and stop the rollout. Preserve `next` for diagnosis or
   move it to the corrected version.
-- If `latest` promotion fails partway, first finish or retry the idempotent
-  promotion loop. If 0.7.0 itself must be withdrawn, restore each package's
-  recorded pre-promotion target and leave 0.7.0 on `next` for diagnosis:
+- If `latest` promotion fails partway, first finish or retry only the idempotent
+  promotion loop with the original snapshot. If 0.8.0 itself must be withdrawn,
+  restore each package's recorded pre-promotion target and leave 0.8.0 on `next`
+  for diagnosis:
 
 ```bash
-while IFS=$'\t' read -r package previous_latest; do
-  if [ -n "$previous_latest" ]; then
+(
+  set -euo pipefail
+
+  release_state_dir=".omx/releases/0.8.0"
+  release_commit_file="$release_state_dir/release-commit-sha"
+  lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
+  test -f "$release_commit_file"
+  release_commit="$(<"$release_commit_file")"
+  test "$(git rev-parse HEAD)" = "$release_commit"
+  test -f "$lock_owner_file"
+  lock_commit="$(<"$lock_owner_file")"
+  test "$(gh api repos/amplifthq/opentag/git/ref/heads/release-lock/npm-dist-tags --jq '.object.sha')" = "$lock_commit"
+  test "$(gh api "repos/amplifthq/opentag/git/commits/$lock_commit" --jq '.parents[0].sha')" = "$release_commit"
+  rollback_file=".omx/releases/0.8.0/pre-promotion-latest.tsv"
+  test -f "$rollback_file"
+  test "$(wc -l <"$rollback_file" | tr -d ' ')" = "16"
+  test "$(cut -f1 "$rollback_file" | sort -u | wc -l | tr -d ' ')" = "16"
+  test "$(cut -f2 "$rollback_file" | sort -u)" = "0.7.0"
+  for manifest in packages/*/package.json; do
+    [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
+    package="$(jq -r '.name' "$manifest")"
+    previous_latest="$(awk -F '\t' -v package="$package" '$1 == package { print $2 }' "$rollback_file")"
+    test "$previous_latest" = "0.7.0"
     test "$(npm view "$package@$previous_latest" version)" = "$previous_latest"
-    npm dist-tag add "$package@$previous_latest" latest
-  else
-    current_latest="$(npm view "$package" dist-tags.latest)"
-    if [ -n "$current_latest" ]; then
-      npm dist-tag rm "$package" latest
-    fi
-  fi
-  npm dist-tag add "$package@0.7.0" next
-done <"$rollback_file"
+    current_tags_json="$(npm view "$package" dist-tags --json)"
+    current_latest="$(jq -er '.latest | select(type == "string" and length > 0)' <<<"$current_tags_json")"
+    current_next="$(jq -er '.next | select(type == "string" and length > 0)' <<<"$current_tags_json")"
+    test "$current_next" = "0.8.0"
+    case "$current_latest" in
+      "$previous_latest") ;;
+      "0.8.0") npm dist-tag add "$package@$previous_latest" latest ;;
+      *) echo "Refusing to replace drifted $package latest=$current_latest" >&2; exit 1 ;;
+    esac
+    test "$(npm view "$package" dist-tags.latest)" = "$previous_latest"
+    test "$(npm view "$package" dist-tags.next)" = "0.8.0"
+  done
+)
 ```
 
-Verify all dist-tags after rollback and publish a clear incident note. A later
-fix must use a new version; never overwrite `0.7.0`.
+Verify all dist-tags after rollback, publish a clear incident note, then release
+the exclusive window with the guarded command above. A later fix must use a new
+version; never overwrite `0.8.0`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -32,7 +32,7 @@ Private runnable apps are not published:
 
 ## Pre-1.0 Policy
 
-The current public release is `0.7.0`. The public API is still settling, so all releases remain in the `0.x` line until the package contracts are stable enough for `1.0.0`.
+The source package family is prepared at `0.8.0`; npm dist-tags remain authoritative for the currently published channel versions. The public API is still settling, so all releases remain in the `0.x` line until the package contracts are stable enough for `1.0.0`.
 
 The first npm release was published as the coordinated `0.1.0` package family.
 The `0.2.0` release added the published CLI, local runtime package, and Lark and Telegram packages.
@@ -43,6 +43,7 @@ The `0.4.0` release adds GitLab source-thread ingestion, note callbacks, and mer
 The `0.5.0` release adds Discord, Linear, and Microsoft Teams adapters, ACP-first agent execution, durable Attempt leases and fencing, governed material-action receipts and reconciliation, and the corresponding Client/Runner migration.
 The `0.6.0` release moves all built-in coding agents onto Generic ACP, adds Cursor, OpenCode, and OpenClaw executor profiles, requires Node.js 22 for the CLI/Local Runtime/Runner, and hardens ACP isolation, cancellation conformance, Slack summaries, and the coordinated release gate.
 The `0.7.0` release completes the Phase 1 completion-governance vertical slice with durable work threads and contracts, deterministic evidence-backed assessments, GitHub PR/check/merge evidence ingestion, replay-safe reassessment, CLI explanations and bounded waivers, and a 16-package publication set that includes `@opentag/governance`.
+The `0.8.0` release completes the first provider-live recipe-driven factory loop with access identity, bounded human escalation, explainable multi-runner routing, immutable recipes and WorkThread-only workstreams, restart-safe batch admission, authoritative accepted-outcome metrics, and a real GitHub issue-to-merge-to-receipt proof while keeping planning external.
 
 For each npm release:
 
@@ -105,11 +106,13 @@ After `1.0.0`, follow SemVer:
 9. Confirm the exact version and `next` dist-tag for every package from the npm
    registry.
 10. Install `@opentag/cli@<version>` from the registry in a clean directory.
-11. Run CLI version/help, setup, doctor, start, and at least one real-platform
-    ingest-to-receipt smoke from that registry installation.
+11. Run CLI version/help, setup, doctor, and start from that registry
+    installation, then repeat the GitHub factory acceptance loop through
+    external source, batch admission, local execution, PR, required check,
+    merge, completion, restart, source receipt, and workstream metrics.
 12. Promote the same package versions to `latest` by changing dist-tags only.
 13. Confirm `latest` and `next` for the complete package family.
-14. Create and push the matching annotated git tag, for example `v0.7.0`, from
+14. Create and push the matching annotated git tag, for example `v0.8.0`, from
     the exact publication commit.
 15. Create the matching GitHub Release with the changelog notes and verify its
     tag target.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "OpenTag command line interface.",
   "type": "module",
   "engines": {

--- a/packages/cli/test/docs-contract.test.ts
+++ b/packages/cli/test/docs-contract.test.ts
@@ -7,6 +7,41 @@ function repoFile(path: string): string {
 }
 
 describe("platform setup docs contract", () => {
+  it("keeps the 0.8.0 release procedure explicit and concurrency-safe", () => {
+    const releaseGuide = repoFile("docs/npm-release.md");
+    const liveGuide = repoFile("docs/live-e2e-smoke-harness.md");
+
+    expect(liveGuide).toContain("npm install --no-audit --no-fund @opentag/cli@0.8.0");
+    expect(liveGuide).toContain('smoke_root="$(mktemp -d)"\n(\n  set -euo pipefail');
+    expect(releaseGuide).toContain("refs/heads/release-lock/npm-dist-tags");
+    expect(releaseGuide).toContain("npm-dist-tags.lock-sha");
+    expect(releaseGuide).toContain("release-commit-sha");
+    expect(releaseGuide).toContain("lock_nonce=\"$(openssl rand -hex 16)\"");
+    expect(releaseGuide).toContain("parents[]=$release_commit");
+    expect(releaseGuide).toContain(".parents[0].sha");
+    expect(releaseGuide).toContain('= "$lock_commit"');
+    expect(releaseGuide).toContain('current_latest="$(jq -er');
+    expect(releaseGuide).toContain('current_next="$(jq -er');
+    expect(releaseGuide).toContain('test "$current_next" = "0.8.0"');
+    expect(releaseGuide.match(/test "\$\("\$smoke_root\/node_modules\/\.bin\/opentag" --version\)" = "0\.8\.0"/gu))
+      .toHaveLength(2);
+    expect(releaseGuide).toContain('smoke_root="$(mktemp -d)"\n(\n  set -euo pipefail');
+    expect(releaseGuide).toContain(
+      'Also verify every package and its canary tag before promotion:\n\n```bash\n(\n  set -euo pipefail'
+    );
+    expect(releaseGuide).toContain('git tag -a v0.8.0 "$release_commit" -m "OpenTag v0.8.0"');
+    expect(releaseGuide).toContain("git show-ref --verify --quiet refs/tags/v0.8.0");
+    expect(releaseGuide).toContain("git cat-file -t refs/tags/v0.8.0");
+    expect(releaseGuide).toContain('git rev-parse \'v0.8.0^{}\'');
+    expect(releaseGuide).toContain('git/tags/$release_tag_object');
+    expect(releaseGuide).toContain("gh api --paginate 'repos/amplifthq/opentag/releases?per_page=100'");
+    expect(releaseGuide).toContain('case "$existing_release_state" in');
+    expect(releaseGuide).toContain("$'v0.8.0\\tfalse\\tfalse\\ttrue'");
+    expect(releaseGuide).toContain("'.draft'");
+    expect(releaseGuide).toContain("'.prerelease'");
+    expect(releaseGuide).toContain('.published_at | select(type == "string" and length > 0)');
+  });
+
   it("keeps the agent-readable install guide aligned with OpenTag source-thread boundaries", () => {
     const guide = repoFile("docs/agent-install.md");
     const readme = repoFile("README.md");

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "HTTP client SDK for creating, claiming, and updating OpenTag dispatcher runs.",
   "type": "module",
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Core OpenTag protocol schemas, types, JSON Schema, and mention parsing.",
   "type": "module",
   "engines": {

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/discord",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Discord interactions normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/dispatcher/package.json
+++ b/packages/dispatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/dispatcher",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Embeddable OpenTag dispatcher Hono app and callback sinks.",
   "type": "module",
   "engines": {

--- a/packages/dispatcher/src/completion-governance.ts
+++ b/packages/dispatcher/src/completion-governance.ts
@@ -240,7 +240,7 @@ function githubFactTemplates(input: {
   };
   const provenance = (kind: string) => ({
     adapter: "@opentag/github",
-    adapterVersion: "0.7.0",
+    adapterVersion: "0.8.0",
     payloadDigest: factDigest(semanticDigest, kind),
     providerDeliveryId: input.snapshot.deliveryId
   });

--- a/packages/dispatcher/test/github-factory-acceptance.test.ts
+++ b/packages/dispatcher/test/github-factory-acceptance.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   buildGitHubFactoryAcceptanceReport,
@@ -6,6 +7,10 @@ import {
 } from "../../../scripts/test/github-factory-acceptance.js";
 
 const digest = `sha256:${"a".repeat(64)}`;
+
+function integrity(value: string): string {
+  return `sha512-${createHash("sha512").update(value).digest("base64")}`;
+}
 
 function completion(state: string, requiredChecks: string, merge: string) {
   return {
@@ -150,6 +155,29 @@ function evidence(): GitHubFactoryAcceptanceEvidence {
   };
 }
 
+function registryRuntimeArtifact() {
+  return {
+    expectedVersion: "0.8.0",
+    package: "@opentag/cli" as const,
+    version: "0.8.0",
+    registry: "https://registry.npmjs.org",
+    resolved: "https://registry.npmjs.org/@opentag/cli/-/cli-0.8.0.tgz",
+    integrity: integrity("cli-0.8.0"),
+    sourceNormalizer: {
+      package: "@opentag/github" as const,
+      version: "0.8.0",
+      resolved: "https://registry.npmjs.org/@opentag/github/-/github-0.8.0.tgz",
+      integrity: integrity("github-0.8.0")
+    },
+    eventSchema: {
+      package: "@opentag/core" as const,
+      version: "0.8.0",
+      resolved: "https://registry.npmjs.org/@opentag/core/-/core-0.8.0.tgz",
+      integrity: integrity("core-0.8.0")
+    }
+  };
+}
+
 describe("GitHub factory live acceptance report", () => {
   it("normalizes one real-source-shaped issue comment into a factory admission event", () => {
     const event = normalizeGitHubFactorySourceEvent({
@@ -197,6 +225,62 @@ describe("GitHub factory live acceptance report", () => {
     });
     expect(Object.values(report.assertions).every((value) => value === true)).toBe(true);
     expect(JSON.stringify(report)).not.toContain("fencingToken");
+  });
+
+  it("requires registry artifact identity for a registry-installed proof", () => {
+    const input = evidence();
+    input.runtimeSource = "registry_install";
+
+    expect(() => buildGitHubFactoryAcceptanceReport(input)).toThrow(/registry runtime artifact identity is missing/u);
+  });
+
+  it("retains a version- and integrity-bound registry artifact receipt", () => {
+    const input = evidence();
+    input.runtimeSource = "registry_install";
+    input.runtimeArtifact = registryRuntimeArtifact();
+
+    expect(buildGitHubFactoryAcceptanceReport(input)).toMatchObject({
+      runtimeSource: "registry_install",
+      runtimeArtifact: registryRuntimeArtifact()
+    });
+  });
+
+  it("rejects stale or incomplete registry artifact identity", () => {
+    const stale = evidence();
+    stale.runtimeSource = "registry_install";
+    stale.runtimeArtifact = {
+      ...registryRuntimeArtifact(),
+      version: "0.7.0"
+    };
+    expect(() => buildGitHubFactoryAcceptanceReport(stale)).toThrow(/does not match expected version/u);
+
+    const missingIntegrity = evidence();
+    missingIntegrity.runtimeSource = "registry_install";
+    missingIntegrity.runtimeArtifact = {
+      ...registryRuntimeArtifact(),
+      integrity: ""
+    };
+    expect(() => buildGitHubFactoryAcceptanceReport(missingIntegrity)).toThrow(/CLI integrity is missing/u);
+
+    const staleCore = evidence();
+    staleCore.runtimeSource = "registry_install";
+    staleCore.runtimeArtifact = {
+      ...registryRuntimeArtifact(),
+      eventSchema: {
+        ...registryRuntimeArtifact().eventSchema,
+        version: "0.7.0"
+      }
+    };
+    expect(() => buildGitHubFactoryAcceptanceReport(staleCore)).toThrow(/event schema version/u);
+
+    const untrustedRegistry = evidence();
+    untrustedRegistry.runtimeSource = "registry_install";
+    untrustedRegistry.runtimeArtifact = {
+      ...registryRuntimeArtifact(),
+      registry: "https://packages.example.test",
+      resolved: "https://packages.example.test/@opentag/cli/-/cli-0.8.0.tgz"
+    };
+    expect(() => buildGitHubFactoryAcceptanceReport(untrustedRegistry)).toThrow(/trusted npm registry/u);
   });
 
   it("rejects a required check that is not bound to the pull request head", () => {

--- a/packages/dispatcher/test/github-registry-artifact.test.ts
+++ b/packages/dispatcher/test/github-registry-artifact.test.ts
@@ -1,0 +1,175 @@
+import { createHash } from "node:crypto";
+import { chmod, mkdir, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtemp } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import {
+  inspectRegistryCliArtifact,
+  normalizeRegistryGitHubFactorySourceEvent
+} from "../../../scripts/test/github-registry-artifact.js";
+
+const integrity = `sha512-${createHash("sha512").update("registry-artifact-fixture").digest("base64")}`;
+
+async function createRegistryInstall(
+  version = "0.8.0",
+  lockPackageRoot = "node_modules",
+  registryOrigin = "https://registry.npmjs.org"
+) {
+  const root = await mkdtemp(join(tmpdir(), "opentag-registry-artifact-"));
+  const cliRoot = join(root, "node_modules", "@opentag", "cli");
+  const githubRoot = join(root, "node_modules", "@opentag", "github");
+  const coreRoot = join(root, "node_modules", "@opentag", "core");
+  const binRoot = join(root, "node_modules", ".bin");
+  await Promise.all([
+    mkdir(join(cliRoot, "dist"), { recursive: true }),
+    mkdir(join(githubRoot, "dist"), { recursive: true }),
+    mkdir(join(coreRoot, "dist"), { recursive: true }),
+    mkdir(binRoot, { recursive: true })
+  ]);
+
+  await writeFile(join(cliRoot, "package.json"), JSON.stringify({
+    name: "@opentag/cli",
+    version,
+    type: "module",
+    bin: { opentag: "./dist/index.js" },
+    dependencies: { "@opentag/core": version, "@opentag/github": version }
+  }));
+  await writeFile(
+    join(cliRoot, "dist", "index.js"),
+    `#!/usr/bin/env node\nif (process.argv[2] === "--version") console.log(${JSON.stringify(version)});\n`
+  );
+  await chmod(join(cliRoot, "dist", "index.js"), 0o755);
+
+  await writeFile(join(githubRoot, "package.json"), JSON.stringify({
+    name: "@opentag/github",
+    version,
+    type: "module",
+    main: "./dist/index.js",
+    exports: { ".": "./dist/index.js" }
+  }));
+  await writeFile(
+    join(githubRoot, "dist", "index.js"),
+    "export const normalizeGitHubIssueComment = (input) => ({ id: `registry_${input.id}`, marker: 'registry-github' });\n"
+  );
+
+  await writeFile(join(coreRoot, "package.json"), JSON.stringify({
+    name: "@opentag/core",
+    version,
+    type: "module",
+    main: "./dist/index.js",
+    exports: { ".": "./dist/index.js" }
+  }));
+  await writeFile(
+    join(coreRoot, "dist", "index.js"),
+    "export const OpenTagEventSchema = { parse: (value) => ({ ...value, marker: `${value.marker}+registry-core` }) };\n"
+  );
+
+  await symlink("../@opentag/cli/dist/index.js", join(binRoot, "opentag"));
+  await writeFile(join(root, "package-lock.json"), JSON.stringify({
+    name: "registry-fixture",
+    lockfileVersion: 3,
+    packages: {
+      [`${lockPackageRoot}/@opentag/cli`]: {
+        version,
+        resolved: `${registryOrigin}/@opentag/cli/-/cli-${version}.tgz`,
+        integrity
+      },
+      [`${lockPackageRoot}/@opentag/github`]: {
+        version,
+        resolved: `${registryOrigin}/@opentag/github/-/github-${version}.tgz`,
+        integrity
+      },
+      [`${lockPackageRoot}/@opentag/core`]: {
+        version,
+        resolved: `${registryOrigin}/@opentag/core/-/core-${version}.tgz`,
+        integrity
+      }
+    }
+  }));
+
+  return { root, cliBin: join(binRoot, "opentag") };
+}
+
+describe("GitHub registry artifact acceptance", () => {
+  it("binds the executable, source normalizer, and event schema to registry lockfile integrity", async () => {
+    const fixture = await createRegistryInstall();
+    const previousNodeOptions = process.env["NODE_OPTIONS"];
+    process.env["NODE_OPTIONS"] = "--conditions=development";
+    let inspection: Awaited<ReturnType<typeof inspectRegistryCliArtifact>>;
+    try {
+      inspection = await inspectRegistryCliArtifact({
+        cliBin: fixture.cliBin,
+        expectedVersion: "0.8.0"
+      });
+    } finally {
+      if (previousNodeOptions === undefined) delete process.env["NODE_OPTIONS"];
+      else process.env["NODE_OPTIONS"] = previousNodeOptions;
+    }
+
+    expect(inspection.runtimeArtifact).toMatchObject({
+      expectedVersion: "0.8.0",
+      package: "@opentag/cli",
+      version: "0.8.0",
+      registry: "https://registry.npmjs.org",
+      integrity,
+      sourceNormalizer: {
+        package: "@opentag/github",
+        version: "0.8.0",
+        integrity
+      },
+      eventSchema: {
+        package: "@opentag/core",
+        version: "0.8.0",
+        integrity
+      }
+    });
+
+    await expect(normalizeRegistryGitHubFactorySourceEvent(inspection, { id: "100" }))
+      .resolves.toMatchObject({ id: "registry_100", marker: "registry-github+registry-core" });
+  });
+
+  it("fails closed for a stale installed candidate", async () => {
+    const fixture = await createRegistryInstall("0.7.0");
+
+    await expect(inspectRegistryCliArtifact({
+      cliBin: fixture.cliBin,
+      expectedVersion: "0.8.0"
+    })).rejects.toThrow(/expected 0\.8\.0/u);
+  });
+
+  it("rejects an arbitrary executable without npm package provenance", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opentag-arbitrary-cli-"));
+    const cliBin = join(root, "opentag");
+    await writeFile(cliBin, "#!/usr/bin/env node\nconsole.log('0.8.0');\n");
+    await chmod(cliBin, 0o755);
+
+    await expect(inspectRegistryCliArtifact({ cliBin, expectedVersion: "0.8.0" }))
+      .rejects.toThrow(/package root/u);
+  });
+
+  it("rejects a same-version lockfile entry for a different install path", async () => {
+    const fixture = await createRegistryInstall(
+      "0.8.0",
+      "node_modules/unrelated/node_modules"
+    );
+
+    await expect(inspectRegistryCliArtifact({
+      cliBin: fixture.cliBin,
+      expectedVersion: "0.8.0"
+    })).rejects.toThrow(/lockfile provenance/u);
+  });
+
+  it("rejects an artifact resolved from an untrusted HTTPS registry", async () => {
+    const fixture = await createRegistryInstall(
+      "0.8.0",
+      "node_modules",
+      "https://packages.example.test"
+    );
+
+    await expect(inspectRegistryCliArtifact({
+      cliBin: fixture.cliBin,
+      expectedVersion: "0.8.0"
+    })).rejects.toThrow(/trusted npm registry/u);
+  });
+});

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/github",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "GitHub event normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/gitlab",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "GitLab webhook normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/governance",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Deterministic execution governance for OpenTag work loops.",
   "type": "module",
   "engines": {

--- a/packages/lark/package.json
+++ b/packages/lark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/lark",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Lark/Feishu message normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/linear/package.json
+++ b/packages/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/linear",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Linear webhook normalization, callback rendering, and issue mutation helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/local-runtime/package.json
+++ b/packages/local-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/local-runtime",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Local OpenTag dispatcher, daemon, and diagnostics runtime helpers.",
   "type": "module",
   "engines": {

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/runner",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Executor contracts and built-in runner adapters for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/slack",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Slack app mention normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/store",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "SQLite and Drizzle persistence primitives for OpenTag runs and leases.",
   "type": "module",
   "engines": {

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/teams",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Microsoft Teams activity normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": { "node": ">=20" },

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/telegram",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Telegram message normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/scripts/dev/run-github-webhook-live-test.sh
+++ b/scripts/dev/run-github-webhook-live-test.sh
@@ -42,6 +42,10 @@ Helpful env:
   OPENTAG_GH_LIVE_REPORT          optional structured evidence JSON path
   OPENTAG_GH_LIVE_CLI_BIN         optional installed `opentag` executable;
                                      defaults to the source CLI through tsx
+  OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION
+                                     required with OPENTAG_GH_LIVE_CLI_BIN;
+                                     binds the executable and npm lockfile
+                                     integrity to the retained report
   OPENTAG_GH_LIVE_DISABLE_APPLY_TOKEN
                                      true/false, default false. Keeps GitHub
                                      callbacks working but verifies Needs setup
@@ -103,6 +107,7 @@ BATCH_ID=""
 BATCH_INPUT_DIGEST=""
 INITIAL_BATCH_RECEIPT_PATH=""
 REPLAYED_BATCH_RECEIPT_PATH=""
+RUNTIME_ARTIFACT_PATH=""
 
 bool_true() {
   case "${1:-}" in
@@ -374,6 +379,10 @@ run_factory_acceptance_tool() {
   NODE_OPTIONS='--conditions=development' corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/github-factory-acceptance.ts "$@"
 }
 
+run_registry_artifact_tool() {
+  corepack pnpm --dir apps/dispatcher exec tsx ../../scripts/test/github-registry-artifact.ts "$@"
+}
+
 capture_workstream_metrics() {
   local output_path="$1"
   curl -fsS \
@@ -632,6 +641,19 @@ PY
 ensure_port_free "$OPENTAG_DISPATCHER_PORT" "dispatcher"
 ensure_port_free "$OPENTAG_GITHUB_PORT" "GitHub ingress"
 
+if [[ -n "${OPENTAG_GH_LIVE_CLI_BIN:-}" ]]; then
+  if [[ -z "${OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION:-}" ]]; then
+    echo "OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION is required with OPENTAG_GH_LIVE_CLI_BIN." >&2
+    exit 1
+  fi
+  RUNTIME_ARTIFACT_PATH="$TMP_ROOT/registry-runtime-artifact.json"
+  run_registry_artifact_tool inspect \
+    "$OPENTAG_GH_LIVE_CLI_BIN" \
+    "$OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION" \
+    "$RUNTIME_ARTIFACT_PATH"
+  echo "Verified registry CLI package version and npm lockfile integrity."
+fi
+
 start_cli_stack
 
 PUBLIC_URL="${OPENTAG_GH_PUBLIC_URL:-}"
@@ -714,7 +736,11 @@ payload = {
 Path(output_path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 Path(output_path).chmod(0o600)
 PY
-  run_factory_acceptance_tool event "$SOURCE_EVENT_INPUT_PATH" "$EVENT_PATH"
+  if [[ -n "$RUNTIME_ARTIFACT_PATH" ]]; then
+    run_registry_artifact_tool event "$RUNTIME_ARTIFACT_PATH" "$SOURCE_EVENT_INPUT_PATH" "$EVENT_PATH"
+  else
+    run_factory_acceptance_tool event "$SOURCE_EVENT_INPUT_PATH" "$EVENT_PATH"
+  fi
   EVENT_ID="$(python3 - "$EVENT_PATH" <<'PY'
 import json
 import sys
@@ -1032,7 +1058,7 @@ PY
       "$METRICS_BEFORE_PROVIDER_PATH" "$METRICS_AFTER_MERGE_PATH" "$METRICS_AFTER_RESTART_PATH" "$SOURCE_COMMENTS_PATH" "$SOURCE_COMMENTS_AFTER_RESTART_PATH" "$SOURCE_ISSUE_PATH" \
       "$OWNER/$REPO" "$ISSUE_URL" "$MENTION_URL" "$ISSUE_NUMBER" "$COMMENT_ID" "$EVENT_ID" "$WORK_THREAD_ID" \
       "$RECIPE_ID" "$WORKSTREAM_ID" "$BATCH_ID" "$BATCH_INPUT_DIGEST" "$ASSESSMENT_COUNT" \
-      "$RECEIPTS_BEFORE_RESTART" "$RECEIPTS_AFTER_RESTART" "$RUNTIME_SOURCE" "$OPENTAG_GH_LIVE_REQUIRED_CHECK" <<'PY'
+      "$RECEIPTS_BEFORE_RESTART" "$RECEIPTS_AFTER_RESTART" "$RUNTIME_SOURCE" "$RUNTIME_ARTIFACT_PATH" "$OPENTAG_GH_LIVE_REQUIRED_CHECK" <<'PY'
 import hashlib
 import json
 import sys
@@ -1074,6 +1100,7 @@ from pathlib import Path
     receipts_before_restart,
     receipts_after_restart,
     runtime_source,
+    runtime_artifact_path,
     required_check_context,
 ) = sys.argv[1:]
 
@@ -1176,6 +1203,10 @@ evidence = {
         "countAfterRestart": int(receipts_after_restart),
     },
 }
+if runtime_source == "registry_install":
+    if not runtime_artifact_path:
+        raise SystemExit("Registry-installed factory acceptance is missing runtime artifact evidence.")
+    evidence["runtimeArtifact"] = read(runtime_artifact_path)["runtimeArtifact"]
 target = Path(evidence_path)
 target.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 target.chmod(0o600)
@@ -1185,7 +1216,7 @@ PY
   else
     python3 - \
       "$REPORT_PATH" "$INITIAL_COMPLETION_PATH" "$CHECKED_COMPLETION_PATH" "$FINAL_COMPLETION_PATH" "$RESTARTED_COMPLETION_PATH" "$PR_INFO_PATH" \
-      "$OWNER/$REPO" "$ISSUE_URL" "$RUN_ID" "$OPENTAG_GH_LIVE_REQUIRED_CHECK" "$ASSESSMENT_COUNT" "$RECEIPTS_AFTER_RESTART" "$RUNTIME_SOURCE" <<'PY'
+      "$OWNER/$REPO" "$ISSUE_URL" "$RUN_ID" "$OPENTAG_GH_LIVE_REQUIRED_CHECK" "$ASSESSMENT_COUNT" "$RECEIPTS_AFTER_RESTART" "$RUNTIME_SOURCE" "$RUNTIME_ARTIFACT_PATH" <<'PY'
 import json
 import sys
 from datetime import datetime, timezone
@@ -1205,6 +1236,7 @@ from pathlib import Path
     assessment_count,
     receipt_count,
     runtime_source,
+    runtime_artifact_path,
 ) = sys.argv[1:]
 
 def read(path):
@@ -1229,6 +1261,10 @@ report = {
     "assessmentCount": int(assessment_count),
     "providerVerifiedReceiptCount": int(receipt_count),
 }
+if runtime_source == "registry_install":
+    if not runtime_artifact_path:
+        raise SystemExit("Registry-installed completion acceptance is missing runtime artifact evidence.")
+    report["runtimeArtifact"] = read(runtime_artifact_path)["runtimeArtifact"]
 Path(report_path).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 Path(report_path).chmod(0o600)
 PY

--- a/scripts/test/github-factory-acceptance.ts
+++ b/scripts/test/github-factory-acceptance.ts
@@ -6,11 +6,34 @@ import { OpenTagEventSchema, type OpenTagEvent } from "../../packages/core/src/i
 import { normalizeGitHubIssueComment, type GitHubIssueCommentInput } from "../../packages/github/src/index.js";
 
 type JsonObject = Record<string, unknown>;
+const TRUSTED_NPM_REGISTRY_ORIGIN = "https://registry.npmjs.org";
+
+export type GitHubFactoryRegistryRuntimeArtifact = {
+  expectedVersion: string;
+  package: "@opentag/cli";
+  version: string;
+  registry: string;
+  resolved: string;
+  integrity: string;
+  sourceNormalizer: {
+    package: "@opentag/github";
+    version: string;
+    resolved: string;
+    integrity: string;
+  };
+  eventSchema: {
+    package: "@opentag/core";
+    version: string;
+    resolved: string;
+    integrity: string;
+  };
+};
 
 export type GitHubFactoryAcceptanceEvidence = {
   recordedAt: string;
   repository: string;
   runtimeSource: "source_checkout" | "registry_install";
+  runtimeArtifact?: GitHubFactoryRegistryRuntimeArtifact;
   source: {
     issueUrl: string;
     mentionUrl: string;
@@ -135,6 +158,11 @@ function string(value: unknown, label: string): string {
   return value;
 }
 
+function isSha512Integrity(value: string): boolean {
+  const match = /^sha512-([A-Za-z0-9+/]+={0,2})$/u.exec(value);
+  return Boolean(match?.[1] && Buffer.from(match[1], "base64").byteLength === 64);
+}
+
 function number(value: unknown, label: string): number {
   if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a finite number.`);
   return value;
@@ -201,6 +229,78 @@ function invariant(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`GitHub factory acceptance failed: ${message}`);
 }
 
+function validateRegistryRuntimeArtifact(
+  runtimeSource: GitHubFactoryAcceptanceEvidence["runtimeSource"],
+  artifact: GitHubFactoryRegistryRuntimeArtifact | undefined
+): void {
+  if (runtimeSource === "source_checkout") {
+    invariant(!artifact, "source-checkout proof must not claim registry runtime artifact identity");
+    return;
+  }
+
+  invariant(artifact, "registry runtime artifact identity is missing");
+  invariant(artifact.package === "@opentag/cli", `registry runtime package is ${artifact.package}`);
+  invariant(artifact.expectedVersion.length > 0, "expected registry CLI version is missing");
+  invariant(
+    artifact.version === artifact.expectedVersion,
+    `registry CLI version ${artifact.version} does not match expected version ${artifact.expectedVersion}`
+  );
+  invariant(isSha512Integrity(artifact.integrity), "registry CLI integrity is missing or invalid");
+  invariant(artifact.sourceNormalizer.package === "@opentag/github", "registry source normalizer package is invalid");
+  invariant(
+    artifact.sourceNormalizer.version === artifact.expectedVersion,
+    `registry source normalizer version ${artifact.sourceNormalizer.version} does not match expected version ${artifact.expectedVersion}`
+  );
+  invariant(
+    isSha512Integrity(artifact.sourceNormalizer.integrity),
+    "registry source normalizer integrity is missing or invalid"
+  );
+  invariant(artifact.eventSchema.package === "@opentag/core", "registry event schema package is invalid");
+  invariant(
+    artifact.eventSchema.version === artifact.expectedVersion,
+    `registry event schema version ${artifact.eventSchema.version} does not match expected version ${artifact.expectedVersion}`
+  );
+  invariant(
+    isSha512Integrity(artifact.eventSchema.integrity),
+    "registry event schema integrity is missing or invalid"
+  );
+
+  let resolved: URL;
+  let normalizerResolved: URL;
+  let eventSchemaResolved: URL;
+  try {
+    resolved = new URL(artifact.resolved);
+    normalizerResolved = new URL(artifact.sourceNormalizer.resolved);
+    eventSchemaResolved = new URL(artifact.eventSchema.resolved);
+  } catch {
+    throw new Error("GitHub factory acceptance failed: registry artifact resolution is not a valid URL.");
+  }
+  invariant(resolved.protocol === "https:", "registry CLI artifact was not resolved over HTTPS");
+  invariant(normalizerResolved.protocol === "https:", "registry source normalizer was not resolved over HTTPS");
+  invariant(eventSchemaResolved.protocol === "https:", "registry event schema was not resolved over HTTPS");
+  invariant(artifact.registry === TRUSTED_NPM_REGISTRY_ORIGIN, "registry CLI did not use the trusted npm registry");
+  invariant(resolved.origin === TRUSTED_NPM_REGISTRY_ORIGIN, "registry CLI artifact did not use the trusted npm registry");
+  invariant(
+    normalizerResolved.origin === TRUSTED_NPM_REGISTRY_ORIGIN,
+    "registry source normalizer did not use the trusted npm registry"
+  );
+  invariant(
+    eventSchemaResolved.origin === TRUSTED_NPM_REGISTRY_ORIGIN,
+    "registry event schema did not use the trusted npm registry"
+  );
+  invariant(artifact.registry === resolved.origin, "registry CLI origin does not match its resolved artifact URL");
+  for (const [label, url] of [
+    ["registry CLI artifact", resolved],
+    ["registry source normalizer", normalizerResolved],
+    ["registry event schema", eventSchemaResolved]
+  ] as const) {
+    invariant(
+      !url.username && !url.password && !url.search && !url.hash,
+      `${label} URL contains credentials, query parameters, or fragments`
+    );
+  }
+}
+
 export function normalizeGitHubFactorySourceEvent(input: GitHubIssueCommentInput): OpenTagEvent {
   const event = normalizeGitHubIssueComment(input);
   if (!event) throw new Error("GitHub factory source comment does not contain a valid @opentag command.");
@@ -210,6 +310,7 @@ export function normalizeGitHubFactorySourceEvent(input: GitHubIssueCommentInput
 export function buildGitHubFactoryAcceptanceReport(
   evidence: GitHubFactoryAcceptanceEvidence
 ): GitHubFactoryAcceptanceReport {
+  validateRegistryRuntimeArtifact(evidence.runtimeSource, evidence.runtimeArtifact);
   const admission = receiptAdmission(evidence.factory.batch.initialReceipt);
   const replayAdmission = receiptAdmission(evidence.factory.batch.replayedReceipt);
   const initialCompletion = completionState(evidence.completion.afterExecutorSuccess);
@@ -278,6 +379,7 @@ export function buildGitHubFactoryAcceptanceReport(
     recordedAt: evidence.recordedAt,
     repository: evidence.repository,
     runtimeSource: evidence.runtimeSource,
+    ...(evidence.runtimeArtifact ? { runtimeArtifact: evidence.runtimeArtifact } : {}),
     source: evidence.source,
     factory: {
       workThreadId: evidence.factory.workThreadId,

--- a/scripts/test/github-registry-artifact.ts
+++ b/scripts/test/github-registry-artifact.ts
@@ -1,0 +1,302 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { GitHubFactoryRegistryRuntimeArtifact } from "./github-factory-acceptance.js";
+
+type JsonObject = Record<string, unknown>;
+const TRUSTED_NPM_REGISTRY_ORIGIN = "https://registry.npmjs.org";
+
+type PackageJson = {
+  name?: unknown;
+  version?: unknown;
+  bin?: unknown;
+  main?: unknown;
+  exports?: unknown;
+};
+
+type PackageLock = {
+  packages?: Record<string, {
+    version?: unknown;
+    resolved?: unknown;
+    integrity?: unknown;
+  }>;
+};
+
+export type RegistryCliArtifactInspection = {
+  runtimeArtifact: GitHubFactoryRegistryRuntimeArtifact;
+  installation: {
+    cliPackageRoot: string;
+    githubEntrypoint: string;
+    coreEntrypoint: string;
+  };
+};
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}
+
+function object(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as JsonObject;
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function isSha512Integrity(value: string): boolean {
+  const match = /^sha512-([A-Za-z0-9+/]+={0,2})$/u.exec(value);
+  return Boolean(match?.[1] && Buffer.from(match[1], "base64").byteLength === 64);
+}
+
+async function findPackageRoot(entrypoint: string, expectedName: string): Promise<string> {
+  let current = dirname(await realpath(entrypoint));
+  while (true) {
+    try {
+      const manifest = object(await readJson(join(current, "package.json")), `${expectedName} package manifest`);
+      if (manifest["name"] === expectedName) return current;
+    } catch (error) {
+      const code = error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
+      if (code !== "ENOENT") throw error;
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Could not find the ${expectedName} package root for ${entrypoint}.`);
+}
+
+function packageLockKey(installRoot: string, packageRoot: string): string {
+  return relative(installRoot, packageRoot).split(sep).join("/");
+}
+
+async function findLockfileEntry(packageRoot: string, expectedName: string) {
+  let current = packageRoot;
+  while (true) {
+    try {
+      const lock = object(await readJson(join(current, "package-lock.json")), "npm package lock") as PackageLock;
+      const key = packageLockKey(current, packageRoot);
+      const entry = lock.packages?.[key];
+      if (entry) return { installRoot: current, entry };
+    } catch (error) {
+      const code = error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
+      if (code !== "ENOENT") throw error;
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Could not find npm lockfile provenance for ${expectedName}.`);
+}
+
+function packageNameSegments(packageName: string): string[] {
+  return packageName.split("/").filter(Boolean);
+}
+
+async function resolveInstalledDependencyRoot(fromPackageRoot: string, packageName: string): Promise<string> {
+  let current = fromPackageRoot;
+  while (true) {
+    const candidate = join(current, "node_modules", ...packageNameSegments(packageName));
+    try {
+      const manifest = object(await readJson(join(candidate, "package.json")), `${packageName} package manifest`);
+      if (manifest["name"] === packageName) return candidate;
+    } catch (error) {
+      const code = error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
+      if (code !== "ENOENT") throw error;
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`Could not resolve installed dependency ${packageName} from @opentag/cli.`);
+}
+
+async function packageImportEntrypoint(packageRoot: string, packageName: string): Promise<string> {
+  const manifest = object(await readJson(join(packageRoot, "package.json")), `${packageName} package manifest`) as PackageJson;
+  let entrypoint: unknown;
+  if (typeof manifest.exports === "string") {
+    entrypoint = manifest.exports;
+  } else if (manifest.exports && typeof manifest.exports === "object" && !Array.isArray(manifest.exports)) {
+    const rootExport = (manifest.exports as JsonObject)["."];
+    if (typeof rootExport === "string") {
+      entrypoint = rootExport;
+    } else if (rootExport && typeof rootExport === "object" && !Array.isArray(rootExport)) {
+      const conditions = rootExport as JsonObject;
+      entrypoint = conditions["import"] ?? conditions["default"];
+    }
+  }
+  entrypoint ??= manifest.main;
+  return realpath(resolve(packageRoot, string(entrypoint, `${packageName} import entrypoint`)));
+}
+
+async function inspectInstalledPackage(
+  entrypoint: string,
+  expectedName: string,
+  expectedVersion: string
+): Promise<{
+  packageRoot: string;
+  version: string;
+  registry: string;
+  resolved: string;
+  integrity: string;
+}> {
+  const packageRoot = await findPackageRoot(entrypoint, expectedName);
+  const manifest = object(await readJson(join(packageRoot, "package.json")), `${expectedName} package manifest`) as PackageJson;
+  const name = string(manifest.name, `${expectedName} package name`);
+  const version = string(manifest.version, `${expectedName} package version`);
+  if (name !== expectedName) throw new Error(`Resolved ${name}; expected ${expectedName}.`);
+  if (version !== expectedVersion) throw new Error(`${expectedName} is ${version}; expected ${expectedVersion}.`);
+
+  const { entry } = await findLockfileEntry(packageRoot, expectedName);
+  const lockedVersion = string(entry.version, `${expectedName} lockfile version`);
+  const resolvedUrl = string(entry.resolved, `${expectedName} resolved artifact`);
+  const integrity = string(entry.integrity, `${expectedName} lockfile integrity`);
+  if (lockedVersion !== version) {
+    throw new Error(`${expectedName} lockfile version ${lockedVersion} does not match installed version ${version}.`);
+  }
+  if (!isSha512Integrity(integrity)) {
+    throw new Error(`${expectedName} lockfile integrity must be a sha512 receipt.`);
+  }
+  const parsedUrl = new URL(resolvedUrl);
+  if (parsedUrl.protocol !== "https:") {
+    throw new Error(`${expectedName} resolved artifact must use HTTPS.`);
+  }
+  if (parsedUrl.origin !== TRUSTED_NPM_REGISTRY_ORIGIN) {
+    throw new Error(`${expectedName} resolved artifact must use the trusted npm registry.`);
+  }
+  if (parsedUrl.username || parsedUrl.password || parsedUrl.search || parsedUrl.hash) {
+    throw new Error(`${expectedName} resolved artifact URL must not contain credentials, query parameters, or fragments.`);
+  }
+  return {
+    packageRoot,
+    version,
+    registry: parsedUrl.origin,
+    resolved: resolvedUrl,
+    integrity
+  };
+}
+
+function executableVersion(cliBin: string): Promise<string> {
+  return new Promise((resolvePromise, reject) => {
+    execFile(cliBin, ["--version"], {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: { ...process.env, NODE_OPTIONS: "" }
+    }, (error, stdout) => {
+      if (error) {
+        reject(new Error(`Installed OpenTag CLI --version failed: ${error.message}`));
+        return;
+      }
+      resolvePromise(stdout.trim());
+    });
+  });
+}
+
+export async function inspectRegistryCliArtifact(input: {
+  cliBin: string;
+  expectedVersion: string;
+}): Promise<RegistryCliArtifactInspection> {
+  const expectedVersion = string(input.expectedVersion, "expected registry CLI version");
+  const cliBin = await realpath(resolve(input.cliBin));
+  const cli = await inspectInstalledPackage(cliBin, "@opentag/cli", expectedVersion);
+  const manifest = object(await readJson(join(cli.packageRoot, "package.json")), "@opentag/cli package manifest") as PackageJson;
+  const bin = object(manifest.bin, "@opentag/cli bin map");
+  const expectedEntrypoint = await realpath(resolve(cli.packageRoot, string(bin["opentag"], "@opentag/cli bin entry")));
+  if (expectedEntrypoint !== cliBin) {
+    throw new Error(`Installed OpenTag executable does not match the @opentag/cli bin entry.`);
+  }
+  const reportedVersion = await executableVersion(cliBin);
+  if (reportedVersion !== expectedVersion) {
+    throw new Error(`Installed OpenTag executable reports ${reportedVersion}; expected ${expectedVersion}.`);
+  }
+
+  const githubRoot = await resolveInstalledDependencyRoot(cli.packageRoot, "@opentag/github");
+  const coreRoot = await resolveInstalledDependencyRoot(cli.packageRoot, "@opentag/core");
+  const githubEntrypoint = await packageImportEntrypoint(githubRoot, "@opentag/github");
+  const coreEntrypoint = await packageImportEntrypoint(coreRoot, "@opentag/core");
+  const github = await inspectInstalledPackage(githubEntrypoint, "@opentag/github", expectedVersion);
+  const core = await inspectInstalledPackage(coreEntrypoint, "@opentag/core", expectedVersion);
+
+  return {
+    runtimeArtifact: {
+      expectedVersion,
+      package: "@opentag/cli",
+      version: cli.version,
+      registry: cli.registry,
+      resolved: cli.resolved,
+      integrity: cli.integrity,
+      sourceNormalizer: {
+        package: "@opentag/github",
+        version: github.version,
+        resolved: github.resolved,
+        integrity: github.integrity
+      },
+      eventSchema: {
+        package: "@opentag/core",
+        version: core.version,
+        resolved: core.resolved,
+        integrity: core.integrity
+      }
+    },
+    installation: {
+      cliPackageRoot: cli.packageRoot,
+      githubEntrypoint,
+      coreEntrypoint
+    }
+  };
+}
+
+export async function normalizeRegistryGitHubFactorySourceEvent(
+  inspection: RegistryCliArtifactInspection,
+  input: unknown
+): Promise<unknown> {
+  const github = await import(pathToFileURL(inspection.installation.githubEntrypoint).href) as {
+    normalizeGitHubIssueComment?: (value: unknown) => unknown;
+  };
+  const core = await import(pathToFileURL(inspection.installation.coreEntrypoint).href) as {
+    OpenTagEventSchema?: { parse(value: unknown): unknown };
+  };
+  if (typeof github.normalizeGitHubIssueComment !== "function") {
+    throw new Error("Installed @opentag/github does not export normalizeGitHubIssueComment.");
+  }
+  if (!core.OpenTagEventSchema || typeof core.OpenTagEventSchema.parse !== "function") {
+    throw new Error("Installed @opentag/core does not export OpenTagEventSchema.");
+  }
+  const event = github.normalizeGitHubIssueComment(input);
+  if (!event) throw new Error("GitHub factory source comment does not contain a valid @opentag command.");
+  return core.OpenTagEventSchema.parse(event);
+}
+
+async function writePrivateJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+async function main(argv: string[]): Promise<void> {
+  const [command, first, second, third, ...rest] = argv;
+  if (rest.length > 0 || !first || !second || !third || (command !== "inspect" && command !== "event")) {
+    throw new Error(
+      "Usage: github-registry-artifact.ts inspect <cli-bin> <expected-version> <output.json> | event <inspection.json> <input.json> <output.json>"
+    );
+  }
+  if (command === "inspect") {
+    await writePrivateJson(third, await inspectRegistryCliArtifact({ cliBin: first, expectedVersion: second }));
+    return;
+  }
+  const inspection = await readJson(first) as RegistryCliArtifactInspection;
+  await writePrivateJson(third, await normalizeRegistryGitHubFactorySourceEvent(inspection, await readJson(second)));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- prepare the coordinated 0.8.0 source release across all 16 public `@opentag/*` packages and document the Phase 2-5 software-factory capabilities
- make registry-installed GitHub factory acceptance fail closed on executable identity, exact package-lock install paths, version, HTTPS resolution, sha512 integrity, and installed source normalization
- add deterministic factory conformance to CI and document a non-overwritable, fail-fast dist-tag promotion/rollback procedure

## Verification

- `corepack pnpm release:publication-set` — 16 coordinated packages at 0.8.0
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm test` — 138 files, 1,796 tests passed
- `corepack pnpm smoke:factory-conformance` — echo and ACP paths, restart replay, 2/2 accepted outcomes
- governance matrix 8/8 and privacy redaction checks
- `corepack pnpm release:check` — pack/install/audit and installed CLI/governance checks
- real npm `@opentag/cli@0.7.0` fresh-directory install passed the exact-path artifact inspector, including installed `@opentag/github` provenance
- independent code/security and architecture/release-safety reviews: CLEAR

## Release boundary

This PR prepares source and release gates only. It does not publish npm packages, mutate dist-tags, create `v0.8.0`, or create a GitHub Release. The registry-installed provider-live 0.8.0 proof remains a post-publish-to-`next` gate before promotion to `latest`. The planning system remains external; this adds no DAG or operator console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic factory conformance checks to release validation.
  * Enhanced live factory verification with registry-installed CLI evidence (version, HTTPS resolution, `package-lock` `sha512` integrity) and richer runtime artifact reporting.
  * Extended GitHub factory acceptance to conditionally include registry runtime evidence.

* **Bug Fixes**
  * Improved fail-closed handling for stale, incomplete, mismatched, or malformed acceptance artifacts, including restart-safe behavior.

* **Security**
  * Tightened credential and access-profile enforcement; hardened completion-governance and metrics validation.

* **Documentation / Chores / Tests**
  * Updated docs, guides, and package versions to **v0.8.0**; expanded integrity-focused test coverage and CI gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->