### PR TITLE
chore(deps): stop auto-proposing TypeScript and @types/node majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       timezone: Asia/Shanghai
     open-pull-requests-limit: 10
     versioning-strategy: increase-if-necessary
+    ignore:
+      # Must track the lowest Node version in `engines`, not the newest release,
+      # so typecheck cannot accept APIs that are missing on the Node we support.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      # Majors need a migration pass rather than a bump. See issue #129.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       production-dependencies:
         dependency-type: production


### PR DESCRIPTION
## Summary

- Ignore semver-major updates for `@types/node`: the types major must track the *lowest* Node version in `engines` (`>=22.14.0` for `@opentag/cli`, `dispatcher`, `store`, `local-runtime`; `>=20` elsewhere), so typechecking cannot silently accept APIs that are missing on the runtimes we claim to support. This closes [#123](https://github.com/amplifthq/opentag/pull/123) (22 → 26).
- Ignore semver-major updates for `typescript`: TypeScript 7 needs a migration, not a bump. It fails the build today because `@types/node` is only declared at the workspace root, so no package resolves Node types under TS 7. This closes [#122](https://github.com/amplifthq/opentag/pull/122) and is tracked in [#129](https://github.com/amplifthq/opentag/issues/129).

Minor and patch updates for both packages continue to flow through the existing `development-dependencies` group, so security and bugfix releases are unaffected.

## Test plan

- [x] `.github/dependabot.yml` parses as YAML with the two `ignore` entries present and the existing `groups` and `github-actions` blocks unchanged.
- [ ] Confirm no new major PRs for `typescript` or `@types/node` appear on the next Monday Dependabot run.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured dependency update settings to skip major-version updates for TypeScript tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->