### PR TITLE
fix: reject repository writes without attempt attestation

### DIFF
--- a/packages/runner/src/acp-executor.ts
+++ b/packages/runner/src/acp-executor.ts
@@ -1019,8 +1019,8 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
                     attestation: permissionWorkspaceAttestation }) : undefined;
                 // Human approval cannot expand an Attempt's filesystem boundary.
                 // Do not authorize a write that cannot produce exact local evidence.
-                if (workspace.kind === "repository" && permissionWorkspaceAttestation
-                  && ["write", "edit"].includes(target.operation) && !observeWrite) {
+                if (workspace.kind === "repository" && ["write", "edit"].includes(target.operation)
+                  && (!permissionWorkspaceAttestation || observeWrite === undefined)) {
                   await sink.emit({ type: "executor.progress",
                     message: "Write rejected: use a bounded full-file write inside the supplied Attempt workspace.",
                     at: new Date().toISOString() });

--- a/packages/runner/src/acp-executor.ts
+++ b/packages/runner/src/acp-executor.ts
@@ -970,7 +970,6 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
                 name: option.name,
                 kind: option.kind
               }));
-              const governedResolver = input.permissionResolver;
               const target = structuredPermissionTarget(ctx.params.toolCall.rawInput, ctx.params.toolCall.kind);
               const request = {
                 runId: input.runId,
@@ -984,48 +983,49 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
                 options: requestOptions,
                 permissionScopes: input.permissions?.map((permission) => permission.scope) ?? []
               };
+              if (workspace.kind === "repository" && workspaceAttestation
+                && input.attemptId && input.attemptAuthority) {
+                const refreshed = await attestAttemptWorkspace({ runner,
+                  workspacePath: executionPath, repositoryPath: workspace.path,
+                  workspaceId: workspaceAttestation.workspaceId,
+                  baseRevision: workspaceAttestation.baseRevision,
+                  attemptId: input.attemptId,
+                  attemptNumber: input.attemptAuthority.attemptNumber,
+                  fencingTokenDigest: input.attemptAuthority.fencingTokenDigest,
+                  credentialId: input.attemptAuthority.credentialId,
+                  leaseExpiresAt: workspaceAttestation.leaseExpiresAt });
+                if (refreshed.workspacePathDigest !== workspaceAttestation.workspacePathDigest
+                  || refreshed.repositoryPathDigest !== workspaceAttestation.repositoryPathDigest
+                  || refreshed.worktreeIdentityDigest !== workspaceAttestation.worktreeIdentityDigest
+                  || refreshed.baseRevision !== workspaceAttestation.baseRevision
+                  || refreshed.attemptId !== workspaceAttestation.attemptId
+                  || refreshed.attemptNumber !== workspaceAttestation.attemptNumber
+                  || refreshed.fencingTokenDigest !== workspaceAttestation.fencingTokenDigest
+                  || refreshed.credentialId !== workspaceAttestation.credentialId) {
+                  throw new Error("attempt_workspace_identity_changed_before_material_action");
+                }
+                workspaceAttestation = refreshed;
+                await sink.emit({ type: "executor.progress",
+                  message: "Attempt workspace re-attested before material authorization.",
+                  at: new Date().toISOString(), workspaceAttestation });
+              }
+              const permissionWorkspaceAttestation = workspaceAttestation;
+              const observeWrite = workspace.kind === "repository" && permissionWorkspaceAttestation
+                ? await prepareLocalWriteObservation({ rawInput: ctx.params.toolCall.rawInput,
+                  operation: target.operation, targetFingerprint: target.targetFingerprint,
+                  workspacePath: executionPath, sessionCwd: childCwd,
+                  attestation: permissionWorkspaceAttestation }) : undefined;
+              // Human approval cannot expand an Attempt's filesystem boundary.
+              // Apply the same write-evidence gate before choosing either resolver.
+              if (workspace.kind === "repository" && ["write", "edit"].includes(target.operation)
+                && (!permissionWorkspaceAttestation || observeWrite === undefined)) {
+                await sink.emit({ type: "executor.progress",
+                  message: "Write rejected: use a bounded full-file write inside the supplied Attempt workspace.",
+                  at: new Date().toISOString() });
+                return permissionResponseForDecision({ decision: "deny" }, requestOptions);
+              }
+              const governedResolver = input.permissionResolver;
               if (governedResolver) {
-                if (workspace.kind === "repository" && workspaceAttestation
-                  && input.attemptId && input.attemptAuthority) {
-                  const refreshed = await attestAttemptWorkspace({ runner,
-                    workspacePath: executionPath, repositoryPath: workspace.path,
-                    workspaceId: workspaceAttestation.workspaceId,
-                    baseRevision: workspaceAttestation.baseRevision,
-                    attemptId: input.attemptId,
-                    attemptNumber: input.attemptAuthority.attemptNumber,
-                    fencingTokenDigest: input.attemptAuthority.fencingTokenDigest,
-                    credentialId: input.attemptAuthority.credentialId,
-                    leaseExpiresAt: workspaceAttestation.leaseExpiresAt });
-                  if (refreshed.workspacePathDigest !== workspaceAttestation.workspacePathDigest
-                    || refreshed.repositoryPathDigest !== workspaceAttestation.repositoryPathDigest
-                    || refreshed.worktreeIdentityDigest !== workspaceAttestation.worktreeIdentityDigest
-                    || refreshed.baseRevision !== workspaceAttestation.baseRevision
-                    || refreshed.attemptId !== workspaceAttestation.attemptId
-                    || refreshed.attemptNumber !== workspaceAttestation.attemptNumber
-                    || refreshed.fencingTokenDigest !== workspaceAttestation.fencingTokenDigest
-                    || refreshed.credentialId !== workspaceAttestation.credentialId) {
-                    throw new Error("attempt_workspace_identity_changed_before_material_action");
-                  }
-                  workspaceAttestation = refreshed;
-                  await sink.emit({ type: "executor.progress",
-                    message: "Attempt workspace re-attested before material authorization.",
-                    at: new Date().toISOString(), workspaceAttestation });
-                }
-                const permissionWorkspaceAttestation = workspaceAttestation;
-                const observeWrite = workspace.kind === "repository" && permissionWorkspaceAttestation
-                  ? await prepareLocalWriteObservation({ rawInput: ctx.params.toolCall.rawInput,
-                    operation: target.operation, targetFingerprint: target.targetFingerprint,
-                    workspacePath: executionPath, sessionCwd: childCwd,
-                    attestation: permissionWorkspaceAttestation }) : undefined;
-                // Human approval cannot expand an Attempt's filesystem boundary.
-                // Do not authorize a write that cannot produce exact local evidence.
-                if (workspace.kind === "repository" && ["write", "edit"].includes(target.operation)
-                  && (!permissionWorkspaceAttestation || observeWrite === undefined)) {
-                  await sink.emit({ type: "executor.progress",
-                    message: "Write rejected: use a bounded full-file write inside the supplied Attempt workspace.",
-                    at: new Date().toISOString() });
-                  return permissionResponseForDecision({ decision: "deny" }, requestOptions);
-                }
                 const resolution = await governedResolver({
                   toolCallId: request.toolCall.toolCallId,
                   title: request.toolCall.title,

--- a/packages/runner/src/acp-executor.ts
+++ b/packages/runner/src/acp-executor.ts
@@ -222,10 +222,15 @@ function structuredPermissionTarget(rawInput: unknown, kind: string | null | und
   resourceVersion?: string;
   targetConstraints?: Record<string, unknown>;
   targetFingerprint?: string;
-} {
+} | undefined {
   const rawRecord = rawInput && typeof rawInput === "object" && !Array.isArray(rawInput)
     ? rawInput as Record<string, unknown>
     : {};
+  const toolKind = kind?.trim().toLowerCase();
+  // A raw operation must not relabel a tool-declared write before authorization.
+  if (["write", "edit"].includes(toolKind ?? "") && Object.hasOwn(rawRecord, "operation")
+    && (typeof rawRecord["operation"] !== "string"
+      || rawRecord["operation"].trim().toLowerCase() !== toolKind)) return undefined;
   const safeTarget = credentialSafeTarget(rawRecord);
   const record = safeTarget && typeof safeTarget === "object" && !Array.isArray(safeTarget)
     ? safeTarget as Record<string, unknown>
@@ -971,6 +976,12 @@ export function createAcpExecutor(options: AcpExecutorOptions): ExecutorAdapter 
                 kind: option.kind
               }));
               const target = structuredPermissionTarget(ctx.params.toolCall.rawInput, ctx.params.toolCall.kind);
+              if (!target) {
+                await sink.emit({ type: "executor.progress",
+                  message: "Write rejected: tool kind conflicts with the requested operation.",
+                  at: new Date().toISOString() });
+                return permissionResponseForDecision({ decision: "deny" }, requestOptions);
+              }
               const request = {
                 runId: input.runId,
                 toolCall: {

--- a/packages/runner/test/acp-executor.test.ts
+++ b/packages/runner/test/acp-executor.test.ts
@@ -411,6 +411,23 @@ describe("ACP executor", () => {
     expect(existsSync(join(root, "outside-write.txt"))).toBe(false);
   });
 
+  it.each([false, true])("rejects outside repository writes with only the options resolver (attested: %s)", async attested => {
+    const repo = initRepo(); const root = tempDir("options-outside-write");
+    const permissionResolver = vi.fn(async () => ({ decision: "allow_once" as const }));
+    const executor = createAcpExecutor({ manifest: manifest("local-write-outside"), permissionResolver });
+    await executor.run({ ...input({ kind: "repository", path: repo }, "run_options_write"),
+      worktreeRoot: root,
+      ...(attested ? { attemptId: "attempt_options_write", attemptAuthority: {
+        attemptNumber: 1, fencingTokenDigest: `sha256:${"a".repeat(64)}`,
+        credentialId: "credential_options_write", leaseExpiresAt: "2099-01-01T00:00:00.000Z",
+      } } : {}),
+    }, { emit: async () => undefined });
+    expect(permissionResolver).not.toHaveBeenCalled();
+    expect(existsSync(join(root, "outside-write.txt"))).toBe(false);
+    expect(JSON.parse(git(repo, ["show", "opentag/run_options_write:acp-permission.json"])))
+      .toEqual({ outcome: { outcome: "selected", optionId: "reject-once" } });
+  });
+
   it.each(["local-write", "local-write-mismatch"])("uses native file readback, not tool success, for %s", async mode => {
     const repo = initRepo(); const reports: Array<{ outcome: string; provider: string; localWriteObservation?: unknown }> = [];
     const executor = createAcpExecutor({ manifest: manifest(mode) });

--- a/packages/runner/test/acp-executor.test.ts
+++ b/packages/runner/test/acp-executor.test.ts
@@ -428,6 +428,35 @@ describe("ACP executor", () => {
       .toEqual({ outcome: { outcome: "selected", optionId: "reject-once" } });
   });
 
+  it.each([
+    ["read", "input"], ["write", "input"], ["read", "options"], ["write", "options"],
+  ] as const)("rejects conflicting edit/%s operations before the %s resolver", async (operation, resolverSource) => {
+    const repo = initRepo(); const root = tempDir("conflicting-write");
+    const config = permissionWorkspace("conflicting-operation", {
+      OPENTAG_ACP_TEST_OPERATION: operation,
+    });
+    const configured = manifest("local-write-outside");
+    configured.bindings.agent.args.push(join(config, ".acp-test-config.json"));
+    const permissionResolver = vi.fn(async () => ({ actionId: "outside", decision: "allow_once" as const, material: true }));
+    const executor = createAcpExecutor({ manifest: configured,
+      ...(resolverSource === "options" ? { permissionResolver } : {}),
+    });
+    const emit = vi.fn(async () => undefined);
+    await executor.run({ ...input({ kind: "repository", path: repo }, "run_conflicting_write"),
+      worktreeRoot: root, attemptId: "attempt_conflicting_write",
+      attemptAuthority: { attemptNumber: 1, fencingTokenDigest: `sha256:${"a".repeat(64)}`,
+        credentialId: "credential_conflicting_write", leaseExpiresAt: "2099-01-01T00:00:00.000Z" },
+      ...(resolverSource === "input" ? { permissionResolver } : {}),
+    }, { emit });
+    expect(permissionResolver).not.toHaveBeenCalled();
+    expect(existsSync(join(root, "outside-write.txt"))).toBe(false);
+    expect(emit).toHaveBeenCalledWith(expect.objectContaining({
+      type: "executor.progress", message: "Write rejected: tool kind conflicts with the requested operation.",
+    }));
+    expect(JSON.parse(git(repo, ["show", "opentag/run_conflicting_write:acp-permission.json"])))
+      .toEqual({ outcome: { outcome: "selected", optionId: "reject-once" } });
+  });
+
   it.each(["local-write", "local-write-mismatch"])("uses native file readback, not tool success, for %s", async mode => {
     const repo = initRepo(); const reports: Array<{ outcome: string; provider: string; localWriteObservation?: unknown }> = [];
     const executor = createAcpExecutor({ manifest: manifest(mode) });

--- a/packages/runner/test/acp-executor.test.ts
+++ b/packages/runner/test/acp-executor.test.ts
@@ -400,6 +400,17 @@ describe("ACP executor", () => {
     expect(prompt).toContain(realpathSync(root) + "/run_outside-attempt_outside");
   });
 
+  it("rejects a repository write without an Attempt attestation before resolving permission", async () => {
+    const repo = initRepo(); const root = tempDir("unattested-write");
+    const permissionResolver = vi.fn(async () => ({ actionId: "outside", decision: "allow_once" as const, material: true }));
+    const executor = createAcpExecutor({ manifest: manifest("local-write-outside") });
+    await executor.run({ ...input({ kind: "repository", path: repo }, "run_unattested"),
+      worktreeRoot: root, permissionResolver,
+    }, { emit: async () => undefined });
+    expect(permissionResolver).not.toHaveBeenCalled();
+    expect(existsSync(join(root, "outside-write.txt"))).toBe(false);
+  });
+
   it.each(["local-write", "local-write-mismatch"])("uses native file readback, not tool success, for %s", async mode => {
     const repo = initRepo(); const reports: Array<{ outcome: string; provider: string; localWriteObservation?: unknown }> = [];
     const executor = createAcpExecutor({ manifest: manifest(mode) });

--- a/packages/runner/test/fixtures/acp-agent.mjs
+++ b/packages/runner/test/fixtures/acp-agent.mjs
@@ -133,6 +133,8 @@ const app = acp
           status: "pending",
           rawInput: mode.startsWith("local-write") ? {
             file_path: writePath, content: "verified native bytes\n",
+            ...(fixtureConfig.OPENTAG_ACP_TEST_OPERATION !== undefined
+              ? { operation: fixtureConfig.OPENTAG_ACP_TEST_OPERATION } : {}),
           } : {
             provider: fixtureConfig.OPENTAG_ACP_TEST_PROVIDER ?? "npm",
             connectionId: fixtureConfig.OPENTAG_ACP_TEST_CONNECTION ?? "npm:team",

--- a/packages/runner/test/local-write-observation.test.ts
+++ b/packages/runner/test/local-write-observation.test.ts
@@ -20,8 +20,8 @@ function fixture() {
     operation: "edit", targetFingerprint: hash("exact-request"), workspacePath: root, attestation } };
 }
 
-it("observes bounded exact file contents without trusting a reported result", async () => {
-  const f = fixture(); const observe = await prepareLocalWriteObservation(f.input);
+it.each(["write", "edit"])("observes bounded exact %s contents without trusting a reported result", async operation => {
+  const f = fixture(); const observe = await prepareLocalWriteObservation({ ...f.input, operation });
   expect(observe).toBeTypeOf("function");
   expect(await observe!()).toBeUndefined();
   writeFileSync(f.path, "wrong\n"); expect(await observe!()).toBeUndefined();


### PR DESCRIPTION
## Summary

Follow-up to #165. Require repository `write` and `edit` operations in the ACP permission flow to have both an Attempt workspace attestation and an admissible local write observer before selecting either the input-level or options-level permission resolver.

- Reject when `permissionWorkspaceAttestation` is absent **or** `observeWrite` is undefined.
- Add a regression using the outside-write fixture, a separate worktree root, and an allowing permission resolver, without `attemptId` or `attemptAuthority`.
- Assert that the resolver is never called and the outside file is not created.
- Cover options-only resolvers both without attestation and with an attested but outside target; preserve the ACP `reject-once` response.
- Reject a tool-declared write/edit whose raw operation conflicts before selecting either resolver, rather than allowing the raw operation to bypass write gating.
- Cover conflicting edit/read and edit/write requests targeting outside the Attempt workspace for both resolver paths, and verify exact native observation for both write and edit operations.

## Verification

- Confirmed the finding against current `main` after #165 merged.
- Red/green: the new regression failed on the previous condition because the resolver was called once; it passes after the fix.
- ACP executor and local write observation tests: **70 passed**.
- Root `pnpm typecheck`: passed.
- `pnpm --filter @opentag/runner lint`: passed.
- `git diff --check`: passed.

## Scope and compatibility

- Four files only (executor, two test files, and fixture); no dependency, protocol, or database migration changes.
- Repository write/edit calls without the required evidence now fail closed before permission resolution. Conflicting write/edit operation declarations are rejected for all workspace types. Valid attested writes and non-conflicting scratch execution retain their existing behavior.
- This change does not grant new permissions or alter approval, permit, or lease deadlines.
- No deployment or live provider operation was performed for this follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Repository write and edit actions are now blocked unless workspace authorization and local write verification are both available, regardless of permission resolver configuration.
  - Unauthorized or out-of-workspace write attempts are rejected before permission checks proceed, preventing files from being created.
  - Requests with conflicting operation details, such as a write request identified as a read, are now rejected.
  - Rejected write attempts now consistently record the appropriate rejection outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->