### PR TITLE
Reposition OpenTag around verified agent completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,39 @@
 
 ## Unreleased
 
-No changes yet.
+OpenTag now applies a zero-config verified completion tier to GitHub-backed
+runs. When a run ships a pull request and the repository has no explicit
+completion policy, the run stays open after executor success until GitHub
+webhook evidence verifies that the pull request exists and every observed
+check passes on the current head. Runs that ship no pull request keep
+executor-success semantics.
+
+### Added
+
+- A default `governed` completion contract for GitHub-backed pull-request runs
+  without a configured completion policy, gating completion on a verified
+  pull-request artifact and an all-observed-checks-passing rollup, without
+  requiring merge.
+- A `source_control.observed_checks_rollup` verified evidence fact derived
+  from every reconciled GitHub pull-request snapshot, aggregating observed
+  check states into one passed/failed/pending outcome.
+- A compatibility thread that starts with informational runs upgrades to the
+  default verified contract when a later run in the same WorkThread ships a
+  pull request.
+- Opt-out and plumbing: `defaultGitHubCompletion` on the dispatcher app and
+  local runtime, the daemon config field `daemon.defaultGitHubCompletion`, and
+  the `OPENTAG_GITHUB_DEFAULT_COMPLETION` environment variable (`governed`
+  default, `compat` preserves legacy executor-success semantics).
+
+### Compatibility and migration
+
+- Existing explicit completion policies are unchanged and still take
+  precedence for their repositories.
+- Runs that do not produce a pull request, non-GitHub runs, and threads with
+  an existing governed contract behave exactly as before.
+- To restore the previous default for pull-request runs, set
+  `OPENTAG_GITHUB_DEFAULT_COMPLETION=compat` or
+  `daemon.defaultGitHubCompletion: "compat"`.
 
 ## v0.9.0 - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ executor-success semantics.
   without a configured completion policy, gating completion on a verified
   pull-request artifact and an all-observed-checks-passing rollup, without
   requiring merge.
+- Slack mentions bound to a repository now carry a durable `workItem` for the
+  source thread (with the bound repo as `ownerContainer`), so WorkThread-backed
+  completion governance applies to the Slack → GitHub PR path.
 - A `source_control.observed_checks_rollup` verified evidence fact derived
   from every reconciled GitHub pull-request snapshot, aggregating observed
   check states into one passed/failed/pending outcome.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ executor-success semantics.
 ### Added
 
 - A default `governed` completion contract for GitHub-backed pull-request runs
-  without a configured completion policy, gating completion on a verified
-  pull-request artifact and an all-observed-checks-passing rollup, without
-  requiring merge.
+  without a configured completion policy, gating completion on a
+  provider-verified pull-request existence fact and an
+  all-observed-checks-passing rollup, without requiring merge. An
+  executor-reported pull request URL resolves the delivery target but never
+  satisfies completion on its own.
 - Slack mentions bound to a repository now carry a durable `workItem` for the
   source thread (with the bound repo as `ownerContainer`), so WorkThread-backed
   completion governance applies to the Slack → GitHub PR path.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **[opentag.im](https://opentag.im)**
 
-**Turn an existing work thread into a governed agent work loop.**
+**Mention any coding agent. Get proof, not promises.**
 
 [![Release](https://img.shields.io/github/v/release/amplifthq/opentag?include_prereleases&label=release)](https://github.com/amplifthq/opentag/releases)
 [![npm](https://img.shields.io/npm/v/@opentag/cli?label=%40opentag%2Fcli)](https://www.npmjs.com/package/@opentag/cli)
@@ -25,9 +25,13 @@
 [![Node](https://img.shields.io/badge/Node-%3E%3D20-339933)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](#license)
 
-OpenTag lets your team mention a coding agent from the collaboration platforms they already use. It turns that source thread into a bounded, auditable run: OpenTag curates the context packet, checks permissions and executor capability, runs an ACP coding agent locally, records an agent work ledger, and returns concise artifacts and safe next actions to the same thread.
+OpenTag is the open, local-first gateway between your team's threads and coding agents. Mention `@opentag` in Slack or GitHub, and it runs Claude Code, Codex, Cursor, or any [Agent Client Protocol](https://agentclientprotocol.com) agent on your own machine — then replies in the same thread with evidence, not just a summary.
 
-The concrete setup still connects Slack, GitHub, GitLab, Linear, Lark / Feishu, Telegram, Discord, or Microsoft Teams to a local coding agent. The product boundary is broader than a connector: OpenTag is source-thread-native, local-first, and executor-neutral, so work stays where it already has context while the agent's inputs, authority, outputs, and callbacks remain reviewable.
+- **Any agent, one protocol.** Six built-in executors — Codex, Claude Code, Cursor, OpenCode, Hermes, OpenClaw — and custom runners all speak ACP. The mention is never tied to one vendor.
+- **Local-first by default.** Your code, credentials, and full execution traces stay on your machine. Platforms receive only the messages needed to acknowledge, reply, and apply actions you approve.
+- **"Done" requires evidence.** An executor reporting success is not completion. OpenTag can hold a run open until verifiable evidence — a pull request, green checks, a merge — satisfies configured completion gates, with the whole trail recorded in a local audit ledger.
+
+Slack, GitHub, GitLab, Linear, and Lark / Feishu are fully supported today; Telegram, Discord, and Microsoft Teams ship as previews.
 
 ## Demo
 
@@ -116,16 +120,16 @@ Agents can also follow the full agent-readable setup checklist in [Agent-readabl
 
 Use the guide for the platform you choose in `opentag setup`.
 
-| Platform | Best first path | Guide |
-| --- | --- | --- |
-| Slack | Use Socket Mode for local development | [Slack setup](docs/platforms/slack.en.md) |
-| GitHub | Use a repository webhook and GitHub token | [GitHub setup](docs/platforms/github.en.md) |
-| GitLab | Use a project Note Hook and GitLab access token | [GitLab setup](docs/platforms/gitlab.en.md) |
-| Linear | Use a workspace webhook and OAuth App install | [Linear setup](docs/platforms/linear.en.md) |
-| Lark / Feishu | Scan the Personal Agent QR code from setup | [Lark / Feishu setup](docs/platforms/lark.en.md) |
-| Telegram | Use BotFather token with local getUpdates polling | [Telegram setup](docs/platforms/telegram.en.md) |
-| Discord | Use a bot token with local Gateway delivery | [Discord setup](docs/platforms/discord.en.md) |
-| Microsoft Teams | Use an Azure Bot and public HTTPS tunnel to the local dispatcher (relay mode is not supported) | [Microsoft Teams setup](docs/platforms/teams.en.md) |
+| Platform | Status | Best first path | Guide |
+| --- | --- | --- | --- |
+| Slack | ✅ Full | Use Socket Mode for local development | [Slack setup](docs/platforms/slack.en.md) |
+| GitHub | ✅ Full | Use a repository webhook and GitHub token | [GitHub setup](docs/platforms/github.en.md) |
+| GitLab | ✅ Full | Use a project Note Hook and GitLab access token | [GitLab setup](docs/platforms/gitlab.en.md) |
+| Linear | ✅ Full | Use a workspace webhook and OAuth App install | [Linear setup](docs/platforms/linear.en.md) |
+| Lark / Feishu | ✅ Full | Scan the Personal Agent QR code from setup | [Lark / Feishu setup](docs/platforms/lark.en.md) |
+| Telegram | 🧪 Preview | Use BotFather token with local getUpdates polling | [Telegram setup](docs/platforms/telegram.en.md) |
+| Discord | 🧪 Preview | Use a bot token with local Gateway delivery (slash command only) | [Discord setup](docs/platforms/discord.en.md) |
+| Microsoft Teams | 🧪 Preview | Use an Azure Bot and public HTTPS tunnel to the local dispatcher (relay mode is not supported) | [Microsoft Teams setup](docs/platforms/teams.en.md) |
 
 ## What Runs Locally
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@
 
 **[opentag.im](https://opentag.im)**
 
-**把现有协作线程变成一个可授权、可审计、可回放的 agent 工作回路。**
+**@ 任何 coding agent，拿到的是证据，不是口头汇报。**
 
 [![Release](https://img.shields.io/github/v/release/amplifthq/opentag?include_prereleases&label=release)](https://github.com/amplifthq/opentag/releases)
 [![npm](https://img.shields.io/npm/v/@opentag/cli?label=%40opentag%2Fcli)](https://www.npmjs.com/package/@opentag/cli)
@@ -25,9 +25,13 @@
 [![Node](https://img.shields.io/badge/Node-%3E%3D20-339933)](https://nodejs.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](#许可证)
 
-OpenTag 让团队可以在已经使用的协作软件里提及一个 coding agent。它会把这个源线程变成一个有边界、可审计的 run：OpenTag 组装 context packet，检查权限和 executor capability，在你的电脑上运行 ACP coding agent，记录 agent work ledger，然后把简洁的产物和安全下一步回复回同一个 thread。
+OpenTag 是团队协作线程和 coding agent 之间的开源、本地优先网关。在 Slack 或 GitHub 里 @opentag，它会在你自己的电脑上运行 Claude Code、Codex、Cursor 或任何 [Agent Client Protocol](https://agentclientprotocol.com) agent，然后把带证据的结果回复到同一个 thread——而不只是一段总结。
 
-具体 setup 仍然会把 Slack、GitHub、GitLab、Linear、Lark / 飞书、Telegram、Discord 或 Microsoft Teams 连接到本地 coding agent。但 OpenTag 不只是 connector：它保持 source-thread-native、local-first、executor-neutral，让工作留在已有上下文里，同时让 agent 看到了什么、被允许做什么、产出了什么、回调到了哪里都可以复盘。
+- **任何 agent，一个协议。** Codex、Claude Code、Cursor、OpenCode、Hermes、OpenClaw 六个内置执行器和自定义 runner 全部通过 ACP 运行。提及不绑定任何一家厂商。
+- **默认本地优先。** 代码、凭据和完整执行轨迹留在你的机器上。平台只收到确认、回复和你批准执行的动作所需的消息。
+- **「完成」需要证据。** executor 报告成功不等于工作完成。OpenTag 可以让 run 保持打开，直到可验证的证据——pull request、绿色 checks、merge——满足配置的 completion gates，全程记录在本地审计账本里。
+
+Slack、GitHub、GitLab、Linear、Lark / 飞书今天已完整支持；Telegram、Discord、Microsoft Teams 为预览状态。
 
 ## 演示
 
@@ -114,16 +118,16 @@ OpenTag 会在本地运行你选择的 coding agent，并通过对应的平台�
 
 在 `opentag setup` 里选择哪个平台，就看对应教程。
 
-| 平台 | 推荐首选路径 | 教程 |
-| --- | --- | --- |
-| Slack | 本地开发优先使用 Socket Mode | [Slack 配置](docs/platforms/slack.zh-CN.md) |
-| GitHub | 使用 repository webhook 和 GitHub token | [GitHub 配置](docs/platforms/github.zh-CN.md) |
-| GitLab | 使用 project Note Hook 和 GitLab access token | [GitLab 配置](docs/platforms/gitlab.zh-CN.md) |
-| Linear | 使用 workspace webhook 和 OAuth App 安装 | [Linear 配置](docs/platforms/linear.zh-CN.md) |
-| Lark / 飞书 | 在 setup 里扫码创建 Personal Agent | [Lark / 飞书配置](docs/platforms/lark.zh-CN.md) |
-| Telegram | 使用 BotFather token 和本地 getUpdates polling | [Telegram 配置](docs/platforms/telegram.zh-CN.md) |
-| Discord | 使用 bot token 和本地 Gateway 接收 | [Discord 配置](docs/platforms/discord.zh-CN.md) |
-| Microsoft Teams | 使用 Azure Bot 和公网 HTTPS tunnel 连接本地 dispatcher（暂不支持 relay 模式） | [Microsoft Teams 配置](docs/platforms/teams.zh-CN.md) |
+| 平台 | 状态 | 推荐首选路径 | 教程 |
+| --- | --- | --- | --- |
+| Slack | ✅ 完整 | 本地开发优先使用 Socket Mode | [Slack 配置](docs/platforms/slack.zh-CN.md) |
+| GitHub | ✅ 完整 | 使用 repository webhook 和 GitHub token | [GitHub 配置](docs/platforms/github.zh-CN.md) |
+| GitLab | ✅ 完整 | 使用 project Note Hook 和 GitLab access token | [GitLab 配置](docs/platforms/gitlab.zh-CN.md) |
+| Linear | ✅ 完整 | 使用 workspace webhook 和 OAuth App 安装 | [Linear 配置](docs/platforms/linear.zh-CN.md) |
+| Lark / 飞书 | ✅ 完整 | 在 setup 里扫码创建 Personal Agent | [Lark / 飞书配置](docs/platforms/lark.zh-CN.md) |
+| Telegram | 🧪 预览 | 使用 BotFather token 和本地 getUpdates polling | [Telegram 配置](docs/platforms/telegram.zh-CN.md) |
+| Discord | 🧪 预览 | 使用 bot token 和本地 Gateway 接收（仅 slash 命令） | [Discord 配置](docs/platforms/discord.zh-CN.md) |
+| Microsoft Teams | 🧪 预览 | 使用 Azure Bot 和公网 HTTPS tunnel 连接本地 dispatcher（暂不支持 relay 模式） | [Microsoft Teams 配置](docs/platforms/teams.zh-CN.md) |
 
 ## 本地会运行什么
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,8 @@ that Gateway-owned tool subprocesses have stopped.
 | `security` | none | Runner security policy |
 | `githubToken` | none | GitHub token for callback comments, dispatcher GitHub apply helpers, and optional legacy PR creation |
 | `githubApplyToken` | `githubToken` | Optional dispatcher direct-apply token override. Set to `null` to keep GitHub callbacks enabled while rendering direct-apply actions as setup-required. |
+| `completionPolicies` | none | Per-repository strict GitHub completion policies (`owner`, `repo`, `requiredChecks`, optional `baseBranch` and `requireMerge`) that gate completion on named checks and merge evidence |
+| `defaultGitHubCompletion` | `governed` | Zero-config completion tier for GitHub-backed runs without a matching completion policy. `governed` holds a run that ships a pull request open until the PR exists and every observed check passes on the current head; `compat` preserves legacy executor-success semantics. Runs that ship no pull request keep executor-success semantics in both modes. |
 | `preparePullRequestBranch` | `false` | Commits and pushes executor run branches so a later source-thread `apply 1` can create the PR through an ApplyPlan |
 | `allowAutoCreatePullRequest` | `false` | Legacy mode that creates a PR immediately when executor results include changes |
 | `pollIntervalMs` | `5000` | Poll interval for `serve` |
@@ -703,6 +705,8 @@ executor startup.
 | `OPENTAG_GITHUB_CALLBACK_TOKEN` | `OPENTAG_GITHUB_TOKEN` | Optional token override for GitHub callback posting |
 | `OPENTAG_GITHUB_APPLY_TOKEN` | `OPENTAG_GITHUB_TOKEN` | Optional token override for GitHub direct apply |
 | `OPENTAG_GITHUB_APPLY_DISABLED` | `false` | Set to `true` to disable GitHub direct apply while keeping callbacks enabled |
+| `OPENTAG_GITHUB_COMPLETION_POLICIES_JSON` | none | JSON array of per-repository strict GitHub completion policies (`provider`, `owner`, `repo`, `requiredChecks`, optional `baseBranch` and `requireMerge`) |
+| `OPENTAG_GITHUB_DEFAULT_COMPLETION` | `governed` | Zero-config completion tier for GitHub-backed runs without a matching policy: `governed` gates pull-request runs on verified PR existence plus all observed checks passing; `compat` preserves legacy executor-success semantics |
 | `OPENTAG_SLACK_BOT_TOKEN` | none | Single Slack bot token for callback posting |
 | `OPENTAG_SLACK_BOT_TOKENS_JSON` | none | JSON object mapping `agentId` to Slack bot token |
 | `LARK_APP_ID` | none | Lark app id for the callback sink that posts replies via the Lark API |

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -249,6 +249,7 @@ const DaemonConfigSchema = z
     githubToken: SecretStringSchema.optional(),
     githubApplyToken: SecretStringSchema.nullable().optional(),
     completionPolicies: z.array(GitHubCompletionPolicySchema).optional(),
+    defaultGitHubCompletion: z.enum(["governed", "compat"]).optional(),
     preparePullRequestBranch: z.boolean().optional(),
     allowAutoCreatePullRequest: z.boolean().optional(),
     runnerToken: SecretStringSchema.optional(),
@@ -541,7 +542,10 @@ export const OpenTagCliConfigSchema = z
   .strict();
 
 export type OpenTagCliConfig = Omit<z.infer<typeof OpenTagCliConfigSchema>, "daemon"> & {
-  daemon: OpenTagDaemonConfig & { completionPolicies?: GitHubCompletionPolicyConfig[] };
+  daemon: OpenTagDaemonConfig & {
+    completionPolicies?: GitHubCompletionPolicyConfig[];
+    defaultGitHubCompletion?: "governed" | "compat";
+  };
 };
 
 export type OpenTagCliPreferences = NonNullable<OpenTagCliConfig["preferences"]>;
@@ -591,6 +595,9 @@ export function parseCliConfig(value: unknown): OpenTagCliConfig {
       ...parseDaemonConfig(parsed.daemon),
       ...(parsed.daemon.completionPolicies !== undefined
         ? { completionPolicies: parsed.daemon.completionPolicies }
+        : {}),
+      ...(parsed.daemon.defaultGitHubCompletion !== undefined
+        ? { defaultGitHubCompletion: parsed.daemon.defaultGitHubCompletion }
         : {})
     }
   };

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -423,6 +423,9 @@ export function dispatcherRuntimeInputFromCliConfig(
     ...(config.daemon.completionPolicies !== undefined
       ? { completionPolicies: config.daemon.completionPolicies }
       : {}),
+    ...(config.daemon.defaultGitHubCompletion !== undefined
+      ? { defaultGitHubCompletion: config.daemon.defaultGitHubCompletion }
+      : {}),
     ...(config.daemon.githubApplyToken !== undefined
       ? { githubApplyToken: config.daemon.githubApplyToken }
       : config.daemon.githubToken

--- a/packages/dispatcher/src/completion-governance.ts
+++ b/packages/dispatcher/src/completion-governance.ts
@@ -152,6 +152,16 @@ function defaultVerifiedContract(input: {
     resolvedFrom: [{ scope: "organization_default", ref: `github-default:${input.repository.owner}/${input.repository.repo}`, version: "1" }],
     gates: [
       { id: "pull_request", kind: "artifact", targetKey: "primary_change", artifactKind: "pull_request", minimum: 1 },
+      // The artifact gate only proves the executor reported a pull request URL.
+      // Existence must still be confirmed by provider-verified evidence.
+      {
+        id: "verified_pull_request",
+        kind: "verification",
+        targetKey: "primary_change",
+        evidenceKind: "source_control.pull_request",
+        requiredOutcome: "passed",
+        minimumAssurance: "verified"
+      },
       {
         id: "observed_checks",
         kind: "verification",

--- a/packages/dispatcher/src/completion-governance.ts
+++ b/packages/dispatcher/src/completion-governance.ts
@@ -38,6 +38,14 @@ export type GitHubCompletionPolicy = {
   requireMerge?: boolean;
 };
 
+/**
+ * Zero-config completion behavior for GitHub-backed runs without an explicit
+ * completion policy. "governed" gates runs that produce a pull request on
+ * verified PR existence plus all observed checks passing; "compat" preserves
+ * the legacy executor-success semantics.
+ */
+export type GitHubDefaultCompletionMode = "governed" | "compat";
+
 export type BoundedCompletionWaiverInput = Pick<
   CompletionWaiver,
   "actor" | "reason" | "scope" | "policyScope" | "gateIds" | "waivedAt" | "expiresAt"
@@ -121,6 +129,37 @@ function strictContract(input: {
             requiredState: "merged",
             minimumAssurance: "verified" as const
           }])
+    ],
+    maxAutomaticRetries: 1,
+    onSatisfied: "report_only",
+    createdAt: input.createdAt
+  });
+}
+
+function defaultVerifiedContract(input: {
+  workThreadId: string;
+  repository: { owner: string; repo: string };
+  createdAt: string;
+  version?: number;
+}): CompletionContract {
+  return CompletionContractSchema.parse({
+    id: `completion:${input.workThreadId}:github-pr-default`,
+    version: input.version ?? 1,
+    workThreadId: input.workThreadId,
+    cycle: 1,
+    mode: "governed",
+    targetSelectors: [{ key: "primary_change", kind: "change_request", lineage: "current_cycle", cardinality: "exactly_one" }],
+    resolvedFrom: [{ scope: "organization_default", ref: `github-default:${input.repository.owner}/${input.repository.repo}`, version: "1" }],
+    gates: [
+      { id: "pull_request", kind: "artifact", targetKey: "primary_change", artifactKind: "pull_request", minimum: 1 },
+      {
+        id: "observed_checks",
+        kind: "verification",
+        targetKey: "primary_change",
+        evidenceKind: "source_control.observed_checks_rollup",
+        requiredOutcome: "passed",
+        minimumAssurance: "verified"
+      }
     ],
     maxAutomaticRetries: 1,
     onSatisfied: "report_only",
@@ -223,6 +262,13 @@ function githubCompletionSemanticDigest(snapshot: GitHubVerifiedPullRequestSnaps
     .digest("hex")}`;
 }
 
+function observedChecksRollupOutcome(checks: Record<string, "passed" | "failed" | "pending">): "passed" | "failed" | "pending" {
+  const states = Object.values(checks);
+  if (states.some((state) => state === "failed")) return "failed";
+  if (states.some((state) => state === "pending")) return "pending";
+  return "passed";
+}
+
 function githubFactTemplates(input: {
   snapshot: GitHubVerifiedPullRequestSnapshot;
   receivedAt: string;
@@ -275,6 +321,17 @@ function githubFactTemplates(input: {
       kind: "source_control.pull_request_state",
       claim: { predicate: "state", outcome: input.snapshot.pullRequest.state },
       provenance: provenance("source_control.pull_request_state")
+    },
+    {
+      ...common,
+      id: `${idPrefix}:checks-rollup`,
+      kind: "source_control.observed_checks_rollup",
+      claim: {
+        predicate: "checks_rollup",
+        outcome: observedChecksRollupOutcome(input.snapshot.checks),
+        observations: input.snapshot.checks
+      },
+      provenance: provenance("source_control.observed_checks_rollup")
     }
   ];
 }
@@ -516,15 +573,42 @@ async function ensureContract(input: {
   run: OpenTagRun;
   event: OpenTagEvent;
   policies: readonly GitHubCompletionPolicy[];
+  defaultGitHubCompletion: GitHubDefaultCompletionMode;
 }): Promise<CompletionContract> {
   const workThreadId = input.run.thread?.id;
   if (!workThreadId) throw new Error(`Run ${input.run.id} has no durable WorkThread.`);
-  const existing = await input.repo.getLatestCompletionContractForWorkThread({ workThreadId });
-  if (existing) return existing;
   const policy = matchingPolicy(input.event, input.policies);
+  const repository = repositoryIdentity(input.event);
+  const defaultVerifiedEligible = !policy
+    && input.defaultGitHubCompletion === "governed"
+    && repository?.provider === "github"
+    && githubPullRequestResourceRefs({ run: input.run, event: input.event }).size > 0;
+  const existing = await input.repo.getLatestCompletionContractForWorkThread({ workThreadId });
+  if (existing) {
+    // A thread that started with informational runs holds the compatibility
+    // contract; once a later run ships a pull request, upgrade it to the
+    // default verified contract so the new change is evidence-gated.
+    const upgradeable = existing.mode === "execution_compat"
+      && existing.id === `completion:${workThreadId}:compat`
+      && defaultVerifiedEligible;
+    if (!upgradeable) return existing;
+    const upgraded = defaultVerifiedContract({
+      workThreadId,
+      repository: { owner: repository!.owner, repo: repository!.repo },
+      createdAt: input.run.createdAt,
+      version: existing.version + 1
+    });
+    return (await input.repo.recordCompletionContract({ contract: upgraded })).contract;
+  }
   const contract = policy
     ? strictContract({ workThreadId, policy, createdAt: input.run.createdAt })
-    : compatibilityContract({ workThreadId, createdAt: input.run.createdAt });
+    : defaultVerifiedEligible
+      ? defaultVerifiedContract({
+          workThreadId,
+          repository: { owner: repository!.owner, repo: repository!.repo },
+          createdAt: input.run.createdAt
+        })
+      : compatibilityContract({ workThreadId, createdAt: input.run.createdAt });
   return (await input.repo.recordCompletionContract({ contract })).contract;
 }
 
@@ -557,10 +641,12 @@ export type CompletionSourceThreadTransition = {
 export function createDispatcherCompletionGovernance(input: {
   repo: OpenTagRepository;
   policies?: readonly GitHubCompletionPolicy[];
+  defaultGitHubCompletion?: GitHubDefaultCompletionMode;
   now?: () => string;
   deferReassessment?: boolean;
 }) {
   const policies = validatePolicies(input.policies ?? []);
+  const defaultGitHubCompletion = input.defaultGitHubCompletion ?? "governed";
   const governanceRepository: GovernanceRepository = {
     async loadEvaluationSnapshot(workThreadId): Promise<CompletionEvaluationSnapshot> {
       const contract = await input.repo.getLatestCompletionContractForWorkThread({ workThreadId });
@@ -803,7 +889,7 @@ export function createDispatcherCompletionGovernance(input: {
     async ingestRunResult(runId: string): Promise<GovernanceCommandResult | null> {
       const stored = await input.repo.getRun({ runId });
       if (!stored?.run.thread?.id || !stored.run.result) return null;
-      await ensureContract({ repo: input.repo, run: stored.run, event: stored.event, policies });
+      await ensureContract({ repo: input.repo, run: stored.run, event: stored.event, policies, defaultGitHubCompletion });
       const correlationIndex = await loadCurrentWorkThreadCorrelationIndex({ repo: input.repo });
       await attachCorrelatableEvidence({
         repo: input.repo,

--- a/packages/dispatcher/src/server.ts
+++ b/packages/dispatcher/src/server.ts
@@ -352,7 +352,8 @@ import { createDefaultCallbackPresentation, type CallbackPresentation, type Lark
 import {
   createDispatcherCompletionGovernance,
   currentWorkThreadRun,
-  type GitHubCompletionPolicy
+  type GitHubCompletionPolicy,
+  type GitHubDefaultCompletionMode
 } from "./completion-governance.js";
 import { createSourceThreadControlHandler } from "./source-thread-control.js";
 
@@ -2959,6 +2960,7 @@ export function createDispatcherApp(input: {
     platforms?: RelayPlatformCapability[];
   };
   completionPolicies?: GitHubCompletionPolicy[];
+  defaultGitHubCompletion?: GitHubDefaultCompletionMode;
   completionNow?: () => string;
   reassessmentObligations?: {
     autoStart?: boolean;
@@ -3019,6 +3021,7 @@ export function createDispatcherApp(input: {
   const completionGovernance = createDispatcherCompletionGovernance({
     repo,
     policies: input.completionPolicies ?? [],
+    ...(input.defaultGitHubCompletion ? { defaultGitHubCompletion: input.defaultGitHubCompletion } : {}),
     deferReassessment: !inlineReassessmentEnabled,
     ...(input.completionNow ? { now: input.completionNow } : {})
   });

--- a/packages/dispatcher/test/completion-governance.test.ts
+++ b/packages/dispatcher/test/completion-governance.test.ts
@@ -472,10 +472,11 @@ describe("dispatcher completion governance", () => {
         completion: "pending",
         evidenceBacked: true,
         contract: { mode: "governed", cycle: 1, version: 1 },
-        missingGateIds: ["observed_checks"],
+        missingGateIds: ["verified_pull_request", "observed_checks"],
         currentAssessment: {
           gateResults: [
             { gateId: "pull_request", state: "passed" },
+            { gateId: "verified_pull_request", state: "missing" },
             { gateId: "observed_checks", state: "missing" }
           ]
         }
@@ -561,7 +562,7 @@ describe("dispatcher completion governance", () => {
         completion: "pending",
         evidenceBacked: true,
         contract: { mode: "governed", cycle: 1, version: 2 },
-        missingGateIds: ["observed_checks"]
+        missingGateIds: ["verified_pull_request", "observed_checks"]
       }
     });
   });

--- a/packages/dispatcher/test/completion-governance.test.ts
+++ b/packages/dispatcher/test/completion-governance.test.ts
@@ -97,6 +97,7 @@ function jsonRequest(body: unknown) {
 async function startRun(input: {
   runId: string;
   completionPolicies?: GitHubCompletionPolicy[];
+  defaultGitHubCompletion?: "governed" | "compat";
   databasePath?: string;
   completionNow?: () => string;
   issueNumber?: number;
@@ -110,6 +111,7 @@ async function startRun(input: {
   const app = createDispatcherApp({
     databasePath: input.databasePath ?? ":memory:",
     ...(input.completionPolicies ? { completionPolicies: input.completionPolicies } : {}),
+    ...(input.defaultGitHubCompletion ? { defaultGitHubCompletion: input.defaultGitHubCompletion } : {}),
     ...(input.completionNow ? { completionNow: input.completionNow } : {}),
     reassessmentObligations: input.reassessmentObligations ?? { autoStart: false },
     callbackSink: {
@@ -152,6 +154,7 @@ async function completeRun(input: {
   conclusion: "success" | "failure" | "cancelled" | "timed_out";
   idempotencyKey?: string;
   pullRequestNumber?: number;
+  omitPullRequest?: boolean;
 }) {
   return input.setup.app.request(`/v1/runners/runner_1/runs/${input.runId}/complete`, jsonRequest({
     ...input.setup.claim,
@@ -159,7 +162,7 @@ async function completeRun(input: {
     result: {
       conclusion: input.conclusion,
       summary: `${input.conclusion} result`,
-      ...(input.conclusion === "success"
+      ...(input.conclusion === "success" && !input.omitPullRequest
         ? { createdPullRequestUrl: `https://github.com/acme/demo/pull/${input.pullRequestNumber ?? 7}` }
         : {})
     }
@@ -424,9 +427,9 @@ describe("dispatcher completion governance", () => {
     expect(after).toEqual(before);
   });
 
-  it("preserves executor-success semantics for repositories without a strict policy", async () => {
+  it("preserves executor-success semantics for a run that ships no pull request", async () => {
     const setup = await startRun({ runId: "run_compat" });
-    const response = await completeRun({ setup, runId: "run_compat", conclusion: "success" });
+    const response = await completeRun({ setup, runId: "run_compat", conclusion: "success", omitPullRequest: true });
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
@@ -439,6 +442,128 @@ describe("dispatcher completion governance", () => {
       }
     });
     expect(setup.delivered.at(-1)?.body).toContain("success result");
+  });
+
+  it("preserves executor-success semantics for a pull request run when the default is opted out", async () => {
+    const setup = await startRun({ runId: "run_compat_opt_out", defaultGitHubCompletion: "compat" });
+    const response = await completeRun({ setup, runId: "run_compat_opt_out", conclusion: "success" });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      completion: {
+        execution: "succeeded",
+        completion: "satisfied",
+        evidenceBacked: false,
+        contract: { mode: "execution_compat" }
+      }
+    });
+  });
+
+  it("gates a zero-config pull request run on verified PR existence and observed checks", async () => {
+    const setup = await startRun({ runId: "run_default_verified" });
+    const response = await completeRun({ setup, runId: "run_default_verified", conclusion: "success" });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      completion: {
+        execution: "succeeded",
+        completion: "pending",
+        evidenceBacked: true,
+        contract: { mode: "governed", cycle: 1, version: 1 },
+        missingGateIds: ["observed_checks"],
+        currentAssessment: {
+          gateResults: [
+            { gateId: "pull_request", state: "passed" },
+            { gateId: "observed_checks", state: "missing" }
+          ]
+        }
+      }
+    });
+    expect(setup.delivered.at(-1)?.body).toContain("Execution succeeded");
+    expect(setup.delivered.at(-1)?.body).toContain("verified repository evidence");
+
+    const evidence = await setup.app.request(
+      "/v1/completion-evidence/github",
+      jsonRequest(githubSnapshot({ deliveryId: "delivery-default-verified", state: "open" }))
+    );
+    expect(evidence.status).toBe(201);
+    await expect(evidence.json()).resolves.toMatchObject({
+      outcome: "recorded",
+      completion: {
+        execution: "succeeded",
+        completion: "satisfied",
+        evidenceBacked: true,
+        missingGateIds: [],
+        failedGateIds: []
+      }
+    });
+  });
+
+  it("keeps the zero-config observed-checks gate unsatisfied while any check is failing", async () => {
+    const setup = await startRun({ runId: "run_default_failing_check" });
+    await completeRun({ setup, runId: "run_default_failing_check", conclusion: "success" });
+
+    const failing = await setup.app.request(
+      "/v1/completion-evidence/github",
+      jsonRequest(githubSnapshot({
+        deliveryId: "delivery-default-failing",
+        state: "open",
+        checks: { build: "passed", test: "failed" },
+        observedAt: "2026-07-21T10:05:00.000Z"
+      }))
+    );
+    expect(failing.status).toBe(201);
+    await expect(failing.json()).resolves.toMatchObject({
+      completion: {
+        completion: "unsatisfied",
+        failedGateIds: ["observed_checks"]
+      }
+    });
+
+    const green = await setup.app.request(
+      "/v1/completion-evidence/github",
+      jsonRequest(githubSnapshot({
+        deliveryId: "delivery-default-green",
+        state: "open",
+        checks: { build: "passed", test: "passed" },
+        observedAt: "2026-07-21T10:06:00.000Z"
+      }))
+    );
+    expect(green.status).toBe(201);
+    await expect(green.json()).resolves.toMatchObject({
+      completion: { completion: "satisfied", failedGateIds: [] }
+    });
+  });
+
+  it("upgrades a compatibility thread to the default verified contract once a run ships a pull request", async () => {
+    const setup = await startRun({ runId: "run_upgrade_1" });
+    const first = await completeRun({ setup, runId: "run_upgrade_1", conclusion: "success", omitPullRequest: true });
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toMatchObject({
+      completion: { completion: "satisfied", contract: { mode: "execution_compat", version: 1 } }
+    });
+
+    expect((await setup.app.request("/v1/runs", jsonRequest({
+      runId: "run_upgrade_2",
+      event: githubIssueEvent({ id: "event_run_upgrade_2", sourceEventId: "comment_run_upgrade_2" })
+    }))).status).toBe(201);
+    setup.claim = await (await setup.app.request("/v1/runners/runner_1/claim", { method: "POST" })).json() as {
+      attemptId: string;
+      fencingToken: string;
+    };
+    const second = await completeRun({ setup, runId: "run_upgrade_2", conclusion: "success" });
+
+    expect(second.status).toBe(200);
+    await expect(second.json()).resolves.toMatchObject({
+      completion: {
+        completion: "pending",
+        evidenceBacked: true,
+        contract: { mode: "governed", cycle: 1, version: 2 },
+        missingGateIds: ["observed_checks"]
+      }
+    });
   });
 
   it("returns the current assessment without duplicating side effects on completion replay", async () => {
@@ -1181,7 +1306,7 @@ describe("dispatcher completion governance", () => {
     await expect(first.json()).resolves.toMatchObject({ outcome: "recorded", workThreadIds: [expect.any(String)] });
     const sqlite = new Database(databasePath);
     expect((sqlite.prepare("SELECT COUNT(*) AS count FROM verification_evidence WHERE delivery_id = ?")
-      .get("delivery-multi-pr") as { count: number }).count).toBe(7);
+      .get("delivery-multi-pr") as { count: number }).count).toBe(9);
 
     const replay = await setup.app.request("/v1/completion-evidence/github/batch", jsonRequest({ snapshots: [...snapshots].reverse() }));
     expect(replay.status).toBe(200);
@@ -1192,7 +1317,7 @@ describe("dispatcher completion governance", () => {
     expect((await setup.app.request("/v1/completion-evidence/github/batch", jsonRequest({ snapshots: changedFacts }))).status).toBe(409);
     expect((await setup.app.request("/v1/completion-evidence/github/batch", jsonRequest({ snapshots: [snapshots[0]] }))).status).toBe(409);
     expect((sqlite.prepare("SELECT COUNT(*) AS count FROM verification_evidence WHERE delivery_id = ?")
-      .get("delivery-multi-pr") as { count: number }).count).toBe(7);
+      .get("delivery-multi-pr") as { count: number }).count).toBe(9);
     sqlite.close();
   });
 

--- a/packages/local-runtime/src/dispatcher.ts
+++ b/packages/local-runtime/src/dispatcher.ts
@@ -17,6 +17,7 @@ import {
   createTelegramCallbackSink,
   type ChannelPrincipalCredential,
   type GitHubCompletionPolicy,
+  type GitHubDefaultCompletionMode,
   type LinearTokenProvider
 } from "@opentag/dispatcher";
 import type { DispatcherRateLimitOptions, LinearOAuthInstallOptions, RelayPlatformCapability } from "@opentag/dispatcher";
@@ -61,6 +62,7 @@ export type LocalDispatcherRuntimeInput = {
   githubCallbackToken?: string;
   githubApplyToken?: string | null;
   completionPolicies?: GitHubCompletionPolicy[];
+  defaultGitHubCompletion?: GitHubDefaultCompletionMode;
   reassessmentObligations?: Parameters<typeof createDispatcherApp>[0]["reassessmentObligations"];
   gitlabToken?: string;
   gitlabBaseUrl?: string;
@@ -283,6 +285,13 @@ function parseGitHubCompletionPolicies(raw: string | undefined): GitHubCompletio
   } catch (error) {
     throw new Error(`Failed to parse OPENTAG_GITHUB_COMPLETION_POLICIES_JSON: ${error instanceof Error ? error.message : String(error)}`);
   }
+}
+
+function parseGitHubDefaultCompletion(raw: string | undefined): GitHubDefaultCompletionMode | undefined {
+  if (!raw) return undefined;
+  const value = raw.trim().toLowerCase();
+  if (value === "governed" || value === "compat") return value;
+  throw new Error(`OPENTAG_GITHUB_DEFAULT_COMPLETION must be "governed" or "compat", received "${raw}".`);
 }
 
 function parseCsvList(raw: string | undefined): string[] | undefined {
@@ -612,6 +621,7 @@ export function dispatcherRuntimeInputFromEnv(env: NodeJS.ProcessEnv): LocalDisp
         ? env.OPENTAG_GITHUB_APPLY_TOKEN
         : undefined;
   const completionPolicies = parseGitHubCompletionPolicies(env.OPENTAG_GITHUB_COMPLETION_POLICIES_JSON);
+  const defaultGitHubCompletion = parseGitHubDefaultCompletion(env.OPENTAG_GITHUB_DEFAULT_COMPLETION);
   const reassessmentObligations = reassessmentObligationTestRuntimeInputFromEnv(env);
 
   return {
@@ -626,6 +636,7 @@ export function dispatcherRuntimeInputFromEnv(env: NodeJS.ProcessEnv): LocalDisp
     ...(env.OPENTAG_GITHUB_CALLBACK_TOKEN ? { githubCallbackToken: env.OPENTAG_GITHUB_CALLBACK_TOKEN } : {}),
     ...(githubApplyToken !== undefined ? { githubApplyToken } : {}),
     ...(completionPolicies ? { completionPolicies } : {}),
+    ...(defaultGitHubCompletion ? { defaultGitHubCompletion } : {}),
     ...(reassessmentObligations ? { reassessmentObligations } : {}),
     ...(env.OPENTAG_GITLAB_TOKEN ? { gitlabToken: env.OPENTAG_GITLAB_TOKEN } : {}),
     ...(env.OPENTAG_GITLAB_BASE_URL ? { gitlabBaseUrl: env.OPENTAG_GITLAB_BASE_URL } : {}),
@@ -790,6 +801,7 @@ export function startDispatcher(input: LocalDispatcherRuntimeInput): LocalDispat
   const app = createDispatcherApp({
     databasePath: input.databasePath,
     ...(input.completionPolicies ? { completionPolicies: input.completionPolicies } : {}),
+    ...(input.defaultGitHubCompletion ? { defaultGitHubCompletion: input.defaultGitHubCompletion } : {}),
     ...(reassessmentObligations ? { reassessmentObligations } : {}),
     ...(input.pairingToken ? { pairingToken: input.pairingToken } : {}),
     ...(input.runnerToken ? { runnerToken: input.runnerToken } : {}),

--- a/packages/local-runtime/test/dispatcher.test.ts
+++ b/packages/local-runtime/test/dispatcher.test.ts
@@ -130,6 +130,22 @@ describe("local dispatcher runtime", () => {
     })).toThrow("requiredChecks must be a non-empty string array");
   });
 
+  it("parses the zero-config GitHub completion tier from env", () => {
+    expect(dispatcherRuntimeInputFromEnv({}).defaultGitHubCompletion).toBeUndefined();
+    expect(dispatcherRuntimeInputFromEnv({
+      OPENTAG_GITHUB_DEFAULT_COMPLETION: "compat"
+    }).defaultGitHubCompletion).toBe("compat");
+    expect(dispatcherRuntimeInputFromEnv({
+      OPENTAG_GITHUB_DEFAULT_COMPLETION: " Governed "
+    }).defaultGitHubCompletion).toBe("governed");
+  });
+
+  it("rejects an unknown zero-config GitHub completion tier", () => {
+    expect(() => dispatcherRuntimeInputFromEnv({
+      OPENTAG_GITHUB_DEFAULT_COMPLETION: "strict"
+    })).toThrow('OPENTAG_GITHUB_DEFAULT_COMPLETION must be "governed" or "compat", received "strict".');
+  });
+
   it("registers matching standalone Slack and Lark channel principals from env", () => {
     expect(
       dispatcherRuntimeInputFromEnv({

--- a/packages/slack/src/normalize.ts
+++ b/packages/slack/src/normalize.ts
@@ -115,6 +115,35 @@ function repositoryMetadataFromBinding(
   };
 }
 
+function ownerContainerUri(repository: { repoProvider: string; owner: string; repo: string }): string | undefined {
+  const id = `${repository.owner}/${repository.repo}`;
+  if (repository.repoProvider === "github") return `https://github.com/${id}`;
+  if (repository.repoProvider === "gitlab") return `https://gitlab.com/${id}`;
+  return undefined;
+}
+
+function workItemFromBoundSlackThread(input: {
+  teamId: string;
+  channelId: string;
+  threadTs: string;
+  threadKey: string;
+  repository: { repoProvider: string; owner: string; repo: string };
+}): NonNullable<OpenTagEvent["workItem"]> {
+  const ownerContainerId = `${input.repository.owner}/${input.repository.repo}`;
+  const ownerContainerUriValue = ownerContainerUri(input.repository);
+  return {
+    provider: "slack",
+    kind: "thread",
+    externalId: input.threadKey,
+    uri: `slack://team/${input.teamId}/channel/${input.channelId}/thread/${input.threadTs}`,
+    ownerContainer: {
+      provider: input.repository.repoProvider,
+      id: ownerContainerId,
+      ...(ownerContainerUriValue ? { uri: ownerContainerUriValue } : {})
+    }
+  };
+}
+
 function commandLooksRepoWriteCapable(command: OpenTagCommand): boolean {
   return UNKNOWN_WRITE_VERB_PATTERN.test(command.rawText) && REPO_WRITE_TARGET_PATTERN.test(command.rawText);
 }
@@ -232,6 +261,11 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
   const replyThreadTs = input.threadTs ?? input.ts;
   const agentId = input.agentId ?? "opentag";
   const repositoryMetadata = repositoryMetadataFromBinding(input.binding);
+  const threadKey = encodeSlackThreadKey({
+    teamId: input.teamId,
+    channelId: input.channelId,
+    threadTs: replyThreadTs
+  });
 
   return {
     id: `evt_slack_app_mention_${input.eventId}`,
@@ -266,15 +300,22 @@ export function normalizeSlackAppMention(input: SlackAppMentionInput): OpenTagEv
       },
       ...contextPointersForCommand(command)
     ],
+    ...(repositoryMetadata
+      ? {
+          workItem: workItemFromBoundSlackThread({
+            teamId: input.teamId,
+            channelId: input.channelId,
+            threadTs: replyThreadTs,
+            threadKey,
+            repository: repositoryMetadata
+          })
+        }
+      : {}),
     permissions: permissionsForCommand(command, repositoryMetadata !== undefined),
     callback: {
       provider: "slack",
       uri: input.callbackUri ?? "https://slack.com/api/chat.postMessage",
-      threadKey: encodeSlackThreadKey({
-        teamId: input.teamId,
-        channelId: input.channelId,
-        threadTs: replyThreadTs
-      })
+      threadKey
     },
     metadata: {
       teamId: input.teamId,

--- a/packages/slack/test/normalize.test.ts
+++ b/packages/slack/test/normalize.test.ts
@@ -97,6 +97,21 @@ describe("Slack normalization", () => {
       webhookSignatureVerified: true,
       signatureState: "verified"
     });
+    expect(event?.workItem).toEqual({
+      provider: "slack",
+      kind: "thread",
+      externalId: encodeSlackThreadKey({
+        teamId: "T123",
+        channelId: "C123",
+        threadTs: "1710000000.000100"
+      }),
+      uri: "slack://team/T123/channel/C123/thread/1710000000.000100",
+      ownerContainer: {
+        provider: "gitlab",
+        id: "acme/demo",
+        uri: "https://gitlab.com/acme/demo"
+      }
+    });
     expect(event?.permissions.map((permission) => permission.scope)).toContain("chat:postMessage");
     expect(event?.permissions.map((permission) => permission.scope)).toContain("reactions:write");
     expect(event?.callback.uri).toBe("http://127.0.0.1:3102/github-comment");

--- a/scripts/dev/smoke-default-verified-completion.ts
+++ b/scripts/dev/smoke-default-verified-completion.ts
@@ -146,6 +146,10 @@ async function main() {
   assert(afterExec.completion.completion === "pending", "expected completion pending");
   assert(afterExec.completion.evidenceBacked === true, "expected evidence-backed");
   assert(afterExec.completion.contract.mode === "governed", "expected default governed contract");
+  assert(
+    afterExec.completion.missingGateIds.includes("verified_pull_request"),
+    "expected verified_pull_request missing until GitHub confirms the pull request"
+  );
   assert(afterExec.completion.missingGateIds.includes("observed_checks"), "expected observed_checks missing");
   assert(
     delivered.at(-1)?.body?.includes("waiting for verified repository evidence")

--- a/scripts/dev/smoke-default-verified-completion.ts
+++ b/scripts/dev/smoke-default-verified-completion.ts
@@ -1,0 +1,194 @@
+/**
+ * Local smoke for the zero-config GitHub verified completion path:
+ * Slack-bound mention → executor success with PR → waiting for evidence →
+ * green checks → satisfied.
+ *
+ * No live Slack/GitHub credentials required; exercises Slack normalize plus
+ * the dispatcher control plane.
+ */
+import { createDispatcherApp, type CallbackMessage } from "../../packages/dispatcher/src/index.js";
+import { normalizeSlackAppMention } from "../../packages/slack/src/index.js";
+
+const HEAD = "b".repeat(40);
+const BASE = "c".repeat(40);
+const RUN_ID = `run_smoke_default_verified_${Date.now()}`;
+
+function slackBoundGitHubEvent() {
+  const event = normalizeSlackAppMention({
+    teamId: "T123",
+    channelId: "C123",
+    userId: "U456",
+    text: "<@U_APP> fix the flaky test",
+    ts: "1719187200.000100",
+    eventId: `Ev_${RUN_ID}`,
+    eventTime: 1719187200,
+    botUserId: "U_APP",
+    binding: {
+      teamId: "T123",
+      channelId: "C123",
+      repoProvider: "github",
+      owner: "acme",
+      repo: "demo"
+    }
+  });
+  if (!event) throw new Error("Slack normalize returned null");
+  return {
+    ...event,
+    actor: { ...event.actor, writeAccess: true as const }
+  };
+}
+
+function githubSnapshot(input: {
+  deliveryId: string;
+  checks: Record<string, "passed" | "failed" | "pending">;
+  observedAt: string;
+}) {
+  return {
+    provider: "github" as const,
+    deliveryId: input.deliveryId,
+    eventName: "check_run" as const,
+    repository: { owner: "acme", repo: "demo" },
+    pullRequest: {
+      number: 42,
+      resourceRef: "github:acme/demo:pull_request:42",
+      headSha: HEAD,
+      baseSha: BASE,
+      baseBranch: "main",
+      state: "open" as const
+    },
+    checks: input.checks,
+    observedAt: input.observedAt,
+    payloadDigest: `sha256:${"e".repeat(64)}`
+  };
+}
+
+async function json(app: ReturnType<typeof createDispatcherApp>, path: string, body?: unknown) {
+  const response = await app.request(path, body === undefined
+    ? { method: path.includes("claim") ? "POST" : "GET" }
+    : {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body)
+      });
+  const payload = await response.json() as Record<string, unknown>;
+  return { status: response.status, payload };
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+async function main() {
+  const delivered: CallbackMessage[] = [];
+  const app = createDispatcherApp({
+    databasePath: ":memory:",
+    reassessmentObligations: { autoStart: false },
+    callbackSink: {
+      async deliver(message) {
+        delivered.push(message);
+      }
+    }
+  });
+
+  console.log("1) Bootstrap runner + GitHub project + Slack channel binding");
+  assert((await json(app, "/v1/runners", { runnerId: "runner_1", name: "Local Runner" })).status === 201, "runner create failed");
+  assert((await json(app, "/v1/repo-bindings", {
+    provider: "github",
+    owner: "acme",
+    repo: "demo",
+    runnerId: "runner_1",
+    workspacePath: "/tmp/opentag-smoke-demo",
+    defaultExecutor: "echo"
+  })).status === 201, "repo binding failed");
+  assert((await json(app, "/v1/channel-bindings", {
+    provider: "slack",
+    accountId: "T123",
+    conversationId: "C123",
+    repoProvider: "github",
+    owner: "acme",
+    repo: "demo"
+  })).status === 201, "slack channel binding failed");
+
+  console.log("2) Slack @mention bound to GitHub project creates a run with a WorkThread");
+  const event = slackBoundGitHubEvent();
+  assert(event.workItem?.kind === "thread", "normalized Slack event must carry a thread work item");
+  const created = await json(app, "/v1/runs", { runId: RUN_ID, event });
+  assert(created.status === 201, `run create failed: ${created.status} ${JSON.stringify(created.payload)}`);
+  const stored = await json(app, `/v1/runs/${RUN_ID}`);
+  const run = (stored.payload as { run?: { thread?: { id?: string } } }).run;
+  assert(run?.thread?.id, `run missing WorkThread: ${JSON.stringify(stored.payload)}`);
+  const claim = await json(app, "/v1/runners/runner_1/claim");
+  assert(claim.status === 200, "claim failed");
+  const claimBody = claim.payload as { attemptId: string; fencingToken: string };
+
+  console.log("3) Executor succeeds and ships a PR");
+  const complete = await json(app, `/v1/runners/runner_1/runs/${RUN_ID}/complete`, {
+    ...claimBody,
+    result: {
+      conclusion: "success",
+      summary: "Opened a pull request with the fix.",
+      createdPullRequestUrl: "https://github.com/acme/demo/pull/42"
+    }
+  });
+  assert(complete.status === 200, `complete failed: ${complete.status}`);
+  const afterExec = complete.payload as {
+    completion?: {
+      execution: string;
+      completion: string;
+      evidenceBacked: boolean;
+      contract: { mode: string };
+      missingGateIds: string[];
+    };
+  };
+  console.log(JSON.stringify({ stage: "after_executor", completion: afterExec.completion, callback: delivered.at(-1)?.body }, null, 2));
+  assert(afterExec.completion, `complete response missing completion projection: ${JSON.stringify(complete.payload)}`);
+  assert(afterExec.completion.execution === "succeeded", "expected execution succeeded");
+  assert(afterExec.completion.completion === "pending", "expected completion pending");
+  assert(afterExec.completion.evidenceBacked === true, "expected evidence-backed");
+  assert(afterExec.completion.contract.mode === "governed", "expected default governed contract");
+  assert(afterExec.completion.missingGateIds.includes("observed_checks"), "expected observed_checks missing");
+  assert(
+    delivered.at(-1)?.body?.includes("waiting for verified repository evidence")
+      || delivered.at(-1)?.body?.includes("verified repository evidence"),
+    `callback missing waiting copy: ${delivered.at(-1)?.body ?? "<empty>"}`
+  );
+
+  console.log("4) GitHub evidence arrives with a failing check — stays unsatisfied");
+  const failing = await json(app, "/v1/completion-evidence/github", githubSnapshot({
+    deliveryId: `delivery-fail-${RUN_ID}`,
+    checks: { build: "passed", test: "failed" },
+    observedAt: "2026-08-07T00:05:00.000Z"
+  }));
+  assert(failing.status === 201, `failing evidence ingest failed: ${failing.status}`);
+  const failingBody = failing.payload as { completion: { completion: string; failedGateIds: string[] } };
+  console.log(JSON.stringify({ stage: "checks_failed", completion: failingBody.completion }, null, 2));
+  assert(failingBody.completion.completion === "unsatisfied", "expected unsatisfied while checks fail");
+  assert(failingBody.completion.failedGateIds.includes("observed_checks"), "expected observed_checks failed");
+
+  console.log("5) Checks turn green — completion becomes satisfied");
+  const green = await json(app, "/v1/completion-evidence/github", githubSnapshot({
+    deliveryId: `delivery-green-${RUN_ID}`,
+    checks: { build: "passed", test: "passed" },
+    observedAt: "2026-08-07T00:06:00.000Z"
+  }));
+  assert(green.status === 201, `green evidence ingest failed: ${green.status}`);
+  const greenBody = green.payload as {
+    completion: { completion: string; missingGateIds: string[]; failedGateIds: string[]; evidenceBacked: boolean };
+  };
+  console.log(JSON.stringify({
+    stage: "checks_green",
+    completion: greenBody.completion,
+    callback: delivered.at(-1)?.body
+  }, null, 2));
+  assert(greenBody.completion.completion === "satisfied", "expected satisfied after green checks");
+  assert(greenBody.completion.evidenceBacked === true, "expected evidence-backed satisfaction");
+  assert(greenBody.completion.missingGateIds.length === 0, "expected no missing gates");
+  assert(greenBody.completion.failedGateIds.length === 0, "expected no failed gates");
+
+  console.log("\nSMOKE PASS: Slack→GitHub PR path reached verified satisfaction without an explicit completion policy.");
+}
+
+main().catch((error) => {
+  console.error("\nSMOKE FAIL:", error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Rewrite the English and Chinese README front doors around “mention any coding agent / get proof, not promises,” with ACP neutrality, local-first execution, and evidence-backed completion as the three pillars; mark Telegram/Discord/Teams as preview.
- Make GitHub pull-request runs zero-config governed by default: after executor success, hold completion open until verified PR existence and an all-observed-checks-passing rollup arrive; keep executor-success semantics for non-PR runs, and let prior compat threads upgrade when a later run ships a PR.
- Wire opt-out through `defaultGitHubCompletion` / `OPENTAG_GITHUB_DEFAULT_COMPLETION=compat`, document the knobs, and cover the new paths in completion-governance tests.

## Test plan
- [x] `corepack pnpm test` (2048 tests)
- [x] `corepack pnpm typecheck`
- [x] Smoke a Slack/GitHub PR path locally: executor success → “waiting for verified repository evidence” → checks green → satisfied
- [x] Confirm opt-out: `OPENTAG_GITHUB_DEFAULT_COMPLETION=compat` restores prior executor-success default for PR runs
- [x] Confirm an explicit `completionPolicies` entry still takes precedence (named checks + merge)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub-backed runs now use governed completion by default, requiring a verified pull request and passing checks.
  * Added observed-check rollups with passed, failed, and pending outcomes.
  * Added governed and compatibility completion modes, including automatic upgrades when a pull request is created.
  * Slack repository mentions now retain linked work-item context.

* **Documentation**
  * Updated English and Chinese documentation with completion evidence requirements, platform statuses, Discord preview limitations, and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->