### PR TITLE
chore(release): prepare OpenTag 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,73 @@
 
 No changes yet.
 
+## v0.9.0 - 2026-07-28
+
+OpenTag 0.9.0 adds a read-only Linear project-backlog query to the Slack source
+thread without turning Linear into an internal planning system or silently
+starting agent work. Authorized channels can request `@OpenTag /linear`, receive
+an ordered backlog summary in the same thread, and safely retry a failed or
+interrupted query. Existing run creation, approval, binding, and mutation paths
+retain their prior delivery semantics.
+
+### Added
+
+- A public `@opentag/linear` backlog query that fetches every unfinished issue
+  page within fixed time and page bounds, validates the Linear response, and
+  orders the complete result by workflow state, priority, and issue identifier.
+- Slack parsing and rendering for the exact `@OpenTag /linear` and
+  `@OpenTag linear` commands, including project name, issue state and priority,
+  safe links, query time, and an explicit display limit.
+- Additive CLI configuration, startup, and doctor support for exact
+  `(teamId, channelId) -> projectId` query authorization and a query-only
+  `platforms.linear.connections.default.token` credential.
+
+### Changed
+
+- Only read-only `/linear` queries use a dedicated bounded asynchronous Slack
+  Events API lane. Run creation, stop, bind/unbind, approvals, and interactive
+  actions remain synchronous so a processing failure is not acknowledged as a
+  successful control-plane delivery.
+- Linear backlog queries read the live OAuth token when available, complete
+  pagination before applying the global display order, and fail closed when the
+  mapped project is missing, inaccessible, over the page bound, or over the
+  request deadline.
+
+### Fixed
+
+- Slack-controlled and Linear-controlled text and URLs are escaped before
+  rendering so issue content cannot inject Slack mrkdwn or malformed links.
+- A failed non-2xx `/linear` processing attempt no longer enters completed-event
+  deduplication and remains safe to retry.
+- Graceful Slack ingress shutdown drains the query lane when possible but
+  resolves after a 30-second maximum wait instead of blocking indefinitely.
+
+### Security
+
+- Slack `/linear` authorization requires an exact team and channel match before
+  OpenTag reads a Linear credential or calls the provider; legacy global project
+  settings do not authorize a channel.
+- Query-only Linear credentials are kept out of mutation dispatcher wiring, and
+  unsupported named connections fail closed instead of falling back to another
+  workspace token.
+
+### Compatibility and migration
+
+- The release is additive and introduces no breaking TypeScript or HTTP
+  contract. Existing Linear webhook, callback, and issue-creation paths remain
+  available and continue to require their mutation-capable configuration.
+- To enable `/linear`, add an exact entry under `platforms.linear.channels` and
+  configure the `default` query connection. `platforms.linear.projectId` and
+  `OPENTAG_LINEAR_PROJECT_ID` are not channel authorization fallbacks.
+
+### Release validation note
+
+Before promotion from npm `next` to `latest`, the exact registry-installed
+`@opentag/cli@0.9.0` candidate must pass the coordinated package checks and the
+real GitHub factory acceptance loop. The Slack-to-Linear query path must also be
+validated with provider-backed credentials or left explicitly unclaimed; source
+tests alone do not prove live Slack or Linear delivery.
+
 ## v0.8.0 - 2026-07-27
 
 OpenTag 0.8.0 completes the first provider-live, recipe-driven software-factory

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ opentag-dev setup
 
 ## Packages
 
-Package source version: `v0.8.0`. npm dist-tags are authoritative for the currently published channel versions. The coordinated package family contains 16 public packages under the `@opentag` scope.
+Package source version: `v0.9.0`. npm dist-tags are authoritative for the currently published channel versions. The coordinated package family contains 16 public packages under the `@opentag` scope.
 
 | Package | Purpose |
 | --- | --- |
@@ -286,7 +286,7 @@ Package source version: `v0.8.0`. npm dist-tags are authoritative for the curren
 | [`@opentag/slack`](https://www.npmjs.com/package/@opentag/slack) | Slack Socket Mode, Events API handling, and thread replies |
 | [`@opentag/github`](https://www.npmjs.com/package/@opentag/github) | GitHub webhook handling, comments, PR helpers, and action application |
 | [`@opentag/gitlab`](https://www.npmjs.com/package/@opentag/gitlab) | GitLab webhook handling, note replies, merge request helpers, and action application |
-| [`@opentag/linear`](https://www.npmjs.com/package/@opentag/linear) | Linear webhook handling, issue comments, and issue action application |
+| [`@opentag/linear`](https://www.npmjs.com/package/@opentag/linear) | Linear webhook handling, read-only project backlog queries, issue comments, and issue action application |
 | [`@opentag/lark`](https://www.npmjs.com/package/@opentag/lark) | Lark / Feishu ingress, Personal Agent registration, and replies |
 | [`@opentag/telegram`](https://www.npmjs.com/package/@opentag/telegram) | Telegram polling/webhook normalization, bot replies, and source-thread controls |
 | [`@opentag/discord`](https://www.npmjs.com/package/@opentag/discord) | Discord Gateway/webhook slash-command interactions and channel replies |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -265,7 +265,7 @@ opentag-dev setup
 
 ## 软件包
 
-当前源码包版本：`v0.8.0`；npm dist-tag 是各发布通道当前公开版本的权威来源。OpenTag 在 `@opentag` scope 下协调发布 16 个公开软件包。
+当前源码包版本：`v0.9.0`；npm dist-tag 是各发布通道当前公开版本的权威来源。OpenTag 在 `@opentag` scope 下协调发布 16 个公开软件包。
 
 | 包 | 用途 |
 | --- | --- |
@@ -277,7 +277,7 @@ opentag-dev setup
 | [`@opentag/slack`](https://www.npmjs.com/package/@opentag/slack) | Slack Socket Mode、Events API 和回复 |
 | [`@opentag/github`](https://www.npmjs.com/package/@opentag/github) | GitHub webhook、评论、PR helper 和 action apply |
 | [`@opentag/gitlab`](https://www.npmjs.com/package/@opentag/gitlab) | GitLab webhook、note 回复、MR helper 和 action apply |
-| [`@opentag/linear`](https://www.npmjs.com/package/@opentag/linear) | Linear webhook、issue comment 回复和 issue action apply |
+| [`@opentag/linear`](https://www.npmjs.com/package/@opentag/linear) | Linear webhook、只读 project backlog 查询、issue comment 回复和 issue action apply |
 | [`@opentag/lark`](https://www.npmjs.com/package/@opentag/lark) | Lark / 飞书入口、Personal Agent 注册和回复 |
 | [`@opentag/telegram`](https://www.npmjs.com/package/@opentag/telegram) | Telegram polling/webhook 规范化、bot 回复和 source-thread controls |
 | [`@opentag/discord`](https://www.npmjs.com/package/@opentag/discord) | Discord Gateway/webhook slash-command interactions 和频道回复 |

--- a/docs/live-e2e-smoke-harness.md
+++ b/docs/live-e2e-smoke-harness.md
@@ -294,7 +294,7 @@ path with `OPENTAG_GH_LIVE_REPORT`. Set
 `OPENTAG_GH_LIVE_STRICT_COMPLETION=false` only when intentionally exercising
 the older optional `apply 1` compatibility flow.
 
-After publishing a candidate to npm `next`, install `@opentag/cli@0.8.0` into a
+After publishing a candidate to npm `next`, install `@opentag/cli@0.9.0` into a
 fresh directory by running the exact install from inside that directory:
 
 ```bash
@@ -304,13 +304,13 @@ smoke_root="$(mktemp -d)"
 
   cd "$smoke_root"
   npm init --yes >/dev/null
-  npm install --no-audit --no-fund @opentag/cli@0.8.0
+  npm install --no-audit --no-fund @opentag/cli@0.9.0
 )
 ```
 
 Then set `OPENTAG_GH_LIVE_CLI_BIN` to that installation's
 `node_modules/.bin/opentag` and
-`OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION=0.8.0`. The harness verifies the
+`OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION=0.9.0`. The harness verifies the
 executable, package manifests, exact package-lock install paths, trusted public
 npm resolution, and integrity receipts before starting, then normalizes and
 validates the source comment through the installed `@opentag/github` and

--- a/docs/npm-release.md
+++ b/docs/npm-release.md
@@ -7,16 +7,16 @@ version.
 ## Target release
 
 ```text
-0.8.0
+0.9.0
 ```
 
 The release is first published on the npm `next` dist-tag, tested from the
 registry, then promoted to `latest`. The exact commit that produced the npm
-artifacts must also receive the matching `v0.8.0` git tag and GitHub Release.
+artifacts must also receive the matching `v0.9.0` git tag and GitHub Release.
 
 The public release set contains 16 packages, including
-`@opentag/governance`. The complete family has a coordinated `0.7.0` release.
-Publishing `0.8.0` with `--tag next` must leave each package's existing
+`@opentag/governance`. The complete family has a coordinated `0.8.0` release.
+Publishing `0.9.0` with `--tag next` must leave each package's existing
 `latest` pointer unchanged until the complete registry, ACP, governance,
 factory, and live-platform gate passes.
 
@@ -45,7 +45,7 @@ plan.
 ## Release gate
 
 Start from the intended release commit with a clean working tree. Confirm that
-all 16 public manifests use `0.8.0` and that the frozen lockfile is current,
+all 16 public manifests use `0.9.0` and that the frozen lockfile is current,
 then run the verification ladder in this order:
 
 ```bash
@@ -114,7 +114,7 @@ authority, then confirm npm access and publish from that same commit:
   set -euo pipefail
 
   test -z "$(git status --porcelain)"
-  release_state_dir=".omx/releases/0.8.0"
+  release_state_dir=".omx/releases/0.9.0"
   release_commit_file="$release_state_dir/release-commit-sha"
   current_release_commit="$(git rev-parse HEAD)"
   mkdir -p "$release_state_dir"
@@ -140,7 +140,7 @@ authority, then confirm npm access and publish from that same commit:
 
 The publish command uses the same automatic publication set and topological
 order as `release:check`. A coordinated release is incomplete until all 16
-packages exist at `0.8.0`; do not promote a partial package family. Preserve
+packages exist at `0.9.0`; do not promote a partial package family. Preserve
 the exact `release-commit-sha` file with the release record. Every later lock,
 tag, rollback, and release check reads that authority instead of recapturing
 the current `HEAD`.
@@ -173,14 +173,14 @@ smoke_root="$(mktemp -d)"
 
   cd "$smoke_root"
   npm init --yes >/dev/null
-  npm install --no-audit --no-fund @opentag/cli@0.8.0
-  test "$("$smoke_root/node_modules/.bin/opentag" --version)" = "0.8.0"
+  npm install --no-audit --no-fund @opentag/cli@0.9.0
+  test "$("$smoke_root/node_modules/.bin/opentag" --version)" = "0.9.0"
   "$smoke_root/node_modules/.bin/opentag" --help
   npm audit --prefix "$smoke_root" --omit=dev --audit-level=high
 )
 ```
 
-The version must be `0.8.0`. With isolated config and state directories, run
+The version must be `0.9.0`. With isolated config and state directories, run
 the setup, doctor, and foreground-start path for one platform that has real
 test credentials:
 
@@ -202,19 +202,19 @@ process after the receipt is visible. Record which platform was tested and the
 redacted evidence in the release notes; never record provider tokens, fencing
 tokens, raw ACP frames, or full private message IDs.
 
-For `0.8.0`, the required provider gate is the GitHub factory acceptance case,
+For `0.9.0`, the required provider gate is the GitHub factory acceptance case,
 run with the registry-installed binary rather than the workspace CLI:
 
 ```bash
 OPENTAG_GH_LIVE_CLI_BIN="$smoke_root/node_modules/.bin/opentag" \
-OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION=0.8.0 \
+OPENTAG_GH_LIVE_EXPECTED_CLI_VERSION=0.9.0 \
 OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture \
-OPENTAG_GH_LIVE_REPORT=.omx/live-e2e/github-factory-live-0.8.0.json \
+OPENTAG_GH_LIVE_REPORT=.omx/live-e2e/github-factory-live-0.9.0.json \
 corepack pnpm smoke:live -- --case github-factory-live
 ```
 
 The harness fails before starting the local stack unless the executable resolves
-to `@opentag/cli@0.8.0`, its `--version` output agrees, and the clean install's
+to `@opentag/cli@0.9.0`, its `--version` output agrees, and the clean install's
 `package-lock.json` has an exact install-path entry with HTTPS registry
 resolution and sha512 integrity for `@opentag/cli`, the installed
 `@opentag/github` source normalizer, and the installed `@opentag/core` event
@@ -239,12 +239,12 @@ Also verify every package and its canary tag before promotion:
 (
   set -euo pipefail
 
-  test "$("$smoke_root/node_modules/.bin/opentag" --version)" = "0.8.0"
+  test "$("$smoke_root/node_modules/.bin/opentag" --version)" = "0.9.0"
   for manifest in packages/*/package.json; do
     [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
     package="$(jq -r '.name' "$manifest")"
-    test "$(npm view "$package@0.8.0" version)" = "0.8.0"
-    test "$(npm view "$package" dist-tags.next)" = "0.8.0"
+    test "$(npm view "$package@0.9.0" version)" = "0.9.0"
+    test "$(npm view "$package" dist-tags.next)" = "0.9.0"
     npm view "$package" dist-tags --json
   done
 )
@@ -261,7 +261,7 @@ window:
 (
   set -euo pipefail
 
-  release_state_dir=".omx/releases/0.8.0"
+  release_state_dir=".omx/releases/0.9.0"
   release_commit_file="$release_state_dir/release-commit-sha"
   lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
   test -f "$release_commit_file"
@@ -312,7 +312,7 @@ retry cannot replace the original rollback authority:
 (
   set -euo pipefail
 
-  release_state_dir=".omx/releases/0.8.0"
+  release_state_dir=".omx/releases/0.9.0"
   release_commit_file="$release_state_dir/release-commit-sha"
   lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
   test -f "$release_commit_file"
@@ -334,12 +334,12 @@ retry cannot replace the original rollback authority:
     package="$(jq -r '.name' "$manifest")"
     dist_tags_json="$(npm view "$package" dist-tags --json)"
     previous_latest="$(jq -er '.latest | select(type == "string" and length > 0)' <<<"$dist_tags_json")"
-    test "$previous_latest" = "0.7.0"
+    test "$previous_latest" = "0.8.0"
     printf '%s\t%s\n' "$package" "$previous_latest" >>"$snapshot_tmp"
   done
   test "$(wc -l <"$snapshot_tmp" | tr -d ' ')" = "16"
   test "$(cut -f1 "$snapshot_tmp" | sort -u | wc -l | tr -d ' ')" = "16"
-  test "$(cut -f2 "$snapshot_tmp" | sort -u)" = "0.7.0"
+  test "$(cut -f2 "$snapshot_tmp" | sort -u)" = "0.8.0"
   mv -n "$snapshot_tmp" "$rollback_file"
   test ! -e "$snapshot_tmp"
 )
@@ -347,7 +347,7 @@ retry cannot replace the original rollback authority:
 
 Keep that exact file until the release is complete. It records the actual
 pre-promotion `latest` target for every package and fails unless the coordinated
-family is still on the known `0.7.0` baseline. A registry lookup failure or a
+family is still on the known `0.8.0` baseline. A registry lookup failure or a
 missing/unexpected tag stops the release; it is never interpreted as rollback
 authority. Back the snapshot up outside the ephemeral shell session before
 changing any dist-tag.
@@ -360,7 +360,7 @@ package has been promoted:
 (
   set -euo pipefail
 
-  release_state_dir=".omx/releases/0.8.0"
+  release_state_dir=".omx/releases/0.9.0"
   release_commit_file="$release_state_dir/release-commit-sha"
   lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
   test -f "$release_commit_file"
@@ -370,77 +370,93 @@ package has been promoted:
   lock_commit="$(<"$lock_owner_file")"
   test "$(gh api repos/amplifthq/opentag/git/ref/heads/release-lock/npm-dist-tags --jq '.object.sha')" = "$lock_commit"
   test "$(gh api "repos/amplifthq/opentag/git/commits/$lock_commit" --jq '.parents[0].sha')" = "$release_commit"
-  rollback_file=".omx/releases/0.8.0/pre-promotion-latest.tsv"
+  rollback_file=".omx/releases/0.9.0/pre-promotion-latest.tsv"
   test -f "$rollback_file"
   test "$(wc -l <"$rollback_file" | tr -d ' ')" = "16"
   test "$(cut -f1 "$rollback_file" | sort -u | wc -l | tr -d ' ')" = "16"
-  test "$(cut -f2 "$rollback_file" | sort -u)" = "0.7.0"
+  test "$(cut -f2 "$rollback_file" | sort -u)" = "0.8.0"
 
   for manifest in packages/*/package.json; do
     [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
     package="$(jq -r '.name' "$manifest")"
     previous_latest="$(awk -F '\t' -v package="$package" '$1 == package { print $2 }' "$rollback_file")"
-    test "$previous_latest" = "0.7.0"
+    test "$previous_latest" = "0.8.0"
     current_tags_json="$(npm view "$package" dist-tags --json)"
     current_latest="$(jq -er '.latest | select(type == "string" and length > 0)' <<<"$current_tags_json")"
     current_next="$(jq -er '.next | select(type == "string" and length > 0)' <<<"$current_tags_json")"
-    test "$current_next" = "0.8.0"
+    test "$current_next" = "0.9.0"
     case "$current_latest" in
-      "$previous_latest") npm dist-tag add "$package@0.8.0" latest ;;
-      "0.8.0") ;;
+      "$previous_latest") npm dist-tag add "$package@0.9.0" latest ;;
+      "0.9.0") ;;
       *) echo "Refusing to replace drifted $package latest=$current_latest" >&2; exit 1 ;;
     esac
-    test "$(npm view "$package" dist-tags.latest)" = "0.8.0"
-    test "$(npm view "$package" dist-tags.next)" = "0.8.0"
+    test "$(npm view "$package" dist-tags.latest)" = "0.9.0"
+    test "$(npm view "$package" dist-tags.next)" = "0.9.0"
   done
 )
 ```
 
 Rerun the package loop from the registry-verification section and confirm both
-`next` and `latest` point at `0.8.0` for all 16 packages.
+`next` and `latest` point at `0.9.0` for all 16 packages.
 
 ## Create the matching source release
 
 Create the source tag from the exact clean commit used for `release:publish`.
-Copy the `v0.8.0` section of `CHANGELOG.md` into a temporary release-notes file,
+Copy the `v0.9.0` section of `CHANGELOG.md` into a temporary release-notes file,
 then run:
 
 ```bash
 (
   set -euo pipefail
 
-  release_commit_file=".omx/releases/0.8.0/release-commit-sha"
+  release_commit_file=".omx/releases/0.9.0/release-commit-sha"
   test -f "$release_commit_file"
   release_commit="$(<"$release_commit_file")"
   test "$(git rev-parse HEAD)" = "$release_commit"
   test -z "$(git status --porcelain)"
 
-  if git show-ref --verify --quiet refs/tags/v0.8.0; then
-    test "$(git cat-file -t refs/tags/v0.8.0)" = "tag"
-    test "$(git rev-parse 'v0.8.0^{}')" = "$release_commit"
-  else
-    git tag -a v0.8.0 "$release_commit" -m "OpenTag v0.8.0"
+  release_tag_probe="$(mktemp)"
+  if ! gh api --include --silent repos/amplifthq/opentag/git/ref/tags/v0.9.0 >"$release_tag_probe"; then
+    : # Inspect the HTTP status below; only a confirmed 404 permits tag creation.
   fi
-  test "$(git rev-parse 'v0.8.0^{}')" = "$release_commit"
-  git push origin v0.8.0
-  release_tag_ref="$(gh api repos/amplifthq/opentag/git/ref/tags/v0.8.0)"
+  release_tag_status="$(awk 'toupper($1) ~ /^HTTP\// {status=$2} END {print status}' "$release_tag_probe")"
+  rm -f "$release_tag_probe"
+  case "$release_tag_status" in
+    200)
+      release_tag_ref="$(gh api repos/amplifthq/opentag/git/ref/tags/v0.9.0)"
+      ;;
+    404)
+      if git show-ref --verify --quiet refs/tags/v0.9.0; then
+        test "$(git cat-file -t refs/tags/v0.9.0)" = "tag"
+        test "$(git rev-parse 'v0.9.0^{}')" = "$release_commit"
+      else
+        git tag -a v0.9.0 "$release_commit" -m "OpenTag v0.9.0"
+      fi
+      git push origin refs/tags/v0.9.0
+      release_tag_ref="$(gh api repos/amplifthq/opentag/git/ref/tags/v0.9.0)"
+      ;;
+    *)
+      echo "Refusing tag creation after upstream lookup returned HTTP ${release_tag_status:-unavailable}" >&2
+      exit 1
+      ;;
+  esac
   test "$(jq -r '.object.type' <<<"$release_tag_ref")" = "tag"
   release_tag_object="$(jq -r '.object.sha' <<<"$release_tag_ref")"
   test "$(gh api "repos/amplifthq/opentag/git/tags/$release_tag_object" --jq '.object.sha')" = "$release_commit"
   existing_release_state="$(gh api --paginate 'repos/amplifthq/opentag/releases?per_page=100' \
-    --jq '.[] | select(.tag_name == "v0.8.0") | [.tag_name, .draft, .prerelease, (.published_at != null)] | @tsv')"
+    --jq '.[] | select(.tag_name == "v0.9.0") | [.tag_name, .draft, .prerelease, (.published_at != null)] | @tsv')"
   case "$existing_release_state" in
     "")
-      gh release create v0.8.0 \
+      gh release create v0.9.0 \
         --verify-tag \
-        --title "OpenTag v0.8.0" \
-        --notes-file /tmp/opentag-v0.8.0-release-notes.md
+        --title "OpenTag v0.9.0" \
+        --notes-file /tmp/opentag-v0.9.0-release-notes.md
       ;;
-    $'v0.8.0\tfalse\tfalse\ttrue') ;;
-    *) echo "Refusing conflicting draft, prerelease, unpublished, or duplicate v0.8.0 GitHub Release state" >&2; exit 1 ;;
+    $'v0.9.0\tfalse\tfalse\ttrue') ;;
+    *) echo "Refusing conflicting draft, prerelease, unpublished, or duplicate v0.9.0 GitHub Release state" >&2; exit 1 ;;
   esac
-  release_state="$(gh api repos/amplifthq/opentag/releases/tags/v0.8.0)"
-  test "$(jq -r '.tag_name' <<<"$release_state")" = "v0.8.0"
+  release_state="$(gh api repos/amplifthq/opentag/releases/tags/v0.9.0)"
+  test "$(jq -r '.tag_name' <<<"$release_state")" = "v0.9.0"
   test "$(jq -r '.draft' <<<"$release_state")" = "false"
   test "$(jq -r '.prerelease' <<<"$release_state")" = "false"
   jq -er '.published_at | select(type == "string" and length > 0)' <<<"$release_state" >/dev/null
@@ -453,11 +469,11 @@ the pushed remote tag must also be annotated and target that commit. The
 paginated release lookup must succeed before an absent release is created, so a
 network or API failure is never misread as authoritative absence. An existing
 draft, prerelease, unpublished object, or duplicate match is conflicting state:
-stop and inspect it rather than treating it as the completed `v0.8.0` release.
+stop and inspect it rather than treating it as the completed `v0.9.0` release.
 
 Verify that the GitHub Release tag resolves to the same commit that produced
 the npm tarballs. The release is not complete until npm, git, and GitHub all
-identify version `0.8.0`. After that verification—or after a completed and
+identify version `0.9.0`. After that verification—or after a completed and
 verified rollback—release the exclusive window only when it still points at
 your release commit:
 
@@ -465,7 +481,7 @@ your release commit:
 (
   set -euo pipefail
 
-  release_state_dir=".omx/releases/0.8.0"
+  release_state_dir=".omx/releases/0.9.0"
   release_commit_file="$release_state_dir/release-commit-sha"
   lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
   test -f "$release_commit_file"
@@ -488,15 +504,15 @@ Do not unpublish immutable package versions during rollback.
   `latest` tag unchanged and stop the rollout. Preserve `next` for diagnosis or
   move it to the corrected version.
 - If `latest` promotion fails partway, first finish or retry only the idempotent
-  promotion loop with the original snapshot. If 0.8.0 itself must be withdrawn,
-  restore each package's recorded pre-promotion target and leave 0.8.0 on `next`
+  promotion loop with the original snapshot. If 0.9.0 itself must be withdrawn,
+  restore each package's recorded pre-promotion target and leave 0.9.0 on `next`
   for diagnosis:
 
 ```bash
 (
   set -euo pipefail
 
-  release_state_dir=".omx/releases/0.8.0"
+  release_state_dir=".omx/releases/0.9.0"
   release_commit_file="$release_state_dir/release-commit-sha"
   lock_owner_file="$release_state_dir/npm-dist-tags.lock-sha"
   test -f "$release_commit_file"
@@ -506,32 +522,32 @@ Do not unpublish immutable package versions during rollback.
   lock_commit="$(<"$lock_owner_file")"
   test "$(gh api repos/amplifthq/opentag/git/ref/heads/release-lock/npm-dist-tags --jq '.object.sha')" = "$lock_commit"
   test "$(gh api "repos/amplifthq/opentag/git/commits/$lock_commit" --jq '.parents[0].sha')" = "$release_commit"
-  rollback_file=".omx/releases/0.8.0/pre-promotion-latest.tsv"
+  rollback_file=".omx/releases/0.9.0/pre-promotion-latest.tsv"
   test -f "$rollback_file"
   test "$(wc -l <"$rollback_file" | tr -d ' ')" = "16"
   test "$(cut -f1 "$rollback_file" | sort -u | wc -l | tr -d ' ')" = "16"
-  test "$(cut -f2 "$rollback_file" | sort -u)" = "0.7.0"
+  test "$(cut -f2 "$rollback_file" | sort -u)" = "0.8.0"
   for manifest in packages/*/package.json; do
     [ "$(jq -r '.publishConfig.access // ""' "$manifest")" = "public" ] || continue
     package="$(jq -r '.name' "$manifest")"
     previous_latest="$(awk -F '\t' -v package="$package" '$1 == package { print $2 }' "$rollback_file")"
-    test "$previous_latest" = "0.7.0"
+    test "$previous_latest" = "0.8.0"
     test "$(npm view "$package@$previous_latest" version)" = "$previous_latest"
     current_tags_json="$(npm view "$package" dist-tags --json)"
     current_latest="$(jq -er '.latest | select(type == "string" and length > 0)' <<<"$current_tags_json")"
     current_next="$(jq -er '.next | select(type == "string" and length > 0)' <<<"$current_tags_json")"
-    test "$current_next" = "0.8.0"
+    test "$current_next" = "0.9.0"
     case "$current_latest" in
       "$previous_latest") ;;
-      "0.8.0") npm dist-tag add "$package@$previous_latest" latest ;;
+      "0.9.0") npm dist-tag add "$package@$previous_latest" latest ;;
       *) echo "Refusing to replace drifted $package latest=$current_latest" >&2; exit 1 ;;
     esac
     test "$(npm view "$package" dist-tags.latest)" = "$previous_latest"
-    test "$(npm view "$package" dist-tags.next)" = "0.8.0"
+    test "$(npm view "$package" dist-tags.next)" = "0.9.0"
   done
 )
 ```
 
 Verify all dist-tags after rollback, publish a clear incident note, then release
 the exclusive window with the guarded command above. A later fix must use a new
-version; never overwrite `0.8.0`.
+version; never overwrite `0.9.0`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -32,7 +32,7 @@ Private runnable apps are not published:
 
 ## Pre-1.0 Policy
 
-The source package family is prepared at `0.8.0`; npm dist-tags remain authoritative for the currently published channel versions. The public API is still settling, so all releases remain in the `0.x` line until the package contracts are stable enough for `1.0.0`.
+The source package family is prepared at `0.9.0`; npm dist-tags remain authoritative for the currently published channel versions. The public API is still settling, so all releases remain in the `0.x` line until the package contracts are stable enough for `1.0.0`.
 
 The first npm release was published as the coordinated `0.1.0` package family.
 The `0.2.0` release added the published CLI, local runtime package, and Lark and Telegram packages.
@@ -44,6 +44,7 @@ The `0.5.0` release adds Discord, Linear, and Microsoft Teams adapters, ACP-firs
 The `0.6.0` release moves all built-in coding agents onto Generic ACP, adds Cursor, OpenCode, and OpenClaw executor profiles, requires Node.js 22 for the CLI/Local Runtime/Runner, and hardens ACP isolation, cancellation conformance, Slack summaries, and the coordinated release gate.
 The `0.7.0` release completes the Phase 1 completion-governance vertical slice with durable work threads and contracts, deterministic evidence-backed assessments, GitHub PR/check/merge evidence ingestion, replay-safe reassessment, CLI explanations and bounded waivers, and a 16-package publication set that includes `@opentag/governance`.
 The `0.8.0` release completes the first provider-live recipe-driven factory loop with access identity, bounded human escalation, explainable multi-runner routing, immutable recipes and WorkThread-only workstreams, restart-safe batch admission, authoritative accepted-outcome metrics, and a real GitHub issue-to-merge-to-receipt proof while keeping planning external.
+The `0.9.0` release adds an authorized, read-only Slack-to-Linear project backlog query with bounded pagination, deterministic ordering, live OAuth token use, exact channel authorization, a query-only credential boundary, and an isolated best-effort Events API lane that does not change control or mutation delivery semantics.
 
 For each npm release:
 
@@ -112,7 +113,7 @@ After `1.0.0`, follow SemVer:
     merge, completion, restart, source receipt, and workstream metrics.
 12. Promote the same package versions to `latest` by changing dist-tags only.
 13. Confirm `latest` and `next` for the complete package family.
-14. Create and push the matching annotated git tag, for example `v0.8.0`, from
+14. Create and push the matching annotated git tag, for example `v0.9.0`, from
     the exact publication commit.
 15. Create the matching GitHub Release with the changelog notes and verify its
     tag target.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "OpenTag command line interface.",
   "type": "module",
   "engines": {

--- a/packages/cli/test/docs-contract.test.ts
+++ b/packages/cli/test/docs-contract.test.ts
@@ -7,11 +7,11 @@ function repoFile(path: string): string {
 }
 
 describe("platform setup docs contract", () => {
-  it("keeps the 0.8.0 release procedure explicit and concurrency-safe", () => {
+  it("keeps the 0.9.0 release procedure explicit and concurrency-safe", () => {
     const releaseGuide = repoFile("docs/npm-release.md");
     const liveGuide = repoFile("docs/live-e2e-smoke-harness.md");
 
-    expect(liveGuide).toContain("npm install --no-audit --no-fund @opentag/cli@0.8.0");
+    expect(liveGuide).toContain("npm install --no-audit --no-fund @opentag/cli@0.9.0");
     expect(liveGuide).toContain('smoke_root="$(mktemp -d)"\n(\n  set -euo pipefail');
     expect(releaseGuide).toContain("refs/heads/release-lock/npm-dist-tags");
     expect(releaseGuide).toContain("npm-dist-tags.lock-sha");
@@ -22,21 +22,33 @@ describe("platform setup docs contract", () => {
     expect(releaseGuide).toContain('= "$lock_commit"');
     expect(releaseGuide).toContain('current_latest="$(jq -er');
     expect(releaseGuide).toContain('current_next="$(jq -er');
-    expect(releaseGuide).toContain('test "$current_next" = "0.8.0"');
-    expect(releaseGuide.match(/test "\$\("\$smoke_root\/node_modules\/\.bin\/opentag" --version\)" = "0\.8\.0"/gu))
+    expect(releaseGuide).toContain('test "$current_next" = "0.9.0"');
+    expect(releaseGuide.match(/test "\$previous_latest" = "0\.8\.0"/gu)).toHaveLength(3);
+    expect(releaseGuide.match(/cut -f2 "\$(?:snapshot_tmp|rollback_file)" \| sort -u\)" = "0\.8\.0"/gu)).toHaveLength(3);
+    expect(releaseGuide).not.toContain('"0.7.0"');
+    expect(releaseGuide.match(/test "\$\("\$smoke_root\/node_modules\/\.bin\/opentag" --version\)" = "0\.9\.0"/gu))
       .toHaveLength(2);
     expect(releaseGuide).toContain('smoke_root="$(mktemp -d)"\n(\n  set -euo pipefail');
     expect(releaseGuide).toContain(
       'Also verify every package and its canary tag before promotion:\n\n```bash\n(\n  set -euo pipefail'
     );
-    expect(releaseGuide).toContain('git tag -a v0.8.0 "$release_commit" -m "OpenTag v0.8.0"');
-    expect(releaseGuide).toContain("git show-ref --verify --quiet refs/tags/v0.8.0");
-    expect(releaseGuide).toContain("git cat-file -t refs/tags/v0.8.0");
-    expect(releaseGuide).toContain('git rev-parse \'v0.8.0^{}\'');
+    expect(releaseGuide).toContain('git tag -a v0.9.0 "$release_commit" -m "OpenTag v0.9.0"');
+    expect(releaseGuide).toContain(
+      "if ! gh api --include --silent repos/amplifthq/opentag/git/ref/tags/v0.9.0"
+    );
+    expect(releaseGuide).toContain("only a confirmed 404 permits tag creation");
+    expect(releaseGuide).toContain("release_tag_status=\"$(awk 'toupper($1) ~ /^HTTP\\//");
+    expect(releaseGuide).toContain('case "$release_tag_status" in\n    200)');
+    expect(releaseGuide).toContain("    404)\n      if git show-ref --verify --quiet refs/tags/v0.9.0; then");
+    expect(releaseGuide).toContain("Refusing tag creation after upstream lookup returned HTTP");
+    expect(releaseGuide).toContain("git show-ref --verify --quiet refs/tags/v0.9.0");
+    expect(releaseGuide).toContain("git cat-file -t refs/tags/v0.9.0");
+    expect(releaseGuide).toContain('git rev-parse \'v0.9.0^{}\'');
+    expect(releaseGuide).toContain("git push origin refs/tags/v0.9.0");
     expect(releaseGuide).toContain('git/tags/$release_tag_object');
     expect(releaseGuide).toContain("gh api --paginate 'repos/amplifthq/opentag/releases?per_page=100'");
     expect(releaseGuide).toContain('case "$existing_release_state" in');
-    expect(releaseGuide).toContain("$'v0.8.0\\tfalse\\tfalse\\ttrue'");
+    expect(releaseGuide).toContain("$'v0.9.0\\tfalse\\tfalse\\ttrue'");
     expect(releaseGuide).toContain("'.draft'");
     expect(releaseGuide).toContain("'.prerelease'");
     expect(releaseGuide).toContain('.published_at | select(type == "string" and length > 0)');

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "HTTP client SDK for creating, claiming, and updating OpenTag dispatcher runs.",
   "type": "module",
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Core OpenTag protocol schemas, types, JSON Schema, and mention parsing.",
   "type": "module",
   "engines": {

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/discord",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Discord interactions normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/dispatcher/package.json
+++ b/packages/dispatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/dispatcher",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Embeddable OpenTag dispatcher Hono app and callback sinks.",
   "type": "module",
   "engines": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/github",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "GitHub event normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/gitlab",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "GitLab webhook normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/governance",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Deterministic execution governance for OpenTag work loops.",
   "type": "module",
   "engines": {

--- a/packages/lark/package.json
+++ b/packages/lark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/lark",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Lark/Feishu message normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/linear/package.json
+++ b/packages/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/linear",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Linear webhook normalization, callback rendering, and issue mutation helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/local-runtime/package.json
+++ b/packages/local-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/local-runtime",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Local OpenTag dispatcher, daemon, and diagnostics runtime helpers.",
   "type": "module",
   "engines": {

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/runner",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Executor contracts and built-in runner adapters for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/slack",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Slack app mention normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/store",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "SQLite and Drizzle persistence primitives for OpenTag runs and leases.",
   "type": "module",
   "engines": {

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/teams",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Microsoft Teams activity normalization and callback rendering for OpenTag.",
   "type": "module",
   "engines": { "node": ">=20" },

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentag/telegram",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Telegram message normalization and callback helpers for OpenTag.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump all 16 coordinated public packages to `0.9.0`
- document the read-only Slack to Linear backlog release, authorization boundary, retry semantics, and migration guidance
- retarget the release runbook, registry artifact smoke, and docs contract to `0.9.0`

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm release:publication-set`
- `corepack pnpm build`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test` — 142 files, 1918 tests
- `corepack pnpm smoke:governance -- --all --report .omx/governance-matrix/all-0.9.0.json`
- `corepack pnpm smoke:privacy -- --allow-missing --report .omx/governance-matrix/privacy-0.9.0.json`
- `OPENTAG_FACTORY_CONFORMANCE_REPORT=.omx/live-e2e/factory-conformance-0.9.0.json corepack pnpm smoke:factory-conformance`
- `corepack pnpm release:check` — packed all 16 packages, clean install, high-severity audit found 0 vulnerabilities, installed CLI checks passed
- `git diff --check`

## Rollout

After merge, publish the exact merged commit to npm `next`, validate the registry-installed artifact and real provider path, promote the same immutable artifacts to `latest`, then create the matching annotated `v0.9.0` tag and GitHub Release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authorized, read-only Linear project backlog queries accessible via Slack commands, returning a deterministic ordered summary with safe retry after interrupted/failed queries.

- **Security & Reliability**
  - Hardened exact Slack channel authorization, improved escaping to prevent injection, ensured query-only credential boundaries, avoided completion deduplication on non-2xx attempts, and added bounded shutdown draining for the query lane.

- **Documentation**
  - Updated README and multilingual docs, plus v0.9.0 release/version guidance and live E2E smoke-harness setup.

- **Tests**
  - Updated contract and live-smoke expectations for v0.9.0.

- **Chores**
  - Bumped package versions across the release family to v0.9.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->