### PR TITLE
test(live): prove registry-installed Slack Linear loop

### DIFF
--- a/docs/live-e2e-smoke-harness.md
+++ b/docs/live-e2e-smoke-harness.md
@@ -26,6 +26,7 @@ Current cases:
 | `github-webhook-live` | Yes | Real GitHub repository webhook, local CLI stack, current-head required check, merged PR, durable satisfied assessment, and restart-safe final receipt |
 | `github-factory-live` | Yes | Real external GitHub source thread admitted through a recipe/workstream batch, local execution, PR/check/merge, authoritative accepted metrics, restart replay, and deduplicated source receipt |
 | `github-cli-live` | Yes | Real GitHub issue callback using dispatcher-assisted run creation |
+| `slack-linear-registry-live` | Yes | Registry-installed CLI receives a real Slack `/linear` mention through Socket Mode, queries the exact mapped Linear project read-only, and posts a verified thread reply |
 | `slack-local-live` | Yes | Real Slack callback using dispatcher-assisted run creation |
 | `slack-ui-live` | Yes | Real Slack source-thread mention or button flow through Socket Mode or Events API |
 | `lark-patch-live` | Yes | Real Lark reply plus final card patch through `lark-cli` |
@@ -41,6 +42,7 @@ corepack pnpm smoke:live -- --case github-webhook-live --dry-run
 OPENTAG_GH_LIVE_EXECUTOR=phase1-fixture \
 corepack pnpm smoke:live -- --case github-factory-live --dry-run
 corepack pnpm smoke:live -- --case slack-ui-live --dry-run --allow-missing
+corepack pnpm smoke:live -- --case slack-linear-registry-live --dry-run
 ```
 
 `--allow-missing` turns missing credentials or commands into `SKIPPED` instead
@@ -92,6 +94,67 @@ The live pass is only credible when the source thread has a concise final
 callback, `opentag status --run` shows the Context Packet and Agent Work Ledger,
 artifacts exist, and provider-visible action receipts do not expose raw executor
 logs.
+
+### Slack /linear Registry Acceptance
+
+`slack-linear-registry-live` is the release-artifact acceptance for the
+read-only Slack-to-Linear query path. The wrapper loads `.env.slack-test` and
+`.env.linear` by default. When running from an isolated worktree, point
+`OPENTAG_SLACK_LINEAR_SLACK_ENV_FILE` and
+`OPENTAG_SLACK_LINEAR_LINEAR_ENV_FILE` at the authorized files without copying
+credentials into the worktree.
+
+The case installs the exact version selected by
+`OPENTAG_SLACK_LINEAR_EXPECTED_CLI_VERSION` (default `0.9.0`) into a temporary
+npm root. It rejects the artifact unless the executable plus
+`@opentag/slack`, `@opentag/linear`, and `@opentag/core` all resolve from the
+trusted public npm registry at that version with sha512 receipts in the npm
+lockfile. The source checkout only supplies the acceptance harness; the
+OpenTag runtime under test is the registry install.
+
+Installation is deliberately two-phase. The first `npm install` disables
+lifecycle scripts while the harness validates registry and SHA-512 receipts for
+the OpenTag packages and `better-sqlite3`. Only then does it rebuild the verified
+native dependency required by the registry CLI's SQLite store. The final report
+records that ordering and the native dependency receipt.
+
+After Slack `auth.test`, channel-access validation, and Linear project
+discovery, the harness writes a mode-0600 temporary config whose credentials
+are env SecretRefs. The config contains only the exact Slack team/channel to
+Linear project mapping and `connections.default.token`; it deliberately has no
+top-level Linear mutation token or webhook secret. A loopback GraphQL audit
+proxy forwards the real backlog queries, records pagination counts, and rejects
+every mutation before it can reach Linear. Provider-live acceptance is pinned
+to the canonical `https://api.linear.app/graphql` endpoint; endpoint overrides,
+alternate hosts, and mock providers fail closed. Both npm installation and the
+registry CLI run with explicit allowlisted environments, so ambient npm
+credentials, Node preload hooks, and unrelated provider credentials do not
+cross into the artifact under test. The proxy adds a random, non-secret marker
+to the returned project name without changing Linear; the Slack reply must carry
+that marker, binding the provider read and reply to this registry runtime.
+
+When the stack prints the bot mention, send exactly one human message in the
+configured channel:
+
+```text
+@OpenTag /linear
+```
+
+The case passes only after Socket Mode observes one unambiguous human provider
+event, the real Linear endpoint answers `OpenTagProjectBacklog` queries after
+that source timestamp, and Slack history shows one successful timestamped bot
+reply in the same thread after every audited query completed. It then observes
+the thread for the fixed 10-second duplicate-reply window to reject duplicate
+replies. It rejects processing or reply errors in the registry CLI log, then
+requires shutdown to be handled gracefully, with a normal zero exit rather
+than direct signal termination. The retained mode-0600
+report contains package receipts, causal timing, provider-path booleans,
+counts, and SHA-256 fingerprints; it omits tokens, project names, issue titles,
+raw Slack messages, and the raw correlation marker. It records the query-only
+configuration and mutation-blocking proxy separately from the token's unknown
+provider scope. `OPENTAG_SLACK_LINEAR_REPORT` selects the report path, and
+`OPENTAG_SLACK_LINEAR_PROXY_PAGE_SIZE` (default `2`) makes pagination observable
+when the mapped project has enough unfinished issues.
 
 ### Factory Conformance
 

--- a/packages/dispatcher/test/github-registry-artifact.test.ts
+++ b/packages/dispatcher/test/github-registry-artifact.test.ts
@@ -6,6 +6,7 @@ import { mkdtemp } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
   inspectRegistryCliArtifact,
+  inspectRegistryCliPackageSet,
   normalizeRegistryGitHubFactorySourceEvent
 } from "../../../scripts/test/github-registry-artifact.js";
 
@@ -20,11 +21,15 @@ async function createRegistryInstall(
   const cliRoot = join(root, "node_modules", "@opentag", "cli");
   const githubRoot = join(root, "node_modules", "@opentag", "github");
   const coreRoot = join(root, "node_modules", "@opentag", "core");
+  const slackRoot = join(root, "node_modules", "@opentag", "slack");
+  const linearRoot = join(root, "node_modules", "@opentag", "linear");
   const binRoot = join(root, "node_modules", ".bin");
   await Promise.all([
     mkdir(join(cliRoot, "dist"), { recursive: true }),
     mkdir(join(githubRoot, "dist"), { recursive: true }),
     mkdir(join(coreRoot, "dist"), { recursive: true }),
+    mkdir(join(slackRoot, "dist"), { recursive: true }),
+    mkdir(join(linearRoot, "dist"), { recursive: true }),
     mkdir(binRoot, { recursive: true })
   ]);
 
@@ -33,7 +38,12 @@ async function createRegistryInstall(
     version,
     type: "module",
     bin: { opentag: "./dist/index.js" },
-    dependencies: { "@opentag/core": version, "@opentag/github": version }
+    dependencies: {
+      "@opentag/core": version,
+      "@opentag/github": version,
+      "@opentag/linear": version,
+      "@opentag/slack": version
+    }
   }));
   await writeFile(
     join(cliRoot, "dist", "index.js"),
@@ -65,6 +75,20 @@ async function createRegistryInstall(
     "export const OpenTagEventSchema = { parse: (value) => ({ ...value, marker: `${value.marker}+registry-core` }) };\n"
   );
 
+  for (const [packageRoot, packageName] of [
+    [slackRoot, "@opentag/slack"],
+    [linearRoot, "@opentag/linear"]
+  ] as const) {
+    await writeFile(join(packageRoot, "package.json"), JSON.stringify({
+      name: packageName,
+      version,
+      type: "module",
+      main: "./dist/index.js",
+      exports: { ".": "./dist/index.js" }
+    }));
+    await writeFile(join(packageRoot, "dist", "index.js"), "export const registryFixture = true;\n");
+  }
+
   await symlink("../@opentag/cli/dist/index.js", join(binRoot, "opentag"));
   await writeFile(join(root, "package-lock.json"), JSON.stringify({
     name: "registry-fixture",
@@ -83,6 +107,16 @@ async function createRegistryInstall(
       [`${lockPackageRoot}/@opentag/core`]: {
         version,
         resolved: `${registryOrigin}/@opentag/core/-/core-${version}.tgz`,
+        integrity
+      },
+      [`${lockPackageRoot}/@opentag/slack`]: {
+        version,
+        resolved: `${registryOrigin}/@opentag/slack/-/slack-${version}.tgz`,
+        integrity
+      },
+      [`${lockPackageRoot}/@opentag/linear`]: {
+        version,
+        resolved: `${registryOrigin}/@opentag/linear/-/linear-${version}.tgz`,
         integrity
       }
     }
@@ -127,6 +161,31 @@ describe("GitHub registry artifact acceptance", () => {
 
     await expect(normalizeRegistryGitHubFactorySourceEvent(inspection, { id: "100" }))
       .resolves.toMatchObject({ id: "registry_100", marker: "registry-github+registry-core" });
+  });
+
+  it("binds an arbitrary installed OpenTag provider set to the same registry version and lockfile", async () => {
+    const fixture = await createRegistryInstall("0.9.0");
+
+    const inspection = await inspectRegistryCliPackageSet({
+      cliBin: fixture.cliBin,
+      expectedVersion: "0.9.0",
+      packageNames: ["@opentag/slack", "@opentag/linear", "@opentag/core"]
+    });
+
+    expect(inspection).toMatchObject({
+      expectedVersion: "0.9.0",
+      executable: {
+        package: "@opentag/cli",
+        version: "0.9.0",
+        registry: "https://registry.npmjs.org",
+        integrity
+      },
+      packages: {
+        "@opentag/slack": { version: "0.9.0", integrity },
+        "@opentag/linear": { version: "0.9.0", integrity },
+        "@opentag/core": { version: "0.9.0", integrity }
+      }
+    });
   });
 
   it("fails closed for a stale installed candidate", async () => {

--- a/packages/dispatcher/test/github-registry-artifact.test.ts
+++ b/packages/dispatcher/test/github-registry-artifact.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   inspectRegistryCliArtifact,
   inspectRegistryCliPackageSet,
+  inspectRegistryInstalledDependency,
   normalizeRegistryGitHubFactorySourceEvent
 } from "../../../scripts/test/github-registry-artifact.js";
 
@@ -23,6 +24,7 @@ async function createRegistryInstall(
   const coreRoot = join(root, "node_modules", "@opentag", "core");
   const slackRoot = join(root, "node_modules", "@opentag", "slack");
   const linearRoot = join(root, "node_modules", "@opentag", "linear");
+  const sqliteRoot = join(root, "node_modules", "better-sqlite3");
   const binRoot = join(root, "node_modules", ".bin");
   await Promise.all([
     mkdir(join(cliRoot, "dist"), { recursive: true }),
@@ -30,6 +32,7 @@ async function createRegistryInstall(
     mkdir(join(coreRoot, "dist"), { recursive: true }),
     mkdir(join(slackRoot, "dist"), { recursive: true }),
     mkdir(join(linearRoot, "dist"), { recursive: true }),
+    mkdir(join(sqliteRoot, "lib"), { recursive: true }),
     mkdir(binRoot, { recursive: true })
   ]);
 
@@ -89,6 +92,13 @@ async function createRegistryInstall(
     await writeFile(join(packageRoot, "dist", "index.js"), "export const registryFixture = true;\n");
   }
 
+  await writeFile(join(sqliteRoot, "package.json"), JSON.stringify({
+    name: "better-sqlite3",
+    version: "11.10.0",
+    main: "./lib/index.js"
+  }));
+  await writeFile(join(sqliteRoot, "lib", "index.js"), "module.exports = {};\n");
+
   await symlink("../@opentag/cli/dist/index.js", join(binRoot, "opentag"));
   await writeFile(join(root, "package-lock.json"), JSON.stringify({
     name: "registry-fixture",
@@ -117,6 +127,11 @@ async function createRegistryInstall(
       [`${lockPackageRoot}/@opentag/linear`]: {
         version,
         resolved: `${registryOrigin}/@opentag/linear/-/linear-${version}.tgz`,
+        integrity
+      },
+      [`${lockPackageRoot}/better-sqlite3`]: {
+        version: "11.10.0",
+        resolved: `${registryOrigin}/better-sqlite3/-/better-sqlite3-11.10.0.tgz`,
         integrity
       }
     }
@@ -169,7 +184,11 @@ describe("GitHub registry artifact acceptance", () => {
     const inspection = await inspectRegistryCliPackageSet({
       cliBin: fixture.cliBin,
       expectedVersion: "0.9.0",
-      packageNames: ["@opentag/slack", "@opentag/linear", "@opentag/core"]
+      packageNames: ["@opentag/slack", "@opentag/linear", "@opentag/core"],
+      executableEnv: {
+        ...process.env,
+        NODE_OPTIONS: `--require=${join(fixture.root, "must-not-load.cjs")}`
+      }
     });
 
     expect(inspection).toMatchObject({
@@ -186,6 +205,35 @@ describe("GitHub registry artifact acceptance", () => {
         "@opentag/core": { version: "0.9.0", integrity }
       }
     });
+  });
+
+  it("verifies a transitive native dependency before its lifecycle scripts run", async () => {
+    const fixture = await createRegistryInstall("0.9.0");
+
+    await expect(
+      inspectRegistryInstalledDependency({
+        cliBin: fixture.cliBin,
+        packageName: "better-sqlite3",
+        expectedVersion: "11.10.0"
+      })
+    ).resolves.toMatchObject({
+      package: "better-sqlite3",
+      version: "11.10.0",
+      registry: "https://registry.npmjs.org",
+      integrity
+    });
+  });
+
+  it("fails closed when a native dependency does not match the expected version", async () => {
+    const fixture = await createRegistryInstall("0.9.0");
+
+    await expect(
+      inspectRegistryInstalledDependency({
+        cliBin: fixture.cliBin,
+        packageName: "better-sqlite3",
+        expectedVersion: "11.9.0"
+      })
+    ).rejects.toThrow(/better-sqlite3 is 11\.10\.0; expected 11\.9\.0/u);
   });
 
   it("fails closed for a stale installed candidate", async () => {

--- a/packages/dispatcher/test/slack-linear-live-acceptance.test.ts
+++ b/packages/dispatcher/test/slack-linear-live-acceptance.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendSlackLinearCleanupFailure,
+  buildSlackLinearDiagnosticLog,
+  buildRegistrySlackLinearConfig,
+  buildRegistrySlackLinearChildEnv,
+  buildRegistryInstallerEnv,
+  describeLinearProjectDiscoveryFailure,
+  expectedLinearBacklogPageCount,
+  hasExpectedLinearBacklogProjectMapping,
+  isGracefulCliExit,
+  normalizeLinearIssueRef,
+  runSlackLinearCleanupActions,
+  selectLinearProjectFromDiscoveryResponse,
+  selectCorrelatedSlackLinearReply,
+  selectSlackChannelBinding,
+  stopSlackLinearProcessForCleanup,
+  summarizeSlackLinearReply,
+  validateLinearLiveGraphqlUrl
+} from "../../../scripts/test/slack-linear-live-acceptance.js";
+
+describe("Slack /linear registry live acceptance helpers", () => {
+  it("selects an exact legacy Slack binding without carrying repository authority", () => {
+    expect(
+      selectSlackChannelBinding(
+        {
+          slackChannels: [
+            { teamId: "T1", channelId: "C1", owner: "example", repo: "one" },
+            { teamId: "T2", channelId: "C2", owner: "example", repo: "two" }
+          ]
+        },
+        "C2"
+      )
+    ).toEqual({ teamId: "T2", channelId: "C2" });
+  });
+
+  it("selects the configured Slack platform binding", () => {
+    expect(
+      selectSlackChannelBinding({
+        platforms: { slack: { teamId: "T-live", channelId: "C-live" } }
+      })
+    ).toEqual({ teamId: "T-live", channelId: "C-live" });
+  });
+
+  it("fails closed when an explicit channel is not configured", () => {
+    expect(() =>
+      selectSlackChannelBinding(
+        { slackChannels: [{ teamId: "T1", channelId: "C1", owner: "example", repo: "one" }] },
+        "C-missing"
+      )
+    ).toThrow(/No Slack channel binding/);
+  });
+
+  it("normalizes Linear issue URLs and identifiers", () => {
+    expect(normalizeLinearIssueRef("https://linear.app/acme/issue/ENG-123/example")).toBe("ENG-123");
+    expect(normalizeLinearIssueRef("ENG-456")).toBe("ENG-456");
+  });
+
+  it("distinguishes auth, missing-issue, and provider failures", () => {
+    for (const status of [401, 403]) {
+      expect(describeLinearProjectDiscoveryFailure({ status, messages: [] })).toMatch(
+        /Reauthorize.*OPENTAG_LINEAR_SMOKE_TOKEN/u
+      );
+    }
+    expect(
+      describeLinearProjectDiscoveryFailure({ status: 200, messages: ["Authentication required, not authenticated"] })
+    ).toMatch(/Reauthorize.*OPENTAG_LINEAR_SMOKE_TOKEN/u);
+    expect(describeLinearProjectDiscoveryFailure({ status: 200, messages: ["Entity not found: Issue."] })).toMatch(
+      /Update OPENTAG_LINEAR_SMOKE_ISSUE/u
+    );
+    for (const status of [429, 500]) {
+      expect(describeLinearProjectDiscoveryFailure({ status, messages: [] })).toMatch(/Retry.*Linear API status/u);
+    }
+    expect(describeLinearProjectDiscoveryFailure({ status: 200, messages: ["Unexpected schema failure"] })).toMatch(
+      /Retry.*Linear API status/u
+    );
+  });
+
+  it("distinguishes a missing issue, an unmapped issue, and a malformed provider response", () => {
+    expect(() => selectLinearProjectFromDiscoveryResponse({ status: 200, body: { data: { issue: null } } })).toThrow(
+      /Update OPENTAG_LINEAR_SMOKE_ISSUE/u
+    );
+    expect(() =>
+      selectLinearProjectFromDiscoveryResponse({ status: 200, body: { data: { issue: { project: null } } } })
+    ).toThrow(/not assigned to a project/u);
+    expect(() => selectLinearProjectFromDiscoveryResponse({ status: 200, body: {} })).toThrow(
+      /Linear provider project discovery failed/u
+    );
+    expect(
+      selectLinearProjectFromDiscoveryResponse({
+        status: 200,
+        body: { data: { issue: { project: { id: "project-1", name: "Factory" } } } }
+      })
+    ).toEqual({ id: "project-1", name: "Factory" });
+  });
+
+  it("always builds a redacted diagnostic log for early failure, empty CLI output, and success", () => {
+    expect(
+      buildSlackLinearDiagnosticLog({
+        cliOutput: "",
+        failureMessage: "Slack auth failed with xoxb-private and pairing-private",
+        sensitiveValues: ["xoxb-private", "pairing-private"]
+      })
+    ).toBe(
+      "[opentag-live] no CLI output was captured.\n[opentag-live] harness failure: Slack auth failed with [REDACTED] and [REDACTED]\n"
+    );
+    expect(buildSlackLinearDiagnosticLog({ cliOutput: "" })).toBe(
+      "[opentag-live] no CLI output was captured.\n"
+    );
+    expect(buildSlackLinearDiagnosticLog({ cliOutput: "OpenTag is running.\n" })).toBe("OpenTag is running.\n");
+  });
+
+  it("requires at least one matching Linear project identifier and rejects every mismatch", () => {
+    expect(hasExpectedLinearBacklogProjectMapping({ projectId: "project-1" }, "project-1")).toBe(true);
+    expect(hasExpectedLinearBacklogProjectMapping({ projectKey: "project-1" }, "project-1")).toBe(true);
+    expect(
+      hasExpectedLinearBacklogProjectMapping({ projectId: "project-1", projectKey: "project-1" }, "project-1")
+    ).toBe(true);
+    expect(hasExpectedLinearBacklogProjectMapping({}, "project-1")).toBe(false);
+    expect(hasExpectedLinearBacklogProjectMapping({ projectId: "project-2" }, "project-1")).toBe(false);
+    expect(
+      hasExpectedLinearBacklogProjectMapping({ projectId: "project-1", projectKey: "project-2" }, "project-1")
+    ).toBe(false);
+  });
+
+  it("derives the authoritative pagination depth from the accepted open count", () => {
+    expect(expectedLinearBacklogPageCount(10, 2)).toBe(5);
+    expect(expectedLinearBacklogPageCount(3, 2)).toBe(2);
+    expect(expectedLinearBacklogPageCount(0, 2)).toBe(1);
+    expect(() => expectedLinearBacklogPageCount(-1, 2)).toThrow(/non-negative safe integer/u);
+    expect(() => expectedLinearBacklogPageCount(10, 0)).toThrow(/positive safe integer/u);
+  });
+
+  it("fails cleanup after a SIGTERM timeout and preserves both primary and cleanup failures", async () => {
+    const signals: string[] = [];
+    let cleanupFailure: unknown;
+    try {
+      await stopSlackLinearProcessForCleanup({
+        sendSignal: (signal) => {
+          signals.push(signal);
+          return signal === "SIGTERM";
+        },
+        waitForExit: async () => {
+          throw new Error("shutdown timeout");
+        }
+      });
+    } catch (error) {
+      cleanupFailure = error;
+    }
+
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(cleanupFailure).toBeInstanceOf(Error);
+    expect((cleanupFailure as Error).message).toMatch(/SIGTERM sent=true, SIGKILL sent=false/u);
+    const failure = appendSlackLinearCleanupFailure("provider failed", cleanupFailure);
+    expect(buildSlackLinearDiagnosticLog({ cliOutput: "", failureMessage: failure })).toContain(
+      "provider failed; cleanup failed: Registry CLI cleanup did not complete"
+    );
+  });
+
+  it("attempts every cleanup action and reports every failure", async () => {
+    const calls: string[] = [];
+    let cleanupFailure: unknown;
+    try {
+      await runSlackLinearCleanupActions([
+        {
+          name: "child",
+          run: async () => {
+            calls.push("child");
+            throw new Error("shutdown timeout");
+          }
+        },
+        {
+          name: "proxy",
+          run: async () => {
+            calls.push("proxy");
+            throw new Error("close failed");
+          }
+        }
+      ]);
+    } catch (error) {
+      cleanupFailure = error;
+    }
+
+    expect(calls).toEqual(["child", "proxy"]);
+    expect(cleanupFailure).toBeInstanceOf(AggregateError);
+    expect((cleanupFailure as AggregateError).message).toMatch(/child: shutdown timeout; proxy: close failed/u);
+  });
+
+  it("accepts only the canonical live Linear GraphQL endpoint", () => {
+    expect(validateLinearLiveGraphqlUrl("https://api.linear.app/graphql")).toBe("https://api.linear.app/graphql");
+    for (const value of [
+      "http://api.linear.app/graphql",
+      "https://api.linear.app/graphql?fixture=true",
+      "https://api.linear.app/graphql#fixture",
+      "https://user:pass@api.linear.app/graphql",
+      "https://localhost/graphql",
+      "https://api.linear.app/graphql/"
+    ]) {
+      expect(() => validateLinearLiveGraphqlUrl(value)).toThrow(/canonical Linear GraphQL endpoint/);
+    }
+  });
+
+  it("gives the registry child only the required runtime and provider environment", () => {
+    const childEnv = buildRegistrySlackLinearChildEnv({
+      baseEnv: {
+        HOME: "/Users/example",
+        PATH: "/usr/bin:/bin",
+        TMPDIR: "/tmp",
+        LANG: "en_US.UTF-8",
+        NODE_OPTIONS: "--import=/tmp/inject.mjs",
+        NODE_PATH: "/tmp/injected-modules",
+        LINEAR_OAUTH_CLIENT_SECRET: "must-not-cross",
+        OPENTAG_GITHUB_TOKEN: "must-not-cross"
+      },
+      appToken: "xapp-test",
+      botToken: "xoxb-test",
+      linearToken: "linear-read-test",
+      pairingToken: "pairing-test"
+    });
+
+    expect(childEnv).toMatchObject({
+      HOME: "/Users/example",
+      PATH: "/usr/bin:/bin",
+      TMPDIR: "/tmp",
+      LANG: "en_US.UTF-8",
+      OPENTAG_SLACK_APP_TOKEN: "xapp-test",
+      OPENTAG_SLACK_BOT_TOKEN: "xoxb-test",
+      OPENTAG_LINEAR_SMOKE_TOKEN: "linear-read-test",
+      OPENTAG_SLACK_LINEAR_PAIRING_TOKEN: "pairing-test"
+    });
+    expect(childEnv).not.toHaveProperty("NODE_OPTIONS");
+    expect(childEnv).not.toHaveProperty("NODE_PATH");
+    expect(childEnv).not.toHaveProperty("LINEAR_OAUTH_CLIENT_SECRET");
+    expect(childEnv).not.toHaveProperty("OPENTAG_GITHUB_TOKEN");
+  });
+
+  it("installs the registry artifact without ambient Node hooks or npm configuration", () => {
+    const env = buildRegistryInstallerEnv({
+      baseEnv: {
+        PATH: "/usr/bin:/bin",
+        HOME: "/Users/example",
+        NODE_OPTIONS: "--import=/tmp/inject.mjs",
+        NPM_CONFIG_REGISTRY: "https://registry.example.test",
+        NPM_TOKEN: "must-not-cross"
+      },
+      cacheDirectory: "/tmp/acceptance-npm-cache",
+      userConfigPath: "/tmp/acceptance-npm-userconfig",
+      globalConfigPath: "/tmp/acceptance-npm-globalconfig"
+    });
+
+    expect(env).toMatchObject({
+      PATH: "/usr/bin:/bin",
+      NPM_CONFIG_CACHE: "/tmp/acceptance-npm-cache",
+      NPM_CONFIG_REGISTRY: "https://registry.npmjs.org",
+      NPM_CONFIG_USERCONFIG: "/tmp/acceptance-npm-userconfig",
+      NPM_CONFIG_GLOBALCONFIG: "/tmp/acceptance-npm-globalconfig"
+    });
+    expect(env.NPM_CONFIG_USERCONFIG).not.toBe(env.NPM_CONFIG_GLOBALCONFIG);
+    expect(env).not.toHaveProperty("NODE_OPTIONS");
+    expect(env).not.toHaveProperty("NPM_TOKEN");
+  });
+
+  it("distinguishes a handled SIGTERM exit from direct signal termination", () => {
+    expect(isGracefulCliExit({ code: 0, signal: null })).toBe(true);
+    expect(isGracefulCliExit({ code: null, signal: "SIGTERM" })).toBe(false);
+    expect(isGracefulCliExit({ code: 1, signal: null })).toBe(false);
+  });
+
+  it("builds a query-only config that contains SecretRefs instead of credential values", () => {
+    const config = buildRegistrySlackLinearConfig({
+      stateDirectory: "/tmp/state",
+      databasePath: "/tmp/state/opentag.db",
+      worktreeRoot: "/tmp/worktrees",
+      dispatcherUrl: "http://127.0.0.1:31234",
+      graphqlUrl: "http://127.0.0.1:31235/graphql",
+      teamId: "T1",
+      channelId: "C1",
+      projectId: "project-1"
+    });
+
+    expect(config).toMatchObject({
+      schemaVersion: 1,
+      daemon: {
+        repositories: [],
+        pairingToken: { kind: "env", name: "OPENTAG_SLACK_LINEAR_PAIRING_TOKEN" }
+      },
+      platforms: {
+        slack: {
+          mode: "socket_mode",
+          appToken: { kind: "env", name: "OPENTAG_SLACK_APP_TOKEN" },
+          botToken: { kind: "env", name: "OPENTAG_SLACK_BOT_TOKEN" },
+          teamId: "T1",
+          channelId: "C1"
+        },
+        linear: {
+          connections: {
+            default: { token: { kind: "env", name: "OPENTAG_LINEAR_SMOKE_TOKEN" } }
+          },
+          channels: [{ teamId: "T1", channelId: "C1", projectId: "project-1", connection: "default" }]
+        }
+      }
+    });
+    expect(config.platforms.linear).not.toHaveProperty("token");
+    expect(config.platforms.linear).not.toHaveProperty("webhookSecret");
+    expect(JSON.stringify(config)).not.toContain("xox");
+  });
+
+  it("accepts only a successful, timestamped Linear backlog reply", () => {
+    expect(
+      summarizeSlackLinearReply("*Factory backlog · 3 open*\n• ENG-1 item\n\n_Linear · queried 08:10 UTC_")
+    ).toEqual({ kind: "backlog", displayedIssueCount: 1, reportedOpenCount: 3 });
+    expect(summarizeSlackLinearReply("*Factory backlog · 0 open* 🎉\nNo unfinished issues in this Linear project.\n\n_Linear · queried 08:10 UTC_")).toEqual({
+      kind: "empty",
+      displayedIssueCount: 0,
+      reportedOpenCount: 0
+    });
+    expect(() => summarizeSlackLinearReply("Linear API is unavailable right now; try again later.")).toThrow(
+      /not a successful \/linear reply/
+    );
+  });
+
+  it("rejects a competing successful reply before the audited Linear query completes", () => {
+    expect(() =>
+      selectCorrelatedSlackLinearReply({
+        messages: [
+          {
+            ts: "200.000000",
+            user: "U_BOT",
+            text: "*Factory backlog · 1 open*\n• ENG-1 item\n\n_Linear · queried 08:10 UTC_"
+          }
+        ],
+        threadTs: "100.000000",
+        botUserId: "U_BOT",
+        correlationMarker: "OpenTagLive-marker"
+      })
+    ).toThrow(/before the audited Linear query completed/);
+  });
+
+  it("requires exact bot authorship, completed-query ordering, and the runtime marker", () => {
+    const matchingText =
+      "*Factory · OpenTagLive-marker · 1 open*\n• ENG-1 item\n\n_Linear · queried 08:10 UTC_";
+    expect(
+      selectCorrelatedSlackLinearReply({
+        messages: [
+          { ts: "200.000000", user: "U_OTHER", text: matchingText },
+          { ts: "201.000000", user: "U_BOT", text: matchingText }
+        ],
+        threadTs: "100.000000",
+        botUserId: "U_BOT",
+        correlationMarker: "OpenTagLive-marker",
+        auditCompletedAtMs: 200_500
+      })
+    ).toMatchObject({ message: { ts: "201.000000", user: "U_BOT" } });
+
+    expect(() =>
+      selectCorrelatedSlackLinearReply({
+        messages: [{ ts: "201.000000", user: "U_BOT", text: matchingText.replace("OpenTagLive-marker", "other") }],
+        threadTs: "100.000000",
+        botUserId: "U_BOT",
+        correlationMarker: "OpenTagLive-marker",
+        auditCompletedAtMs: 200_500
+      })
+    ).toThrow(/does not carry the registry runtime correlation marker/);
+  });
+
+  it("rejects duplicate successful replies even when one carries the runtime marker", () => {
+    expect(() =>
+      selectCorrelatedSlackLinearReply({
+        messages: [
+          {
+            ts: "201.000000",
+            user: "U_BOT",
+            text: "*Factory · OpenTagLive-marker · 1 open*\n• ENG-1 item\n\n_Linear · queried 08:10 UTC_"
+          },
+          {
+            ts: "202.000000",
+            user: "U_BOT",
+            text: "*Factory backlog · 1 open*\n• ENG-1 item\n\n_Linear · queried 08:10 UTC_"
+          }
+        ],
+        threadTs: "100.000000",
+        botUserId: "U_BOT",
+        correlationMarker: "OpenTagLive-marker",
+        auditCompletedAtMs: 200_500
+      })
+    ).toThrow(/multiple successful Slack \/linear replies/);
+  });
+});

--- a/scripts/dev/run-slack-linear-backlog-live-test.sh
+++ b/scripts/dev/run-slack-linear-backlog-live-test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+: "${OPENTAG_SLACK_LINEAR_SLACK_ENV_FILE:=$ROOT_DIR/.env.slack-test}"
+: "${OPENTAG_SLACK_LINEAR_LINEAR_ENV_FILE:=$ROOT_DIR/.env.linear}"
+
+load_env_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "Missing live acceptance env file: $path" >&2
+    exit 1
+  fi
+  echo "Loading live acceptance env: $path"
+  set -a
+  # shellcheck disable=SC1090
+  source "$path"
+  set +a
+}
+
+load_env_file "$OPENTAG_SLACK_LINEAR_SLACK_ENV_FILE"
+load_env_file "$OPENTAG_SLACK_LINEAR_LINEAR_ENV_FILE"
+
+: "${OPENTAG_CONFIG_PATH:?Set OPENTAG_CONFIG_PATH in the Slack env file.}"
+: "${OPENTAG_SLACK_BOT_TOKEN:?Set OPENTAG_SLACK_BOT_TOKEN in the Slack env file.}"
+: "${OPENTAG_SLACK_APP_TOKEN:?Set OPENTAG_SLACK_APP_TOKEN in the Slack env file for real Socket Mode delivery.}"
+: "${OPENTAG_LINEAR_SMOKE_TOKEN:?Set a currently valid OPENTAG_LINEAR_SMOKE_TOKEN in the Linear env file.}"
+if [[ -z "${OPENTAG_LINEAR_SMOKE_ISSUE:-${OPENTAG_LINEAR_SMOKE_ISSUE_ID:-}}" ]]; then
+  echo "Set OPENTAG_LINEAR_SMOKE_ISSUE or OPENTAG_LINEAR_SMOKE_ISSUE_ID in the Linear env file." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+exec node --import ./apps/dispatcher/node_modules/tsx/dist/loader.mjs scripts/dev/run-slack-linear-backlog-live-test.ts

--- a/scripts/dev/run-slack-linear-backlog-live-test.ts
+++ b/scripts/dev/run-slack-linear-backlog-live-test.ts
@@ -1,0 +1,654 @@
+#!/usr/bin/env node
+import { createHash, randomBytes } from "node:crypto";
+import { execFile as execFileCallback, spawn, type ChildProcess } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { inspectRegistryCliPackageSet, inspectRegistryInstalledDependency } from "../test/github-registry-artifact.js";
+import {
+  appendSlackLinearCleanupFailure,
+  buildSlackLinearDiagnosticLog,
+  buildRegistrySlackLinearConfig,
+  buildRegistrySlackLinearChildEnv,
+  buildRegistryInstallerEnv,
+  expectedLinearBacklogPageCount,
+  hasExpectedLinearBacklogProjectMapping,
+  isGracefulCliExit,
+  normalizeLinearIssueRef,
+  runSlackLinearCleanupActions,
+  selectLinearProjectFromDiscoveryResponse,
+  selectCorrelatedSlackLinearReply,
+  selectSlackChannelBinding,
+  stopSlackLinearProcessForCleanup,
+  validateLinearLiveGraphqlUrl
+} from "../test/slack-linear-live-acceptance.js";
+
+const execFile = promisify(execFileCallback);
+const DEFAULT_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+const DEFAULT_WAIT_SECONDS = 300;
+const REPLY_DUPLICATE_OBSERVATION_MS = 10_000;
+const EXPECTED_BETTER_SQLITE3_VERSION = "11.10.0";
+const MAX_LOG_BYTES = 64 * 1024;
+
+type JsonObject = Record<string, unknown>;
+
+type SlackApiResponse = JsonObject & { ok?: boolean; error?: string };
+
+type LinearProxyEvidence = {
+  requestCount: number;
+  backlogQueryCount: number;
+  correlationInjectionCount: number;
+  mutationAttemptCount: number;
+  requests: Array<{
+    receivedAtMs: number;
+    completedAtMs?: number;
+    after: string | null;
+  }>;
+  upstreamErrorCount: number;
+};
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for the Slack /linear registry live acceptance.`);
+  return value;
+}
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value || undefined;
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function integerEnv(name: string, fallback: number, minimum = 1): number {
+  const raw = optionalEnv(name);
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < minimum) throw new Error(`${name} must be an integer >= ${minimum}.`);
+  return value;
+}
+
+function linearAuthorizationHeader(token: string): string {
+  const trimmed = token.trim();
+  if (/^bearer\s+/iu.test(trimmed)) return trimmed;
+  if (trimmed.startsWith("lin_api_")) return trimmed;
+  return `Bearer ${trimmed}`;
+}
+
+async function slackApi<T extends SlackApiResponse>(method: string, token: string, query?: URLSearchParams): Promise<T> {
+  const url = new URL(`https://slack.com/api/${method}`);
+  if (query) url.search = query.toString();
+  const response = await fetch(url, { headers: { authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(15_000) });
+  const body = (await response.json().catch(() => ({}))) as T;
+  if (!response.ok || !body.ok) throw new Error(`Slack ${method} failed: ${body.error ?? `http_${response.status}`}`);
+  return body;
+}
+
+async function fetchLinearProject(input: { token: string; issueRef: string; graphqlUrl: string }) {
+  const response = await fetch(input.graphqlUrl, {
+    method: "POST",
+    headers: {
+      authorization: linearAuthorizationHeader(input.token),
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      query: `query OpenTagSlackLinearLiveIssue($id: String!) {
+  issue(id: $id) { id identifier project { id name } }
+}`,
+      variables: { id: input.issueRef }
+    }),
+    signal: AbortSignal.timeout(15_000)
+  });
+  const body = await response.json().catch(() => undefined);
+  return selectLinearProjectFromDiscoveryResponse({ status: response.status, body });
+}
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolvePromise());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Could not resolve local acceptance proxy port.");
+  return address.port;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+}
+
+async function startLinearAuditProxy(input: {
+  upstreamUrl: string;
+  forcedPageSize: number;
+  expectedProjectId: string;
+  correlationMarker: string;
+}): Promise<{ server: Server; url: string; evidence: LinearProxyEvidence }> {
+  const evidence: LinearProxyEvidence = {
+    requestCount: 0,
+    backlogQueryCount: 0,
+    correlationInjectionCount: 0,
+    mutationAttemptCount: 0,
+    requests: [],
+    upstreamErrorCount: 0
+  };
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.method !== "POST" || request.url !== "/graphql") {
+        response.writeHead(404).end();
+        return;
+      }
+      let raw = "";
+      for await (const chunk of request) {
+        raw += String(chunk);
+        if (raw.length > 1024 * 1024) throw new Error("Linear proxy request exceeded 1 MiB.");
+      }
+      const body = JSON.parse(raw) as { query?: unknown; variables?: unknown };
+      const query = typeof body.query === "string" ? body.query : "";
+      const variables = isObject(body.variables) ? { ...body.variables } : {};
+      evidence.requestCount += 1;
+      if (/\bmutation\b/iu.test(query)) {
+        evidence.mutationAttemptCount += 1;
+        response.writeHead(405, { "content-type": "application/json" });
+        response.end(JSON.stringify({ errors: [{ message: "Mutation blocked by Slack /linear live acceptance." }] }));
+        return;
+      }
+      if (!/\bquery\s+OpenTagProjectBacklog\b/u.test(query)) {
+        response.writeHead(400, { "content-type": "application/json" });
+        response.end(JSON.stringify({ errors: [{ message: "Unexpected GraphQL operation in Slack /linear live acceptance." }] }));
+        return;
+      }
+      if (!hasExpectedLinearBacklogProjectMapping(variables, input.expectedProjectId)) {
+        response.writeHead(400, { "content-type": "application/json" });
+        response.end(JSON.stringify({ errors: [{ message: "Linear backlog query used an unexpected project mapping." }] }));
+        return;
+      }
+      evidence.backlogQueryCount += 1;
+      const receipt: LinearProxyEvidence["requests"][number] = {
+        receivedAtMs: Date.now(),
+        after: typeof variables.after === "string" ? variables.after : null
+      };
+      evidence.requests.push(receipt);
+      variables.first = input.forcedPageSize;
+
+      const upstream = await fetch(input.upstreamUrl, {
+        method: "POST",
+        headers: {
+          authorization: String(request.headers.authorization ?? ""),
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ query, variables }),
+        signal: AbortSignal.timeout(15_000)
+      });
+      let upstreamBody = await upstream.text();
+      if (upstream.ok) {
+        const providerBody = JSON.parse(upstreamBody) as unknown;
+        if (!isObject(providerBody) || !isObject(providerBody.data) || !isObject(providerBody.data.project)) {
+          throw new Error("Linear backlog response did not contain the audited project receipt.");
+        }
+        const projectName = providerBody.data.project.name;
+        if (typeof projectName !== "string" || !projectName.trim()) {
+          throw new Error("Linear backlog response did not contain an auditable project name.");
+        }
+        providerBody.data.project.name = `${projectName} · ${input.correlationMarker}`;
+        upstreamBody = JSON.stringify(providerBody);
+        evidence.correlationInjectionCount += 1;
+      }
+      receipt.completedAtMs = Date.now();
+      if (!upstream.ok) evidence.upstreamErrorCount += 1;
+      response.writeHead(upstream.status, { "content-type": upstream.headers.get("content-type") ?? "application/json" });
+      response.end(upstreamBody);
+    } catch (error) {
+      evidence.upstreamErrorCount += 1;
+      if (response.headersSent) {
+        response.destroy();
+        return;
+      }
+      response.writeHead(502, { "content-type": "application/json" });
+      response.end(JSON.stringify({ errors: [{ message: error instanceof Error ? error.message : "Linear proxy failure" }] }));
+    }
+  });
+  const port = await listen(server);
+  return { server, url: `http://127.0.0.1:${port}/graphql`, evidence };
+}
+
+async function freeLocalPort(): Promise<number> {
+  const server = createServer();
+  const port = await listen(server);
+  await closeServer(server);
+  return port;
+}
+
+async function waitForLog(input: { child: ChildProcess; readLog: () => string; pattern: RegExp; timeoutMs: number }): Promise<void> {
+  const deadline = Date.now() + input.timeoutMs;
+  while (Date.now() < deadline) {
+    if (input.pattern.test(input.readLog())) return;
+    if (input.child.exitCode !== null) throw new Error(`Registry OpenTag CLI exited before readiness with code ${input.child.exitCode}.`);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+  }
+  throw new Error(`Timed out waiting for registry OpenTag CLI readiness (${input.pattern.source}).`);
+}
+
+async function waitForExit(child: ChildProcess, timeoutMs: number): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) return { code: child.exitCode, signal: child.signalCode };
+  return await new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timed out waiting for registry OpenTag CLI shutdown.")), timeoutMs);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      resolvePromise({ code, signal });
+    });
+  });
+}
+
+type SlackMessage = {
+  ts?: string;
+  thread_ts?: string;
+  text?: string;
+  user?: string;
+  bot_id?: string;
+  subtype?: string;
+};
+
+async function waitForSlackSourceMessage(input: {
+  token: string;
+  channelId: string;
+  botUserId: string;
+  startedAt: number;
+  timeoutMs: number;
+}): Promise<SlackMessage & { ts: string }> {
+  const deadline = Date.now() + input.timeoutMs;
+  const expectedText = `<@${input.botUserId}> /linear`;
+  while (Date.now() < deadline) {
+    const body = await slackApi<SlackApiResponse & { messages?: SlackMessage[] }>(
+      "conversations.history",
+      input.token,
+      new URLSearchParams({ channel: input.channelId, oldest: input.startedAt.toFixed(6), limit: "20", inclusive: "true" })
+    );
+    const messages = body.messages?.filter(
+      (candidate) =>
+        candidate.ts &&
+        Number(candidate.ts) >= input.startedAt &&
+        candidate.user &&
+        candidate.user !== input.botUserId &&
+        !candidate.bot_id &&
+        !candidate.subtype &&
+        candidate.text?.trim() === expectedText
+    );
+    if ((messages?.length ?? 0) > 1) throw new Error("Observed multiple matching human Slack /linear source messages; correlation is ambiguous.");
+    const message = messages?.[0];
+    if (message?.ts) return { ...message, ts: message.ts };
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 2_000));
+  }
+  throw new Error(`Timed out waiting for a real Slack message containing exactly ${expectedText}.`);
+}
+
+async function waitForSlackReply(input: {
+  token: string;
+  channelId: string;
+  threadTs: string;
+  botUserId: string;
+  correlationMarker: string;
+  getAuditCompletedAtMs: () => number | undefined;
+  timeoutMs: number;
+}): Promise<NonNullable<ReturnType<typeof selectCorrelatedSlackLinearReply>>> {
+  const deadline = Date.now() + input.timeoutMs;
+  let firstSuccessfulReplyObservedAt: number | undefined;
+  while (Date.now() < deadline) {
+    const body = await slackApi<SlackApiResponse & { messages?: SlackMessage[] }>(
+      "conversations.replies",
+      input.token,
+      new URLSearchParams({ channel: input.channelId, ts: input.threadTs, limit: "30" })
+    );
+    const auditCompletedAtMs = input.getAuditCompletedAtMs();
+    const reply = selectCorrelatedSlackLinearReply({
+      messages: body.messages ?? [],
+      threadTs: input.threadTs,
+      botUserId: input.botUserId,
+      correlationMarker: input.correlationMarker,
+      ...(auditCompletedAtMs !== undefined ? { auditCompletedAtMs } : {})
+    });
+    if (reply) {
+      firstSuccessfulReplyObservedAt ??= Date.now();
+      if (Date.now() - firstSuccessfulReplyObservedAt >= REPLY_DUPLICATE_OBSERVATION_MS) return reply;
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 2_000));
+  }
+  if (firstSuccessfulReplyObservedAt !== undefined) {
+    throw new Error("Observed a successful Slack /linear reply but timed out before completing the duplicate-reply observation window.");
+  }
+  throw new Error("Timed out waiting for the successful Slack /linear thread reply.");
+}
+
+async function main(): Promise<void> {
+  const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+  const expectedVersion = optionalEnv("OPENTAG_SLACK_LINEAR_EXPECTED_CLI_VERSION") ?? "0.9.0";
+  const configSourcePath = resolve(requiredEnv("OPENTAG_CONFIG_PATH"));
+  const botToken = requiredEnv("OPENTAG_SLACK_BOT_TOKEN");
+  const appToken = requiredEnv("OPENTAG_SLACK_APP_TOKEN");
+  const linearToken = requiredEnv("OPENTAG_LINEAR_SMOKE_TOKEN");
+  const linearIssueRef = normalizeLinearIssueRef(
+    optionalEnv("OPENTAG_LINEAR_SMOKE_ISSUE") ?? requiredEnv("OPENTAG_LINEAR_SMOKE_ISSUE_ID")
+  );
+  const linearUpstreamUrl = validateLinearLiveGraphqlUrl(
+    optionalEnv("OPENTAG_LINEAR_SMOKE_GRAPHQL_URL") ?? DEFAULT_LINEAR_GRAPHQL_URL
+  );
+  const waitSeconds = integerEnv("OPENTAG_SLACK_LINEAR_WAIT_SECONDS", DEFAULT_WAIT_SECONDS);
+  const forcedPageSize = integerEnv("OPENTAG_SLACK_LINEAR_PROXY_PAGE_SIZE", 2);
+  const correlationMarker = `OpenTagLive-${randomBytes(12).toString("hex")}`;
+  const tempRoot = await mkdtemp(join(tmpdir(), "opentag-slack-linear-registry-live-"));
+  const installRoot = join(tempRoot, "registry-install");
+  const stateDirectory = join(tempRoot, "state");
+  const configPath = join(tempRoot, "opentag.config.json");
+  const cliLogPath = join(tempRoot, "opentag.log");
+  const reportPath = resolve(
+    optionalEnv("OPENTAG_SLACK_LINEAR_REPORT") ??
+      join(rootDir, ".omx", "live-e2e", `slack-linear-registry-live-${new Date().toISOString().replaceAll(/[:.]/gu, "-")}.json`)
+  );
+  let proxy: Awaited<ReturnType<typeof startLinearAuditProxy>> | undefined;
+  let child: ChildProcess | undefined;
+  let logText = "";
+  let harnessFailure: string | undefined;
+  let pairingToken: string | undefined;
+  let primaryFailure: unknown;
+  let hadPrimaryFailure = false;
+  let cleanupFailure: unknown;
+  let diagnosticFailure: unknown;
+  let gracefulShutdown = false;
+
+  try {
+    const sourceConfig = JSON.parse(await readFile(configSourcePath, "utf8")) as unknown;
+    const binding = selectSlackChannelBinding(sourceConfig, optionalEnv("OPENTAG_SLACK_CHANNEL_ID"));
+    const slackAuth = await slackApi<SlackApiResponse & { team_id?: string; user_id?: string }>("auth.test", botToken);
+    if (!slackAuth.team_id || !slackAuth.user_id) throw new Error("Slack auth.test did not return team_id and user_id.");
+    if (slackAuth.team_id !== binding.teamId) {
+      throw new Error("Slack bot token team does not match the configured Slack channel binding.");
+    }
+    await slackApi(
+      "conversations.history",
+      botToken,
+      new URLSearchParams({ channel: binding.channelId, oldest: (Date.now() / 1000).toFixed(6), limit: "1" })
+    );
+
+    const project = await fetchLinearProject({ token: linearToken, issueRef: linearIssueRef, graphqlUrl: linearUpstreamUrl });
+    proxy = await startLinearAuditProxy({
+      upstreamUrl: linearUpstreamUrl,
+      forcedPageSize,
+      expectedProjectId: project.id,
+      correlationMarker
+    });
+    const dispatcherPort = await freeLocalPort();
+    pairingToken = randomBytes(32).toString("hex");
+
+    await mkdir(installRoot, { recursive: true });
+    await writeFile(
+      join(installRoot, "package.json"),
+      `${JSON.stringify({ name: "opentag-slack-linear-registry-live", private: true }, null, 2)}\n`,
+      { mode: 0o600 }
+    );
+    console.log(`Installing @opentag/cli@${expectedVersion} from the npm registry into an isolated temp root...`);
+    const npmUserConfigPath = join(tempRoot, "npm-userconfig");
+    const npmGlobalConfigPath = join(tempRoot, "npm-globalconfig");
+    await Promise.all([
+      writeFile(npmUserConfigPath, "", { mode: 0o600 }),
+      writeFile(npmGlobalConfigPath, "", { mode: 0o600 })
+    ]);
+    const registryProcessEnv = buildRegistryInstallerEnv({
+      baseEnv: process.env,
+      cacheDirectory: join(tempRoot, "npm-cache"),
+      userConfigPath: npmUserConfigPath,
+      globalConfigPath: npmGlobalConfigPath
+    });
+    await execFile(
+      "npm",
+      ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--save-exact", `@opentag/cli@${expectedVersion}`],
+      {
+        cwd: installRoot,
+        env: registryProcessEnv,
+        maxBuffer: 8 * 1024 * 1024
+      }
+    );
+    const cliBin = join(installRoot, "node_modules", ".bin", "opentag");
+    const registryInspection = await inspectRegistryCliPackageSet({
+      cliBin,
+      expectedVersion,
+      packageNames: ["@opentag/slack", "@opentag/linear", "@opentag/core"],
+      executableEnv: registryProcessEnv
+    });
+    const nativeDependencyInspection = await inspectRegistryInstalledDependency({
+      cliBin,
+      packageName: "better-sqlite3",
+      expectedVersion: EXPECTED_BETTER_SQLITE3_VERSION
+    });
+    await execFile("npm", ["rebuild", "better-sqlite3", "--foreground-scripts", "--no-audit", "--no-fund"], {
+      cwd: installRoot,
+      env: registryProcessEnv,
+      maxBuffer: 8 * 1024 * 1024
+    });
+
+    const config = buildRegistrySlackLinearConfig({
+      stateDirectory,
+      databasePath: join(stateDirectory, "opentag.db"),
+      worktreeRoot: join(tempRoot, "worktrees"),
+      dispatcherUrl: `http://127.0.0.1:${dispatcherPort}`,
+      graphqlUrl: proxy.url,
+      teamId: binding.teamId,
+      channelId: binding.channelId,
+      projectId: project.id
+    });
+    await mkdir(stateDirectory, { recursive: true });
+    await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+
+    child = spawn(cliBin, ["start", "--config", configPath], {
+      env: buildRegistrySlackLinearChildEnv({
+        baseEnv: process.env,
+        appToken,
+        botToken,
+        linearToken,
+        pairingToken
+      }),
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    const collectLog = (chunk: Buffer | string) => {
+      logText = `${logText}${String(chunk)}`.slice(-MAX_LOG_BYTES);
+    };
+    child.stdout?.on("data", collectLog);
+    child.stderr?.on("data", collectLog);
+    await waitForLog({ child, readLog: () => logText, pattern: /OpenTag is running\./u, timeoutMs: 45_000 });
+    await waitForLog({ child, readLog: () => logText, pattern: /Slack: using Socket Mode/u, timeoutMs: 10_000 });
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 2_000));
+    if (child.exitCode !== null) throw new Error(`Registry OpenTag CLI exited after readiness with code ${child.exitCode}.`);
+    if (proxy.evidence.requestCount !== 0) {
+      throw new Error("Linear audit proxy observed backlog traffic before the selected Slack source message.");
+    }
+
+    const startedAt = Date.now() / 1000;
+    console.log("Registry-installed Slack → Linear acceptance stack is ready.");
+    console.log(`Send exactly this message in the configured Slack channel within ${waitSeconds} seconds:`);
+    console.log(`  <@${slackAuth.user_id}> /linear`);
+    const sourceMessage = await waitForSlackSourceMessage({
+      token: botToken,
+      channelId: binding.channelId,
+      botUserId: slackAuth.user_id,
+      startedAt,
+      timeoutMs: waitSeconds * 1_000
+    });
+    const sourceAtMs = Number(sourceMessage.ts) * 1_000;
+    if (!Number.isFinite(sourceAtMs)) throw new Error("Slack source message timestamp is invalid.");
+    const queryDeadline = Date.now() + 60_000;
+    while (proxy.evidence.requests.length === 0 && Date.now() < queryDeadline) {
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+    }
+    const firstQuery = proxy.evidence.requests[0];
+    if (!firstQuery || firstQuery.receivedAtMs < sourceAtMs - 5_000) {
+      throw new Error("The audited Linear backlog query is not causally ordered after the selected Slack source message.");
+    }
+    const reply = await waitForSlackReply({
+      token: botToken,
+      channelId: binding.channelId,
+      threadTs: sourceMessage.ts,
+      botUserId: slackAuth.user_id,
+      correlationMarker,
+      getAuditCompletedAtMs: () => {
+        const requests = proxy?.evidence.requests;
+        if (!requests?.length || requests.some((request) => request.completedAtMs === undefined)) {
+          return undefined;
+        }
+        return Math.max(...requests.map((request) => request.completedAtMs!));
+      },
+      timeoutMs: 75_000
+    });
+    if (proxy.evidence.backlogQueryCount < 1) throw new Error("No audited Linear backlog query reached the real provider.");
+    const expectedPageCount = expectedLinearBacklogPageCount(reply.summary.reportedOpenCount, forcedPageSize);
+    if (proxy.evidence.requests.length !== expectedPageCount) {
+      throw new Error(
+        `Audited Linear pagination used ${proxy.evidence.requests.length} pages; expected ${expectedPageCount} for ${reply.summary.reportedOpenCount} open issues at page size ${forcedPageSize}.`
+      );
+    }
+    if (proxy.evidence.mutationAttemptCount !== 0) throw new Error("The read-only /linear path attempted a Linear mutation.");
+    if (proxy.evidence.upstreamErrorCount !== 0) throw new Error("The audited Linear provider path recorded an upstream error.");
+    if (proxy.evidence.correlationInjectionCount !== proxy.evidence.backlogQueryCount) {
+      throw new Error("Not every audited Linear backlog page received the registry runtime correlation marker.");
+    }
+    if (/\[slack\] failed to handle Socket Mode event:|linear backlog query failed|deliver Slack self-service reply failed/iu.test(logText)) {
+      throw new Error("Registry OpenTag CLI logged a Slack /linear processing or reply failure.");
+    }
+
+    child.kill("SIGTERM");
+    const exit = await waitForExit(child, 35_000);
+    gracefulShutdown = isGracefulCliExit(exit);
+    if (!gracefulShutdown) throw new Error(`Registry OpenTag CLI did not shut down gracefully (code=${exit.code}, signal=${exit.signal}).`);
+    child = undefined;
+
+    const packageReceipt = Object.fromEntries(
+      Object.entries(registryInspection.packages).map(([name, receipt]) => [
+        name,
+        { version: receipt.version, registry: receipt.registry, integrity: receipt.integrity }
+      ])
+    );
+    const report = {
+      schemaVersion: "opentag.slack-linear-registry-live.v1",
+      acceptedAt: new Date().toISOString(),
+      runtime: {
+        source: "registry_install",
+        credentialEnvironment: "allowlisted",
+        expectedVersion,
+        executable: {
+          package: registryInspection.executable.package,
+          version: registryInspection.executable.version,
+          registry: registryInspection.executable.registry,
+          integrity: registryInspection.executable.integrity
+        },
+        packages: packageReceipt,
+        nativeDependencies: {
+          "better-sqlite3": {
+            version: nativeDependencyInspection.version,
+            registry: nativeDependencyInspection.registry,
+            integrity: nativeDependencyInspection.integrity,
+            lifecycleScriptsExecutedAfterReceiptVerification: true
+          }
+        }
+      },
+      slack: {
+        delivery: "provider_socket_mode",
+        authVerified: true,
+        teamIdSha256: sha256(binding.teamId),
+        channelIdSha256: sha256(binding.channelId),
+        sourceThreadObserved: true,
+        sourceWasHuman: true,
+        runtimeCorrelationMatched: true,
+        runtimeCorrelationMarkerSha256: sha256(correlationMarker),
+        sourceMessageTsSha256: sha256(sourceMessage.ts),
+        replyObserved: true,
+        uniqueSuccessfulReply: true,
+        replyTsSha256: sha256(reply.message.ts),
+        reply: reply.summary,
+        sourceToFirstLinearRequestMs: firstQuery.receivedAtMs - sourceAtMs
+      },
+      linear: {
+        provider: new URL(linearUpstreamUrl).origin,
+        canonicalEndpointVerified: true,
+        projectIdSha256: sha256(project.id),
+        queryOnlyConfiguration: true,
+        credentialScope: "unknown",
+        mutationBlockedByAuditProxy: true,
+        tokenSource: "configured_smoke_token",
+        forcedPageSize,
+        graphqlRequestCount: proxy.evidence.requestCount,
+        backlogQueryCount: proxy.evidence.backlogQueryCount,
+        pageCount: proxy.evidence.requests.length,
+        mutationAttemptCount: proxy.evidence.mutationAttemptCount,
+        upstreamErrorCount: proxy.evidence.upstreamErrorCount
+      },
+      lifecycle: { gracefulShutdown, exitCode: exit.code, exitSignal: exit.signal },
+      acceptance: { passed: true }
+    };
+    await mkdir(dirname(reportPath), { recursive: true });
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+    await chmod(reportPath, 0o600);
+    const mode = (await stat(reportPath)).mode & 0o777;
+    if (mode !== 0o600) throw new Error(`Acceptance report permissions are ${mode.toString(8)}; expected 600.`);
+    console.log(`Slack → Linear registry-installed live acceptance passed: ${reportPath}`);
+  } catch (error) {
+    primaryFailure = error;
+    hadPrimaryFailure = true;
+    harnessFailure = error instanceof Error ? error.message : String(error);
+  } finally {
+    try {
+      const cleanupActions: Array<{ name: string; run: () => Promise<void> }> = [];
+      if (child && child.exitCode === null && child.signalCode === null) {
+        const runningChild = child;
+        cleanupActions.push({
+          name: "registry CLI cleanup",
+          run: async () => {
+            await stopSlackLinearProcessForCleanup({
+              sendSignal: (signal) => runningChild.kill(signal),
+              waitForExit: async () => {
+                await waitForExit(runningChild, 35_000);
+              }
+            });
+          }
+        });
+      }
+      if (proxy) {
+        const proxyServer = proxy.server;
+        cleanupActions.push({ name: "Linear audit proxy cleanup", run: async () => closeServer(proxyServer) });
+      }
+      await runSlackLinearCleanupActions(cleanupActions);
+    } catch (error) {
+      cleanupFailure = error;
+      harnessFailure = appendSlackLinearCleanupFailure(harnessFailure, error);
+    }
+    try {
+      const diagnosticLog = buildSlackLinearDiagnosticLog({
+        cliOutput: logText,
+        failureMessage: harnessFailure,
+        sensitiveValues: [botToken, appToken, linearToken, pairingToken].filter(
+          (value): value is string => value !== undefined
+        )
+      });
+      await writeFile(cliLogPath, diagnosticLog, { mode: 0o600 });
+      await chmod(cliLogPath, 0o600);
+      console.log(`Temporary diagnostic log retained with mode 0600: ${cliLogPath}`);
+    } catch (error) {
+      console.error(`Could not retain the temporary CLI diagnostic log: ${error instanceof Error ? error.message : error}`);
+      if (!harnessFailure) diagnosticFailure = error;
+    }
+    console.log(`Temporary acceptance root retained for local audit: ${tempRoot}`);
+  }
+  if (hadPrimaryFailure) throw primaryFailure;
+  if (cleanupFailure) throw cleanupFailure;
+  if (diagnosticFailure) throw diagnosticFailure;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/test/github-registry-artifact.ts
+++ b/scripts/test/github-registry-artifact.ts
@@ -32,6 +32,20 @@ export type RegistryCliArtifactInspection = {
   };
 };
 
+export type RegistryPackageReceipt = {
+  package: string;
+  version: string;
+  registry: string;
+  resolved: string;
+  integrity: string;
+};
+
+export type RegistryCliPackageSetInspection = {
+  expectedVersion: string;
+  executable: RegistryPackageReceipt;
+  packages: Record<string, RegistryPackageReceipt>;
+};
+
 async function readJson(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8")) as unknown;
 }
@@ -196,6 +210,55 @@ function executableVersion(cliBin: string): Promise<string> {
       resolvePromise(stdout.trim());
     });
   });
+}
+
+export async function inspectRegistryCliPackageSet(input: {
+  cliBin: string;
+  expectedVersion: string;
+  packageNames: string[];
+}): Promise<RegistryCliPackageSetInspection> {
+  const expectedVersion = string(input.expectedVersion, "expected registry CLI version");
+  const cliBin = await realpath(resolve(input.cliBin));
+  const cli = await inspectInstalledPackage(cliBin, "@opentag/cli", expectedVersion);
+  const manifest = object(await readJson(join(cli.packageRoot, "package.json")), "@opentag/cli package manifest") as PackageJson;
+  const bin = object(manifest.bin, "@opentag/cli bin map");
+  const expectedEntrypoint = await realpath(resolve(cli.packageRoot, string(bin["opentag"], "@opentag/cli bin entry")));
+  if (expectedEntrypoint !== cliBin) {
+    throw new Error("Installed OpenTag executable does not match the @opentag/cli bin entry.");
+  }
+  const reportedVersion = await executableVersion(cliBin);
+  if (reportedVersion !== expectedVersion) {
+    throw new Error(`Installed OpenTag executable reports ${reportedVersion}; expected ${expectedVersion}.`);
+  }
+
+  const packages: Record<string, RegistryPackageReceipt> = {};
+  for (const packageName of [...new Set(input.packageNames)]) {
+    if (!packageName.startsWith("@opentag/") || packageName === "@opentag/cli") {
+      throw new Error(`Registry provider package must be an @opentag/* dependency other than @opentag/cli: ${packageName}`);
+    }
+    const packageRoot = await resolveInstalledDependencyRoot(cli.packageRoot, packageName);
+    const entrypoint = await packageImportEntrypoint(packageRoot, packageName);
+    const inspected = await inspectInstalledPackage(entrypoint, packageName, expectedVersion);
+    packages[packageName] = {
+      package: packageName,
+      version: inspected.version,
+      registry: inspected.registry,
+      resolved: inspected.resolved,
+      integrity: inspected.integrity
+    };
+  }
+
+  return {
+    expectedVersion,
+    executable: {
+      package: "@opentag/cli",
+      version: cli.version,
+      registry: cli.registry,
+      resolved: cli.resolved,
+      integrity: cli.integrity
+    },
+    packages
+  };
 }
 
 export async function inspectRegistryCliArtifact(input: {

--- a/scripts/test/github-registry-artifact.ts
+++ b/scripts/test/github-registry-artifact.ts
@@ -196,12 +196,12 @@ async function inspectInstalledPackage(
   };
 }
 
-function executableVersion(cliBin: string): Promise<string> {
+function executableVersion(cliBin: string, env?: NodeJS.ProcessEnv): Promise<string> {
   return new Promise((resolvePromise, reject) => {
     execFile(cliBin, ["--version"], {
       encoding: "utf8",
       timeout: 10_000,
-      env: { ...process.env, NODE_OPTIONS: "" }
+      env: { ...(env ?? process.env), NODE_OPTIONS: "" }
     }, (error, stdout) => {
       if (error) {
         reject(new Error(`Installed OpenTag CLI --version failed: ${error.message}`));
@@ -216,6 +216,7 @@ export async function inspectRegistryCliPackageSet(input: {
   cliBin: string;
   expectedVersion: string;
   packageNames: string[];
+  executableEnv?: NodeJS.ProcessEnv;
 }): Promise<RegistryCliPackageSetInspection> {
   const expectedVersion = string(input.expectedVersion, "expected registry CLI version");
   const cliBin = await realpath(resolve(input.cliBin));
@@ -226,7 +227,7 @@ export async function inspectRegistryCliPackageSet(input: {
   if (expectedEntrypoint !== cliBin) {
     throw new Error("Installed OpenTag executable does not match the @opentag/cli bin entry.");
   }
-  const reportedVersion = await executableVersion(cliBin);
+  const reportedVersion = await executableVersion(cliBin, input.executableEnv);
   if (reportedVersion !== expectedVersion) {
     throw new Error(`Installed OpenTag executable reports ${reportedVersion}; expected ${expectedVersion}.`);
   }
@@ -258,6 +259,40 @@ export async function inspectRegistryCliPackageSet(input: {
       integrity: cli.integrity
     },
     packages
+  };
+}
+
+export async function inspectRegistryInstalledDependency(input: {
+  cliBin: string;
+  packageName: string;
+  expectedVersion?: string;
+}): Promise<RegistryPackageReceipt> {
+  const packageName = string(input.packageName, "registry dependency package name");
+  const segments = packageNameSegments(packageName);
+  if (
+    segments.length === 0 ||
+    segments.length > 2 ||
+    segments.some((segment) => segment === "." || segment === ".." || !/^[A-Za-z0-9._-]+$/u.test(segment))
+  ) {
+    throw new Error(`Invalid registry dependency package name: ${packageName}`);
+  }
+  const cliBin = await realpath(resolve(input.cliBin));
+  const cliRoot = await findPackageRoot(cliBin, "@opentag/cli");
+  const packageRoot = await resolveInstalledDependencyRoot(cliRoot, packageName);
+  const manifest = object(await readJson(join(packageRoot, "package.json")), `${packageName} package manifest`) as PackageJson;
+  const version = string(manifest.version, `${packageName} package version`);
+  const expectedVersion =
+    input.expectedVersion === undefined
+      ? version
+      : string(input.expectedVersion, `expected ${packageName} package version`);
+  const entrypoint = await packageImportEntrypoint(packageRoot, packageName);
+  const inspected = await inspectInstalledPackage(entrypoint, packageName, expectedVersion);
+  return {
+    package: packageName,
+    version: inspected.version,
+    registry: inspected.registry,
+    resolved: inspected.resolved,
+    integrity: inspected.integrity
   };
 }
 

--- a/scripts/test/live-e2e-smoke.mjs
+++ b/scripts/test/live-e2e-smoke.mjs
@@ -137,6 +137,19 @@ const cases = [
     ]
   },
   {
+    id: "slack-linear-registry-live",
+    label: "Registry-installed live Slack /linear acceptance",
+    live: true,
+    command: "scripts/dev/run-slack-linear-backlog-live-test.sh",
+    requiredCommands: ["corepack", "node", "npm"],
+    notes: [
+      "Loads .env.slack-test and .env.linear by default; override the two OPENTAG_SLACK_LINEAR_*_ENV_FILE paths for an isolated worktree.",
+      "Installs the exact expected @opentag/cli release from npm, verifies CLI/Slack/Linear/Core lockfile sha512 receipts, and runs the installed CLI in Slack Socket Mode.",
+      "Requires one real human Slack message containing exactly @OpenTag /linear, then verifies the provider-delivered source event, real Linear GraphQL reads, and provider-visible Slack thread reply.",
+      "The Linear audit proxy fails closed on mutations; retained evidence is mode 0600 and contains hashes/counts instead of credentials, Linear issue titles, or raw Slack messages."
+    ]
+  },
+  {
     id: "slack-local-live",
     label: "Live Slack dispatcher-assisted local executor smoke",
     live: true,

--- a/scripts/test/slack-linear-live-acceptance.ts
+++ b/scripts/test/slack-linear-live-acceptance.ts
@@ -1,0 +1,434 @@
+type JsonObject = Record<string, unknown>;
+
+export type SlackChannelBinding = {
+  teamId: string;
+  channelId: string;
+};
+
+export type LinearProjectSelection = {
+  id: string;
+  name: string;
+};
+
+export type RegistrySlackLinearConfig = {
+  schemaVersion: 1;
+  state: {
+    directory: string;
+    databasePath: string;
+    worktreeRoot: string;
+  };
+  runtime: { mode: "local" };
+  daemon: {
+    runnerId: string;
+    dispatcherUrl: string;
+    repositories: [];
+    pairingToken: { kind: "env"; name: "OPENTAG_SLACK_LINEAR_PAIRING_TOKEN" };
+    pollIntervalMs: number;
+    heartbeatIntervalMs: number;
+  };
+  platforms: {
+    slack: {
+      mode: "socket_mode";
+      appToken: { kind: "env"; name: "OPENTAG_SLACK_APP_TOKEN" };
+      botToken: { kind: "env"; name: "OPENTAG_SLACK_BOT_TOKEN" };
+      teamId: string;
+      channelId: string;
+    };
+    linear: {
+      connections: {
+        default: { token: { kind: "env"; name: "OPENTAG_LINEAR_SMOKE_TOKEN" } };
+      };
+      channels: Array<{
+        teamId: string;
+        channelId: string;
+        projectId: string;
+        connection: "default";
+      }>;
+      graphqlUrl: string;
+    };
+  };
+};
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonBlank(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function hasExpectedLinearBacklogProjectMapping(
+  variables: Record<string, unknown>,
+  expectedProjectId: string
+): boolean {
+  const suppliedProjectIds = ["projectId", "projectKey"]
+    .filter((key) => Object.hasOwn(variables, key))
+    .map((key) => variables[key]);
+  return suppliedProjectIds.length > 0 && suppliedProjectIds.every((value) => value === expectedProjectId);
+}
+
+export function expectedLinearBacklogPageCount(reportedOpenCount: number, forcedPageSize: number): number {
+  if (!Number.isSafeInteger(reportedOpenCount) || reportedOpenCount < 0) {
+    throw new Error("Reported Linear open count must be a non-negative safe integer.");
+  }
+  if (!Number.isSafeInteger(forcedPageSize) || forcedPageSize < 1) {
+    throw new Error("Forced Linear page size must be a positive safe integer.");
+  }
+  return Math.max(1, Math.ceil(reportedOpenCount / forcedPageSize));
+}
+
+function candidateBinding(value: unknown): SlackChannelBinding | undefined {
+  if (!isObject(value)) return undefined;
+  const teamId = nonBlank(value.teamId) ?? nonBlank(value.accountId);
+  const channelId = nonBlank(value.channelId) ?? nonBlank(value.conversationId);
+  return teamId && channelId ? { teamId, channelId } : undefined;
+}
+
+export function selectSlackChannelBinding(config: unknown, requestedChannelId?: string): SlackChannelBinding {
+  if (!isObject(config)) throw new Error("OpenTag config must be a JSON object.");
+  const candidates: SlackChannelBinding[] = [];
+
+  if (isObject(config.platforms) && isObject(config.platforms.slack)) {
+    const binding = candidateBinding(config.platforms.slack);
+    if (binding) candidates.push(binding);
+  }
+  if (Array.isArray(config.slackChannels)) {
+    for (const value of config.slackChannels) {
+      const binding = candidateBinding(value);
+      if (binding) candidates.push(binding);
+    }
+  }
+  if (Array.isArray(config.channelBindings)) {
+    for (const value of config.channelBindings) {
+      if (!isObject(value) || value.provider !== "slack") continue;
+      const binding = candidateBinding(value);
+      if (binding) candidates.push(binding);
+    }
+  }
+
+  const deduplicated = [...new Map(candidates.map((binding) => [`${binding.teamId}\u0000${binding.channelId}`, binding])).values()];
+  const requested = nonBlank(requestedChannelId);
+  if (requested) {
+    const selected = deduplicated.find((binding) => binding.channelId === requested);
+    if (!selected) throw new Error(`No Slack channel binding found for requested channel ${requested}.`);
+    return selected;
+  }
+  if (!deduplicated[0]) throw new Error("OpenTag config has no Slack channel binding.");
+  return deduplicated[0];
+}
+
+export function normalizeLinearIssueRef(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) throw new Error("Linear smoke issue reference must not be empty.");
+  const pathMatch = trimmed.match(/\/issue\/([^/#?]+)/u);
+  return pathMatch?.[1] ? decodeURIComponent(pathMatch[1]) : trimmed;
+}
+
+export function describeLinearProjectDiscoveryFailure(input: { status: number; messages: string[] }): string {
+  const detail = input.messages.filter(Boolean).join("; ") || `http_${input.status}`;
+  if (
+    input.status === 401 ||
+    input.status === 403 ||
+    /authentication required|not authenticated|unauthorized|forbidden|permission denied|access denied/iu.test(detail)
+  ) {
+    return `Linear project discovery failed: ${detail}. Reauthorize the Linear live acceptance and refresh OPENTAG_LINEAR_SMOKE_TOKEN.`;
+  }
+  if (/entity not found:\s*issue|issue(?:\s+\S+){0,3}\s+not found|could not find(?:\s+\S+){0,3}\s+issue/iu.test(detail)) {
+    return `Linear smoke issue discovery failed: ${detail}. Update OPENTAG_LINEAR_SMOKE_ISSUE to an issue in a project accessible to the configured token.`;
+  }
+  return `Linear provider project discovery failed: ${detail}. Retry the acceptance or check the Linear API status and response.`;
+}
+
+export function selectLinearProjectFromDiscoveryResponse(input: {
+  status: number;
+  body: unknown;
+}): LinearProjectSelection {
+  const body = isObject(input.body) ? input.body : {};
+  const messages = Array.isArray(body.errors)
+    ? body.errors.flatMap((value) => (isObject(value) ? [nonBlank(value.message)].filter((message): message is string => Boolean(message)) : []))
+    : [];
+  if (input.status < 200 || input.status >= 300 || messages.length > 0) {
+    throw new Error(describeLinearProjectDiscoveryFailure({ status: input.status, messages }));
+  }
+  if (!isObject(body.data) || !("issue" in body.data)) {
+    throw new Error(
+      "Linear provider project discovery failed: the response did not contain data.issue. Retry the acceptance or check the Linear API status and response."
+    );
+  }
+  if (body.data.issue === null) {
+    throw new Error(
+      "Linear smoke issue discovery failed: issue not found. Update OPENTAG_LINEAR_SMOKE_ISSUE to an issue in a project accessible to the configured token."
+    );
+  }
+  if (!isObject(body.data.issue)) {
+    throw new Error(
+      "Linear provider project discovery failed: data.issue was malformed. Retry the acceptance or check the Linear API status and response."
+    );
+  }
+  const project = body.data.issue.project;
+  if (project === null) {
+    throw new Error("The configured Linear smoke issue is not assigned to a project; /linear requires a project mapping.");
+  }
+  if (!isObject(project) || !nonBlank(project.id) || !nonBlank(project.name)) {
+    throw new Error(
+      "Linear provider project discovery failed: data.issue.project was malformed. Retry the acceptance or check the Linear API status and response."
+    );
+  }
+  return { id: nonBlank(project.id)!, name: nonBlank(project.name)! };
+}
+
+export function buildSlackLinearDiagnosticLog(input: {
+  cliOutput: string;
+  failureMessage?: string;
+  sensitiveValues?: string[];
+}): string {
+  const redact = (value: string): string => {
+    let result = value;
+    for (const sensitiveValue of input.sensitiveValues ?? []) {
+      if (sensitiveValue) result = result.replaceAll(sensitiveValue, "[REDACTED]");
+    }
+    return result
+      .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/giu, "Bearer [REDACTED]")
+      .replace(/\bx(?:app|ox[baprs])-[A-Za-z0-9-]+/giu, "[REDACTED]")
+      .replace(/\blin_api_[A-Za-z0-9_-]+/giu, "[REDACTED]");
+  };
+  const output = redact(input.cliOutput).trimEnd();
+  const sections = [output || "[opentag-live] no CLI output was captured."];
+  if (input.failureMessage) sections.push(`[opentag-live] harness failure: ${redact(input.failureMessage)}`);
+  return `${sections.join("\n")}\n`;
+}
+
+export function appendSlackLinearCleanupFailure(primaryFailure: string | undefined, cleanupFailure: unknown): string {
+  const detail = cleanupFailure instanceof Error ? cleanupFailure.message : String(cleanupFailure);
+  return primaryFailure ? `${primaryFailure}; cleanup failed: ${detail}` : `Cleanup failed: ${detail}`;
+}
+
+export async function stopSlackLinearProcessForCleanup(input: {
+  sendSignal: (signal: "SIGTERM" | "SIGKILL") => boolean;
+  waitForExit: () => Promise<void>;
+}): Promise<void> {
+  const termSent = input.sendSignal("SIGTERM");
+  try {
+    await input.waitForExit();
+  } catch (error) {
+    const killSent = input.sendSignal("SIGKILL");
+    throw new Error(
+      `Registry CLI cleanup did not complete after SIGTERM; SIGTERM sent=${termSent}, SIGKILL sent=${killSent}.`,
+      { cause: error }
+    );
+  }
+}
+
+export async function runSlackLinearCleanupActions(
+  actions: Array<{ name: string; run: () => Promise<void> }>
+): Promise<void> {
+  const failures: Error[] = [];
+  for (const action of actions) {
+    try {
+      await action.run();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      failures.push(new Error(`${action.name}: ${detail}`, { cause: error }));
+    }
+  }
+  if (failures.length === 1) throw failures[0];
+  if (failures.length > 1) {
+    throw new AggregateError(failures, failures.map((failure) => failure.message).join("; "));
+  }
+}
+
+export function validateLinearLiveGraphqlUrl(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("Live acceptance requires the canonical Linear GraphQL endpoint.");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "api.linear.app" ||
+    url.port ||
+    url.pathname !== "/graphql" ||
+    url.search ||
+    url.hash ||
+    url.username ||
+    url.password
+  ) {
+    throw new Error("Live acceptance requires the canonical Linear GraphQL endpoint https://api.linear.app/graphql.");
+  }
+  return "https://api.linear.app/graphql";
+}
+
+const REGISTRY_CHILD_ENV_ALLOWLIST = ["HOME", "PATH", "TMPDIR", "TMP", "TEMP", "LANG", "LC_ALL", "LC_CTYPE", "TZ"] as const;
+
+function allowlistedBaseEnvironment(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const name of REGISTRY_CHILD_ENV_ALLOWLIST) {
+    const value = baseEnv[name];
+    if (value) env[name] = value;
+  }
+  return env;
+}
+
+export function buildRegistryInstallerEnv(input: {
+  baseEnv: NodeJS.ProcessEnv;
+  cacheDirectory: string;
+  userConfigPath: string;
+  globalConfigPath: string;
+}): NodeJS.ProcessEnv {
+  return {
+    ...allowlistedBaseEnvironment(input.baseEnv),
+    NPM_CONFIG_AUDIT: "false",
+    NPM_CONFIG_CACHE: input.cacheDirectory,
+    NPM_CONFIG_FUND: "false",
+    NPM_CONFIG_GLOBALCONFIG: input.globalConfigPath,
+    NPM_CONFIG_REGISTRY: "https://registry.npmjs.org",
+    NPM_CONFIG_USERCONFIG: input.userConfigPath
+  };
+}
+
+export function buildRegistrySlackLinearChildEnv(input: {
+  baseEnv: NodeJS.ProcessEnv;
+  appToken: string;
+  botToken: string;
+  linearToken: string;
+  pairingToken: string;
+}): NodeJS.ProcessEnv {
+  return {
+    ...allowlistedBaseEnvironment(input.baseEnv),
+    OPENTAG_SLACK_APP_TOKEN: input.appToken,
+    OPENTAG_SLACK_BOT_TOKEN: input.botToken,
+    OPENTAG_LINEAR_SMOKE_TOKEN: input.linearToken,
+    OPENTAG_SLACK_LINEAR_PAIRING_TOKEN: input.pairingToken
+  };
+}
+
+export function isGracefulCliExit(input: { code: number | null; signal: NodeJS.Signals | null }): boolean {
+  return input.code === 0 && input.signal === null;
+}
+
+export function buildRegistrySlackLinearConfig(input: {
+  stateDirectory: string;
+  databasePath: string;
+  worktreeRoot: string;
+  dispatcherUrl: string;
+  graphqlUrl: string;
+  teamId: string;
+  channelId: string;
+  projectId: string;
+}): RegistrySlackLinearConfig {
+  return {
+    schemaVersion: 1,
+    state: {
+      directory: input.stateDirectory,
+      databasePath: input.databasePath,
+      worktreeRoot: input.worktreeRoot
+    },
+    runtime: { mode: "local" },
+    daemon: {
+      runnerId: "runner_slack_linear_registry_live",
+      dispatcherUrl: input.dispatcherUrl,
+      repositories: [],
+      pairingToken: { kind: "env", name: "OPENTAG_SLACK_LINEAR_PAIRING_TOKEN" },
+      pollIntervalMs: 1_000,
+      heartbeatIntervalMs: 15_000
+    },
+    platforms: {
+      slack: {
+        mode: "socket_mode",
+        appToken: { kind: "env", name: "OPENTAG_SLACK_APP_TOKEN" },
+        botToken: { kind: "env", name: "OPENTAG_SLACK_BOT_TOKEN" },
+        teamId: input.teamId,
+        channelId: input.channelId
+      },
+      linear: {
+        connections: {
+          default: { token: { kind: "env", name: "OPENTAG_LINEAR_SMOKE_TOKEN" } }
+        },
+        channels: [
+          {
+            teamId: input.teamId,
+            channelId: input.channelId,
+            projectId: input.projectId,
+            connection: "default"
+          }
+        ],
+        graphqlUrl: input.graphqlUrl
+      }
+    }
+  };
+}
+
+export type SlackLinearReplySummary = {
+  kind: "backlog" | "empty";
+  displayedIssueCount: number;
+  reportedOpenCount: number;
+};
+
+export type SlackLinearReplyCandidate = {
+  ts?: string;
+  text?: string;
+  user?: string;
+};
+
+export type CorrelatedSlackLinearReply = {
+  message: SlackLinearReplyCandidate & { ts: string; text: string; user: string };
+  summary: SlackLinearReplySummary;
+};
+
+export function summarizeSlackLinearReply(text: string): SlackLinearReplySummary {
+  if (!/_Linear · queried \d{2}:\d{2} UTC_/u.test(text)) {
+    throw new Error("Slack response is not a successful /linear reply.");
+  }
+  const openMatch = text.match(/· (\d+) open\*/u);
+  if (!openMatch) throw new Error("Slack response does not report the authoritative open issue count.");
+  const reportedOpenCount = Number(openMatch[1]);
+  const displayedIssueCount = text.split("\n").filter((line) => line.startsWith("• ")).length;
+  if (reportedOpenCount === 0) {
+    if (!text.includes("No unfinished issues in this Linear project.")) {
+      throw new Error("Slack response reports an empty backlog without the empty-state receipt.");
+    }
+    return { kind: "empty", displayedIssueCount, reportedOpenCount };
+  }
+  if (displayedIssueCount === 0) throw new Error("Slack response reports open Linear issues but displays none.");
+  return { kind: "backlog", displayedIssueCount, reportedOpenCount };
+}
+
+export function selectCorrelatedSlackLinearReply(input: {
+  messages: SlackLinearReplyCandidate[];
+  threadTs: string;
+  botUserId: string;
+  correlationMarker: string;
+  auditCompletedAtMs?: number;
+}): CorrelatedSlackLinearReply | undefined {
+  const successfulReplies: CorrelatedSlackLinearReply[] = [];
+  for (const candidate of input.messages) {
+    if (!candidate.ts || candidate.ts === input.threadTs || !candidate.text || candidate.user !== input.botUserId) continue;
+    try {
+      successfulReplies.push({
+        message: { ...candidate, ts: candidate.ts, text: candidate.text, user: candidate.user },
+        summary: summarizeSlackLinearReply(candidate.text)
+      });
+    } catch {
+      // The thread may include other bot receipts; only successful /linear replies participate in correlation.
+    }
+  }
+  if (successfulReplies.length > 1) {
+    throw new Error("Observed multiple successful Slack /linear replies in the source thread; runtime ownership is ambiguous.");
+  }
+  const reply = successfulReplies[0];
+  if (!reply) return undefined;
+  if (input.auditCompletedAtMs === undefined) {
+    throw new Error("A successful Slack /linear reply arrived before the audited Linear query completed.");
+  }
+  const replyAtMs = Number(reply.message.ts) * 1_000;
+  if (!Number.isFinite(replyAtMs) || replyAtMs < input.auditCompletedAtMs) {
+    throw new Error("A successful Slack /linear reply is not ordered after the audited Linear query completed.");
+  }
+  if (!reply.message.text.includes(input.correlationMarker)) {
+    throw new Error("The Slack /linear reply does not carry the registry runtime correlation marker.");
+  }
+  return reply;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["packages/**/*.test.ts", "apps/**/*.test.ts"],
-    globals: false
+    globals: false,
+    testTimeout: process.env.CI ? 15_000 : 5_000
   },
   resolve: {
     conditions: ["development"]


### PR DESCRIPTION
## Summary

- add a registry-installed Slack to Linear live acceptance case for the published 0.9.0 CLI and provider package set
- prove one real human Slack app mention through Socket Mode, canonical Linear read-only pagination, and one correlated Slack thread reply
- fail closed on non-canonical Linear endpoints, ambient credential leakage, mutation attempts, ambiguous correlation, duplicate successful replies, and non-zero or signaled runtime exits
- install native dependencies in two phases: verify npm registry and SHA-512 receipts before rebuilding better-sqlite3
- pin and verify the expected better-sqlite3 version before allowing its native lifecycle script
- retain sanitized mode-0600 local evidence and diagnostic logs without committing credentials, raw Slack messages, issue content, or temporary markers
- use a 15-second test timeout only on CI runners while preserving the 5-second local timeout, after two exact-head runs timed out in different existing dispatcher tests

## Validation

- live provider acceptance passed against registry-installed 0.9.0: 5 Linear pages, 10 authoritative open issues, 1 correlated Slack reply, 0 mutation attempts, 0 upstream errors, normal exit code 0 with no signal
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build
- corepack pnpm test (143 files, 1941 tests with the 5-second local timeout)
- CI=true corepack pnpm test (143 files, 1941 tests)
- focused live-acceptance and registry-artifact tests (2 files, 28 tests)
- corepack pnpm release:publication-set (16 public packages)
- git diff --check

## Notes

- the live acceptance report and provider diagnostic log are local ignored artifacts with mode 0600; neither is part of this PR
- the harness reports the Linear credential scope as unknown and separately proves query-only configuration plus audit-proxy mutation blocking
- review hardening keeps the primary failure authoritative, drains both cleanup paths, redacts the runtime pairing token, and validates every supplied Linear project identifier
- pagination depth is reconciled against the authoritative Slack open-count receipt and forced page size, so the observed 10 issues imply exactly 5 audited pages without hard-coding mutable provider data
- this changes test, developer-script, and documentation surfaces only; it does not change published package runtime code or require a patch package release
- the CI-only timeout adjustment addresses hosted-runner variance; assertions and local fail-fast behavior are unchanged
