### PR TITLE
fix: respect Actions allowlist for image publication

### DIFF
--- a/.github/workflows/control-plane-image.yml
+++ b/.github/workflows/control-plane-image.yml
@@ -87,5 +87,27 @@ jobs:
         if: always()
         run: |
           if test -n "${OPENTAG_GHCR_DOCKER_CONFIG:-}"; then
-            docker --config "$OPENTAG_GHCR_DOCKER_CONFIG" logout ghcr.io
+            ghcr_cleanup_root="$(cd -- "${RUNNER_TEMP:?}" && pwd -P)"
+            ghcr_cleanup_parent="$(cd -- "$(dirname -- "$OPENTAG_GHCR_DOCKER_CONFIG")" && pwd -P)"
+            ghcr_cleanup_name="${OPENTAG_GHCR_DOCKER_CONFIG##*/}"
+            if [[ "$ghcr_cleanup_parent" != "$ghcr_cleanup_root" ||
+                  ! "$ghcr_cleanup_name" =~ ^opentag-ghcr\.[a-zA-Z0-9]{6}$ ||
+                  -L "$OPENTAG_GHCR_DOCKER_CONFIG" ]]; then
+              printf '%s\n' '::error::Refusing unsafe registry cleanup target.' >&2
+              exit 1
+            fi
+            if test ! -e "$OPENTAG_GHCR_DOCKER_CONFIG"; then
+              exit 0
+            fi
+            if [[ ! -d "$OPENTAG_GHCR_DOCKER_CONFIG" || ! -O "$OPENTAG_GHCR_DOCKER_CONFIG" ]]; then
+              printf '%s\n' '::error::Registry cleanup target is not an owned directory.' >&2
+              exit 1
+            fi
+            # EXIT also covers logout failure; INT/TERM request a normal exit.
+            # SIGKILL and runner loss cannot execute a shell cleanup handler.
+            trap 'rm -rf -- "$OPENTAG_GHCR_DOCKER_CONFIG"' EXIT
+            trap 'exit 130' INT
+            trap 'exit 143' TERM
+            docker --config "$OPENTAG_GHCR_DOCKER_CONFIG" logout ghcr.io ||
+              printf '%s\n' '::warning::Registry logout failed; removing its temporary configuration.' >&2
           fi

--- a/.github/workflows/control-plane-image.yml
+++ b/.github/workflows/control-plane-image.yml
@@ -46,15 +46,16 @@ jobs:
           test "$(docker image inspect opentag-control-plane:verified --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$SOURCE_SHA"
           test "$(docker image inspect opentag-control-plane:verified --format '{{.Config.User}}')" = opentag
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ghcr_config="$(mktemp -d "$RUNNER_TEMP/opentag-ghcr.XXXXXX")"
+          printf 'OPENTAG_GHCR_DOCKER_CONFIG=%s\n' "$ghcr_config" >> "$GITHUB_ENV"
+          printf '%s' "$GHCR_TOKEN" | docker --config "$ghcr_config" login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
       - name: Publish without rebuilding or overwriting a release tag
         run: |
           docker tag opentag-control-plane:verified "$IMAGE:$IMAGE_TAG"
-          docker push "$IMAGE:$IMAGE_TAG"
+          docker --config "$OPENTAG_GHCR_DOCKER_CONFIG" push "$IMAGE:$IMAGE_TAG"
           docker image inspect "$IMAGE:$IMAGE_TAG" > image-inspect.json
           node --input-type=module <<'NODE'
           import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
@@ -82,3 +83,9 @@ jobs:
           reference="$(node -p "const r=require('./control-plane-image.json'); r.image+'@'+r.digest")"
           anonymous_config="$(mktemp -d)"
           docker --config "$anonymous_config" pull "$reference"
+      - name: Remove registry credentials
+        if: always()
+        run: |
+          if test -n "${OPENTAG_GHCR_DOCKER_CONFIG:-}"; then
+            docker --config "$OPENTAG_GHCR_DOCKER_CONFIG" logout ghcr.io
+          fi

--- a/apps/control-plane/test/deployment-contract.test.ts
+++ b/apps/control-plane/test/deployment-contract.test.ts
@@ -15,6 +15,8 @@ describe("Control Plane deployment contract", () => {
     expect(workflow).toContain("--password-stdin");
     expect(workflow).toContain('docker --config "$OPENTAG_GHCR_DOCKER_CONFIG" push');
     expect(workflow).toContain('docker --config "$OPENTAG_GHCR_DOCKER_CONFIG" logout ghcr.io');
+    expect(workflow).toContain('rm -rf -- "$OPENTAG_GHCR_DOCKER_CONFIG"');
+    expect(workflow).toContain("trap 'exit 143' TERM");
     expect(workflow).not.toMatch(/--password(?:=|\s)/u);
   });
 

--- a/apps/control-plane/test/deployment-contract.test.ts
+++ b/apps/control-plane/test/deployment-contract.test.ts
@@ -7,6 +7,17 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../.
 const read = (path: string) => readFile(resolve(repositoryRoot, path), "utf8");
 
 describe("Control Plane deployment contract", () => {
+  it("keeps publication actions within the repository's selected-actions policy", async () => {
+    const workflow = await read(".github/workflows/control-plane-image.yml");
+    for (const match of workflow.matchAll(/uses: ([^\s]+)/gu)) {
+      expect(match[1]).toMatch(/^(?:(?:actions|github|amplifthq)\/[^@]+|pnpm\/action-setup)@[a-f0-9]{40}$/u);
+    }
+    expect(workflow).toContain("--password-stdin");
+    expect(workflow).toContain('docker --config "$OPENTAG_GHCR_DOCKER_CONFIG" push');
+    expect(workflow).toContain('docker --config "$OPENTAG_GHCR_DOCKER_CONFIG" logout ghcr.io');
+    expect(workflow).not.toMatch(/--password(?:=|\s)/u);
+  });
+
   it("publishes only the tested image from a successful main push", async () => {
     const [ci, publish] = await Promise.all([
       read(".github/workflows/ci.yml"), read(".github/workflows/control-plane-image.yml"),

--- a/apps/control-plane/test/image-publication-cleanup.test.ts
+++ b/apps/control-plane/test/image-publication-cleanup.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const workflowPath = fileURLToPath(new URL("../../../.github/workflows/control-plane-image.yml", import.meta.url));
+const directories: string[] = [];
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+const fixture = async () => {
+  const root = await mkdtemp(join(tmpdir(), "opentag-cleanup-test-"));
+  directories.push(root);
+  const target = await mkdtemp(join(root, "opentag-ghcr."));
+  await writeFile(join(target, "config.json"), '{"auths":{"ghcr.io":{"auth":"test-only"}}}', { mode: 0o600 });
+  return { root, target };
+};
+
+async function runCleanup(root: string, target: string | undefined, scenario = "success") {
+  const workflow = await readFile(workflowPath, "utf8");
+  const match = workflow.match(/      - name: Remove registry credentials\n        if: always\(\)\n        run: \|\n((?:          [^\n]*\n?)*)/u);
+  expect(match, "the test must execute the actual always-run cleanup step").not.toBeNull();
+  const script = match![1]!.replace(/^          /gmu, "");
+  const env = { ...process.env, RUNNER_TEMP: root,
+    OPENTAG_GHCR_DOCKER_CONFIG: target ?? "", OPENTAG_TEST_LOGOUT_SCENARIO: scenario };
+  return spawnSync("bash", ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", `
+docker() {
+  case "$OPENTAG_TEST_LOGOUT_SCENARIO" in
+    failure) return 7 ;;
+    INT|TERM) kill -s "$OPENTAG_TEST_LOGOUT_SCENARIO" "$$" ;;
+  esac
+}
+${script}`], { env, encoding: "utf8", timeout: 3_000 });
+}
+
+describe("publication credential cleanup", () => {
+  it.each(["success", "failure", "INT", "TERM"])(
+    "removes credential files after logout %s", async (scenario) => {
+      const { root, target } = await fixture();
+      const result = await runCleanup(root, target, scenario);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(scenario === "INT" ? 130 : scenario === "TERM" ? 143 : 0);
+      await expect(stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+      expect((await stat(root)).isDirectory()).toBe(true);
+      expect(`${result.stdout}${result.stderr}`).not.toContain("test-only");
+    },
+  );
+
+  it("accepts missing configuration and already-removed temporary directories", async () => {
+    const { root, target } = await fixture();
+    expect((await runCleanup(root, undefined)).status).toBe(0);
+    expect((await stat(target)).isDirectory()).toBe(true);
+    await rm(target, { recursive: true });
+    expect((await runCleanup(root, target)).status).toBe(0);
+  });
+
+  it("refuses the runner root, unrelated paths, traversal and symlink targets", async () => {
+    const first = await fixture();
+    const outside = await fixture();
+    const linked = join(first.root, "opentag-ghcr.linked");
+    await symlink(outside.target, linked);
+    const nested = join(first.target, "opentag-ghcr.nested");
+    await mkdir(nested);
+    for (const target of [first.root, outside.target, resolve(first.root, ".."), linked, nested]) {
+      const result = await runCleanup(first.root, target);
+      expect(result.status).not.toBe(0);
+      expect(result.error).toBeUndefined();
+      expect(await readFile(join(outside.target, "config.json"), "utf8")).toContain("test-only");
+      expect(await readFile(join(first.target, "config.json"), "utf8")).toContain("test-only");
+    }
+  });
+});

--- a/apps/control-plane/test/image-publication-cleanup.test.ts
+++ b/apps/control-plane/test/image-publication-cleanup.test.ts
@@ -11,8 +11,11 @@ afterEach(async () => {
   await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
 });
 const fixture = async () => {
-  const root = await mkdtemp(join(tmpdir(), "opentag-cleanup-test-"));
-  directories.push(root);
+  const sandbox = await mkdtemp(join(tmpdir(), "opentag-cleanup-test-"));
+  directories.push(sandbox);
+  // Even a broken guard must keep the traversal probe inside disposable state.
+  const root = join(sandbox, "runner");
+  await mkdir(root, { mode: 0o700 });
   const target = await mkdtemp(join(root, "opentag-ghcr."));
   await writeFile(join(target, "config.json"), '{"auths":{"ghcr.io":{"auth":"test-only"}}}', { mode: 0o600 });
   return { root, target };


### PR DESCRIPTION
## Summary

Fix the first post-merge Control Plane image publication startup failure without changing the repository's Actions allowlist.

GitHub rejected `docker/login-action` before any job started: this repository permits GitHub-owned actions, Amplift-owned actions, and `pnpm/action-setup@*`, with full-SHA pinning. The merged source CI passed, but the separate `workflow_run` publication workflow could not start.

Failure: https://github.com/amplifthq/opentag/actions/runs/34218001548
Successful main CI: https://github.com/amplifthq/opentag/actions/runs/34217368631

## Changes

- Replace the disallowed login action with native `docker login --password-stdin`, using only the existing workflow `GITHUB_TOKEN`.
- Keep registry authentication in a dedicated temporary Docker configuration, reuse it only for push, and log out in an `always()` cleanup step. Anonymous pull verification remains unauthenticated.
- Add a regression test for the repository's selected-actions policy and safe token transport.

No application, database, template, permissions, or allowlist changes. Main-only successful-CI gating, exact tested-image reuse, unique release tags, receipts, and public-pull checks remain unchanged.

## Validation

- The new allowlist regression was run against the previous workflow and failed on `docker/login-action`.
- After the fix, all 15 deployment contract tests passed.
- Workflow YAML and every shell step passed syntax validation.
- `actionlint` v1.7.12 passed (`-shellcheck=`; shell syntax was checked separately with `bash -n`).
- `git diff --check` passed.

The original published-image workflow still has `startup_failure`; no registry push occurred in that run. Merge through normal review, then verify the new main CI and actual publication before importing an image digest into `amplifthq/opentag-railway#1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved container image publishing with temporary registry credentials that are securely removed afterward.
  - Added safeguards to prevent credential leakage and unsafe cleanup targets.

- **Chores**
  - Hardened automated image publishing workflows, including cleanup handling during interruptions or failures.

- **Tests**
  - Added coverage for credential cleanup, interrupted workflows, missing or unsafe paths, and secure authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->