### PR TITLE
feat: publish verified control plane images for Railway

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,9 @@
 **/*.tsbuildinfo
 .pnpm-store
 .superpowers
+**/.env
+**/.env.*
+**/secrets
+.worktrees
+.agents
+.codex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  control-plane-image:
+    name: Control Plane image smoke
+    needs: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Build the release image
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: docker build --pull --platform linux/amd64 --build-arg "OPENTAG_RELEASE_SHA=$SOURCE_SHA" --file apps/control-plane/Dockerfile --tag opentag-control-plane:verified .
+      - name: Verify container startup and restart
+        run: node scripts/test/control-plane-image-smoke.mjs opentag-control-plane:verified
+      - name: Audit image runtime dependencies
+        run: docker run --rm --interactive --entrypoint node opentag-control-plane:verified --input-type=module < scripts/release/audit-control-plane-image.mjs
+      - name: Save the exact tested image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: docker save opentag-control-plane:verified --output control-plane-image.tar
+      - name: Upload the exact tested image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: control-plane-image-${{ github.sha }}
+          path: control-plane-image.tar
+          compression-level: 0
+          retention-days: 3
+          if-no-files-found: error
+
   check:
     name: Build, lint, typecheck, test, and release checks
     runs-on: ubuntu-latest

--- a/.github/workflows/control-plane-image.yml
+++ b/.github/workflows/control-plane-image.yml
@@ -1,0 +1,84 @@
+name: Publish Control Plane image
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: control-plane-image-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish the tested main image to GHCR
+    if: >-
+      github.repository == 'amplifthq/opentag' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      packages: write
+    env:
+      SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+      IMAGE: ghcr.io/amplifthq/opentag-control-plane
+      IMAGE_TAG: sha-${{ github.event.workflow_run.head_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Download the image from the successful main CI run
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: control-plane-image-${{ github.event.workflow_run.head_sha }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Verify artifact revision and runtime user
+        run: |
+          docker load --input control-plane-image.tar
+          test "$(docker image inspect opentag-control-plane:verified --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$SOURCE_SHA"
+          test "$(docker image inspect opentag-control-plane:verified --format '{{.Config.User}}')" = opentag
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish without rebuilding or overwriting a release tag
+        run: |
+          docker tag opentag-control-plane:verified "$IMAGE:$IMAGE_TAG"
+          docker push "$IMAGE:$IMAGE_TAG"
+          docker image inspect "$IMAGE:$IMAGE_TAG" > image-inspect.json
+          node --input-type=module <<'NODE'
+          import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+          const [image] = JSON.parse(readFileSync('image-inspect.json', 'utf8'));
+          const reference = image.RepoDigests.find(value => value.startsWith(`${process.env.IMAGE}@sha256:`));
+          if (!reference || !/^ghcr\.io\/amplifthq\/opentag-control-plane@sha256:[a-f0-9]{64}$/.test(reference)) {
+            throw new Error('published_image_digest_missing');
+          }
+          const receipt = { schemaVersion: 1, image: process.env.IMAGE,
+            tag: process.env.IMAGE_TAG, digest: reference.split('@')[1],
+            sourceSha: process.env.SOURCE_SHA, platform: 'linux/amd64' };
+          writeFileSync('control-plane-image.json', JSON.stringify(receipt, null, 2) + '\n');
+          appendFileSync(process.env.GITHUB_STEP_SUMMARY,
+            `Published tested image: \`${reference}\`\n\nSource: \`${receipt.sourceSha}\`\n`);
+          NODE
+      - name: Retain the immutable image receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: control-plane-image-receipt-${{ github.event.workflow_run.head_sha }}
+          path: control-plane-image.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Verify public pull access for deployment templates
+        run: |
+          reference="$(node -p "const r=require('./control-plane-image.json'); r.image+'@'+r.digest")"
+          anonymous_config="$(mktemp -d)"
+          docker --config "$anonymous_config" pull "$reference"

--- a/apps/control-plane/Dockerfile
+++ b/apps/control-plane/Dockerfile
@@ -41,10 +41,16 @@ RUN corepack pnpm --filter @opentag/control-plane \
 
 FROM node:22-bookworm-slim AS runtime
 
+ARG OPENTAG_RELEASE_SHA=local
 ENV NODE_ENV=production
+ENV OPENTAG_RELEASE_SHA=$OPENTAG_RELEASE_SHA
+LABEL org.opencontainers.image.source="https://github.com/amplifthq/opentag" \
+  org.opencontainers.image.licenses="MIT" \
+  org.opencontainers.image.revision=$OPENTAG_RELEASE_SHA
 WORKDIR /workspace
 RUN groupadd --gid 10001 opentag \
-  && useradd --uid 10001 --gid 10001 --create-home --shell /usr/sbin/nologin opentag
+  && useradd --uid 10001 --gid 10001 --create-home --shell /usr/sbin/nologin opentag \
+  && install -d -m 0700 -o 10001 -g 10001 /run/secrets
 
 COPY --from=build --chown=opentag:opentag /output/package.json ./apps/control-plane/package.json
 COPY --from=build --chown=opentag:opentag /output/node_modules ./apps/control-plane/node_modules

--- a/apps/control-plane/src/container.ts
+++ b/apps/control-plane/src/container.ts
@@ -1,0 +1,221 @@
+import { lstat, mkdir, open } from "node:fs/promises";
+import { constants } from "node:fs";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { z } from "zod";
+import { RelayCapabilitiesResponseV1Schema } from "@opentag/control-protocol";
+import { parseAdminBootstrapConfig, parseControlPlaneConfig, parseSlackBootstrapConfig } from "./config.js";
+import { checkPostgresReadiness, createPostgresRuntime } from "./database/postgres.js";
+type CommandRunner = typeof import("./index.js").main;
+
+const SECRET_DIRECTORY = "/run/secrets";
+const secretFiles = {
+  OPENTAG_CONTAINER_RELAY_CONTENT_KEK: "opentag_relay_content_kek",
+  OPENTAG_CONTAINER_SLACK_SIGNING_SECRET: "opentag_slack_signing_secret",
+  OPENTAG_CONTAINER_SLACK_BOT_TOKEN: "opentag_slack_bot_token",
+} as const;
+const credential = z.string().min(1).max(4096)
+  .refine((value) => value === value.trim()
+    && Buffer.byteLength(value, "utf8") <= 4096
+    && !/[\r\n\0\ufffd]/u.test(value) && !value.startsWith("replace-with-"));
+const ContainerSecretsSchema = z.object({
+  OPENTAG_CONTAINER_RELAY_CONTENT_KEK: z.string().regex(/^[a-f0-9]{64}$/iu),
+  OPENTAG_CONTAINER_SLACK_SIGNING_SECRET: credential,
+  OPENTAG_CONTAINER_SLACK_BOT_TOKEN: credential,
+});
+const ContainerRoleSchema = z.enum(["serve", "jobs"]);
+type ContainerRole = z.infer<typeof ContainerRoleSchema>;
+
+// Runtime code continues to consume file references. Only this container
+// boundary accepts platform-injected values, and removes them from its env.
+export async function prepareContainerEnvironment(
+  input: NodeJS.ProcessEnv,
+  secretDirectory = SECRET_DIRECTORY,
+): Promise<NodeJS.ProcessEnv> {
+  const parsed = ContainerSecretsSchema.safeParse(input);
+  for (const name of Object.keys(secretFiles)) delete input[name];
+  if (!parsed.success) throw new Error("container_secrets_invalid");
+  const env = { ...input };
+  const references = {
+    OPENTAG_RELAY_CONTENT_KEK_FILE: join(secretDirectory, secretFiles.OPENTAG_CONTAINER_RELAY_CONTENT_KEK),
+    OPENTAG_SLACK_SIGNING_SECRET_REF: `file:${join(secretDirectory, secretFiles.OPENTAG_CONTAINER_SLACK_SIGNING_SECRET)}`,
+    OPENTAG_SLACK_BOT_TOKEN_REF: `file:${join(secretDirectory, secretFiles.OPENTAG_CONTAINER_SLACK_BOT_TOKEN)}`,
+  };
+  for (const [name, value] of Object.entries(references)) {
+    if (env[name] !== undefined && env[name] !== value) {
+      throw new Error("container_secret_reference_conflict");
+    }
+    env[name] = value;
+  }
+  env.OPENTAG_PORT ??= env.PORT;
+  parseControlPlaneConfig(env);
+  try {
+    await mkdir(secretDirectory, { mode: 0o700 });
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) {
+      throw new Error("container_secret_directory_unavailable");
+    }
+  }
+  const directory = await lstat(secretDirectory);
+  if (!directory.isDirectory() || directory.isSymbolicLink()
+    || (directory.mode & 0o777) !== 0o700
+    || (process.getuid && directory.uid !== process.getuid())) {
+    throw new Error("container_secret_directory_unsafe");
+  }
+  for (const name of Object.keys(secretFiles) as Array<keyof typeof secretFiles>) {
+    const path = join(secretDirectory, secretFiles[name]);
+    const content = Buffer.from(parsed.data[name], "utf8");
+    let file: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      file = await open(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL
+        | constants.O_NOFOLLOW, 0o400);
+      await file.writeFile(content);
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) {
+        throw new Error("container_secret_file_unavailable");
+      }
+      // Restarts may see an existing file. Never replace a mounted secret or
+      // silently rotate a key: only the exact private regular file is reusable.
+      const existing = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+      try {
+        const stat = await existing.stat();
+        if (!stat.isFile() || stat.nlink !== 1 || (stat.mode & 0o777) !== 0o400
+          || stat.size !== content.length
+          || (process.getuid && stat.uid !== process.getuid())
+          || !(await existing.readFile()).equals(content)) {
+          throw new Error("container_secret_file_conflict");
+        }
+      } finally {
+        await existing.close();
+      }
+    } finally {
+      await file?.close();
+      content.fill(0);
+    }
+  }
+  return env;
+}
+
+export async function waitForContainerDependency(
+  probe: () => Promise<boolean>,
+  options: { signal: AbortSignal; pollMs?: number },
+): Promise<void> {
+  while (true) {
+    options.signal.throwIfAborted();
+    if (await probe()) return;
+    await delay(options.pollMs ?? 1_000, undefined, { signal: options.signal });
+  }
+}
+
+export async function containerControlPlaneReady(input: {
+  origin: string; releaseSha: string; signal: AbortSignal;
+  fetchImpl?: typeof fetch;
+}): Promise<boolean> {
+  const origin = new URL(input.origin);
+  if (!["http:", "https:"].includes(origin.protocol) || origin.username
+    || origin.password || origin.pathname !== "/" || origin.search || origin.hash) {
+    throw new Error("container_control_plane_url_invalid");
+  }
+  const request = input.fetchImpl ?? fetch;
+  try {
+    const options = { signal: AbortSignal.any([input.signal, AbortSignal.timeout(5_000)]),
+      redirect: "error" as const };
+    const ready = await request(new URL("/readyz", origin), options);
+    if (!ready.ok) { await ready.body?.cancel(); return false; }
+    const state = z.object({ status: z.literal("ready") }).safeParse(await ready.json());
+    if (!state.success) return false;
+    const response = await request(new URL("/v1/relay/capabilities", origin), options);
+    if (!response.ok) { await response.body?.cancel(); return false; }
+    const capabilities = RelayCapabilitiesResponseV1Schema.safeParse(await response.json());
+    return capabilities.success && capabilities.data.deployment.releaseSha === input.releaseSha;
+  } catch {
+    // Both requests are read-only observations. A missing or malformed response
+    // keeps jobs waiting; the bounded startup deadline makes failure visible.
+    return false;
+  }
+}
+
+export async function startContainerRole(input: {
+  role: ContainerRole; env: NodeJS.ProcessEnv; signal: AbortSignal;
+  runCommand: CommandRunner;
+  waitForDatabase: () => Promise<void>;
+  waitForControlPlane: () => Promise<void>;
+}): Promise<void> {
+  const run = input.runCommand;
+  if (input.role === "serve") {
+    // Validate every bootstrap input before migrations can mutate the database.
+    parseAdminBootstrapConfig(input.env);
+    parseSlackBootstrapConfig(input.env);
+    await input.waitForDatabase();
+    for (const command of ["migrate", "bootstrap-admin", "bootstrap-slack"]) {
+      input.signal.throwIfAborted();
+      let abort = () => {};
+      try {
+        const cancelled = new Promise<never>((_resolve, reject) => {
+          abort = () => reject(new Error("container_startup_cancelled"));
+          input.signal.addEventListener("abort", abort, { once: true });
+          if (input.signal.aborted) abort();
+        });
+        await Promise.race([run({ argv: [command], env: input.env }), cancelled]);
+      } catch {
+        throw new Error(`container_${command.replaceAll("-", "_")}_failed`);
+      } finally {
+        input.signal.removeEventListener("abort", abort);
+      }
+    }
+  } else {
+    await input.waitForControlPlane();
+  }
+  input.signal.throwIfAborted();
+  // Long-running roles do not need the owner's bootstrap password.
+  delete input.env.OPENTAG_BOOTSTRAP_ADMIN_PASSWORD;
+  await run({ argv: [input.role], env: input.env });
+}
+
+export async function containerMain(input: {
+  argv: readonly string[]; env: NodeJS.ProcessEnv; runCommand: CommandRunner;
+}): Promise<void> {
+  const role = ContainerRoleSchema.parse(input.argv[0]);
+  if (input.argv.length !== 1) throw new Error("container_role_invalid");
+  const env = await prepareContainerEnvironment(input.env);
+  const config = parseControlPlaneConfig(env);
+  const deadline = AbortSignal.timeout(300_000);
+  const interrupted = new AbortController();
+  const interrupt = () => interrupted.abort();
+  process.once("SIGTERM", interrupt);
+  process.once("SIGINT", interrupt);
+  const signal = AbortSignal.any([deadline, interrupted.signal]);
+  const wait = async (dependency: string, probe: () => Promise<boolean>) => {
+    console.info("control_plane_container_waiting", { dependency });
+    try { await waitForContainerDependency(probe, { signal }); }
+    catch { throw new Error(`container_${dependency}_wait_failed`); }
+  };
+  try {
+    await startContainerRole({ role, env, signal,
+      waitForDatabase: async () => {
+        const postgres = createPostgresRuntime({ databaseUrl: config.databaseUrl, poolMax: 1 });
+        try { await wait("database", async () => (await checkPostgresReadiness(postgres.pool)).ready); }
+        finally { await postgres.close(); }
+      },
+      waitForControlPlane: async () => {
+        const origin = env.OPENTAG_CONTAINER_CONTROL_PLANE_URL;
+        if (!origin) throw new Error("container_control_plane_url_missing");
+        await wait("control_plane", () => containerControlPlaneReady({
+          origin, releaseSha: config.releaseSha, signal,
+        }));
+      },
+      runCommand: async (command) => {
+        if (command?.argv?.[0] === role) {
+          delete input.env.OPENTAG_BOOTSTRAP_ADMIN_PASSWORD;
+          process.off("SIGTERM", interrupt);
+          process.off("SIGINT", interrupt);
+          console.info("control_plane_container_starting", { role, releaseSha: config.releaseSha });
+        }
+        await input.runCommand(command);
+      },
+    });
+  } finally {
+    process.off("SIGTERM", interrupt);
+    process.off("SIGINT", interrupt);
+  }
+}

--- a/apps/control-plane/src/index.ts
+++ b/apps/control-plane/src/index.ts
@@ -17,6 +17,7 @@ import { createControlPlaneRuntime } from "./runtime.js";
 import { bootstrapSlackInstallation } from "./modules/slack-installation-bootstrap/index.js";
 import type { ControlPlaneConfig } from "./config.js";
 import type { SqlMigration } from "./database/migrations.js";
+import { containerMain } from "./container.js";
 
 export function createEnvironmentSlackSecretResolver(
   env: Record<string, string | undefined>,
@@ -77,6 +78,10 @@ export async function main(input: {
   const argv = input.argv ?? process.argv.slice(2);
   const env = input.env ?? process.env;
   const command = argv[0] ?? "serve";
+  if (command === "container") {
+    await containerMain({ argv: argv.slice(1), env, runCommand: main });
+    return;
+  }
   const config = parseControlPlaneConfig(env);
   const migrations = await loadSqlMigrations(migrationDirectory);
 
@@ -204,5 +209,14 @@ export async function main(input: {
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  await main();
+  if (process.argv[2] === "container") {
+    main().catch((error: unknown) => {
+      const code = error instanceof Error && /^container_[a-z_]+$/u.test(error.message)
+        ? error.message : "container_start_failed";
+      console.error("control_plane_container_failed", { code });
+      process.exit(1);
+    });
+  } else {
+    await main();
+  }
 }

--- a/apps/control-plane/test/container.test.ts
+++ b/apps/control-plane/test/container.test.ts
@@ -1,0 +1,236 @@
+import { chmod, lstat, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { containerControlPlaneReady, prepareContainerEnvironment,
+  startContainerRole, waitForContainerDependency } from "../src/container.js";
+
+const releaseSha = "a".repeat(40);
+const environment = (): NodeJS.ProcessEnv => ({
+  DATABASE_URL: "postgresql://test:test@localhost:5432/test",
+  OPENTAG_BOOTSTRAP_ORGANIZATION_ID: "org_test",
+  OPENTAG_BOOTSTRAP_ORGANIZATION_NAME: "Container test",
+  OPENTAG_BOOTSTRAP_PAIRING_TOKEN: "test-pairing-token-only",
+  OPENTAG_FENCING_TOKEN_SECRET: "f".repeat(32),
+  OPENTAG_LOGIN_THROTTLE_SECRET: "t".repeat(32),
+  OPENTAG_ENVIRONMENT: "staging",
+  OPENTAG_PUBLIC_URL: "https://relay.example.test",
+  OPENTAG_RELEASE_SHA: releaseSha,
+  OPENTAG_RELAY_CONTENT_KEY_VERSION: "v1",
+  OPENTAG_CONTAINER_RELAY_CONTENT_KEK: "ab".repeat(32),
+  OPENTAG_CONTAINER_SLACK_SIGNING_SECRET: "test-signing-secret-only",
+  OPENTAG_CONTAINER_SLACK_BOT_TOKEN: "test-bot-token-only",
+  OPENTAG_BOOTSTRAP_ADMIN_EMAIL: "owner@example.test",
+  OPENTAG_BOOTSTRAP_ADMIN_NAME: "Test Owner",
+  OPENTAG_BOOTSTRAP_ADMIN_PASSWORD: "test-owner-password-only",
+  OPENTAG_SLACK_INSTALLATION_ID: "slack_primary",
+  OPENTAG_SLACK_BINDING_ID: "slack_binding",
+  OPENTAG_SLACK_ROUTE_IDENTITY: "route_identity_test_only",
+  OPENTAG_SLACK_PROJECT_TARGET_ID: "github_primary",
+  OPENTAG_SLACK_TEAM_ID: "T_TEST",
+  OPENTAG_SLACK_APP_ID: "A_TEST",
+  OPENTAG_SLACK_CHANNEL_ID: "C_TEST",
+  OPENTAG_SLACK_BOT_USER_ID: "U_BOT",
+  OPENTAG_SLACK_MEMBER_USER_IDS: "U_OWNER",
+});
+
+describe("container secret custody", () => {
+  const directories: string[] = [];
+  const directory = async () => {
+    const path = await mkdtemp(join(tmpdir(), "opentag-container-test-"));
+    directories.push(path);
+    return path;
+  };
+  afterEach(async () => {
+    await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  });
+
+  it("materializes private bounded files and consumes platform secret variables", async () => {
+    const root = await directory();
+    const input = { ...environment(), PORT: "8123" };
+    const env = await prepareContainerEnvironment(input, root);
+    expect(env.OPENTAG_PORT).toBe("8123");
+    expect(env.OPENTAG_RELAY_CONTENT_KEK_FILE).toBe(join(root, "opentag_relay_content_kek"));
+    expect(env.OPENTAG_SLACK_BOT_TOKEN_REF).toBe(`file:${root}/opentag_slack_bot_token`);
+    for (const [key, name] of [
+      ["OPENTAG_CONTAINER_RELAY_CONTENT_KEK", "opentag_relay_content_kek"],
+      ["OPENTAG_CONTAINER_SLACK_SIGNING_SECRET", "opentag_slack_signing_secret"],
+      ["OPENTAG_CONTAINER_SLACK_BOT_TOKEN", "opentag_slack_bot_token"],
+    ]) {
+      expect(input[key!]).toBeUndefined();
+      expect(env[key!]).toBeUndefined();
+      expect(await readFile(join(root, name!), "utf8")).toBe(environment()[key!]);
+      expect((await lstat(join(root, name!))).mode & 0o777).toBe(0o400);
+    }
+    expect(env.OPENTAG_RELAY_CONTENT_KEK).toBeUndefined();
+  });
+
+  it("reuses only exact existing files without rotating or overwriting secrets", async () => {
+    const root = await directory();
+    await prepareContainerEnvironment(environment(), root);
+    await expect(prepareContainerEnvironment(environment(), root)).resolves.toBeDefined();
+    await expect(prepareContainerEnvironment({ ...environment(),
+      OPENTAG_CONTAINER_RELAY_CONTENT_KEK: "cd".repeat(32) }, root))
+      .rejects.toThrow("container_secret_file_conflict");
+    expect(await readFile(join(root, "opentag_relay_content_kek"), "utf8"))
+      .toBe("ab".repeat(32));
+  });
+
+  it.each(["", "short", "replace-with-a-secret", "ab".repeat(32) + "\n"])(
+    "rejects an invalid KEK and removes all injected values", async (key) => {
+      const root = await directory();
+      const input = { ...environment(), OPENTAG_CONTAINER_RELAY_CONTENT_KEK: key };
+      await expect(prepareContainerEnvironment(input, root)).rejects.toThrow("container_secrets_invalid");
+      expect(input.OPENTAG_CONTAINER_RELAY_CONTENT_KEK).toBeUndefined();
+      expect(input.OPENTAG_CONTAINER_SLACK_BOT_TOKEN).toBeUndefined();
+    },
+  );
+
+  it("rejects credential whitespace, placeholders, invalid bytes and oversized values", async () => {
+    for (const value of ["", " token", "token\n", "token\0value", "replace-with-token", "x".repeat(4097), "😀".repeat(2000)]) {
+      await expect(prepareContainerEnvironment({ ...environment(),
+        OPENTAG_CONTAINER_SLACK_BOT_TOKEN: value }, await directory()))
+        .rejects.toThrow("container_secrets_invalid");
+    }
+  });
+
+  it("does not relax existing config and secret-reference constraints", async () => {
+    const root = await directory();
+    await expect(prepareContainerEnvironment({ ...environment(), OPENTAG_PUBLIC_URL: "http://bad.test" }, root))
+      .rejects.toThrow("configuration_invalid");
+    await expect(prepareContainerEnvironment({ ...environment(),
+      OPENTAG_RELAY_CONTENT_KEK: "not-permitted" }, root)).rejects.toThrow("configuration_invalid");
+    await expect(prepareContainerEnvironment({ ...environment(),
+      OPENTAG_SLACK_BOT_TOKEN_REF: "env:OTHER_TOKEN" }, root))
+      .rejects.toThrow("container_secret_reference_conflict");
+  });
+
+  it("rejects unsafe directories and symlinks without modifying their targets", async () => {
+    const root = await directory();
+    const unsafe = join(root, "unsafe");
+    await symlink(root, unsafe);
+    await expect(prepareContainerEnvironment(environment(), unsafe))
+      .rejects.toThrow("container_secret_directory_unsafe");
+    await chmod(root, 0o755);
+    await expect(prepareContainerEnvironment(environment(), root))
+      .rejects.toThrow("container_secret_directory_unsafe");
+    await chmod(root, 0o700);
+    const target = join(root, "outside");
+    await writeFile(target, "untouched", { mode: 0o400 });
+    await symlink(target, join(root, "opentag_relay_content_kek"));
+    await expect(prepareContainerEnvironment(environment(), root)).rejects.toThrow();
+    expect(await readFile(target, "utf8")).toBe("untouched");
+  });
+});
+
+describe("container startup ordering", () => {
+  const startup = (role: "serve" | "jobs", env = environment()) => {
+    const commands: string[] = [];
+    const runCommand = vi.fn(async (input?: { argv?: readonly string[]; env?: NodeJS.ProcessEnv }) => {
+      commands.push(input?.argv?.[0] ?? "missing");
+    });
+    return { commands, input: { role, env, signal: new AbortController().signal, runCommand,
+      waitForDatabase: async () => { commands.push("database-ready"); },
+      waitForControlPlane: async () => { commands.push("control-plane-ready"); },
+    } };
+  };
+
+  it("starts HTTP only after database, migrations and exact-replay bootstraps", async () => {
+    const { commands, input } = startup("serve");
+    await startContainerRole(input);
+    expect(commands).toEqual(["database-ready", "migrate", "bootstrap-admin", "bootstrap-slack", "serve"]);
+    expect(input.env.OPENTAG_BOOTSTRAP_ADMIN_PASSWORD).toBeUndefined();
+  });
+
+  it.each(["migrate", "bootstrap-admin", "bootstrap-slack"])(
+    "never retries a failed %s or starts the next phase", async (failedCommand) => {
+      const { input } = startup("serve");
+      input.runCommand.mockImplementation(async (command) => {
+        if (command?.argv?.[0] === failedCommand) throw new Error("private database details");
+      });
+      await expect(startContainerRole(input))
+        .rejects.toThrow(`container_${failedCommand.replaceAll("-", "_")}_failed`);
+      const calls = input.runCommand.mock.calls.map(([call]) => call?.argv?.[0]);
+      expect(calls.at(-1)).toBe(failedCommand);
+      expect(calls.filter((command) => command === failedCommand)).toHaveLength(1);
+      expect(calls).not.toContain("serve");
+    },
+  );
+
+  it("validates bootstrap configuration before any database mutation", async () => {
+    const { commands, input } = startup("serve", { ...environment(), OPENTAG_SLACK_CHANNEL_ID: "" });
+    await expect(startContainerRole(input)).rejects.toThrow();
+    expect(commands).toEqual([]);
+  });
+
+  it("keeps jobs behind the ready relay and never bootstraps from the worker", async () => {
+    const { commands, input } = startup("jobs");
+    await startContainerRole(input);
+    expect(commands).toEqual(["control-plane-ready", "jobs"]);
+  });
+
+  it("bounds read-only dependency retries and honors cancellation", async () => {
+    const probe = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    await waitForContainerDependency(probe, { signal: new AbortController().signal, pollMs: 1 });
+    expect(probe).toHaveBeenCalledTimes(2);
+    await expect(waitForContainerDependency(async () => false,
+      { signal: AbortSignal.timeout(10), pollMs: 1 })).rejects.toThrow();
+    const { input } = startup("jobs");
+    input.signal = AbortSignal.abort();
+    await expect(startContainerRole(input)).rejects.toThrow();
+    expect(input.runCommand).not.toHaveBeenCalled();
+  });
+
+  it("cancels a hung initialization command without starting a later phase", async () => {
+    const { input } = startup("serve");
+    const controller = new AbortController();
+    input.signal = controller.signal;
+    input.runCommand.mockImplementation(async () => {
+      controller.abort();
+      await new Promise(() => {});
+    });
+    await expect(startContainerRole(input)).rejects.toThrow("container_migrate_failed");
+    expect(input.runCommand).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("jobs relay observation", () => {
+  const capabilities = (sha = releaseSha) => ({
+    schemaVersion: 1, protocolVersion: "1.0", registryVersion: "opentag.control.capabilities/v1",
+    capabilities: ["relay.readiness.v1"], minimumClient: { schemaVersion: 1, protocolVersion: "1.0" },
+    deployment: { environment: "staging", releaseSha: sha },
+    artifact: { packageName: "@opentag/control-plane", packageVersion: "0.0.0" },
+  });
+  it("accepts readiness only from the same release and performs GETs without credentials", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => Response.json(
+      new URL(String(url)).pathname === "/readyz" ? { status: "ready" } : capabilities()));
+    await expect(containerControlPlaneReady({ origin: "http://control-plane.railway.internal:3000",
+      releaseSha, signal: new AbortController().signal, fetchImpl })).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    for (const [, options] of fetchImpl.mock.calls) {
+      expect(options?.method).toBeUndefined();
+      expect(options?.headers).toBeUndefined();
+      expect(options?.redirect).toBe("error");
+    }
+  });
+  it.each(["not-ready", "old-release", "malformed", "network-failure"])(
+    "keeps jobs waiting after %s", async (failure) => {
+      const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+        if (failure === "network-failure") throw new Error("private transport details");
+        if (failure === "not-ready") return new Response("not-ready", { status: 503 });
+        if (new URL(String(url)).pathname === "/readyz") return Response.json({ status: "ready" });
+        return Response.json(failure === "malformed" ? {} : capabilities("b".repeat(40)));
+      });
+      await expect(containerControlPlaneReady({ origin: "http://relay.internal:3000", releaseSha,
+        signal: new AbortController().signal, fetchImpl })).resolves.toBe(false);
+    },
+  );
+  it("rejects credentials, paths and unsupported schemes before making a request", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    for (const origin of ["http://user:password@relay", "http://relay/path", "file:///tmp/private"]) {
+      await expect(containerControlPlaneReady({ origin, releaseSha,
+        signal: new AbortController().signal, fetchImpl })).rejects.toThrow("container_control_plane_url_invalid");
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/control-plane/test/deployment-contract.test.ts
+++ b/apps/control-plane/test/deployment-contract.test.ts
@@ -7,6 +7,44 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../.
 const read = (path: string) => readFile(resolve(repositoryRoot, path), "utf8");
 
 describe("Control Plane deployment contract", () => {
+  it("publishes only the tested image from a successful main push", async () => {
+    const [ci, publish] = await Promise.all([
+      read(".github/workflows/ci.yml"), read(".github/workflows/control-plane-image.yml"),
+    ]);
+    expect(ci).toContain("control-plane-image-smoke.mjs opentag-control-plane:verified");
+    expect(ci).toContain("audit-control-plane-image.mjs");
+    expect(ci).toContain("docker save opentag-control-plane:verified");
+    expect(publish).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(publish).toContain("github.event.workflow_run.event == 'push'");
+    expect(publish).toContain("github.event.workflow_run.head_branch == 'main'");
+    expect(publish).toContain("github.event.workflow_run.head_repository.full_name == github.repository");
+    expect(publish).toContain("run-id: ${{ github.event.workflow_run.id }}");
+    expect(publish).toContain("docker load --input control-plane-image.tar");
+    expect(publish).not.toContain("docker build");
+    expect(publish).not.toContain(":latest");
+    expect(publish).not.toContain("pull_request_target");
+    expect(publish).toContain("${{ github.run_id }}-${{ github.run_attempt }}");
+    expect(publish).toContain("control-plane-image.json");
+    expect(publish).toContain('docker --config "$anonymous_config" pull "$reference"');
+    for (const match of `${ci}\n${publish}`.matchAll(/uses: ([^\s]+)/gu)) {
+      expect(match[1]).toMatch(/@[a-f0-9]{40}$/u);
+    }
+  });
+
+  it("keeps container custody separate from the existing Compose secret mounts", async () => {
+    const [dockerfile, ignore, container] = await Promise.all([
+      read("apps/control-plane/Dockerfile"), read(".dockerignore"), read("apps/control-plane/src/container.ts"),
+    ]);
+    expect(dockerfile).toContain("ARG OPENTAG_RELEASE_SHA=local");
+    expect(dockerfile).toContain("org.opencontainers.image.revision=$OPENTAG_RELEASE_SHA");
+    expect(dockerfile).toContain("install -d -m 0700 -o 10001 -g 10001 /run/secrets");
+    expect(ignore).toContain("**/.env");
+    expect(ignore).toContain(".worktrees");
+    expect(container).toContain('z.enum(["serve", "jobs"])');
+    expect(container).not.toContain("randomBytes");
+    expect(container).not.toContain("command.execute");
+  });
+
   it("uses one OCI image for migrations, bootstraps, HTTP, and durable jobs", async () => {
     const compose = await read("deploy/compose/compose.yaml");
     expect(compose).toContain("postgres:");

--- a/docs/control-plane-deployment.md
+++ b/docs/control-plane-deployment.md
@@ -7,6 +7,10 @@ commands. This document does not claim that a managed environment is deployed.
 
 ## Minimum topology
 
+For the Railway image profile, see [container image releases](control-plane-image-release.md).
+The [separate Railway template repository](https://github.com/amplifthq/opentag-railway)
+consumes the same application and migration image; it does not own a second runtime.
+
 The reference profile has four application roles and one durable dependency:
 
 | Service | Authority |

--- a/docs/control-plane-image-release.md
+++ b/docs/control-plane-image-release.md
@@ -1,0 +1,123 @@
+# Control Plane image releases
+
+The Control Plane image contains HTTP, durable jobs, migrations, and bootstrap
+commands. Deployment wrappers consume this image; they must not copy application
+code or SQL. The first published platform is `linux/amd64`.
+
+## Publication contract
+
+1. A pull request runs the existing build, lint, typecheck, test, PostgreSQL,
+   release-package, relay-profile, and browser gates. The image job additionally
+   builds the OCI image, audits its installed public runtime dependencies, and
+   checks container bootstrap, jobs ordering, restart, and retired-schema refusal.
+2. On a `main` push, CI saves that exact tested image as a short-lived artifact.
+3. `Publish Control Plane image` runs only after the whole `main` push CI succeeds.
+   It downloads the artifact from that exact run and checks its revision and
+   non-root user. It never rebuilds the image and never publishes from a PR run.
+4. The workflow uses its repository-scoped `GITHUB_TOKEN` with `packages: write`
+   to publish to `ghcr.io/amplifthq/opentag-control-plane`. No personal registry
+   token is required in repository secrets.
+5. Tags include the full source SHA, publication run ID, and attempt. A rerun
+   creates a new tag rather than replacing an earlier release. No `latest` tag
+   is published. Consumers pin the returned `sha256` digest.
+
+The `control-plane-image-receipt-<source-sha>` artifact contains
+`control-plane-image.json`: schema version, image name, tag, digest, source SHA,
+and platform. This is the input to the template repository's `pin-image` command.
+Retain reviewed receipts with template changes; the CI image tar expires after
+three days and the publication receipt artifact after 90 days.
+
+On the first GHCR publication, verify package access in GitHub. The workflow
+checks an anonymous pull after retaining the receipt. If GitHub initially makes
+the package private, set the new package's visibility to public in its settings
+and rerun publication. Do not distribute private registry credentials in a
+deployment template. A failed anonymous pull is not a usable public release.
+
+Source merge, CI success, image publication, public pull access, Railway
+deployment, and real Slack/GitHub acceptance are separate results. A template
+button is published only after fresh-environment validation.
+
+## Platform container entry point
+
+The normal `serve`, `jobs`, `migrate`, `bootstrap-admin`, and `bootstrap-slack`
+commands remain unchanged for Compose. Environment-injecting platforms use:
+
+```sh
+node apps/control-plane/dist/index.js container serve
+node apps/control-plane/dist/index.js container jobs
+```
+
+This entry point accepts only those two roles, not arbitrary shell commands.
+`container serve` validates bootstrap inputs, waits for PostgreSQL, then invokes
+the existing migration, administrator, and Slack bootstrap commands in order.
+Only then does it start HTTP. Initialization failures stop startup; mutations
+are not retried inside the startup sequence. A container restart reuses the
+existing bootstrap replay rules. Bootstrap never resets an owner's password or
+repairs a conflicting Slack binding automatically.
+
+`container jobs` does not initialize state and does not need the bootstrap owner
+password. It waits for `/readyz` and `/v1/relay/capabilities` on
+`OPENTAG_CONTAINER_CONTROL_PLANE_URL`, requiring the same image release SHA,
+before invoking the existing jobs process. Use the Control Plane's private
+HTTP origin on port 3000. Observations have per-request timeouts and dependency
+waiting has a five-minute deadline. Readiness requests do not grant authority
+or prove that Slack credentials are accepted by the provider.
+
+Keep one replica of each application role for this profile. Disable platform
+sleep and allow time for SIGTERM draining. The profile does not claim HA or
+zero-downtime schema upgrades.
+
+## Secret injection
+
+Set the existing non-secret runtime/bootstrap configuration from the Compose
+runbook. `PORT` is used when `OPENTAG_PORT` is not set; the template sets both to
+3000. The image embeds `OPENTAG_RELEASE_SHA`; do not override it with a template
+repository SHA.
+
+Platform secret inputs are:
+
+| Input | File supplied to the existing runtime |
+| --- | --- |
+| `OPENTAG_CONTAINER_RELAY_CONTENT_KEK` | `/run/secrets/opentag_relay_content_kek` |
+| `OPENTAG_CONTAINER_SLACK_SIGNING_SECRET` | `/run/secrets/opentag_slack_signing_secret` |
+| `OPENTAG_CONTAINER_SLACK_BOT_TOKEN` | `/run/secrets/opentag_slack_bot_token` |
+
+The KEK must be 64 hexadecimal characters encoding 32 bytes. Set the immutable
+`OPENTAG_RELAY_CONTENT_KEY_VERSION` to `v1` for a new installation. Generate the
+KEK and each other internal secret once through platform secret facilities,
+then reference the same values from both roles. Never generate keys per boot.
+
+The image prepares `/run/secrets` for UID/GID 10001 with mode 0700. The entry point
+writes mode-0400 regular files, consumes its injected secret variables, and
+passes only file references to the existing runtime. Existing files are reused
+only if their content, type, ownership, and permissions match; symlinks and
+conflicting files fail closed. Compose-mounted secrets are not overwritten.
+Runtime code still forbids inline `OPENTAG_RELAY_CONTENT_KEK`.
+
+The hosting platform and its administrators can access injected variables.
+Removing values from the application environment does not erase the platform's
+stored configuration. Store them only in the platform's protected variable
+settings; never commit them, put them in image build arguments, or copy live
+project secrets into a shared template.
+
+Back up PostgreSQL together with the exact KEK and key version. Container files
+are ephemeral; the platform's retained secret value is needed after redeploy.
+The pre-reset database remains unsupported. Use a separate fresh database and
+preserve the old recovery set as described in the main deployment runbook.
+
+## Local verification
+
+```sh
+docker build --build-arg OPENTAG_RELEASE_SHA=<full-source-sha> \
+  --file apps/control-plane/Dockerfile --tag opentag-control-plane:test .
+node scripts/test/control-plane-image-smoke.mjs opentag-control-plane:test
+docker run --rm --interactive --entrypoint node opentag-control-plane:test \
+  --input-type=module < scripts/release/audit-control-plane-image.mjs
+```
+
+The smoke uses an isolated Docker network, temporary PostgreSQL data, and fake
+provider credentials. It performs no real Slack/GitHub writes and removes its
+own containers and files. The audit sends only installed public dependency
+names and versions to npm's bulk advisory endpoint, and fails on registry
+errors or high/critical findings. It does not constitute an operating-system
+image vulnerability scan.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "smoke:openclaw-acp-conformance": "OPENTAG_RUN_OPENCLAW_ACP_CONFORMANCE=1 vitest run packages/runner/test/openclaw-acp-live-smoke.test.ts",
     "smoke:privacy": "node scripts/test/privacy-redaction-scan.mjs",
     "smoke:control-plane-compose:typecheck": "tsc -p scripts/test/tsconfig.control-plane-compose-smoke.json",
+    "smoke:control-plane-image": "node scripts/test/control-plane-image-smoke.mjs",
     "verify:delivery-fixtures": "vitest run packages/delivery-contract/test/corpus-verifier.test.ts packages/delivery-contract/test/canonical-fixtures.test.ts"
   },
   "devDependencies": {

--- a/scripts/release/audit-control-plane-image.mjs
+++ b/scripts/release/audit-control-plane-image.mjs
@@ -1,0 +1,43 @@
+// Run inside the disposable image: audit installed versions, not a newly
+// resolved lockfile. Only public dependency names and versions leave the image.
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const inventory = Object.create(null);
+async function collect(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) await collect(path);
+    else if (entry.isFile() && entry.name === "package.json") {
+      const { name, version } = JSON.parse(await readFile(path, "utf8"));
+      if (typeof name !== "string" || typeof version !== "string" || name.startsWith("@opentag/")) continue;
+      inventory[name] ??= [];
+      if (!inventory[name].includes(version)) inventory[name].push(version);
+    }
+  }
+}
+await collect("/workspace/apps/control-plane/node_modules");
+if (Object.keys(inventory).length < 1) throw new Error("image_audit_inventory_empty");
+const response = await fetch("https://registry.npmjs.org/-/npm/v1/security/advisories/bulk", {
+  method: "POST", headers: { "content-type": "application/json" },
+  body: JSON.stringify(inventory), signal: AbortSignal.timeout(30_000),
+});
+if (!response.ok) throw new Error(`image_audit_registry_failed:${response.status}`);
+const advisories = await response.json();
+if (!advisories || typeof advisories !== "object" || Array.isArray(advisories)) {
+  throw new Error("image_audit_response_invalid");
+}
+let blocking = false;
+let count = 0;
+for (const [name, entries] of Object.entries(advisories)) {
+  if (!inventory[name] || !Array.isArray(entries)) throw new Error("image_audit_response_invalid");
+  for (const entry of entries) {
+    if (!entry || !["info", "low", "moderate", "high", "critical"].includes(entry.severity)
+      || typeof entry.url !== "string") throw new Error("image_audit_response_invalid");
+    count += 1;
+    console.log(JSON.stringify({ package: name, severity: entry.severity, url: entry.url }));
+    blocking ||= ["high", "critical"].includes(entry.severity);
+  }
+}
+console.log(`Image audit: ${Object.keys(inventory).length} public packages; ${count} advisories.`);
+if (blocking) throw new Error("image_audit_high_or_critical_advisory");

--- a/scripts/test/control-plane-image-smoke.mjs
+++ b/scripts/test/control-plane-image-smoke.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { setTimeout as delay } from "node:timers/promises";
+
+const execute = promisify(execFile);
+const image = process.argv[2];
+if (!image || !/^[a-z0-9][a-z0-9./:@_-]+$/iu.test(image) || process.argv.length !== 3) {
+  throw new Error("Usage: node scripts/test/control-plane-image-smoke.mjs <image>");
+}
+const directory = await mkdtemp(join(tmpdir(), "opentag-image-smoke-"));
+const prefix = `opentag-image-smoke-${randomBytes(6).toString("hex")}`;
+const containers = [];
+let networkCreated = false;
+const secret = () => randomBytes(32).toString("hex");
+const command = ["node", "apps/control-plane/dist/index.js", "container"];
+const docker = async (...args) => {
+  try {
+    const result = await execute("docker", args, { timeout: 180_000, maxBuffer: 4 * 1024 * 1024 });
+    return result.stdout.trim();
+  } catch {
+    // Never echo env-file contents, database details, or arbitrary container logs.
+    throw new Error(`image_smoke_docker_${args[0]}_failed`);
+  }
+};
+const envFile = async (name, env) => {
+  const path = join(directory, name);
+  await writeFile(path, Object.entries(env).map(([key, value]) => `${key}=${value}`).join("\n") + "\n",
+    { mode: 0o600 });
+  return path;
+};
+const wait = async (probe) => {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (await probe()) return;
+    await delay(250);
+  }
+  throw new Error("image_smoke_wait_timeout");
+};
+const start = async (name, args) => {
+  const target = `${prefix}-${name}`;
+  await docker("run", "--detach", "--name", target, "--network", prefix, ...args);
+  containers.push(target);
+  return target;
+};
+let primaryError;
+try {
+  const inspect = JSON.parse(await docker("image", "inspect", image))[0];
+  assert.equal(inspect.Config.User, "opentag");
+  const revision = inspect.Config.Labels["org.opencontainers.image.revision"];
+  assert.match(revision, /^[a-f0-9]{40}$/u);
+  assert.ok(inspect.Config.Env.includes(`OPENTAG_RELEASE_SHA=${revision}`));
+  await docker("network", "create", "--internal", prefix);
+  networkCreated = true;
+  const password = secret();
+  const pgEnv = await envFile("postgres.env", { POSTGRES_USER: "opentag", POSTGRES_DB: "opentag",
+    POSTGRES_PASSWORD: password, PGDATA: "/var/lib/postgresql/data/pgdata" });
+  const pg = await start("postgres", ["--network-alias", "postgres", "--env-file", pgEnv,
+    "--tmpfs", "/var/lib/postgresql/data:rw", "postgres:17-alpine"]);
+  const env = {
+    DATABASE_URL: `postgresql://opentag:${password}@postgres:5432/opentag`,
+    OPENTAG_ENVIRONMENT: "staging", OPENTAG_PUBLIC_URL: "https://relay.example.test",
+    OPENTAG_BOOTSTRAP_ORGANIZATION_ID: "org_smoke", OPENTAG_BOOTSTRAP_ORGANIZATION_NAME: "Image smoke",
+    OPENTAG_BOOTSTRAP_PAIRING_TOKEN: secret(), OPENTAG_FENCING_TOKEN_SECRET: secret(),
+    OPENTAG_LOGIN_THROTTLE_SECRET: secret(), OPENTAG_RELAY_CONTENT_KEY_VERSION: "v1",
+    OPENTAG_CONTAINER_RELAY_CONTENT_KEK: secret(),
+    OPENTAG_CONTAINER_SLACK_SIGNING_SECRET: secret(), OPENTAG_CONTAINER_SLACK_BOT_TOKEN: `xoxb-${secret()}`,
+    OPENTAG_CONTAINER_CONTROL_PLANE_URL: "http://control-plane:3000",
+    OPENTAG_BOOTSTRAP_ADMIN_EMAIL: "owner@example.test", OPENTAG_BOOTSTRAP_ADMIN_NAME: "Owner",
+    OPENTAG_BOOTSTRAP_ADMIN_PASSWORD: secret(),
+    OPENTAG_SLACK_INSTALLATION_ID: "slack_primary", OPENTAG_SLACK_BINDING_ID: "slack_primary_binding",
+    OPENTAG_SLACK_ROUTE_IDENTITY: secret(), OPENTAG_SLACK_PROJECT_TARGET_ID: "github_primary",
+    OPENTAG_SLACK_TEAM_ID: "T_SMOKE", OPENTAG_SLACK_APP_ID: "A_SMOKE", OPENTAG_SLACK_CHANNEL_ID: "C_SMOKE",
+    OPENTAG_SLACK_BOT_USER_ID: "U_BOT", OPENTAG_SLACK_MEMBER_USER_IDS: "U_OWNER",
+  };
+  const file = await envFile("relay.env", env);
+  const jobsEnv = { ...env };
+  delete jobsEnv.OPENTAG_BOOTSTRAP_ADMIN_PASSWORD;
+  const jobsFile = await envFile("jobs.env", jobsEnv);
+  const jobs = await start("jobs", ["--env-file", jobsFile, image, ...command, "jobs"]);
+  await wait(async () => (await docker("logs", jobs)).includes("control_plane_container_waiting"));
+  assert.ok(!(await docker("logs", jobs)).includes("control_plane_container_starting"));
+  const api = await start("api", ["--network-alias", "control-plane", "--env-file", file,
+    image, ...command, "serve"]);
+  const ready = async () => {
+    try {
+      return (await docker("exec", api, "node", "--input-type=module", "-e",
+        "console.log((await fetch('http://127.0.0.1:3000/readyz',{signal:AbortSignal.timeout(3000)})).ok)")) === "true";
+    }
+    catch { return false; }
+  };
+  await wait(ready);
+  const capabilities = JSON.parse(await docker("exec", api, "node", "--input-type=module", "-e",
+    "console.log(JSON.stringify(await (await fetch('http://127.0.0.1:3000/v1/relay/capabilities')).json()))"));
+  assert.equal(capabilities.deployment.releaseSha, revision);
+  await wait(async () => (await docker("logs", jobs)).includes("control_plane_container_starting"));
+  const sql = (statement) => docker("exec", pg, "psql", "-U", "opentag", "-d", "opentag",
+    "-At", "-v", "ON_ERROR_STOP=1", "-c", statement);
+  const snapshot = () => sql(`SELECT json_build_object(
+    'owners',(SELECT count(*) FROM cp_membership WHERE role='owner'),
+    'bindings',(SELECT count(*) FROM cp_slack_binding),
+    'binding',(SELECT binding_digest FROM cp_slack_binding LIMIT 1),
+    'owner_hash',(SELECT password_hash FROM cp_operator LIMIT 1),
+    'migrations',(SELECT count(*) FROM control_plane_migrations))::text`);
+  const before = await snapshot();
+  assert.equal(JSON.parse(before).owners, 1);
+  assert.equal(JSON.parse(before).bindings, 1);
+  await docker("restart", api, jobs);
+  await wait(ready);
+  assert.equal(await snapshot(), before, "restart must preserve owner, binding, and migration identity");
+  assert.equal(JSON.parse(await docker("inspect", jobs))[0].State.Running, true);
+
+  await docker("stop", api, jobs);
+  await sql("INSERT INTO control_plane_migrations(name,checksum) VALUES('retired-schema.sql','test')");
+  const rejected = await start("rejected", ["--env-file", file, image, ...command, "serve"]);
+  assert.equal(await docker("wait", rejected), "1");
+  const logs = await docker("logs", rejected);
+  assert.ok(!logs.includes("control_plane_container_starting"));
+  for (const value of [password, env.OPENTAG_BOOTSTRAP_ADMIN_PASSWORD,
+    env.OPENTAG_CONTAINER_RELAY_CONTENT_KEK, env.OPENTAG_CONTAINER_SLACK_BOT_TOKEN]) {
+    assert.ok(!logs.includes(value), "failure logs must not expose secrets");
+  }
+  console.log(`Control Plane image smoke passed: ${revision}; bootstrap, jobs gate, restart, retired-schema rejection.`);
+} catch (error) {
+  primaryError = error;
+  for (const container of containers) {
+    try {
+      const result = await execute("docker", ["logs", container], { timeout: 5_000 });
+      for (const line of `${result.stdout}\n${result.stderr}`.split("\n")) {
+        if (/^control_plane_container_(failed|waiting|starting)\b/u.test(line)) console.error(line);
+      }
+    } catch { console.error("image_smoke_diagnostics_unavailable"); }
+  }
+} finally {
+  const failures = [];
+  for (const container of containers.reverse()) {
+    try { await docker("rm", "--force", "--volumes", container); }
+    catch { failures.push("container"); }
+  }
+  if (networkCreated) {
+    try { await docker("network", "rm", prefix); }
+    catch { failures.push("network"); }
+  }
+  await rm(directory, { recursive: true, force: true });
+  if (failures.length) throw new Error(`image_smoke_cleanup_failed:${failures.join(",")}`);
+}
+if (primaryError) throw primaryError;


### PR DESCRIPTION
## Summary

- Publish a versioned Control Plane OCI image to GHCR only after a successful `main` push CI run. Publish the exact tested image artifact without rebuilding; emit an image/source/digest receipt and check anonymous pull access.
- Add a closed `container serve|jobs` startup entry point for environment-injecting platforms. Reuse the existing migration and bootstrap commands, preserve file-backed secret custody, and wait for the matching Control Plane revision before starting jobs.
- Keep the Railway deployment wrapper in the separate `amplifthq/opentag-railway` repository. No business tables, Work/Effect protocol, general command execution, or new production dependencies are introduced.

## Boundaries and release risks

- This PR does not deploy Railway resources, publish from unmerged branches, or complete a live-provider canary. The first official image is produced only after merge and successful main CI.
- GHCR publication uses repository-scoped `GITHUB_TOKEN`; only the publish job receives `packages: write`. The first package may need its visibility set to public; a failed anonymous pull is not a usable public release.
- Source SHA is embedded in the image. Tags contain source SHA + publication run/attempt, and consumers pin the immutable digest. Initial platform: `linux/amd64`.
- Container-injected secrets are consumed into private files for UID 10001. Conflicting files, invalid secrets, failed initialization and stale relay revisions fail closed. The host platform still retains its configured variables; file adaptation does not hide secrets from hosting administrators.
- Existing Compose commands and mounts remain unchanged. The pre-reset database still has no in-place upgrade path. Bootstrap does not reset passwords or repair conflicting bindings.
- A full database/KEK backup is required before future upgrades. This is not an HA or zero-downtime migration promise.

## Validation

- Full build, lint, typecheck and Source App boundary check passed.
- PostgreSQL 17 + full repository tests: 1469 passed, 2 existing skipped.
- Publication-set consistency and CLI release-package verification passed.
- Local container image smoke passed for fresh bootstrap, same-version jobs gating, restart identity preservation and retired-schema refusal; final committed-image rerun is recorded in the follow-up verification comment.
- Actual installed image runtime inventory audit: 32 public packages, 0 advisories. This is an npm dependency audit, not an OS image vulnerability scan.
- GitHub Actions YAML syntax and pinned action references checked.

See `docs/control-plane-image-release.md` for publication receipts, container inputs, and recovery boundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a production-ready Control Plane container image supporting API and background job roles.
  - Added readiness checks, dependency waiting, restart handling, and persistent-state validation.
  - Added secure file-based secret injection for container deployments.
  - Added automated image publishing with immutable version and digest references.

- **Documentation**
  - Added deployment guidance, image release procedures, secret configuration, and local verification steps.

- **Quality Improvements**
  - Added automated smoke tests and dependency security auditing for published images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->