### PR TITLE
fix: align attempt workspaces and approval feedback

### DIFF
--- a/apps/control-plane/src/modules/console-reads/index.ts
+++ b/apps/control-plane/src/modules/console-reads/index.ts
@@ -76,9 +76,9 @@ function teammateFromRow(row: TeammateRow,
     ...(row.active_publication_mode?{publication_mode:row.active_publication_mode}:{}),has_candidate:row.active_has_candidate}) : undefined;
   const publicationPending = phase === "publication_pending";
   const waitingForApproval = feedback?.approval?.state === "waiting" || activeWork?.state === "needs_approval";
-  const presentation = activeWork && (publicationPending || waitingForApproval)
+  const presentation = activeWork && (publicationPending || waitingForApproval || feedback?.approval)
     ? composeTeamRelayThreadProjection({runId:activeWork.runId,generation:row.active_run_attempt_number??1,
-        state:publicationPending?"publication_pending":"waiting_for_approval",controls:[],
+        state:publicationPending?"publication_pending":waitingForApproval?"waiting_for_approval":"running",controls:[],
         ...(feedback?.approval?{approval:feedback.approval}:{}),
         ...(feedback?.publication?{publication:feedback.publication}:{})}) : undefined;
   if (!row.configured_project_target_id) {
@@ -104,7 +104,7 @@ function teammateFromRow(row: TeammateRow,
   } else if (waitingForApproval) {
     workState = "needs_attention";
     reason = presentation!.summary;
-  } else if (!row.readiness_expires_at) {
+  } else if (!row.readiness_expires_at && !(activeWork && row.active_attempt_valid)) {
     workState = "runner_offline";
     reason = activeWork
       ? `Runner readiness expired while Run ${activeWork.runId} remains ${activeWork.state}.`
@@ -118,7 +118,7 @@ function teammateFromRow(row: TeammateRow,
     reason = `Run ${activeWork.runId} has no current valid Attempt lease.`;
   } else if (activeWork?.state === "assigned" || activeWork?.state === "running") {
     workState = "working";
-    reason = `Run ${activeWork.runId} is ${activeWork.state} on the paired Runner.`;
+    reason = presentation?.summary ?? `Run ${activeWork.runId} is ${activeWork.state} on the paired Runner.`;
   } else if (activeWork) {
     workState = "needs_attention";
     reason = `Run ${activeWork.runId} has an unexpected active state: ${activeWork.state}.`;
@@ -244,6 +244,12 @@ export function createConsoleReadModel(input: { pool: Pool }) {
                       AND attempt.attempt_number = run.current_attempt_number
                       AND attempt.runner_id = run.runner_id
                       AND attempt.credential_id = runner.current_credential_id
+                      AND EXISTS (SELECT 1 FROM cp_runner_credential current_credential
+                        WHERE current_credential.organization_id=runner.organization_id
+                          AND current_credential.runner_id=runner.runner_id
+                          AND current_credential.credential_id=runner.current_credential_id
+                          AND current_credential.credential_generation=runner.credential_generation
+                          AND current_credential.revoked_at IS NULL)
                       AND attempt.lease_expires_at > clock_timestamp()
                       AND (
                         (run.state = 'assigned' AND attempt.state = 'claimed')

--- a/apps/control-plane/src/modules/console-reads/index.ts
+++ b/apps/control-plane/src/modules/console-reads/index.ts
@@ -1,6 +1,8 @@
 import type { Pool } from "pg";
-import type { TeammateView, TeammateWorkState } from "@opentag/core";
+import { composeTeamRelayThreadProjection, type TeammateView, type TeammateWorkState } from "@opentag/core";
 import type { ConsolePrincipal } from "../identity/index.js";
+import { projectRunPhase, type CanonicalRunStatus } from "../hosted-runs/index.js";
+import { readRunThreadFeedback } from "../hosted-runs/thread-feedback.js";
 
 function boundedLimit(value: number | undefined): number {
   if (value === undefined) return 50;
@@ -41,9 +43,13 @@ type TeammateRow = {
   active_run_updated_at: Date | null;
   active_run_count: number;
   active_attempt_valid: boolean;
+  active_run_attempt_number: number | null;
+  active_publication_mode: string | null;
+  active_has_candidate: boolean;
 };
 
-function teammateFromRow(row: TeammateRow): TeammateView {
+function teammateFromRow(row: TeammateRow,
+  feedback?: Awaited<ReturnType<typeof readRunThreadFeedback>>): TeammateView {
   const activeWork = row.active_run_id && row.active_run_state && row.active_run_updated_at
     ? {
         runId: row.active_run_id,
@@ -66,6 +72,15 @@ function teammateFromRow(row: TeammateRow): TeammateView {
 
   let workState: TeammateWorkState;
   let reason: string;
+  const phase = activeWork ? projectRunPhase({state:activeWork.state as CanonicalRunStatus,
+    ...(row.active_publication_mode?{publication_mode:row.active_publication_mode}:{}),has_candidate:row.active_has_candidate}) : undefined;
+  const publicationPending = phase === "publication_pending";
+  const waitingForApproval = feedback?.approval?.state === "waiting" || activeWork?.state === "needs_approval";
+  const presentation = activeWork && (publicationPending || waitingForApproval)
+    ? composeTeamRelayThreadProjection({runId:activeWork.runId,generation:row.active_run_attempt_number??1,
+        state:publicationPending?"publication_pending":"waiting_for_approval",controls:[],
+        ...(feedback?.approval?{approval:feedback.approval}:{}),
+        ...(feedback?.publication?{publication:feedback.publication}:{})}) : undefined;
   if (!row.configured_project_target_id) {
     workState = "setup_required";
     reason = "This teammate has no GitHub Project Target.";
@@ -78,12 +93,17 @@ function teammateFromRow(row: TeammateRow): TeammateView {
   } else if (row.active_run_count > 1) {
     workState = "needs_attention";
     reason = "More than one active Run is bound to this teammate.";
-  } else if (activeWork?.outcomeState === "outcome_unknown"
-    || activeWork?.state === "needs_approval") {
+  } else if (activeWork?.outcomeState === "outcome_unknown") {
     workState = "needs_attention";
-    reason = activeWork.outcomeState === "outcome_unknown"
-      ? `Run ${activeWork.runId} has an outcome that requires reconciliation.`
-      : `Run ${activeWork.runId} is waiting for a human decision.`;
+    reason = `Run ${activeWork.runId} has an outcome that requires reconciliation.`;
+  } else if (publicationPending) {
+    const publicationState=feedback?.publication?.state;
+    workState = !publicationState || ["requested","attention","outcome_unknown","cancelled_before_permit"].includes(publicationState)
+      ? "needs_attention" : !row.readiness_expires_at ? "runner_offline" : "working";
+    reason = presentation!.summary;
+  } else if (waitingForApproval) {
+    workState = "needs_attention";
+    reason = presentation!.summary;
   } else if (!row.readiness_expires_at) {
     workState = "runner_offline";
     reason = activeWork
@@ -150,6 +170,9 @@ export function createConsoleReadModel(input: { pool: Pool }) {
                 active_run.state AS active_run_state,
                 active_run.outcome_state AS active_run_outcome_state,
                 active_run.updated_at AS active_run_updated_at,
+                active_run.current_attempt_number AS active_run_attempt_number,
+                active_run.publication_mode AS active_publication_mode,
+                COALESCE(active_run.has_candidate,false) AS active_has_candidate,
                 COALESCE(active_run.active_run_count, 0)::int AS active_run_count,
                 COALESCE(active_run.active_attempt_valid, false) AS active_attempt_valid
          FROM active_slack slack
@@ -208,6 +231,10 @@ export function createConsoleReadModel(input: { pool: Pool }) {
          ) readiness ON true
          LEFT JOIN LATERAL (
            SELECT run.run_id, run.state, run.outcome_state, run.updated_at,
+                  run.current_attempt_number,run.publication_mode,
+                  EXISTS (SELECT 1 FROM cp_publication_candidate candidate
+                    WHERE candidate.organization_id=run.organization_id AND candidate.run_id=run.run_id
+                      AND candidate.attempt_number=run.current_attempt_number) AS has_candidate,
                   count(*) OVER()::int AS active_run_count,
                   EXISTS (
                     SELECT 1
@@ -239,7 +266,12 @@ export function createConsoleReadModel(input: { pool: Pool }) {
          ORDER BY slack.team_id, slack.channel_id, slack.binding_id`,
         [principal.organizationId],
       );
-      return result.rows.map(teammateFromRow);
+      return Promise.all(result.rows.map(async row => {
+        const feedback=row.active_run_id && row.active_run_attempt_number
+          ? await readRunThreadFeedback(input.pool,{organizationId:principal.organizationId,
+              runId:row.active_run_id,attemptNumber:row.active_run_attempt_number}) : undefined;
+        return teammateFromRow(row,feedback);
+      }));
     },
 
     async overview(principal: ConsolePrincipal) {

--- a/apps/control-plane/src/modules/effects/index.ts
+++ b/apps/control-plane/src/modules/effects/index.ts
@@ -294,6 +294,18 @@ function externalResource(observation: {
   } as const;
 }
 
+/** Projection reads reuse the same validated Effect view as command responses. */
+export async function readRunPublicationEffect(pool: Pool, input: {
+  organizationId: string; runId: string; attemptNumber: number;
+}): Promise<EffectViewV1 | undefined> {
+  const result = await pool.query<EffectRow>(
+    `SELECT * FROM cp_effect WHERE organization_id=$1 AND run_id=$2
+       AND run_attempt_number=$3 AND effect_kind='github.create_draft_pull_request'
+     ORDER BY created_at DESC,effect_id DESC LIMIT 1`,
+    [input.organizationId,input.runId,input.attemptNumber]);
+  return result.rows[0] ? projectEffect(result.rows[0]) : undefined;
+}
+
 function projectEffect(row: EffectRow): EffectViewV1 {
   const base = {
     effectId: row.effect_id,

--- a/apps/control-plane/src/modules/hosted-runs/index.ts
+++ b/apps/control-plane/src/modules/hosted-runs/index.ts
@@ -298,9 +298,9 @@ function terminalKind(state: HostedRunRow["state"]): TerminalKind | null {
     : null;
 }
 
-function projectRun(run: Pick<HostedRunRow, "state" | "queue_claim_deadline" | "outcome_state">
-  & { publication_mode?: string; has_candidate?: boolean }): HostedRunProjection {
-  const status = run.state === "queued" ? "waiting_for_runner"
+export function projectRunPhase(run: Pick<HostedRunRow, "state">
+  & { publication_mode?: string; has_candidate?: boolean }): HostedRunProjection["status"] {
+  return run.state === "queued" ? "waiting_for_runner"
     : run.state === "needs_approval" ? "waiting_for_approval"
     : run.state === "succeeded" && run.publication_mode === "proposal_only"
       ? "proposal_ready"
@@ -309,7 +309,11 @@ function projectRun(run: Pick<HostedRunRow, "state" | "queue_claim_deadline" | "
       : run.state === "running" && run.publication_mode === "pull_request" && run.has_candidate
         ? "publication_pending"
       : run.state;
-  return { canonicalStatus: run.state, status,
+}
+
+function projectRun(run: Pick<HostedRunRow, "state" | "queue_claim_deadline" | "outcome_state">
+  & { publication_mode?: string; has_candidate?: boolean }): HostedRunProjection {
+  return { canonicalStatus: run.state, status: projectRunPhase(run),
     queueClaimDeadline: run.queue_claim_deadline.toISOString(),
     outcome: run.outcome_state };
 }

--- a/apps/control-plane/src/modules/hosted-runs/thread-feedback.ts
+++ b/apps/control-plane/src/modules/hosted-runs/thread-feedback.ts
@@ -1,0 +1,24 @@
+import type { Pool } from "pg";
+import { PermissionResolutionReceiptEnvelopeV1Schema } from "@opentag/control-protocol";
+import { readRunPublicationEffect } from "../effects/index.js";
+
+/** Shared, read-only approval facts for Console and channel presentation. */
+export async function readRunThreadFeedback(pool: Pool, input: {
+  organizationId: string; runId: string; attemptNumber: number;
+}) {
+  const permissions = await pool.query<{state:string;current_receipt:unknown}>(
+    `SELECT state,current_receipt FROM cp_permission_request
+     WHERE organization_id=$1 AND run_id=$2 AND attempt_number=$3
+       AND (state='waiting' OR current_receipt->'payload'->>'decision' IN ('allow_once','deny'))
+     ORDER BY created_at DESC,permission_request_id DESC LIMIT 1`,
+    [input.organizationId,input.runId,input.attemptNumber]);
+  const permission=permissions.rows[0];
+  const receipt=permission?PermissionResolutionReceiptEnvelopeV1Schema.parse(permission.current_receipt):undefined;
+  if(receipt&&(receipt.organizationId!==input.organizationId||receipt.runId!==input.runId
+    ||receipt.attempt.attemptNumber!==input.attemptNumber||receipt.payload.state!==permission!.state)){
+    throw new Error("projection_permission_receipt_mismatch");
+  }
+  const approval=receipt&&["waiting","authorized","denied"].includes(receipt.payload.state)
+    ? {state:receipt.payload.state as "waiting"|"authorized"|"denied",actionDescriptor:receipt.payload.actionDescriptor}:undefined;
+  return {approval,approvalRef:receipt?.payload.permissionRequestId,publication:await readRunPublicationEffect(pool,input)};
+}

--- a/apps/control-plane/src/modules/provider-delivery/feedback-timing.ts
+++ b/apps/control-plane/src/modules/provider-delivery/feedback-timing.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { isCredentialSafeText } from "@opentag/core";
+
+const id = z.string().min(1).max(256).regex(/^[a-zA-Z0-9_:.-]+$/u).refine(isCredentialSafeText);
+export const FeedbackTimingSchema = z.object({
+  stage:z.enum(["approval_committed","projection_enqueued","delivery_started","delivery_settled"]),
+  runId:id,operationId:id,approvalRef:id.optional(),at:z.string().datetime(),
+  durationMs:z.number().nonnegative().nullable(),queueMs:z.number().nonnegative().nullable().optional(),
+  result:z.enum(["authorized","denied","queued","begun","accepted","rejected","outcome_unknown","attention"]).optional(),
+}).strict();
+
+export function feedbackElapsedMs(start:number,end:number):number|null {
+  return Number.isFinite(start)&&Number.isFinite(end)&&end>=start?Math.round(end-start):null;
+}
+
+/** Content-free diagnostics only. Logging can never change an approval or delivery outcome. */
+export function logFeedbackTiming(input:z.infer<typeof FeedbackTimingSchema>,logger:Pick<Console,"info"|"warn">=console):boolean {
+  try {
+    const parsed=FeedbackTimingSchema.safeParse(input);
+    if(!parsed.success){logger.warn("control_plane_feedback_timing_invalid");return false;}
+    logger.info(JSON.stringify({event:"control_plane_feedback_timing",...parsed.data}));
+    return true;
+  }catch{return false;}
+}

--- a/apps/control-plane/src/modules/provider-delivery/repository.ts
+++ b/apps/control-plane/src/modules/provider-delivery/repository.ts
@@ -7,9 +7,11 @@ import { DELIVERY_ERROR_CODES, DeliveryIntentV2Schema, deliveryCurrentTruthDescr
   type ExpectedDeliveryOwner, type StoredDeliveryIntent } from "@opentag/delivery-contract";
 import type { DeliveryKernelRepository } from "@opentag/delivery-runtime";
 import type { Pool, PoolClient } from "pg";
+import { feedbackElapsedMs, logFeedbackTiming } from "./feedback-timing.js";
 
 type RelayOwner = Pick<ExpectedDeliveryOwner, "runtimeOwnerId" | "runtimeGeneration" | "schemaGeneration">;
 type Row = { intent_id: string; journal_intent_digest: string; intent: unknown; payload: unknown;
+  run_id:string|null;created_at:Date;begun_at:Date|null;
   organization_id: string;
   payload_digest: string; presentation_phase: string; current_truth_key: string;
   projection_revision: number | null;
@@ -327,7 +329,9 @@ export function createPostgresDeliveryRepository(options: { pool: Pool; owner: R
       return result.rowCount === 1;
     },
     async markBegin(input) {
-      const at = now(); return withTx(async (client) => {
+      const at = now(); const started=performance.now();
+      let timing:Parameters<typeof logFeedbackTiming>[0]|undefined;
+      const accepted=await withTx(async (client) => {
         const selected = await client.query<Row & { deadline_at: Date }>(
           "SELECT * FROM cp_provider_delivery_intent WHERE intent_id=$1 FOR UPDATE", [input.intentId]);
         const row = selected.rows[0];
@@ -346,8 +350,15 @@ export function createPostgresDeliveryRepository(options: { pool: Pool; owner: R
           begun_at=$5,updated_at=$5 WHERE intent_id=$6 AND revision=$7 RETURNING *`,
         [input.installationBeginMarkerId, input.installationBeginMarkerDigest,
           input.scopeBeginMarkerId, input.scopeBeginMarkerDigest, at, input.intentId, input.revision]);
+        if(result.rows[0]&&row.run_id&&row.provider_id==="slack"&&row.projection_purpose==="anchor_update"){
+          timing={stage:"delivery_started",runId:row.run_id,operationId:row.intent_id,
+            at:at.toISOString(),durationMs:feedbackElapsedMs(started,performance.now()),
+            queueMs:feedbackElapsedMs(new Date(row.created_at).getTime(),at.getTime()),result:"begun"};
+        }
         return result.rows[0] ? begun(result.rows[0], input.leaseFence) : null;
       });
+      if(timing)logFeedbackTiming(timing);
+      return accepted;
     },
     async settleOrReadTerminal(input: DeliverySettlementInput) {
       if (!SHA256.test(input.evidenceDigest)) throw new Error("evidenceDigest must be a sha256 digest");
@@ -360,7 +371,8 @@ export function createPostgresDeliveryRepository(options: { pool: Pool; owner: R
           || input.externalResourceId.length > 512 || !SHA256.test(input.externalResourceDigest!))))
         throw new Error("external resource identity contract invalid");
       const recordedAt = input.outcomeRecordedAt ? new Date(input.outcomeRecordedAt) : now();
-      return withTx(async (client) => {
+      let timing:Parameters<typeof logFeedbackTiming>[0]|undefined;
+      const accepted=await withTx(async (client) => {
         const selected = await client.query<Row>(
           "SELECT * FROM cp_provider_delivery_intent WHERE intent_id=$1 FOR UPDATE", [input.intentId]);
         const row = selected.rows[0];
@@ -386,8 +398,16 @@ export function createPostgresDeliveryRepository(options: { pool: Pool; owner: R
           input.externalResourceDigest ?? null, input.externalResourceId ?? null,
           recordedAt, input.intentId, input.revision]);
         if (!result.rows[0]) throw new Error(`delivery settlement tuple conflict for attempt ${input.attemptId}`);
+        if(row.run_id&&row.provider_id==="slack"&&row.projection_purpose==="anchor_update"){
+          timing={stage:"delivery_settled",runId:row.run_id,operationId:row.intent_id,
+            at:recordedAt.toISOString(),durationMs:row.begun_at
+              ?feedbackElapsedMs(new Date(row.begun_at).getTime(),recordedAt.getTime()):null,
+            result:input.outcome};
+        }
         return settlement(result.rows[0], input.leaseFence);
       });
+      if(timing)logFeedbackTiming(timing);
+      return accepted;
     },
     async finalizeStrandedBegun(input) {
       const result = await options.pool.query(`UPDATE cp_provider_delivery_intent SET state='outcome_unknown',

--- a/apps/control-plane/src/modules/provider-delivery/team-relay-projection.ts
+++ b/apps/control-plane/src/modules/provider-delivery/team-relay-projection.ts
@@ -8,6 +8,7 @@ import type { Pool } from "pg";
 import type { HostedRunCoordinator } from "../hosted-runs/index.js";
 import { readExactDeliveryAnchor } from "./repository.js";
 import { z } from "zod";
+import { PermissionResolutionReceiptEnvelopeV1Schema } from "@opentag/control-protocol";
 
 const hash = (value: unknown) => `sha256:${createHash("sha256")
   .update(canonicalJsonStringify(value)).digest("hex")}`;
@@ -87,8 +88,26 @@ export function createTeamRelayProjectionService(input: { pool: Pool; hosted: Ho
     const controls = issuedControls.filter((control) => state === "publication_pending"
       ? control.kind === "status" || control.kind === "cancel" || control.kind === "effect_approve"
       : control.kind !== "effect_approve").slice(0, 4);
+    // Read durable permission truth, not the consumed/unconsumed projection copy.
+    const permissions = await input.pool.query<{ state: string; current_receipt: unknown }>(
+      `SELECT state,current_receipt FROM cp_permission_request
+       WHERE organization_id=$1 AND run_id=$2 AND attempt_number=$3
+         AND (state='waiting' OR current_receipt->'payload'->>'decision' IN ('allow_once','deny'))
+       ORDER BY created_at DESC,permission_request_id DESC LIMIT 1`,
+      [command.organizationId,command.runId,generation]);
+    const permission = permissions.rows[0];
+    const receipt = permission
+      ? PermissionResolutionReceiptEnvelopeV1Schema.parse(permission.current_receipt) : undefined;
+    if (receipt && (receipt.organizationId !== command.organizationId || receipt.runId !== command.runId
+      || receipt.attempt.attemptNumber !== generation || receipt.payload.state !== permission!.state)) {
+      throw new Error("projection_permission_receipt_mismatch");
+    }
+    const approval = receipt && ["waiting", "authorized", "denied"].includes(receipt.payload.state)
+      ? { state: receipt.payload.state as "waiting" | "authorized" | "denied",
+          actionDescriptor: receipt.payload.actionDescriptor } : undefined;
     const presentation = composeTeamRelayThreadProjection({ runId: command.runId, generation,
       state: state as Parameters<typeof composeTeamRelayThreadProjection>[0]["state"], controls,
+      ...(approval ? { approval } : {}),
       providerDelivery: { state: deliveryState,
         ...(deliveryErrorCode ? { reasonCode: deliveryErrorCode as any } : {}) } });
     const text = renderSlackTeamRelayProjection(presentation);

--- a/apps/control-plane/src/modules/provider-delivery/team-relay-projection.ts
+++ b/apps/control-plane/src/modules/provider-delivery/team-relay-projection.ts
@@ -9,6 +9,8 @@ import type { HostedRunCoordinator } from "../hosted-runs/index.js";
 import { readExactDeliveryAnchor } from "./repository.js";
 import { z } from "zod";
 import { PermissionResolutionReceiptEnvelopeV1Schema } from "@opentag/control-protocol";
+import { readRunPublicationEffect } from "../effects/index.js";
+import type { DurableJobQueue } from "../jobs/index.js";
 
 const hash = (value: unknown) => `sha256:${createHash("sha256")
   .update(canonicalJsonStringify(value)).digest("hex")}`;
@@ -16,6 +18,7 @@ type Enqueue = { enqueue(input: { intent: DeliveryIntentV2; providerRequest: obj
   phase: "received" | "running" | "terminal"; frozenDeadline: string }): Promise<unknown> };
 
 export function createTeamRelayProjectionService(input: { pool: Pool; hosted: HostedRunCoordinator;
+  jobs: Pick<DurableJobQueue, "enqueue">;
   producer: Enqueue; clock: { now(): Date };
   deliveryOwner?: Pick<ExpectedDeliveryOwner,"runtimeOwnerId"|"runtimeGeneration"|"schemaGeneration">;
   controls?: { issueProjectionControls(input: { organizationId: string; runId: string;
@@ -105,9 +108,12 @@ export function createTeamRelayProjectionService(input: { pool: Pool; hosted: Ho
     const approval = receipt && ["waiting", "authorized", "denied"].includes(receipt.payload.state)
       ? { state: receipt.payload.state as "waiting" | "authorized" | "denied",
           actionDescriptor: receipt.payload.actionDescriptor } : undefined;
+    const publication = await readRunPublicationEffect(input.pool, {
+      organizationId: command.organizationId, runId: command.runId, attemptNumber: generation });
     const presentation = composeTeamRelayThreadProjection({ runId: command.runId, generation,
       state: state as Parameters<typeof composeTeamRelayThreadProjection>[0]["state"], controls,
       ...(approval ? { approval } : {}),
+      ...(publication ? { publication } : {}),
       providerDelivery: { state: deliveryState,
         ...(deliveryErrorCode ? { reasonCode: deliveryErrorCode as any } : {}) } });
     const text = renderSlackTeamRelayProjection(presentation);
@@ -157,6 +163,11 @@ export function createTeamRelayProjectionService(input: { pool: Pool; hosted: Ho
     await input.producer.enqueue({ intent, providerRequest,
       phase: terminal ? "terminal" : state === "running" ? "running" : "received",
       frozenDeadline: row.deadline_at.toISOString() });
+    // The durable projection job is not complete until delivery is woken. A
+    // crash between these enqueues retries this job, never the human decision.
+    const wake = await input.jobs.enqueue({ jobId: `provider-delivery:${intent.sideEffectIntentId}`,
+      organizationId: null, kind: "provider-delivery", payload: {}, maxAttempts: 1 });
+    if (wake.kind === "conflict") throw new Error("projection_delivery_job_conflict");
     return { kind: "queued" as const, presentation, intentId: intent.sideEffectIntentId };
   }, async projectDeliveryIntent(intentId: string) {
     const result = await input.pool.query<{ organization_id: string; run_id: string | null }>(

--- a/apps/control-plane/src/modules/provider-delivery/team-relay-projection.ts
+++ b/apps/control-plane/src/modules/provider-delivery/team-relay-projection.ts
@@ -8,9 +8,9 @@ import type { Pool } from "pg";
 import type { HostedRunCoordinator } from "../hosted-runs/index.js";
 import { readExactDeliveryAnchor } from "./repository.js";
 import { z } from "zod";
-import { PermissionResolutionReceiptEnvelopeV1Schema } from "@opentag/control-protocol";
-import { readRunPublicationEffect } from "../effects/index.js";
+import { readRunThreadFeedback } from "../hosted-runs/thread-feedback.js";
 import type { DurableJobQueue } from "../jobs/index.js";
+import { feedbackElapsedMs, logFeedbackTiming } from "./feedback-timing.js";
 
 const hash = (value: unknown) => `sha256:${createHash("sha256")
   .update(canonicalJsonStringify(value)).digest("hex")}`;
@@ -27,6 +27,7 @@ export function createTeamRelayProjectionService(input: { pool: Pool; hosted: Ho
     projectionRevision?: number; includeControls?: boolean;
     deliveryEvent?: { intentId:string; revision:number; eventSequence:number;
       state:"accepted"|"rejected"|"outcome_unknown"|"attention" } }) {
+    const started=performance.now();
     const run = await input.hosted.inspect(command); if (!run) return { kind: "missing" as const };
     const current = await input.pool.query<{ current_attempt_number: number; projection_revision: string }>(
       "SELECT current_attempt_number,projection_revision::text FROM cp_hosted_run WHERE organization_id=$1 AND run_id=$2",
@@ -91,24 +92,7 @@ export function createTeamRelayProjectionService(input: { pool: Pool; hosted: Ho
     const controls = issuedControls.filter((control) => state === "publication_pending"
       ? control.kind === "status" || control.kind === "cancel" || control.kind === "effect_approve"
       : control.kind !== "effect_approve").slice(0, 4);
-    // Read durable permission truth, not the consumed/unconsumed projection copy.
-    const permissions = await input.pool.query<{ state: string; current_receipt: unknown }>(
-      `SELECT state,current_receipt FROM cp_permission_request
-       WHERE organization_id=$1 AND run_id=$2 AND attempt_number=$3
-         AND (state='waiting' OR current_receipt->'payload'->>'decision' IN ('allow_once','deny'))
-       ORDER BY created_at DESC,permission_request_id DESC LIMIT 1`,
-      [command.organizationId,command.runId,generation]);
-    const permission = permissions.rows[0];
-    const receipt = permission
-      ? PermissionResolutionReceiptEnvelopeV1Schema.parse(permission.current_receipt) : undefined;
-    if (receipt && (receipt.organizationId !== command.organizationId || receipt.runId !== command.runId
-      || receipt.attempt.attemptNumber !== generation || receipt.payload.state !== permission!.state)) {
-      throw new Error("projection_permission_receipt_mismatch");
-    }
-    const approval = receipt && ["waiting", "authorized", "denied"].includes(receipt.payload.state)
-      ? { state: receipt.payload.state as "waiting" | "authorized" | "denied",
-          actionDescriptor: receipt.payload.actionDescriptor } : undefined;
-    const publication = await readRunPublicationEffect(input.pool, {
+    const {approval,publication,approvalRef} = await readRunThreadFeedback(input.pool, {
       organizationId: command.organizationId, runId: command.runId, attemptNumber: generation });
     const presentation = composeTeamRelayThreadProjection({ runId: command.runId, generation,
       state: state as Parameters<typeof composeTeamRelayThreadProjection>[0]["state"], controls,
@@ -168,6 +152,12 @@ export function createTeamRelayProjectionService(input: { pool: Pool; hosted: Ho
     const wake = await input.jobs.enqueue({ jobId: `provider-delivery:${intent.sideEffectIntentId}`,
       organizationId: null, kind: "provider-delivery", payload: {}, maxAttempts: 1 });
     if (wake.kind === "conflict") throw new Error("projection_delivery_job_conflict");
+    const reference=publication
+      ? publication.state!=="requested"?publication.effectId:undefined
+      : approval&&approval.state!=="waiting"?approvalRef:undefined;
+    if(reference) logFeedbackTiming({stage:"projection_enqueued",runId:command.runId,
+      operationId:intent.sideEffectIntentId,approvalRef:reference,at:input.clock.now().toISOString(),
+      durationMs:feedbackElapsedMs(started,performance.now()),result:"queued"});
     return { kind: "queued" as const, presentation, intentId: intent.sideEffectIntentId };
   }, async projectDeliveryIntent(intentId: string) {
     const result = await input.pool.query<{ organization_id: string; run_id: string | null }>(

--- a/apps/control-plane/src/modules/slack-ingress/index.ts
+++ b/apps/control-plane/src/modules/slack-ingress/index.ts
@@ -401,9 +401,18 @@ export function createPostgresSlackIngress(input: { pool: Pool; clock: { now(): 
       // Projection families hold single-decision copies, never source authority.
       // Re-projecting one of those copies would discard its sibling decisions.
       const source = await client.query<ActionRow>(`SELECT DISTINCT ON (action_kind) *
-        FROM cp_slack_action_authority WHERE organization_id=$1 AND run_id=$2
+        FROM cp_slack_action_authority authority WHERE organization_id=$1 AND run_id=$2
           AND attempt_number=$3 AND projection_generation=$3 AND consumed_at IS NULL
           AND authority_family_id NOT LIKE 'projection:%'
+          AND (action_kind <> 'approval' OR EXISTS (
+            SELECT 1 FROM cp_permission_request permission
+            WHERE permission.organization_id=authority.organization_id
+              AND permission.run_id=authority.run_id
+              AND permission.permission_request_id=authority.pending_request_id
+              AND permission.action_id=authority.pending_action_id
+              AND permission.attempt_id=authority.attempt_id
+              AND permission.permission_request_digest=authority.permission_request_digest
+              AND permission.state='waiting'))
           AND expires_at>$4 ORDER BY action_kind,created_at DESC`,
       [command.organizationId, command.runId, command.generation, input.clock.now()]);
       const controls: Array<{ kind: "status" | "cancel" | "approve" | "reject"

--- a/apps/control-plane/src/modules/slack-ingress/index.ts
+++ b/apps/control-plane/src/modules/slack-ingress/index.ts
@@ -413,6 +413,17 @@ export function createPostgresSlackIngress(input: { pool: Pool; clock: { now(): 
               AND permission.attempt_id=authority.attempt_id
               AND permission.permission_request_digest=authority.permission_request_digest
               AND permission.state='waiting'))
+          AND (action_kind <> 'effect' OR EXISTS (
+            SELECT 1 FROM cp_effect effect
+            WHERE effect.organization_id=authority.organization_id
+              AND effect.run_id=authority.run_id
+              AND effect.effect_id=authority.pending_action_id
+              AND effect.run_attempt_id=authority.attempt_id
+              AND effect.run_attempt_number=authority.attempt_number
+              AND effect.approval_request_id=authority.pending_request_id
+              AND effect.approval_request_digest=authority.permission_request_digest
+              AND effect.state='requested' AND effect.approval_id IS NULL
+              AND effect.approval_expires_at>$4))
           AND expires_at>$4 ORDER BY action_kind,created_at DESC`,
       [command.organizationId, command.runId, command.generation, input.clock.now()]);
       const controls: Array<{ kind: "status" | "cancel" | "approve" | "reject"

--- a/apps/control-plane/src/modules/slack-ingress/index.ts
+++ b/apps/control-plane/src/modules/slack-ingress/index.ts
@@ -15,6 +15,7 @@ import type { RelayContentCustody } from "../source-content/index.js";
 import { createSourceIngressService, type SourceIngressService } from "../source-ingress/index.js";
 import type { EffectApproval, EffectApprovalIssue } from "../effects/index.js";
 import { z } from "zod";
+import { feedbackElapsedMs, logFeedbackTiming } from "../provider-delivery/feedback-timing.js";
 
 type HttpResult = { status: number; body: unknown };
 type RawRequest = { rawBody: Uint8Array; headers: Headers; receivedAt: string };
@@ -742,6 +743,7 @@ export function createPostgresSlackIngress(input: { pool: Pool; clock: { now(): 
     },
 
     async receiveInteractivity(routeIdentity: string, request: RawRequest): Promise<HttpResult> {
+      const feedbackStarted=performance.now();
       const commandAuthority = input.commandAuthority;
       if (!commandAuthority) return { status: 503, body: { error: "slack_command_authority_unavailable" } };
       try {
@@ -1015,6 +1017,13 @@ export function createPostgresSlackIngress(input: { pool: Pool; clock: { now(): 
           completed = result.outcome === "completed";
         }
         if (!completed) return { status: 403, body: { error: "source_thread_control_rejected" } };
+        if(claimed.row.action_kind==="approval"||claimed.row.action_kind==="effect"){
+          logFeedbackTiming({stage:"approval_committed",runId:claimed.row.run_id,
+            operationId:claimed.row.action_id,
+            approvalRef:claimed.row.action_kind==="effect"?claimed.row.pending_action_id:claimed.row.pending_request_id,
+            at:input.clock.now().toISOString(),durationMs:feedbackElapsedMs(feedbackStarted,performance.now()),
+            result:!("effectApproval" in claimed)&&claimed.command.type==="reject"?"denied":"authorized"});
+        }
         await input.testHooks?.afterServiceBeforeFinalize?.();
         const terminalDecision = "effectApproval" in claimed
           || (!("effectApproval" in claimed) && claimed.command.type !== "status");

--- a/apps/control-plane/src/runtime.ts
+++ b/apps/control-plane/src/runtime.ts
@@ -584,7 +584,7 @@ export function createControlPlaneRuntime(input: {
     return { intent, persistedPayload };
   } });
   const teamRelayProjection = createTeamRelayProjectionService({ pool: postgres.pool,
-    hosted, producer: providerDeliveryProducer, clock,deliveryOwner:deliveryRuntimeOwner,
+    hosted, jobs, producer: providerDeliveryProducer, clock,deliveryOwner:deliveryRuntimeOwner,
     ...(slack ? { controls: slack } : {}) });
   const providerDeliveryWorker = createProviderDeliveryWorker({ kernel: providerDeliveryKernel,
     preloadSourceApps: async () => {

--- a/apps/control-plane/test/console-reads.postgres.test.ts
+++ b/apps/control-plane/test/console-reads.postgres.test.ts
@@ -41,6 +41,20 @@ function teammateRow(overrides: Record<string, unknown> = {}) {
 }
 
 describe("derived Teammate read model", () => {
+  it.each([true,false])("uses the shared publication phase after execution ends (runner online: %s)", async online => {
+    const row=teammateRow({active_run_id:"run_publication",active_run_state:"running",
+      active_run_updated_at:new Date(),active_run_count:1,active_attempt_valid:false,
+      active_run_attempt_number:1,active_publication_mode:"pull_request",active_has_candidate:true,
+      readiness_expires_at:online?new Date():null});
+    const reads=createConsoleReadModel({pool:{query:async(sql:string)=>({rows:
+      sql.includes("WITH active_slack")?[row]:sql.includes("SELECT * FROM cp_effect")?[{
+        effect_id:"effect_publication",effect_kind:"github.create_draft_pull_request",
+        state:"authorized",updated_at:new Date(),current_attempt_number:0}]:[]})} as never});
+    const [view]=await reads.listTeammates(consolePrincipal);
+    expect(view.workState).toBe(online?"working":"runner_offline");
+    expect(view.reason).toBe("Publication approved. Waiting for the paired Runner to publish the exact candidate.");
+    expect(view.reason).not.toContain("lease");
+  });
   it("returns an empty list when no active Slack binding exists", async () => {
     const query = vi.fn(async () => ({ rows: [] }));
     const reads = createConsoleReadModel({ pool: { query } as never });

--- a/apps/control-plane/test/console-reads.postgres.test.ts
+++ b/apps/control-plane/test/console-reads.postgres.test.ts
@@ -118,9 +118,16 @@ describe("derived Teammate read model", () => {
     {
       name: "expired readiness",
       row: teammateRow({ readiness_expires_at: null, active_run_id: "run_stale",
-        active_run_state: "running",
+        active_run_state: "running", active_attempt_valid: false,
         active_run_updated_at: new Date("2026-09-04T05:10:00.000Z"), active_run_count: 1 }),
       workState: "runner_offline",
+    },
+    {
+      name: "busy Runner with a current leased Attempt",
+      row: teammateRow({ readiness_expires_at: null, active_run_id: "run_busy",
+        active_run_state: "running", active_attempt_valid: true,
+        active_run_updated_at: new Date("2026-09-04T05:10:00.000Z"), active_run_count: 1 }),
+      workState: "working",
     },
     {
       name: "invalid current Attempt",

--- a/apps/control-plane/test/effects.postgres.test.ts
+++ b/apps/control-plane/test/effects.postgres.test.ts
@@ -9,9 +9,11 @@ import {
   type EffectRequestV1,
 } from "@opentag/control-protocol";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { composeTeamRelayThreadProjection } from "@opentag/core";
 import {
   EffectAuthorityStoredStateError,
   createEffectAuthority,
+  readRunPublicationEffect,
 } from "../src/modules/effects/index.js";
 import { createHostedRunCoordinator } from "../src/modules/hosted-runs/index.js";
 import { createRunnerDirectory, type RuntimePrincipal } from "../src/modules/runners/index.js";
@@ -307,6 +309,32 @@ describe.skipIf(!TEST_DATABASE_URL)("EffectAuthority PostgreSQL policy", () => {
       },
     };
   }
+
+  it("commits immediately due approval feedback without any Runner acquisition", async () => {
+    const context = await setup("approval_feedback");
+    await requestAndApprove(context);
+    const publication = await readRunPublicationEffect(fixture.pool, {
+      organizationId: principal.organizationId, runId: context.runId, attemptNumber: 1 });
+    expect(publication).toMatchObject({state:"authorized",currentAttemptNumber:0});
+    const view = composeTeamRelayThreadProjection({runId:context.runId,generation:1,
+      state:"publication_pending",controls:[],publication});
+    expect(view.title).toBe("Publication approved");
+    expect(view.summary).toContain("Waiting for the paired Runner");
+    const jobs = await fixture.pool.query(`SELECT job_id,state,available_at<=clock_timestamp() AS due
+      FROM cp_job WHERE job_kind='team-relay.project.v2' AND payload->>'runId'=$1
+        AND (payload->>'projectionRevision')::integer=(SELECT projection_revision FROM cp_hosted_run
+          WHERE organization_id=$2 AND run_id=$1)`,[context.runId,principal.organizationId]);
+    expect(jobs.rows).toHaveLength(1);
+    expect(jobs.rows[0]).toMatchObject({state:"pending",due:true});
+    expect((await fixture.pool.query("SELECT count(*)::integer AS count FROM cp_effect_attempt WHERE effect_id=$1",
+      [context.request.effectId])).rows).toEqual([{count:0}]);
+    await requestAndApprove(context);
+    expect((await fixture.pool.query("SELECT job_id FROM cp_job WHERE job_id=$1",[jobs.rows[0].job_id])).rows)
+      .toEqual([{job_id:jobs.rows[0].job_id}]);
+    // Keep this test's approved work out of later acquisition tests.
+    await fixture.pool.query("UPDATE cp_effect SET state='cancelled_before_permit',reason_code='test_cleanup' WHERE effect_id=$1",
+      [context.request.effectId]);
+  });
 
   it("rejects stale fences, target generations, and corrupted request digests", async () => {
     const context = await setup("stale");

--- a/apps/control-plane/test/feedback-latency.test.ts
+++ b/apps/control-plane/test/feedback-latency.test.ts
@@ -7,7 +7,7 @@ function sample(index:number){
  const at=(ms:number)=>new Date(Date.UTC(2026,8,8)+ms).toISOString();
  return [{...event,stage:"approval_committed",operationId:`action_${index}`,approvalRef:`effect_${index}`,at:at(0),durationMs:100},
    {...event,stage:"projection_enqueued",operationId:`intent_${index}`,approvalRef:`effect_${index}`,at:at(200),durationMs:30},
-   {...event,stage:"delivery_started",operationId:`intent_${index}`,at:at(300),queueMs:100},
+   {...event,stage:"delivery_started",operationId:`intent_${index}`,at:at(300),queueMs:120},
    {...event,stage:"delivery_settled",operationId:`intent_${index}`,at:at(500),durationMs:200,result:"accepted"}];
 }
 function report(rows:unknown[]){return JSON.parse(execFileSync(process.execPath,[script],{

--- a/apps/control-plane/test/feedback-latency.test.ts
+++ b/apps/control-plane/test/feedback-latency.test.ts
@@ -1,0 +1,24 @@
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {expect,it} from "vitest";
+const script=fileURLToPath(new URL("../../../scripts/test/approval-feedback-latency.mjs",import.meta.url));
+function sample(index:number){
+ const event={event:"control_plane_feedback_timing",runId:`run_${index}`};
+ const at=(ms:number)=>new Date(Date.UTC(2026,8,8)+ms).toISOString();
+ return [{...event,stage:"approval_committed",operationId:`action_${index}`,approvalRef:`effect_${index}`,at:at(0),durationMs:100},
+   {...event,stage:"projection_enqueued",operationId:`intent_${index}`,approvalRef:`effect_${index}`,at:at(200),durationMs:30},
+   {...event,stage:"delivery_started",operationId:`intent_${index}`,at:at(300),queueMs:100},
+   {...event,stage:"delivery_settled",operationId:`intent_${index}`,at:at(500),durationMs:200,result:"accepted"}];
+}
+function report(rows:unknown[]){return JSON.parse(execFileSync(process.execPath,[script],{
+ input:rows.map(x=>JSON.stringify(x)).join("\n"),encoding:"utf8"}));}
+it("correlates exact approved projection without counting replay as another sample",()=>{
+ const rows=sample(1);const result=report([...rows,rows[0]]);
+ expect(result).toMatchObject({sampleCount:1,p95Ms:null,verdict:"insufficient_samples",pending:0});
+ expect(result.samples[0]).toMatchObject({approvalProcessingMs:100,deliveryQueueMs:100,slackRequestMs:200,approvalToAcceptedMs:500});
+ expect(report(rows.slice(0,3))).toMatchObject({sampleCount:0,pending:1});
+});
+it("requires twenty accepted samples and understands Railway log envelopes",()=>{
+ const rows=Array.from({length:20},(_,i)=>sample(i)).flat().map(x=>({message:JSON.stringify(x)}));
+ expect(report(rows)).toMatchObject({sampleCount:20,p95Ms:500,verdict:"within_target"});
+});

--- a/apps/control-plane/test/feedback-latency.test.ts
+++ b/apps/control-plane/test/feedback-latency.test.ts
@@ -21,4 +21,6 @@ it("correlates exact approved projection without counting replay as another samp
 it("requires twenty accepted samples and understands Railway log envelopes",()=>{
  const rows=Array.from({length:20},(_,i)=>sample(i)).flat().map(x=>({message:JSON.stringify(x)}));
  expect(report(rows)).toMatchObject({sampleCount:20,p95Ms:500,verdict:"within_target"});
+ const native=sample(1).map(x=>({...x,message:"",level:"info",timestamp:x.at}));
+ expect(report(native)).toMatchObject({sampleCount:1,pending:0,invalidRecords:0});
 });

--- a/apps/control-plane/test/feedback-timing.test.ts
+++ b/apps/control-plane/test/feedback-timing.test.ts
@@ -1,0 +1,19 @@
+import {describe,expect,it,vi} from "vitest";
+import {feedbackElapsedMs,logFeedbackTiming} from "../src/modules/provider-delivery/feedback-timing.js";
+describe("content-free approval feedback timing",()=>{
+  it("keeps clock anomalies unknown instead of reporting zero latency",()=>{
+    expect(feedbackElapsedMs(100,113.4)).toBe(13);
+    expect(feedbackElapsedMs(100,87)).toBeNull();
+    expect(feedbackElapsedMs(NaN,100)).toBeNull();
+  });
+  it("does not accept source text, URLs, tokens or arbitrary additional fields",()=>{
+    const logger={info:vi.fn(),warn:vi.fn()};
+    const event={stage:"approval_committed" as const,runId:"run_test",operationId:"action_test",
+      approvalRef:"effect_test",at:"2026-09-08T00:00:00.000Z",durationMs:12,result:"authorized" as const};
+    expect(logFeedbackTiming(event,logger)).toBe(true);
+    expect(logFeedbackTiming({...event,operationId:"https://secret.example/token"},logger)).toBe(false);
+    expect(logFeedbackTiming({...event,token:"not-a-real-secret"} as typeof event,logger)).toBe(false);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logFeedbackTiming(event,{info(){throw Error("sink down");},warn(){}})).toBe(false);
+  });
+});

--- a/apps/control-plane/test/permissions.postgres.test.ts
+++ b/apps/control-plane/test/permissions.postgres.test.ts
@@ -675,13 +675,26 @@ describe.skipIf(!TEST_DATABASE_URL)("governed permissions PostgreSQL module", ()
       [inlineRequest.permissionRequestId])).rows[0].state).toBe("waiting");
     await fixture.pool.query("UPDATE cp_hosted_attempt SET workspace_attestation=$3::jsonb WHERE organization_id=$1 AND run_id=$2",
       [principal.organizationId, claim.runId, JSON.stringify(workspaceAttestation)]);
-    await expect(ingress.receiveInteractivity("route_permission", signedAction(inlineToken, "allow_once", "U_APPROVER")))
+    for (let refresh = 0; refresh < 4; refresh += 1) {
+      const controls = await ingress.issueProjectionControls({ organizationId: principal.organizationId,
+        runId: claim.runId, generation: claim.attempt.number });
+      expect(controls.filter(control => control.kind === "approve" || control.kind === "reject")
+        .map(control => control.kind).sort()).toEqual(["approve", "reject"]);
+    }
+    const projected = await ingress.issueProjectionControls({ organizationId: principal.organizationId,
+      runId: claim.runId, generation: claim.attempt.number });
+    const projectedApproval = projected.find(control => control.kind === "approve")!;
+    expect(projectedApproval).toBeDefined();
+    await expect(ingress.receiveInteractivity("route_permission", signedAction(projectedApproval.actionId, "allow_once", "U_APPROVER")))
       .resolves.toEqual({ status: 200, body: { ok: true } });
     const inlineReceipt = PermissionResolutionReceiptEnvelopeV1Schema.parse((await fixture.pool.query(
       "SELECT current_receipt FROM cp_permission_request WHERE organization_id=$1 AND permission_request_id=$2",
       [principal.organizationId, inlineRequest.permissionRequestId])).rows[0].current_receipt);
     expect(inlineReceipt.payload).toMatchObject({ state: "authorized", decisionActorRef: "U_APPROVER",
       workspaceAttestationDigest, permissionRequestDigest: inlineRequest.permissionRequestDigest });
+    expect((await ingress.issueProjectionControls({ organizationId: principal.organizationId,
+      runId: claim.runId, generation: claim.attempt.number }))
+      .filter(control => control.kind === "approve" || control.kind === "reject")).toEqual([]);
     await expect(ingress.receiveInteractivity("route_permission", signedAction(inlineToken, "allow_once", "U_APPROVER")))
       .resolves.toMatchObject({ status: 403 });
     await expect(hosted.inspect({ organizationId: principal.organizationId, runId: claim.runId }))

--- a/apps/control-plane/test/projection-outbox.postgres.test.ts
+++ b/apps/control-plane/test/projection-outbox.postgres.test.ts
@@ -17,7 +17,9 @@ const owner = { runtimeOwnerId: "control-plane", runtimeGeneration: 1, schemaGen
 
 describe.skipIf(!TEST_DATABASE_URL)("team relay projection outbox", () => {
   let fixture: Awaited<ReturnType<typeof createIsolatedPostgres>>;
+  let projectionDeliveryJobs: ReturnType<typeof createDurableJobQueue>;
   beforeEach(async () => { fixture = await createIsolatedPostgres(); await fixture.migrate();
+    projectionDeliveryJobs = createDurableJobQueue({pool:fixture.pool,clock:{now:()=>now},leaseDurationMs:30_000});
     await fixture.pool.query("INSERT INTO cp_organization(organization_id,display_name) VALUES('org_projection','Projection')");
     await fixture.pool.query(`INSERT INTO cp_runner(organization_id,runner_id,registration_generation,
       credential_generation,current_credential_id,capabilities,created_at,updated_at)
@@ -154,7 +156,7 @@ describe.skipIf(!TEST_DATABASE_URL)("team relay projection outbox", () => {
       scopeBeginMarkerDigest:digest("resource-less-marker")}))!;
     await repository.settleOrReadTerminal({...begun,outcome:"accepted",
       evidenceDigest:digest("resource-less-evidence")});
-    const service=createTeamRelayProjectionService({pool:fixture.pool,hosted:{inspect:async()=>({state:"queued",
+    const service=createTeamRelayProjectionService({pool:fixture.pool,jobs:projectionDeliveryJobs,hosted:{inspect:async()=>({state:"queued",
       canonicalStatus:"queued",status:"waiting_for_runner",queueClaimDeadline:new Date(now.getTime()+300_000).toISOString(),
       outcome:null,terminalKind:null,terminalReason:null})} as any,producer:{async enqueue(value){requests.push(value);}},
       clock:{now:()=>new Date(now.getTime()+1)}});
@@ -201,7 +203,7 @@ describe.skipIf(!TEST_DATABASE_URL)("team relay projection outbox", () => {
       externalResourceDigest: digest("resource") });
     let projectionStatus = "waiting_for_runner";
     let controlIssueCount = 0;
-    const service = createTeamRelayProjectionService({ pool: fixture.pool,
+    const service = createTeamRelayProjectionService({ pool: fixture.pool,jobs:projectionDeliveryJobs,
       hosted: { inspect: async () => ({ state: "queued", canonicalStatus: "queued",
         status: projectionStatus, queueClaimDeadline: new Date(now.getTime()+300_000).toISOString(),
         outcome: null, terminalKind: null, terminalReason: null }) } as any,
@@ -213,6 +215,10 @@ describe.skipIf(!TEST_DATABASE_URL)("team relay projection outbox", () => {
     await service.projectRun({ organizationId: "org_projection", runId: "run_projection" });
     expect(requests).toHaveLength(1);
     expect(requests[0].intent.operation).toBe("update");
+    const deliveryWake = await fixture.pool.query(
+      "SELECT job_kind,state,available_at FROM cp_job WHERE job_id=$1",
+      [`provider-delivery:${requests[0].intent.sideEffectIntentId}`]);
+    expect(deliveryWake.rows).toEqual([{ job_kind: "provider-delivery", state: "pending", available_at: now }]);
     expect(requests[0].providerRequest.operation).toEqual({ kind: "update_message",
       channelId: "C1", messageTs: "171.001", threadTs: "1700000000.1" });
     expect(controlIssueCount).toBe(1);
@@ -248,7 +254,7 @@ describe.skipIf(!TEST_DATABASE_URL)("team relay projection outbox", () => {
       FROM cp_projection_delivery_watermark WHERE intent_id='external_rejected' AND delivery_state='rejected'`);
     await fixture.pool.query("UPDATE cp_hosted_run SET updated_at=$1 WHERE run_id='run_projection'",
       [new Date(now.getTime()+3)]);
-    const eventService=createTeamRelayProjectionService({pool:fixture.pool,hosted:{inspect:async()=>({
+    const eventService=createTeamRelayProjectionService({pool:fixture.pool,jobs:projectionDeliveryJobs,hosted:{inspect:async()=>({
       state:"queued",canonicalStatus:"queued",status:"waiting_for_runner",
       queueClaimDeadline:new Date(now.getTime()+300_000).toISOString(),outcome:null,
       terminalKind:null,terminalReason:null})} as any,clock:{now:()=>new Date(now.getTime()+4)},
@@ -346,7 +352,7 @@ describe.skipIf(!TEST_DATABASE_URL)("team relay projection outbox", () => {
     await repository.settleOrReadTerminal({ ...externalBegun, outcome: "outcome_unknown",
       evidenceDigest: digest("truth-external-evidence"), errorCode: "ambiguous_response" });
     const projected: any[] = [];
-    const service = createTeamRelayProjectionService({ pool: fixture.pool,
+    const service = createTeamRelayProjectionService({ pool: fixture.pool,jobs:projectionDeliveryJobs,
       hosted: { inspect: async () => ({ state: "queued", canonicalStatus: "queued",
         status: "waiting_for_runner", queueClaimDeadline: new Date(now.getTime() + 300_000).toISOString(),
         outcome: null, terminalKind: null, terminalReason: null }) } as any,
@@ -404,7 +410,7 @@ describe.skipIf(!TEST_DATABASE_URL)("team relay projection outbox", () => {
     const begun=(await repository.markBegin({ ...renewed, installationBeginMarkerId:"installation",
       installationBeginMarkerDigest:digest("marker"),scopeBeginMarkerId:"scope",
       scopeBeginMarkerDigest:digest("marker") }))!;
-    const service=createTeamRelayProjectionService({ pool:fixture.pool,
+    const service=createTeamRelayProjectionService({ pool:fixture.pool,jobs:projectionDeliveryJobs,
       hosted:{ inspect:async()=>({ state:"running",canonicalStatus:"running",status:"running",
         queueClaimDeadline:new Date(now.getTime()+300_000).toISOString(),outcome:null,
         terminalKind:null,terminalReason:null }) } as any,

--- a/apps/control-plane/test/slack-ingress.postgres.test.ts
+++ b/apps/control-plane/test/slack-ingress.postgres.test.ts
@@ -124,7 +124,7 @@ describe.skipIf(!TEST_DATABASE_URL)("Slack durable ingress", () => {
       fetchImpl: async () => { throw new Error("provider_call_forbidden"); } }) };
   }
 
-  it("preserves both approval decisions across repeated projection refreshes", async () => {
+  it("does not project orphan approval authority without a current permission request", async () => {
     await insertSlackInstallation();
     let tick = 0;
     const { ingress } = productionComponents({ clock: { now: () => new Date(now.getTime() + tick++ * 1000) } });
@@ -140,7 +140,7 @@ describe.skipIf(!TEST_DATABASE_URL)("Slack durable ingress", () => {
       expiresAt: new Date(now.getTime() + 60_000) });
     for (let refresh = 0; refresh < 4; refresh += 1) {
       const controls = await ingress.issueProjectionControls({ organizationId: "org_a", runId: "run_refresh", generation: 1 });
-      expect(controls.map(control => control.kind).sort()).toEqual(["approve", "reject"]);
+      expect(controls).toEqual([]);
     }
     const nestedCopies = await fixture.pool.query(`SELECT action_id FROM cp_slack_action_authority
       WHERE run_id='run_refresh' AND action_id LIKE '%:projection:%:projection:%'`);

--- a/apps/control-plane/test/slack-ingress.postgres.test.ts
+++ b/apps/control-plane/test/slack-ingress.postgres.test.ts
@@ -622,6 +622,7 @@ describe.skipIf(!TEST_DATABASE_URL)("Slack durable ingress", () => {
       policy: { snapshotId: effectApproval.policySnapshotId,
         snapshotDigest: effectApproval.policySnapshotDigest } };
     let effectNow = now; let failEffectFinalize = true; const effectApprovals: any[] = [];
+    let effectTokenSequence = 0;
     const effectRuntime = productionComponents({ commandAuthority: authority,
       clock: { now: () => effectNow },
       effectAuthority: { async approve(command: any) { effectApprovals.push(command);
@@ -635,7 +636,7 @@ describe.skipIf(!TEST_DATABASE_URL)("Slack durable ingress", () => {
         return { kind: effectApprovals.length === 1 ? "approved" as const : "replayed" as const }; } },
       testHooks: { async afterServiceBeforeFinalize() {
         if (failEffectFinalize) { failEffectFinalize = false; throw new Error("effect_finalize_crash"); }
-      } }, tokenFactory: () => "opaque_effect_action_token_abcdefghijklmnopqrstuvwxyz" });
+      } }, tokenFactory: () => `opaque_effect_action_token_${++effectTokenSequence}_abcdefghijklmnopqrstuvwxyz` });
     const effectToken = await effectRuntime.ingress.issueAction({ organizationId: "org_a",
       actionId: "action_effect", installationId: "install_1", bindingId: "binding_1",
       teamId: "T1", appId: "A1", channelId: "C1",
@@ -655,6 +656,10 @@ describe.skipIf(!TEST_DATABASE_URL)("Slack durable ingress", () => {
       action(effectToken,"effect_approve","U_MEMBER"))).resolves.toMatchObject({status:403});
     await expect(effectRuntime.ingress.receiveInteractivity("route_1",
       action(effectToken,"effect_approve","U_APPROVER"))).resolves.toMatchObject({status:503});
+    // The approval committed even though finalization failed. No Runner has
+    // acquired a permit; this must already remove the approval control.
+    expect((await effectRuntime.ingress.issueProjectionControls({organizationId:"org_a",
+      runId:effectApproval.runId,generation:1})).filter(control => control.kind === "effect_approve")).toEqual([]);
     effectNow = new Date(now.getTime()+1_000);
     await expect(effectRuntime.ingress.receiveInteractivity("route_1",
       action(effectToken,"effect_approve","U_APPROVER"))).resolves.toMatchObject({status:200});

--- a/apps/control-plane/test/slack-team-profile.e2e.postgres.test.ts
+++ b/apps/control-plane/test/slack-team-profile.e2e.postgres.test.ts
@@ -142,7 +142,7 @@ describe.skipIf(!TEST_DATABASE_URL)("Slack team relay certification profile", ()
             organizationId: input.intent.organizationId, providerId: "slack", providerInstanceId: "T_CERT",
             providerBindingDigest: digest("binding"), providerConfigGeneration: 1,
             providerConfigGenerationDigest: digest("generation"), ...owner } }) }) };
-    const projection = createTeamRelayProjectionService({ pool: fixture.pool, hosted,
+    const projection = createTeamRelayProjectionService({ pool: fixture.pool, hosted, jobs,
       producer: producer as never, clock, deliveryOwner: owner });
     const queued = await projection.projectRun({ organizationId: "org_cert", runId: "run_cert",
       projectionRevision: 2, includeControls: false });

--- a/packages/core/src/presentation.ts
+++ b/packages/core/src/presentation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { EffectViewV1Schema, type EffectViewV1 } from "@opentag/control-protocol";
 import {
   actionReceiptHeading,
   buildActionReceiptsFromResult,
@@ -226,6 +227,7 @@ export function composeTeamRelayThreadProjection(input: {
   providerDelivery?: { state: "pending" | "accepted" | "rejected" | "outcome_unknown" | "attention";
     reasonCode?: NonNullable<OpenTagSourceThreadProjectionPresentation["providerDelivery"]>["reasonCode"] };
   approval?: { state: "waiting" | "authorized" | "denied"; actionDescriptor: string };
+  publication?: EffectViewV1;
 }): OpenTagSourceThreadProjectionPresentation {
   const copy = TEAM_RELAY_COPY[input.state];
   const deliveryMessage = input.providerDelivery?.state === "outcome_unknown"
@@ -240,11 +242,44 @@ export function composeTeamRelayThreadProjection(input: {
     ? `Approved once: ${approval.actionDescriptor}. This approval does not authorize publication.`
     : approval?.state === "denied" ? `Denied: ${approval.actionDescriptor}. This action will not execute.`
       : waiting ? `Approval required: ${approval.actionDescriptor}. Allow this exact action once or deny it.` : undefined;
+  const publication = input.publication ? EffectViewV1Schema.parse(input.publication) : undefined;
+  // Approval feedback depends only on committed Control Plane truth. An issued
+  // permit is not proof that the Runner has begun or completed provider I/O.
+  let publicationCopy: Pick<OpenTagSourceThreadProjectionPresentation, "title" | "summary"> | undefined;
+  if (publication && (input.state === "publication_pending" || input.state === "ready_for_review")) {
+    switch (publication.state) {
+      case "authorized":
+      case "retry_eligible":
+        publicationCopy = {title:"Publication approved",summary:"Publication approved. Waiting for the paired Runner to publish the exact candidate."};
+        break;
+      case "permit_issued":
+        publicationCopy = {title:"Publication in progress",summary:"Publication approved. The Runner has a permit; the GitHub result is not yet confirmed."};
+        break;
+      case "observing":
+        publicationCopy = {title:"Draft PR created",summary:`Draft PR created: ${publication.externalResource.uri}\nVerification is still pending.`};
+        break;
+      case "succeeded":
+        publicationCopy = {title:"Ready for review",summary:`Draft PR created and verified: ${publication.externalResource.uri}`};
+        break;
+      case "outcome_unknown":
+      case "attention":
+        publicationCopy = {title:"Publication needs attention",summary:"The publication result is not confirmed. Do not repeat the approval or publication; verification is required."};
+        break;
+      case "cancelled_before_permit":
+        publicationCopy = {title:"Publication cancelled",summary:"Publication was cancelled before a permit was issued. This approval cannot be reused."};
+        break;
+      case "requested":
+        publicationCopy = {title:"Publication approval required",summary:"The exact candidate is ready. Approve publication to create its draft PR."};
+        break;
+    }
+  }
   return OpenTagSourceThreadProjectionPresentationSchema.parse({
     kind: "source_thread_projection", runId: input.runId, generation: input.generation,
-    state: input.state, ...copy, controls: input.controls,
+    state: input.state, ...copy, controls: input.controls.filter(control =>
+      control.kind !== "effect_approve" || publication?.state === "requested"),
     ...(waiting ? { title: "Waiting for approval" } : {}),
     ...(approvalMessage ? { summary: waiting ? approvalMessage : `${approvalMessage}\n${copy.summary}` } : {}),
+    ...publicationCopy,
     ...(input.providerDelivery && deliveryMessage ? { providerDelivery: {
       state: input.providerDelivery.state,
       ...(input.providerDelivery.reasonCode ? { reasonCode: input.providerDelivery.reasonCode } : {}),

--- a/packages/core/src/presentation.ts
+++ b/packages/core/src/presentation.ts
@@ -225,6 +225,7 @@ export function composeTeamRelayThreadProjection(input: {
   controls: OpenTagSourceThreadProjectionPresentation["controls"];
   providerDelivery?: { state: "pending" | "accepted" | "rejected" | "outcome_unknown" | "attention";
     reasonCode?: NonNullable<OpenTagSourceThreadProjectionPresentation["providerDelivery"]>["reasonCode"] };
+  approval?: { state: "waiting" | "authorized" | "denied"; actionDescriptor: string };
 }): OpenTagSourceThreadProjectionPresentation {
   const copy = TEAM_RELAY_COPY[input.state];
   const deliveryMessage = input.providerDelivery?.state === "outcome_unknown"
@@ -233,9 +234,17 @@ export function composeTeamRelayThreadProjection(input: {
       ? "Slack status delivery needs attention."
       : input.providerDelivery?.state === "pending" ? "Slack status delivery is pending."
         : input.providerDelivery?.state === "accepted" ? "Slack status delivery was accepted." : undefined;
+  const approval = input.approval;
+  const waiting = approval?.state === "waiting" && copy.runOutcome === "pending";
+  const approvalMessage = approval?.state === "authorized"
+    ? `Approved once: ${approval.actionDescriptor}. This approval does not authorize publication.`
+    : approval?.state === "denied" ? `Denied: ${approval.actionDescriptor}. This action will not execute.`
+      : waiting ? `Approval required: ${approval.actionDescriptor}. Allow this exact action once or deny it.` : undefined;
   return OpenTagSourceThreadProjectionPresentationSchema.parse({
     kind: "source_thread_projection", runId: input.runId, generation: input.generation,
     state: input.state, ...copy, controls: input.controls,
+    ...(waiting ? { title: "Waiting for approval" } : {}),
+    ...(approvalMessage ? { summary: waiting ? approvalMessage : `${approvalMessage}\n${copy.summary}` } : {}),
     ...(input.providerDelivery && deliveryMessage ? { providerDelivery: {
       state: input.providerDelivery.state,
       ...(input.providerDelivery.reasonCode ? { reasonCode: input.providerDelivery.reasonCode } : {}),

--- a/packages/core/test/approval-feedback.test.ts
+++ b/packages/core/test/approval-feedback.test.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from "vitest";
 import { composeTeamRelayThreadProjection } from "../src/presentation.js";
 
 describe("approval feedback on a thread projection", () => {
+  const effect = { effectId: "effect_feedback", effectKind: "github.create_draft_pull_request" as const,
+    updatedAt: "2026-09-08T00:00:00.000Z" };
+  it("shows publication approved before any Runner acquisition and removes the button", () => {
+    const view = composeTeamRelayThreadProjection({ runId: "run_feedback", generation: 1,
+      state: "publication_pending", controls: [{kind:"effect_approve",actionId:"old_button",generation:1}],
+      approval: {state:"authorized", actionDescriptor:"workspace.write"},
+      publication: {...effect,state:"authorized",currentAttemptNumber:0} });
+    expect(view.title).toBe("Publication approved");
+    expect(view.summary).toContain("Waiting for the paired Runner");
+    expect(view.summary).not.toContain("has not been approved");
+    expect(view.summary).not.toContain("workspace.write");
+    expect(view.controls).toEqual([]);
+    expect(view.runOutcome).toBe("pending");
+  });
+  it("links only an observed Draft PR and preserves pending verification", () => {
+    const resource = {provider:"github" as const,resourceRef:"github_pr_95",uri:"https://github.com/acme/demo/pull/95"};
+    const view = composeTeamRelayThreadProjection({runId:"run_feedback",generation:1,
+      state:"publication_pending",controls:[],publication:{...effect,state:"observing",currentAttemptNumber:1,
+        currentEvidenceDigest:`sha256:${"a".repeat(64)}`,externalResource:resource}});
+    expect(view.title).toBe("Draft PR created");
+    expect(view.summary).toContain(resource.uri);
+    expect(view.summary).toContain("Verification is still pending");
+    expect(view.runOutcome).toBe("pending");
+  });
   it("distinguishes a waiting inline action from generic running", () => {
     const view = composeTeamRelayThreadProjection({ runId: "run_feedback", generation: 1,
       state: "running", controls: [], approval: { state: "waiting", actionDescriptor: "workspace.write" } });

--- a/packages/core/test/approval-feedback.test.ts
+++ b/packages/core/test/approval-feedback.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { composeTeamRelayThreadProjection } from "../src/presentation.js";
+
+describe("approval feedback on a thread projection", () => {
+  it("distinguishes a waiting inline action from generic running", () => {
+    const view = composeTeamRelayThreadProjection({ runId: "run_feedback", generation: 1,
+      state: "running", controls: [], approval: { state: "waiting", actionDescriptor: "workspace.write" } });
+    expect(view.title).toBe("Waiting for approval");
+    expect(view.summary).toContain("workspace.write");
+  });
+  it.each(["authorized", "denied"] as const)("shows persisted %s without claiming execution success", state => {
+    const view = composeTeamRelayThreadProjection({ runId: "run_feedback", generation: 1,
+      state: "running", controls: [], approval: { state, actionDescriptor: "workspace.write" },
+      providerDelivery: { state: "pending" } });
+    expect(view.summary).toContain(state === "authorized" ? "Approved once" : "Denied");
+    expect(view.summary).toContain("workspace.write");
+    expect(view.runOutcome).toBe("pending");
+    expect(view.providerDelivery?.state).toBe("pending");
+  });
+  it("retains approval as a separate fact after timeout", () => {
+    const view = composeTeamRelayThreadProjection({ runId: "run_feedback", generation: 1,
+      state: "timed_out", controls: [], approval: { state: "authorized", actionDescriptor: "workspace.write" } });
+    expect(view.title).toBe("Timed out");
+    expect(view.summary).toContain("Approved once");
+    expect(view.runOutcome).toBe("timed_out");
+    expect(view.summary).not.toContain("continuing");
+  });
+});

--- a/packages/local-runtime/src/control-v1.ts
+++ b/packages/local-runtime/src/control-v1.ts
@@ -466,7 +466,9 @@ export function isRunnerControlContextFreshV1(
   maxAgeMs = READINESS_TTL_MS,
 ): boolean {
   const ageMs = now.getTime() - Date.parse(observedAt);
-  return ageMs >= 0 && ageMs <= maxAgeMs;
+  // Context observation only: tolerate up to one second of server-ahead skew.
+  // Never add this allowance to maximum age, permits, approvals, or lease expiry.
+  return ageMs >= -1_000 && ageMs <= maxAgeMs;
 }
 
 function canonicalReadinessAuthority(

--- a/packages/local-runtime/test/control-v1.test.ts
+++ b/packages/local-runtime/test/control-v1.test.ts
@@ -2558,7 +2558,7 @@ describe("Control V1 projection pump", () => {
     })).toThrow("runner_control_context_organization_mismatch");
   });
 
-  it("rejects future and expired server context at the one-minute readiness boundary", () => {
+  it("allows bounded clock skew without extending the one-minute age boundary", () => {
     expect(isRunnerControlContextFreshV1(
       "2026-08-08T23:59:00.000Z",
       now,
@@ -2570,7 +2570,13 @@ describe("Control V1 projection pump", () => {
     expect(isRunnerControlContextFreshV1(
       "2026-08-09T00:00:00.001Z",
       now,
-    )).toBe(false);
+    )).toBe(true);
+    expect(isRunnerControlContextFreshV1("2026-08-09T00:00:00.013Z", now)).toBe(true);
+    expect(isRunnerControlContextFreshV1("2026-08-09T00:00:01.000Z", now)).toBe(true);
+    expect(isRunnerControlContextFreshV1("2026-08-09T00:00:01.001Z", now)).toBe(false);
+    expect(isRunnerControlContextFreshV1("invalid", now)).toBe(false);
+    // Read the clock after the response; a long round trip cannot refresh it.
+    expect(isRunnerControlContextFreshV1(now.toISOString(), new Date(now.getTime()+60_001))).toBe(false);
   });
 
   it("builds readiness only from authoritative control context and public capability digests", async () => {

--- a/packages/runner/src/acp-executor.ts
+++ b/packages/runner/src/acp-executor.ts
@@ -354,7 +354,7 @@ function assertExplicitWorkspace(input: ExecutorRunInput): ExecutorWorkspace {
   return input.workspace;
 }
 
-function promptForRun(input: ExecutorRunInput): string {
+function promptForRun(input: ExecutorRunInput, sessionCwd: string): string {
   const lines = [
     `OpenTag run: ${input.runId}`,
     "",
@@ -378,6 +378,8 @@ function promptForRun(input: ExecutorRunInput): string {
   else lines.push(...input.permissions.map((permission) => `- ${permission.scope}`));
   lines.push(
     "",
+    `Authoritative Attempt workspace (session cwd): ${sessionCwd}`,
+    "Use paths relative to this directory. Never infer a workspace path from the Run ID, previous runs, or repository files. Do not create another workspace directory.",
     "OpenTag owns source-control publication and external material actions. Work only inside the supplied session cwd and request permission through ACP when required.",
     "Do not run, request, or recommend git add, git commit, git push, or gh pr create.",
     "After editing and verification, finish your response. The Runner stages and commits locally after you stop; do not wait for or request shell permission to do that yourself.",
@@ -1013,7 +1015,17 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
                 const observeWrite = workspace.kind === "repository" && permissionWorkspaceAttestation
                   ? await prepareLocalWriteObservation({ rawInput: ctx.params.toolCall.rawInput,
                     operation: target.operation, targetFingerprint: target.targetFingerprint,
-                    workspacePath: executionPath, attestation: permissionWorkspaceAttestation }) : undefined;
+                    workspacePath: executionPath, sessionCwd: childCwd,
+                    attestation: permissionWorkspaceAttestation }) : undefined;
+                // Human approval cannot expand an Attempt's filesystem boundary.
+                // Do not authorize a write that cannot produce exact local evidence.
+                if (workspace.kind === "repository" && permissionWorkspaceAttestation
+                  && ["write", "edit"].includes(target.operation) && !observeWrite) {
+                  await sink.emit({ type: "executor.progress",
+                    message: "Write rejected: use a bounded full-file write inside the supplied Attempt workspace.",
+                    at: new Date().toISOString() });
+                  return permissionResponseForDecision({ decision: "deny" }, requestOptions);
+                }
                 const resolution = await governedResolver({
                   toolCallId: request.toolCall.toolCallId,
                   title: request.toolCall.title,
@@ -1093,7 +1105,7 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
                   }
                   return "cancelled";
                 }
-                void session.prompt(promptForRun(input));
+                void session.prompt(promptForRun(input, childCwd));
                 for (;;) {
                   const message = await session.nextUpdate();
                   if (message.kind === "stop") return message.stopReason;

--- a/packages/runner/src/local-write-observation.ts
+++ b/packages/runner/src/local-write-observation.ts
@@ -31,7 +31,7 @@ async function containedPath(workspace: string, requested: string) {
 /** Only a bounded full-file write has enough request data for exact readback. */
 export async function prepareLocalWriteObservation(input: {
   rawInput: unknown; operation: string; targetFingerprint: string | undefined;
-  workspacePath: string; attestation: AttemptWorkspaceAttestation;
+  workspacePath: string; sessionCwd?: string; attestation: AttemptWorkspaceAttestation;
 }): Promise<(() => Promise<LocalWorkspaceWriteObservationV1 | undefined>) | undefined> {
   if (!["write", "edit"].includes(input.operation) || !input.targetFingerprint
     || !input.rawInput || typeof input.rawInput !== "object" || Array.isArray(input.rawInput)) return undefined;
@@ -45,7 +45,9 @@ export async function prepareLocalWriteObservation(input: {
   try {
     const workspace = await realpath(input.workspacePath);
     if (hash(workspace) !== input.attestation.workspacePathDigest) return undefined;
-    const path = await containedPath(workspace, requested);
+    const sessionCwd = input.sessionCwd ? await realpath(input.sessionCwd) : workspace;
+    const requestedPath = resolve(sessionCwd, requested);
+    const path = await containedPath(workspace, requestedPath);
     const before = await lstat(path).catch((error: NodeJS.ErrnoException) => {
       if (error.code === "ENOENT") return null; throw error;
     });
@@ -55,7 +57,7 @@ export async function prepareLocalWriteObservation(input: {
     return async () => {
       try {
         if (await realpath(input.workspacePath) !== workspace
-          || await containedPath(workspace, requested) !== path) return undefined;
+          || await containedPath(workspace, requestedPath) !== path) return undefined;
         const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
         try {
           const stat = await handle.stat();

--- a/packages/runner/test/acp-executor.test.ts
+++ b/packages/runner/test/acp-executor.test.ts
@@ -384,6 +384,22 @@ describe("ACP executor", () => {
     });
   }, 15_000);
 
+  it("rejects an out-of-worktree write before requesting human authority", async () => {
+    const repo = initRepo(); const root = tempDir("outside-write");
+    const permissionResolver = vi.fn(async () => ({ actionId: "outside", decision: "allow_once" as const, material: true }));
+    const executor = createAcpExecutor({ manifest: manifest("local-write-outside") });
+    await executor.run({ ...input({ kind: "repository", path: repo }, "run_outside"),
+      attemptId: "attempt_outside", worktreeRoot: root,
+      attemptAuthority: { attemptNumber: 1, fencingTokenDigest: `sha256:${"a".repeat(64)}`,
+        credentialId: "credential_write", leaseExpiresAt: "2099-01-01T00:00:00.000Z" },
+      permissionResolver,
+    }, { emit: async () => undefined });
+    expect(permissionResolver).not.toHaveBeenCalled();
+    expect(existsSync(join(root, "outside-write.txt"))).toBe(false);
+    const prompt = JSON.parse(git(repo, ["show", "opentag/run_outside:acp-prompt.json"])).text;
+    expect(prompt).toContain(realpathSync(root) + "/run_outside-attempt_outside");
+  });
+
   it.each(["local-write", "local-write-mismatch"])("uses native file readback, not tool success, for %s", async mode => {
     const repo = initRepo(); const reports: Array<{ outcome: string; provider: string; localWriteObservation?: unknown }> = [];
     const executor = createAcpExecutor({ manifest: manifest(mode) });

--- a/packages/runner/test/fixtures/acp-agent.mjs
+++ b/packages/runner/test/fixtures/acp-agent.mjs
@@ -122,6 +122,8 @@ const app = acp
     });
 
     if (mode === "permission" || mode.startsWith("local-write")) {
+      const writePath = mode === "local-write-outside"
+        ? join(session.cwd, "..", "outside-write.txt") : join(session.cwd, "observed-write.txt");
       const permission = await ctx.client.request(acp.methods.client.session.requestPermission, {
         sessionId: ctx.params.sessionId,
         toolCall: {
@@ -130,7 +132,7 @@ const app = acp
           kind: mode.startsWith("local-write") ? "edit" : "execute",
           status: "pending",
           rawInput: mode.startsWith("local-write") ? {
-            file_path: join(session.cwd, "observed-write.txt"), content: "verified native bytes\n",
+            file_path: writePath, content: "verified native bytes\n",
           } : {
             provider: fixtureConfig.OPENTAG_ACP_TEST_PROVIDER ?? "npm",
             connectionId: fixtureConfig.OPENTAG_ACP_TEST_CONNECTION ?? "npm:team",
@@ -149,8 +151,9 @@ const app = acp
         ]
       });
       await record(session.cwd, "acp-permission.json", permission);
-      if (mode.startsWith("local-write") && permission.outcome.outcome === "selected") {
-        await writeFile(join(session.cwd, "observed-write.txt"), mode === "local-write-mismatch" ? "different\n" : "verified native bytes\n");
+      if (mode.startsWith("local-write") && permission.outcome.outcome === "selected"
+        && permission.outcome.optionId !== "reject-once") {
+        await writeFile(writePath, mode === "local-write-mismatch" ? "different\n" : "verified native bytes\n");
       }
       await ctx.client.notify(acp.methods.client.session.update, {
         sessionId: ctx.params.sessionId,

--- a/packages/runner/test/local-write-observation.test.ts
+++ b/packages/runner/test/local-write-observation.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { linkSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { linkSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, it } from "vitest";
@@ -41,6 +41,15 @@ it("refuses unsupported edits, extra instructions and oversized content", async 
     expect(await prepareLocalWriteObservation({ ...f.input, rawInput })).toBeUndefined();
   }
   expect(await prepareLocalWriteObservation({ ...f.input, operation: "execute" })).toBeUndefined();
+});
+
+it("resolves relative writes from the exact session cwd while retaining the Attempt root", async () => {
+  const f = fixture(); const cwd = join(f.root, "src"); mkdirSync(cwd);
+  const observe = await prepareLocalWriteObservation({ ...f.input, sessionCwd: cwd,
+    rawInput: { path: "result.txt", content: "expected\n" } });
+  writeFileSync(f.path, "expected\n"); expect(await observe!()).toBeUndefined();
+  writeFileSync(join(cwd, "result.txt"), "expected\n");
+  expect(await observe!()).toMatchObject({ filePathDigest: hash(join(cwd, "result.txt")) });
 });
 
 it("refuses outside targets, symlink replacement and hard links", async () => {

--- a/packages/slack/src/render.ts
+++ b/packages/slack/src/render.ts
@@ -255,7 +255,8 @@ export function renderSlackTeamRelayProjection(presentation: OpenTagSourceThread
     `*OpenTag: ${markdownToSlackMrkdwn(presentation.title)}*`,
     markdownToSlackMrkdwn(presentation.summary),
     `Run: \`${escapeSlackText(presentation.runId)}\``,
-    ...(presentation.providerDelivery ? [markdownToSlackMrkdwn(presentation.providerDelivery.message)] : [])
+    ...(presentation.providerDelivery && !["pending", "accepted"].includes(presentation.providerDelivery.state)
+      ? [markdownToSlackMrkdwn(presentation.providerDelivery.message)] : [])
   ].join("\n");
 }
 

--- a/packages/slack/test/render.test.ts
+++ b/packages/slack/test/render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createActionReceiptPresentation, createDoctorSummaryPresentation, createFinalSummaryPresentation, createSourceThreadStatusPresentation, OpenTagApprovalPromptPresentationSchema } from "@opentag/core";
+import { composeTeamRelayThreadProjection, createActionReceiptPresentation, createDoctorSummaryPresentation, createFinalSummaryPresentation, createSourceThreadStatusPresentation, OpenTagApprovalPromptPresentationSchema } from "@opentag/core";
 import {
   createSlackActionReceiptBlocks,
   createSlackApprovalPromptBlocks,
@@ -14,12 +14,21 @@ import {
   markdownToSlackMrkdwn,
   renderSlackActionReceiptPresentation,
   renderSlackAcknowledgement,
+  renderSlackTeamRelayProjection,
   renderSlackFinalSummaryPresentation,
   renderSlackFinalResult,
   slackSourceReceiptReactionName
 } from "../src/render.js";
 
 describe("Slack callback rendering", () => {
+  it.each(["pending", "accepted"] as const)("hides routine %s delivery bookkeeping from the user card", state => {
+    const view = composeTeamRelayThreadProjection({ runId: "run_approval", generation: 1,
+      state: "running", controls: [], providerDelivery: { state },
+      approval: { state: "authorized", actionDescriptor: "workspace.write" } });
+    const text = renderSlackTeamRelayProjection(view);
+    expect(text).toContain("Approved once: workspace.write");
+    expect(text).not.toContain("Slack status delivery");
+  });
   it("renders immutable governed permission choices as native buttons", () => {
     const prompt = OpenTagApprovalPromptPresentationSchema.parse({
       kind: "approval_prompt",

--- a/scripts/test/approval-feedback-latency.mjs
+++ b/scripts/test/approval-feedback-latency.mjs
@@ -10,7 +10,7 @@ const records=[];let invalidRecords=0;
 for(const line of readFileSync(0,"utf8").split("\n").filter(Boolean)){
   try{
     let row=JSON.parse(line);
-    if(typeof row.message==="string")row=JSON.parse(row.message);
+    if(row.event!=="control_plane_feedback_timing"&&typeof row.message==="string")row=JSON.parse(row.message);
     if(row.event!=="control_plane_feedback_timing")continue;
     if(!Number.isFinite(Date.parse(row.at))||typeof row.runId!=="string"||typeof row.operationId!=="string"){
       invalidRecords++;continue;

--- a/scripts/test/approval-feedback-latency.mjs
+++ b/scripts/test/approval-feedback-latency.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Read combined ControlPlane/Jobs JSONL logs from stdin. No network or writes.
+// Reports Slack's accepted update, NOT the time a user's device rendered it.
+import {readFileSync} from "node:fs";
+if(process.argv.includes("--help")){
+  console.log("Usage: node scripts/test/approval-feedback-latency.mjs < feedback.jsonl\nAccepts structured timing logs or Railway JSONL with a JSON message field. Twenty accepted samples are required for the p95 target verdict.");
+  process.exit(0);
+}
+const records=[];let invalidRecords=0;
+for(const line of readFileSync(0,"utf8").split("\n").filter(Boolean)){
+  try{
+    let row=JSON.parse(line);
+    if(typeof row.message==="string")row=JSON.parse(row.message);
+    if(row.event!=="control_plane_feedback_timing")continue;
+    if(!Number.isFinite(Date.parse(row.at))||typeof row.runId!=="string"||typeof row.operationId!=="string"){
+      invalidRecords++;continue;
+    }
+    records.push(row);
+  }catch{invalidRecords++;}
+}
+records.sort((a,b)=>Date.parse(a.at)-Date.parse(b.at));
+const elapsed=(a,b)=>{const value=Date.parse(b.at)-Date.parse(a.at);return value>=0?value:null;};
+const approvals=new Map();
+for(const row of records)if(row.stage==="approval_committed"&&typeof row.approvalRef==="string"){
+  const key=JSON.stringify([row.runId,row.approvalRef]);
+  if(!approvals.has(key))approvals.set(key,row);
+}
+const samples=[];let pending=0;
+for(const approval of approvals.values()){
+  const projections=records.filter(row=>row.stage==="projection_enqueued"&&row.runId===approval.runId
+    &&row.approvalRef===approval.approvalRef&&Date.parse(row.at)>=Date.parse(approval.at));
+  const completed=projections.map(projection=>({projection,settled:records.find(row=>
+    row.stage==="delivery_settled"&&row.result==="accepted"&&row.runId===approval.runId
+      &&row.operationId===projection.operationId&&Date.parse(row.at)>=Date.parse(projection.at))}))
+    .filter(value=>value.settled).sort((a,b)=>Date.parse(a.settled.at)-Date.parse(b.settled.at))[0];
+  if(!completed){pending++;continue;}
+  const {projection,settled}=completed;
+  const started=records.find(row=>row.stage==="delivery_started"&&row.runId===approval.runId
+    &&row.operationId===projection.operationId);
+  samples.push({runId:approval.runId,approvalRef:approval.approvalRef,
+    approvalProcessingMs:approval.durationMs??null,approvalToEnqueuedMs:elapsed(approval,projection),
+    deliveryQueueMs:started?.queueMs??null,slackRequestMs:settled.durationMs??null,
+    approvalToAcceptedMs:elapsed(approval,settled)});
+}
+const durations=samples.map(x=>x.approvalToAcceptedMs).filter(x=>x!==null).sort((a,b)=>a-b);
+const p95Ms=durations.length>=20?durations[Math.ceil(durations.length*0.95)-1]:null;
+console.log(JSON.stringify({metric:"approval_commit_to_slack_update_accepted",targetMs:2000,
+  sampleCount:durations.length,pending,invalidRecords,p95Ms,
+  verdict:pending>0?"incomplete_samples":p95Ms===null?"insufficient_samples":p95Ms<=2000?"within_target":"above_target",samples},null,2));

--- a/scripts/test/approval-feedback-latency.mjs
+++ b/scripts/test/approval-feedback-latency.mjs
@@ -39,7 +39,7 @@ for(const approval of approvals.values()){
     &&row.operationId===projection.operationId);
   samples.push({runId:approval.runId,approvalRef:approval.approvalRef,
     approvalProcessingMs:approval.durationMs??null,approvalToEnqueuedMs:elapsed(approval,projection),
-    deliveryQueueMs:started?.queueMs??null,slackRequestMs:settled.durationMs??null,
+    deliveryQueueMs:started?elapsed(projection,started):null,slackRequestMs:settled.durationMs??null,
     approvalToAcceptedMs:elapsed(approval,settled)});
 }
 const durations=samples.map(x=>x.approvalToAcceptedMs).filter(x=>x!==null).sort((a,b)=>a-b);


### PR DESCRIPTION
## Summary

Complete the local execution and approval-feedback path while retaining one source of authority for each fact. See [ADR 0006](https://github.com/amplifthq/opentag/blob/c389d85c2ea74d9f9375b2343ea072ff80dfe8c2/docs/adr/0006-presence-first-effect-authority.md) for the existing authority/projection boundaries.

- Bind ACP guidance and local write observations to the exact Attempt workspace, including relative writes under a contained session cwd. Reject attested repository write requests that cannot produce admissible exact local evidence before requesting human authorization.
- Render ordinary permissions and Draft PR Effect approvals from durable current state. Remove resolved controls, distinguish approval from execution/publication, and display verified PR links.
- Wake the existing provider-delivery worker immediately after projection enqueue rather than waiting for the minute maintenance sweep.
- Reuse Run phase and approval facts across Console and Slack. Preserve busy Runner presence when a current, non-revoked execution lease remains valid, and distinguish publication waiting from an invalid execution lease.
- Allow at most one second of server-ahead skew for Runner control-context observations only; the existing maximum age and all approval/permit/lease deadlines remain unchanged.
- Add content-free, structured feedback timing plus an offline JSONL report that separates approval handling, projection, delivery queueing, and Slack acknowledgement. Deduplicate samples and require 20 accepted samples before a p95 verdict.

## Verification

- On PR head: `pnpm test` with isolated PostgreSQL — 1,494 passed, 2 skipped.
- On PR head: `pnpm build`, `pnpm lint`, and `pnpm typecheck` — passed.
- Full package/release check on runtime commit `e37012e5` — passed after a bounded network retry; initial clean npm installation had stalled on registry metadata. The subsequent HEAD change is report/test-only and was separately regression-tested and included in the current full test run.
- Production dependency audit and packed-package privacy checks passed.
- Regressions cover resolved control replay, approval feedback before any Runner permit acquisition, immediate delivery wakeup, exact local write observations, unchanged freshness expiry, shared phase rendering, and native Railway JSON log parsing.

## Live validation and limits

- Scoped Slack/GitHub validation completed local execution, human write approval, Runner-generated commit/candidate, separate human publication approval, and an exact-head Draft PR receipt.
- Observed approval-commit-to-Slack-accepted-update samples: 302 ms for write approval and 1,680 ms for publication approval. These are two samples, not a p95/SLA claim or a device-render timing measurement.
- The validation environment currently runs `e37012e5`; HEAD only corrects offline timing-report segmentation. The live Run began on `c685418c` and completed after the presentation follow-up was deployed, so this is not represented as a fresh deployment/full loop on one immutable final head.
- Private test identities, credentials, local paths, and raw provider payloads are intentionally excluded from this public description.

## Compatibility, authority, and rollout

- No database migration, new table, new approval state machine, or production dependency.
- Local write evidence remains deliberately limited to bounded full-file writes. Edit/patch inputs without admissible exact local observation are rejected rather than treated as successful writes. This may require adapters or agents to choose the supported full-file write operation.
- No arbitrary `command.execute` permission, automatic remote publication approval, lease extension, or ambiguous-effect replay is added.
- Slack retry affects presentation only; approval, provider I/O, and canonical Run completion remain separate facts.
- This PR has not been merged and does not advance a public image tag or the deployment repository's fixed image pin. Formal image publication and template pinning follow the reviewed merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack relay updates now show approval status and publication progress, including pending, authorized, denied, and draft-review states.
  * Publication approvals can proceed without requiring Runner acquisition.
  * Delivery jobs are queued automatically after relay updates.

* **Bug Fixes**
  * Removed stale or invalid approval and effect controls from Slack interactions.
  * Routine pending or accepted delivery updates are no longer shown in user-facing Slack cards.
  * Local file actions now respect the session working directory and reject writes outside the permitted workspace.
  * Improved handling of minor server clock differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->